### PR TITLE
Fix db:seed after customer email migration to contacts

### DIFF
--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -247,7 +247,7 @@ class InvoicesController < ApplicationController
     queued_count = 0
 
     invoices.each do |invoice|
-      if invoice.customer.email.present? || invoice.customer.invoice_email_auto_enabled
+      if invoice.customer.has_invoice_email?
         InvoiceEmailSenderJob.perform_later(invoice.id)
         queued_count += 1
       end

--- a/app/mailers/invoice_mailer.rb
+++ b/app/mailers/invoice_mailer.rb
@@ -9,9 +9,9 @@ class InvoiceMailer < ApplicationMailer
     if @invoice.customer.invoice_email_auto_enabled
       subject = @invoice.customer.invoice_email_auto_subject_template.gsub('$CUST_ORDER$', @invoice.cust_order).gsub('$CUST_REF$', @invoice.cust_reference)
       to = @invoice.customer.invoice_email_auto_to
-    elsif @invoice.customer.email
+    elsif @invoice.customer.customer_contacts.receiving_invoices.any?
       subject = "#{@issuer.short_name} Invoice #{@invoice.document_number}"
-      to = @invoice.customer.email
+      to = @invoice.customer.customer_contacts.receiving_invoices.first.email
     else
       to = nil
     end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -28,6 +28,11 @@ class Customer < ApplicationRecord
     used_in_invoices?
   end
 
+  # Helper method to check if customer has email contacts for invoices
+  def has_invoice_email?
+    invoice_email_auto_enabled || customer_contacts.receiving_invoices.any?
+  end
+
   private
 
   def check_if_used

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -5,6 +5,7 @@ class Customer < ApplicationRecord
   belongs_to :sales_tax_customer_class
   has_many :sales_tax_rates, :through => :sales_tax_customer_class
   has_many :invoices
+  has_many :customer_contacts, dependent: :destroy
 
   # Scopes for filtering
   scope :active, -> { where(active: true) }

--- a/app/models/customer_contact.rb
+++ b/app/models/customer_contact.rb
@@ -1,0 +1,11 @@
+class CustomerContact < ApplicationRecord
+  belongs_to :customer
+  has_and_belongs_to_many :projects, join_table: :customer_contact_projects
+
+  validates :name, presence: true
+  validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :email, uniqueness: { scope: :customer_id, message: "already exists for this customer" }
+
+  # Scopes for filtering
+  scope :receiving_invoices, -> { where(receives_invoices: true) }
+end

--- a/app/models/customer_contact_project.rb
+++ b/app/models/customer_contact_project.rb
@@ -1,0 +1,4 @@
+class CustomerContactProject < ApplicationRecord
+  belongs_to :customer_contact
+  belongs_to :project
+end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -5,8 +5,9 @@ class Invoice < ApplicationRecord
   scope :email_sent, -> { where.not(email_sent_at: nil) }
   scope :email_unsent, -> {
     joins(:customer)
+    .left_joins(customer: :customer_contacts)
     .where(email_sent_at: nil)
-    .where("customers.email IS NOT NULL AND customers.email != '' OR customers.invoice_email_auto_enabled = true")
+    .where("customers.invoice_email_auto_enabled = true OR (customer_contacts.receives_invoices = true AND customer_contacts.email IS NOT NULL AND customer_contacts.email != '')")
   }
   scope :published, -> { where(published: true) }
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,7 @@
 class Project < ApplicationRecord
   belongs_to :bill_to_customer, :class_name => 'Customer', :optional => true
   has_many :invoices
+  has_and_belongs_to_many :customer_contacts, join_table: :customer_contact_projects
 
   validates :matchcode, :presence => true
 

--- a/app/views/customers/_form.html.haml
+++ b/app/views/customers/_form.html.haml
@@ -37,10 +37,6 @@
         = f.collection_select :sales_tax_customer_class_id, SalesTaxCustomerClass.all, :id, :name, { prompt: 'Select tax class...' }, {:class => 'form-select', :required => true}
     %hr
     .row.mb-3
