### PR TITLE
Fix Issue #78: Old migrations fail

### DIFF
--- a/db/migrate/20141226231925_create_invoice_tax_classes.rb
+++ b/db/migrate/20141226231925_create_invoice_tax_classes.rb
@@ -1,6 +1,6 @@
 class CreateInvoiceTaxClasses < ActiveRecord::Migration[6.0]
   class Invoice < ActiveRecord::Base
-    serialize :tax_classes
+    serialize :tax_classes, coder: YAML
     has_many :invoice_tax_classes
   end
   class InvoiceTaxClass < ActiveRecord::Base; end


### PR DESCRIPTION
## Summary
Resolves #78

Fixed migration failure that occurred when running fresh migrations from scratch.
The issue was in migration `20141226231925_create_invoice_tax_classes.rb` which used
the legacy serialize syntax without the required `:coder` parameter.

### ✅ **Changes Made**
- Added `coder: YAML` parameter to `serialize :tax_classes` call in migration
- This is required in Rails 8+ when no default coder is configured globally
- Migration now successfully runs with fresh database setup

### 🧪 **Testing**
- Reproduced issue by removing schema.rb and running fresh migrations
- Verified fix allows full migration sequence to complete successfully
- All 111 tests pass with 362 assertions

### 📋 **Technical Details**
The `serialize` method in Rails 8+ requires an explicit `:coder` parameter when no default
coder is configured globally. The fix maintains backward compatibility while meeting
modern Rails requirements.

### Test plan checklist
- [x] Remove db/schema.rb
- [x] Run `rails db:drop db:create`
- [x] Run `rails db:migrate` successfully
- [x] Run full test suite
- [x] Verify all tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)