### PR TITLE
Potential fix for code scanning alert no. 3: CSRF protection weakened or disabled

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,3 @@
 class ApplicationController < ActionController::Base
-  protect_from_forgery
+  protect_from_forgery with: :exception
 end


### PR DESCRIPTION
Potential fix for [https://github.com/Deduktiva/abt/security/code-scanning/3](https://github.com/Deduktiva/abt/security/code-scanning/3)

To fix the problem, update the call to `protect_from_forgery` in `app/controllers/application_controller.rb` to use the `with: :exception` option. This will cause Rails to raise an exception when an invalid CSRF token is encountered, rather than just nullifying the session. This change should be made on line 2 of the file. No additional imports or method definitions are required, as this is standard Rails functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
