### PR TITLE
Fix navbar Configuration dropdown behavior and positioning

### DIFF
--- a/app/javascript/controllers/navbar_controller.js
+++ b/app/javascript/controllers/navbar_controller.js
@@ -5,14 +5,17 @@ export default class extends Controller {
 
   connect() {
     // Close menu when clicking outside
-    document.addEventListener('click', this.closeOnOutsideClick.bind(this))
+    this.boundCloseOnOutsideClick = this.closeOnOutsideClick.bind(this)
+    document.addEventListener('click', this.boundCloseOnOutsideClick)
   }
 
   disconnect() {
-    document.removeEventListener('click', this.closeOnOutsideClick.bind(this))
+    document.removeEventListener('click', this.boundCloseOnOutsideClick)
   }
 
-  toggle() {
+  toggle(event) {
+    event.preventDefault()
+
     if (this.hasMenuTarget) {
       this.menuTarget.classList.toggle('show')
 

--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -24,7 +24,7 @@
     %li.nav-item.dropdown{"data-controller" => "navbar"}
       %a.nav-link.dropdown-toggle{:href => "#", :role => "button", :"data-navbar-target" => "toggle", :"data-action" => "click->navbar#toggle"}
         Configuration
-      %ul.dropdown-menu{"data-navbar-target" => "menu"}
+      %ul.dropdown-menu.dropdown-menu-end{"data-navbar-target" => "menu"}
         %li
           = link_to('Issuer Company', issuer_company_path, :class => 'dropdown-item')
         %li


### PR DESCRIPTION
## Summary
- Fix Configuration dropdown disappearing immediately when clicked
- Prevent dropdown menu from being cut off on right edge of screen
- Improve event listener cleanup in navbar Stimulus controller

## Changes Made
- Added `event.preventDefault()` to prevent navigation when clicking dropdown toggle
- Fixed event listener memory leak by storing bound function reference
- Added `dropdown-menu-end` class to align dropdown menu to right edge

## Test plan
- [x] Configuration dropdown now stays open when clicked
- [x] All menu items (Issuer Company, Product Catalog, Sales Tax) are fully visible
- [x] Dropdown properly closes when clicking outside
- [x] No event listener memory leaks on page navigation

🤖 Generated with [Claude Code](https://claude.ai/code)