-      = f.label :email, 'E-Mail', class: 'col-lg-2 col-md-3 col-form-label'
-      .col-lg-5
-        = f.text_field :email, :class => 'form-control'
-    .row.mb-3
       = f.label :invoice_email_auto_enabled, 'Auto. Invoice E-Mail', class: 'col-lg-2 col-md-3 col-form-label'
       .col-lg-1.col-md-2.col-sm-2
         .form-check

--- a/app/views/customers/show.html.haml
+++ b/app/views/customers/show.html.haml
@@ -52,9 +52,17 @@
       .card-body
         .row.mb-2
           .col-sm-4
-            %strong Email:
+            %strong Email Contacts:
           .col-sm-8
-            = @customer.email
+            - if @customer.customer_contacts.any?
+              - @customer.customer_contacts.each do |contact|
+                .mb-1
+                  %strong= contact.name
+                  = contact.email
+                  - if contact.receives_invoices
+                    %span.badge.bg-primary.ms-2 Receives Invoices
+            - else
+              %em No email contacts
 
         .row.mb-2
           .col-sm-4

--- a/app/views/invoices/show.html.haml
+++ b/app/views/invoices/show.html.haml
@@ -58,7 +58,7 @@
             .col-sm-8
               - if @invoice.email_sent_at
                 %span.badge.bg-success Sent #{format_datetime(@invoice.email_sent_at)}
-              - elsif @invoice.customer.email.present? || @invoice.customer.invoice_email_auto_enabled
+              - elsif @invoice.customer.customer_contacts.receiving_invoices.any? || @invoice.customer.invoice_email_auto_enabled
                 %span.badge.bg-warning Unsent
               - else
                 %span.badge.bg-secondary No Email Address
@@ -142,7 +142,7 @@
       = action_button 'Edit', edit_invoice_path(@invoice), :primary
     - if @invoice.attachment
       = action_button 'PDF', @invoice.attachment, :success, { target: '_blank', data: { turbo: false } }
-      - if @invoice.customer&.email.present? || (@invoice.customer&.invoice_email_auto_enabled && @invoice.customer&.invoice_email_auto_to.present?)
+      - if @invoice.customer&.has_invoice_email?
         %button.btn.btn-warning{"data-action" => "click->email-preview#open"}
           Send E-Mail
     - else

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,6 +20,26 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_05_011102) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "customer_contact_projects", force: :cascade do |t|
+    t.integer "customer_contact_id", null: false
+    t.integer "project_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["customer_contact_id", "project_id"], name: "index_customer_contact_projects_unique", unique: true
+    t.index ["customer_contact_id"], name: "index_customer_contact_projects_on_customer_contact_id"
+    t.index ["project_id"], name: "index_customer_contact_projects_on_project_id"
+  end
+
+  create_table "customer_contacts", force: :cascade do |t|
+    t.integer "customer_id", null: false
+    t.string "name", null: false
+    t.string "email", null: false
+    t.boolean "receives_invoices", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["customer_id"], name: "index_customer_contacts_on_customer_id"
+  end
+
   create_table "customers", force: :cascade do |t|
     t.string "matchcode"
     t.text "name"
@@ -30,7 +50,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_05_011102) do
     t.integer "sales_tax_customer_class_id"
     t.text "vat_id"
     t.text "supplier_number"
-    t.string "email"
     t.integer "payment_terms_days", default: 30, null: false
     t.string "invoice_email_auto_to", default: "", null: false
     t.string "invoice_email_auto_subject_template", default: "", null: false
@@ -174,4 +193,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_05_011102) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
+
+  add_foreign_key "customer_contact_projects", "customer_contacts"
+  add_foreign_key "customer_contact_projects", "projects"
+  add_foreign_key "customer_contacts", "customers"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -100,9 +100,14 @@ if Rails.env.development?
       Poland
     ADDRESS
     customer.vat_id = 'PL0123456789'
-    customer.email = 'accounting-goodeu@example.com'
     customer.notes = 'Long-term client, monthly invoicing'
     customer.sales_tax_customer_class = eu_class
