### PR TITLE
Prevent auto-merge of closed PRs

### DIFF
--- a/.github/workflows/auto-approve-merge.yml
+++ b/.github/workflows/auto-approve-merge.yml
@@ -30,13 +30,20 @@ jobs:
             return {
               head_sha: pr.head.sha,
               mergeable: pr.mergeable,
-              draft: pr.draft
+              draft: pr.draft,
+              state: pr.state
             };
 
       - name: Check if PR is ready
         if: fromJSON(steps.pr.outputs.result).draft == true
         run: |
           echo "PR is still a draft, skipping auto-merge"
+          exit 1
+
+      - name: Check if PR is closed
+        if: fromJSON(steps.pr.outputs.result).state == 'closed'
+        run: |
+          echo "PR is closed, aborting auto-merge"
           exit 1
 
       - name: Wait for CI to complete


### PR DESCRIPTION
## Summary
• Add closed PR check to auto-approve workflow to abort merge process if PR was closed before approval
• Prevents attempting to merge PRs that were closed while waiting for CI or approval
• Workflow now exits early with clear message if PR state is 'closed'

## Test plan
- [ ] Create test PR and close it, then try /approve command to verify workflow aborts
- [ ] Verify normal workflow still works for open PRs

🤖 Generated with [Claude Code](https://claude.ai/code)