### PR TITLE
Fix Stimulus controller imports for production

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,7 @@ For testing against PostgreSQL (matches production environment):
 - When re-attaching listeners to dynamically created elements, remove existing listeners first to prevent duplicates
 - Document event listeners are particularly important to clean up to prevent memory leaks
 - **Run `npm run lint` after writing Stimulus controllers** to check for event listener memory leaks
+- **NEVER use relative imports** like `import Controller from "./other_controller"` - use importmap paths like `import Controller from "controllers/other_controller"` to ensure proper resolution in production
 
 ### Communication Style
 - Use direct, technical language in all communications

--- a/app/javascript/controllers/email_preview_controller.js
+++ b/app/javascript/controllers/email_preview_controller.js
@@ -1,4 +1,4 @@
-import GenericEmailPreviewController from "./generic_email_preview_controller"
+import GenericEmailPreviewController from "controllers/generic_email_preview_controller"
 
 // Invoice-specific email preview controller that extends the generic one
 export default class extends GenericEmailPreviewController {

--- a/app/javascript/controllers/project_dropdown_controller.js
+++ b/app/javascript/controllers/project_dropdown_controller.js
@@ -1,4 +1,4 @@
-import SearchableDropdownController from "./searchable_dropdown_controller"
+import SearchableDropdownController from "controllers/searchable_dropdown_controller"
 
 export default class extends SearchableDropdownController {
   static values = {


### PR DESCRIPTION
- Change relative imports to importmap paths in controller files
- project_dropdown_controller.js: "./searchable_dropdown_controller" → "controllers/searchable_dropdown_controller"
- email_preview_controller.js: "./generic_email_preview_controller" → "controllers/generic_email_preview_controller"
- Recompile assets for production
- Add import guidance to CLAUDE.md

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
