### PR TITLE
Fix booking page duplicate flash messages

### DIFF
--- a/app/views/layouts/_messages.html.haml
+++ b/app/views/layouts/_messages.html.haml
@@ -1,4 +1,5 @@
 - flash.each do |name, msg|
+  - next if name.to_s.start_with?('booking_')  # Skip booking-specific flash messages
   - if msg.is_a?(String)
     %div{:class => "alert alert-#{name == 'notice' ? "success" : "danger"} alert-dismissible fade show"}
       %button.btn-close{"data-bs-dismiss" => "alert", :type => "button", "aria-label" => "Close"}

--- a/test/system/booking_flash_messages_test.rb
+++ b/test/system/booking_flash_messages_test.rb
@@ -1,0 +1,69 @@
+require "test_helper"
+
+class BookingFlashMessagesTest < ActionDispatch::SystemTestCase
+  test "booking page shows only booking-specific flash messages" do
+    invoice = invoices(:draft_invoice)
+
+    # Add an invoice line to make it bookable
+    invoice.invoice_lines.create!(
+      type: 'item',
+      title: 'Test Product',
+      rate: 100.0,
+      quantity: 2.0,
+      sales_tax_product_class: sales_tax_product_classes(:standard),
+      position: 1
+    )
+
+    # Navigate to the booking page and perform test booking
+    visit invoice_path(invoice)
+    click_button 'Test Booking'
+
+    # Check that we're on the booking results page
+    assert_current_path book_invoice_path(invoice)
+
+    # Should see the booking page (even if booking fails, that's OK for this test)
+    assert_text 'Book invoice'
+
+    # The key test: Should NOT see any FLASH messages (with flash_* IDs) in the main layout
+    # The booking page itself can show booking results, but they shouldn't come from flash
+    layout_flash_messages = all('.container > .content > .alert').select do |alert|
+      # Only count alerts that have a flash_* div inside (i.e., came from the layout's _messages partial)
+      alert.all('div[id^="flash_"]').any?
+    end
+
+    booking_flash_count = layout_flash_messages.select { |el|
+      el.text.downcase.include?('booking') || el.text.downcase.include?('book')
+    }.count
+
+    # Our fix should prevent booking-specific FLASH messages from appearing in the layout
+    assert_equal 0, booking_flash_count, "Should not see booking-related FLASH messages in main layout"
+  end
+
+  test "booking page shows error correctly without duplicate messages" do
+    # Create an invoice that will fail booking due to missing customer reference
+    invoice = invoices(:draft_invoice)
+    invoice.update!(cust_reference: '')
+
+    visit invoice_path(invoice)
+    click_button 'Test Booking'
+
+    # Check that we're on the booking results page
+    assert_current_path book_invoice_path(invoice)
+
+    # Should see the booking page
+    assert_text 'Book invoice'
+
+    # The key test: Should NOT see any duplicate FLASH messages in the main layout
+    layout_flash_messages = all('.container > .content > .alert').select do |alert|
+      # Only count alerts that have a flash_* div inside (i.e., came from the layout's _messages partial)
+      alert.all('div[id^="flash_"]').any?
+    end
+
+    booking_flash_count = layout_flash_messages.select { |el|
+      el.text.downcase.include?('booking') || el.text.downcase.include?('book')
+    }.count
+
+    # Our fix should prevent duplicate booking-related FLASH messages in the layout
+    assert_equal 0, booking_flash_count, "Should not see duplicate booking FLASH messages in main layout"
+  end
+end


### PR DESCRIPTION
The booking page was showing both the intended booking result alert and duplicate flash messages from the layout. This occurred because booking-specific flash keys (booking_success, booking_summary, booking_errors) were being displayed by both the booking view and the general layout flash message partial.

• Filter out booking-specific flash keys in layout messages partial
• Add system tests to verify fix prevents duplicate flash messages
• Booking view continues to show its intended result alerts
• Layout no longer shows redundant booking flash messages

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
