### PR TITLE
Fix duplicate flash messages in invoice booking

### DIFF
--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -146,13 +146,7 @@ class InvoicesController < ApplicationController
       @booked = @booker.book want_save
       @booking_log = @booker.log
 
-      if @booked
-        flash[:notice] = "#{action} succeeded."
-      else
-        flash[:error] = "#{action} failed."
-      end
-
-      # Store simplified booking result in flash
+      # Store booking result in flash (no redundant notice/error flash)
       if @booked
         flash[:booking_success] = true
         flash[:booking_summary] = "#{action} succeeded. #{@booking_log.length} log entries."


### PR DESCRIPTION
## Summary
- Remove redundant flash[:notice] and flash[:error] messages that were creating duplicate success/error displays
- Only use flash[:booking_summary] for booking result messages to avoid the three duplicate flash boxes

## Test plan
- [ ] Test-book an invoice and verify only one success message appears
- [ ] Verify booking failure cases show appropriate error messages
- [ ] Check that all booking functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)