### PR TITLE
Split E-Mail templates

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,5 +1,19 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
-  layout 'mailer'
-end
+  def initialize
+    super()
+    setup_issuer
+  end
 
+  default :from => Proc.new { build_default_from }
+  layout 'mailer'
+
+  protected
+
+  def setup_issuer
+    @issuer = IssuerCompany.get_the_issuer!
+  end
+
+  def build_default_from
+    "\"#{@issuer.short_name}\" <#{@issuer.document_email_from}>"
+  end
+end

--- a/app/mailers/invoice_mailer.rb
+++ b/app/mailers/invoice_mailer.rb
@@ -1,6 +1,5 @@
 class InvoiceMailer < ApplicationMailer
   def customer_email
-    @issuer = IssuerCompany.get_the_issuer!
     @invoice = params[:invoice]
     attachments[@invoice.attachment.filename] = {
       mime_type: @invoice.attachment.content_type,
@@ -9,18 +8,20 @@ class InvoiceMailer < ApplicationMailer
 
     if @invoice.customer.invoice_email_auto_enabled
       subject = @invoice.customer.invoice_email_auto_subject_template.gsub('$CUST_ORDER$', @invoice.cust_order).gsub('$CUST_REF$', @invoice.cust_reference)
+      to = @invoice.customer.invoice_email_auto_to
+    elsif @invoice.customer.email
+      subject = "#{@issuer.short_name} Invoice #{@invoice.document_number}"
+      to = @invoice.customer.email
+    else
+      to = nil
+    end
+
+    unless to.nil?
       mail(
-        to: @invoice.customer.invoice_email_auto_to,
+        to: to,
         from: "\"#{@issuer.short_name}\" <#{@issuer.document_email_from}>",
         bcc: @issuer.document_email_auto_bcc,
         subject: subject
-      )
-    elsif @invoice.customer.email
-      mail(
-        to: @invoice.customer.email,
-        from: "\"#{@issuer.short_name}\" <#{@issuer.document_email_from}>",
-        bcc: @issuer.document_email_auto_bcc,
-        subject: "#{@issuer.short_name} Invoice #{@invoice.document_number}"
       )
     end
   end

--- a/app/views/invoice_mailer/customer_email.html.haml
+++ b/app/views/invoice_mailer/customer_email.html.haml
@@ -1,55 +1,19 @@
 - content_for :title, "Invoice #{@invoice.document_number}"
 
-:css
-  .greeting {
-    font-size: 18px;
-    font-weight: 500;
-    margin-bottom: 20px;
-    color: #2c3e50;
-  }
-  .main-message {
-    font-size: 16px;
-    margin-bottom: 20px;
-    line-height: 1.7;
-  }
-  .invoice-highlight {
-    background-color: #f8f9fa;
-    border-left: 4px solid #{@issuer.document_accent_color || '#007bff'};
-    padding: 15px 20px;
-    margin: 20px 0;
-    border-radius: 0 4px 4px 0;
-  }
-  .invoice-number {
-    font-weight: 600;
-    color: #2c3e50;
-    font-size: 16px;
-  }
-  .invoice-detail, .due-date {
-    color: #6c757d;
-    margin-top: 5px;
-    font-size: 14px;
-  }
-  .due-date {
-    margin-top: 8px;
-  }
-  .closing {
-    margin-top: 30px;
-    margin-bottom: 30px;
-  }
 .greeting
   Dear #{@invoice.customer.name},
 
 .main-message
   We've attached your invoice for the services provided. Please review the details and let us know if you have any questions.
 
-.invoice-highlight
-  .invoice-number
+.document-highlight
+  .document-number
     Invoice #{@invoice.document_number}
   - if @invoice.cust_order.present?
-    .invoice-detail
+    .document-detail
       Order: #{@invoice.cust_order}
   - if @invoice.cust_reference.present?
-    .invoice-detail
+    .document-detail
       Reference: #{@invoice.cust_reference}
   .due-date
     Due date: #{@invoice.due_date}

--- a/app/views/invoice_mailer/customer_email.text.haml
+++ b/app/views/invoice_mailer/customer_email.text.haml
@@ -1,16 +1,12 @@
 Dear #{@invoice.customer.name},
-
+\
 We've attached your invoice for the services provided. Please review the details and let us know if you have any questions.
-
+\
 Invoice #{@invoice.document_number}
 - if @invoice.cust_order.present?
   Order: #{@invoice.cust_order}
 - if @invoice.cust_reference.present?
   Reference: #{@invoice.cust_reference}
 Due date: #{@invoice.due_date}
-
+\
 Thank you for your business. We appreciate your continued partnership.
-
-= @issuer.legal_name
-- @issuer.address.split("\n").each do |line|
-  = line

--- a/app/views/layouts/mailer.html.haml
+++ b/app/views/layouts/mailer.html.haml
@@ -52,6 +52,41 @@
         max-width: 180px;
         max-height: 90px;
       }
+      .greeting {
+        font-size: 18px;
+        font-weight: 500;
+        margin-bottom: 20px;
+        color: #2c3e50;
+      }
+      .main-message {
+        font-size: 16px;
+        margin-bottom: 20px;
+        line-height: 1.7;
+      }
+      .document-highlight {
+        background-color: #f8f9fa;
+        border-left: 4px solid #{@issuer&.document_accent_color || '#007bff'};
+        padding: 15px 20px;
+        margin: 20px 0;
+        border-radius: 0 4px 4px 0;
+      }
+      .document-number {
+        font-weight: 600;
+        color: #2c3e50;
+        font-size: 16px;
+      }
+      .document-detail, .due-date {
+        color: #6c757d;
+        margin-top: 5px;
+        font-size: 14px;
+      }
+      .due-date {
+        margin-top: 8px;
+      }
+      .closing {
+        margin-top: 30px;
+        margin-bottom: 30px;
+      }
   %body
     .email-container
       .header-stripe

--- a/app/views/layouts/mailer.text.haml
+++ b/app/views/layouts/mailer.text.haml
@@ -1,1 +1,6 @@
 = yield
+\
+- if @issuer
+  = @issuer.legal_name
+  - @issuer.address.split("\n").each do |line|
+    = line

--- a/test/mailers/invoice_mailer_test.rb
+++ b/test/mailers/invoice_mailer_test.rb
@@ -70,7 +70,7 @@ class InvoiceMailerTest < ActionMailer::TestCase
     assert_match "Dear A Good Company B.V.", text_body
     assert_match "INV-2024-001", text_body
     assert_match invoice.due_date.to_s, text_body
-    assert_match "Example Company B.V.", text_body
+    assert_match "Example Company B.V.", text_body  # issuer legal_name from fixture
   end
 
   test "customer_email subject template handles empty substitution values" do


### PR DESCRIPTION
- Extract common email styling and structure into document_mailer layout templates
- Convert invoice-specific CSS classes to generic document classes (document-highlight, document-number, etc.)