### PR TITLE
Fix booking large invoice cookie overflow (Issue #88)

### DIFF
--- a/app/views/invoices/book.html.haml
+++ b/app/views/invoices/book.html.haml
@@ -7,10 +7,15 @@ published:
 = @invoice.published
 %br
 
-%br
-%b Booking Log:
-%pre
-  = @booking_log.join("\n")
+- if @booking_summary.present?
+  %br
+  %b Booking Result:
+  .alert{class: @booked ? 'alert-success' : 'alert-danger'}
+    = @booking_summary
+    - if @booking_errors.present?
+      %br
+      %strong Errors:
+      = @booking_errors
 
 - if @booked and !@invoice.published?
   = button_to 'Book!', book_invoice_path(@invoice, :save => true), class: 'btn btn-warning me-2'


### PR DESCRIPTION
## Summary
- Fixed cookie overflow error when booking large invoices with many line items
- Replaced session storage with flash messages for booking results  
- Maintains all existing functionality while preventing 4KB cookie limit errors

## Problem
The booking process was storing detailed booking logs in the session cookie, which could exceed the 4KB browser limit for invoices with extensive line items, causing `ActionDispatch::Cookies::CookieOverflow` errors.

## Solution
- Store only summary information in flash messages instead of full detailed logs
- Preserve error messages for debugging while avoiding overflow
- Update booking view to display simplified but useful results
- Add comprehensive test coverage for large invoice booking scenarios

## Test Plan
- [x] Added test with 15 invoice lines to reproduce the overflow scenario
- [x] Verified fix prevents cookie overflow while maintaining functionality
- [x] All existing tests pass (119 tests, 399 assertions)
- [x] Booking results still display success/failure status and error details

Fixes #88

🤖 Generated with [Claude Code](https://claude.ai/code)