### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: Continuous Integration
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ master ]


### PR DESCRIPTION
Potential fix for [https://github.com/Deduktiva/abt/security/code-scanning/2](https://github.com/Deduktiva/abt/security/code-scanning/2)

To fix the problem, add an explicit `permissions` block to the workflow file to restrict the `GITHUB_TOKEN` to the minimum required privileges. In this case, since the jobs only need to check out code and do not perform any write operations, the minimal required permission is `contents: read`. This can be set at the workflow level (applies to all jobs) or at the job level (applies only to the specified job). The best practice is to set it at the workflow level unless a job requires different permissions. 

**Steps:**
- Add the following block near the top of `.github/workflows/ci.yml`, after the `name:` and before `on:`:
  ```yaml
  permissions:
    contents: read
  ```
- No additional imports, methods, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