+  end
+
+  # Create customer contact for good_company
+  good_company.customer_contacts.find_or_create_by(email: 'accounting-goodeu@example.com') do |contact|
+    contact.name = 'Accounting Department'
+    contact.receives_invoices = true
   end
 
   local_company = Customer.find_or_create_by(matchcode: 'LOCALNAT') do |customer|
@@ -113,9 +118,14 @@ if Rails.env.development?
       Netherlands
     ADDRESS
     customer.vat_id = 'NL123456789B01'
-    customer.email = 'accounting-localnat@example.com'
     customer.notes = 'Project-based work'
     customer.sales_tax_customer_class = national_class
+  end
+
+  # Create customer contact for local_company
+  local_company.customer_contacts.find_or_create_by(email: 'accounting-localnat@example.com') do |contact|
+    contact.name = 'Finance Team'
+    contact.receives_invoices = true
   end
 
   export_company = Customer.find_or_create_by(matchcode: 'USACORP') do |customer|
@@ -125,9 +135,14 @@ if Rails.env.development?
       New York, NY 10001
       United States
     ADDRESS
-    customer.email = 'ap-us@example.com'
     customer.notes = 'US-based client, quarterly invoicing'
     customer.sales_tax_customer_class = export_class
+  end
+
+  # Create customer contact for export_company
+  export_company.customer_contacts.find_or_create_by(email: 'ap-us@example.com') do |contact|
+    contact.name = 'Accounts Payable'
+    contact.receives_invoices = true
   end
 
   # Sample projects

--- a/test/fixtures/customer_contact_projects.yml
+++ b/test/fixtures/customer_contact_projects.yml
@@ -1,0 +1,2 @@
+# Join table fixtures for customer_contact_projects
+# Add specific project assignments for customer contacts as needed

--- a/test/fixtures/customer_contacts.yml
+++ b/test/fixtures/customer_contacts.yml
@@ -1,0 +1,23 @@
+good_eu_primary:
+  customer: good_eu
+  name: Primary Contact
+  email: customer@good-company.co.uk
+  receives_invoices: true
+
+good_national_billing:
+  customer: good_national
+  name: Billing Department
+  email: billing@local-company.com
+  receives_invoices: true
+
+auto_email_customer_contact:
+  customer: auto_email_customer
+  name: Main Contact
+  email: customer@autoemail.com
+  receives_invoices: true
+
+auto_email_customer_billing:
+  customer: auto_email_customer
+  name: Billing Contact
+  email: billing@autoemail.com
+  receives_invoices: true

--- a/test/fixtures/customers.yml
+++ b/test/fixtures/customers.yml
@@ -7,7 +7,6 @@ good_eu:
     European Union
   vat_id: EU99999999
   notes: MyText
-  email: customer@good-company.co.uk
   sales_tax_customer_class: eu
   active: true
 
@@ -20,7 +19,6 @@ good_national:
     NATIONAL COUNTRY
   vat_id: NAT9999999
   notes:
-  email: billing@local-company.com
   sales_tax_customer_class: national
   active: true
 
@@ -32,7 +30,6 @@ auto_email_customer:
     12345 Email City
     EMAIL COUNTRY
   vat_id: AUTO123456
-  email: customer@autoemail.com
   invoice_email_auto_enabled: true
   invoice_email_auto_to: billing@autoemail.com
   invoice_email_auto_subject_template: "Invoice $CUST_ORDER$ - Ref: $CUST_REF$"


### PR DESCRIPTION
## Summary
- Fixed db:seed failures caused by removed customer email field
- Customer emails were migrated to separate customer_contacts table  
- Added missing CustomerContact and CustomerContactProject models
- Updated Customer and Project models with proper associations
- Updated seeds to create customer contacts instead of setting email directly

## Test plan
- [x] db:seed runs successfully without errors
- [x] Customer contacts are created properly with email addresses
- [x] All associations work correctly between customers, contacts, and projects
- [x] Existing functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)