### PR TITLE
Add UI test reminder to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,7 @@ For testing against PostgreSQL (matches production environment):
 - Write simple unit tests when implementing new features
 - Test database auto-migrates via `ActiveRecord::Migration.maintain_test_schema!` in test_helper.rb
 - **NEVER use `assigns()` in tests** - it has been extracted to a gem in modern Rails. Use `assert_select` or other response testing methods instead
+- **Run UI tests headless by default before declaring frontend/UI tasks complete** when making frontend/UI changes
 
 ### Multi-Region Compatibility
 - This app supports multiple regions - NEVER hardcode currency symbols like $ or USD


### PR DESCRIPTION
## Summary
- Add note to run UI tests headless by default when making frontend/UI changes

## Test plan
- [ ] Review CLAUDE.md changes
- [ ] Confirm UI test reminder is clear and actionable

🤖 Generated with [Claude Code](https://claude.ai/code)