### PR TITLE
Implement email template translations for customer languages

### DIFF
--- a/app/mailers/delivery_note_mailer.rb
+++ b/app/mailers/delivery_note_mailer.rb
@@ -10,20 +10,23 @@ class DeliveryNoteMailer < ApplicationMailer
       content: pdf_data
     }
 
-    if @delivery_note.customer.email.present?
-      subject = "#{@issuer.short_name} Delivery Note #{@delivery_note.document_number}"
-      to = @delivery_note.customer.email
-    else
-      to = nil
-    end
+    # Set locale based on customer language
+    I18n.with_locale(@delivery_note.customer.language.iso_code) do
+      if @delivery_note.customer.email.present?
+        subject = I18n.t('mailers.delivery_note.subject', issuer_name: @issuer.short_name, document_number: @delivery_note.document_number)
+        to = @delivery_note.customer.email
+      else
+        to = nil
+      end
 
-    unless to.nil?
-      mail(
-        to: to,
-        from: "\"#{@issuer.short_name}\" <#{@issuer.document_email_from}>",
-        bcc: @issuer.document_email_auto_bcc,
-        subject: subject
-      )
+      unless to.nil?
+        mail(
+          to: to,
+          from: "\"#{@issuer.short_name}\" <#{@issuer.document_email_from}>",
+          bcc: @issuer.document_email_auto_bcc,
+          subject: subject
+        )
+      end
     end
   end
 
@@ -41,21 +44,24 @@ class DeliveryNoteMailer < ApplicationMailer
       }
     end
 
-    if @customer.email.present?
-      document_numbers = @delivery_notes.map(&:document_number).join(', ')
-      subject = "#{@issuer.short_name} Delivery Notes #{document_numbers}"
-      to = @customer.email
-    else
-      to = nil
-    end
+    # Set locale based on customer language
+    I18n.with_locale(@customer.language.iso_code) do
+      if @customer.email.present?
+        document_numbers = @delivery_notes.map(&:document_number).join(', ')
+        subject = I18n.t('mailers.delivery_note.bulk_subject', issuer_name: @issuer.short_name, document_numbers: document_numbers)
+        to = @customer.email
+      else
+        to = nil
+      end
 
-    unless to.nil?
-      mail(
-        to: to,
-        from: "\"#{@issuer.short_name}\" <#{@issuer.document_email_from}>",
-        bcc: @issuer.document_email_auto_bcc,
-        subject: subject
-      )
+      unless to.nil?
+        mail(
+          to: to,
+          from: "\"#{@issuer.short_name}\" <#{@issuer.document_email_from}>",
+          bcc: @issuer.document_email_auto_bcc,
+          subject: subject
+        )
+      end
     end
   end
 end

--- a/app/mailers/invoice_mailer.rb
+++ b/app/mailers/invoice_mailer.rb
@@ -7,23 +7,26 @@ class InvoiceMailer < ApplicationMailer
       content: @invoice.attachment.data
     }
 
-    if @invoice.customer.invoice_email_auto_enabled
-      subject = @invoice.customer.invoice_email_auto_subject_template.gsub('$CUST_ORDER$', @invoice.cust_order).gsub('$CUST_REF$', @invoice.cust_reference)
-      to = @invoice.customer.invoice_email_auto_to
-    elsif @invoice.customer.email
-      subject = "#{@issuer.short_name} Invoice #{@invoice.document_number}"
-      to = @invoice.customer.email
-    else
-      to = nil
-    end
+    # Set locale based on customer language
+    I18n.with_locale(@invoice.customer.language.iso_code) do
+      if @invoice.customer.invoice_email_auto_enabled
+        subject = @invoice.customer.invoice_email_auto_subject_template.gsub('$CUST_ORDER$', @invoice.cust_order).gsub('$CUST_REF$', @invoice.cust_reference)
+        to = @invoice.customer.invoice_email_auto_to
+      elsif @invoice.customer.email
+        subject = I18n.t('mailers.invoice.subject', issuer_name: @issuer.short_name, document_number: @invoice.document_number)
+        to = @invoice.customer.email
+      else
+        to = nil
+      end
 
-    unless to.nil?
-      mail(
-        to: to,
-        from: "\"#{@issuer.short_name}\" <#{@issuer.document_email_from}>",
-        bcc: @issuer.document_email_auto_bcc,
-        subject: subject
-      )
+      unless to.nil?
+        mail(
+          to: to,
+          from: "\"#{@issuer.short_name}\" <#{@issuer.document_email_from}>",
+          bcc: @issuer.document_email_auto_bcc,
+          subject: subject
+        )
+      end
     end
   end
 end

--- a/app/views/delivery_note_mailer/bulk_customer_email.html.haml
+++ b/app/views/delivery_note_mailer/bulk_customer_email.html.haml
@@ -1,33 +1,32 @@
-- content_for :title, "Delivery Notes #{@delivery_notes.map(&:document_number).join(', ')}"
+- content_for :title, t('mailers.delivery_note.bulk_subject', issuer_name: @issuer.short_name, document_numbers: @delivery_notes.map(&:document_number).join(', '))
 
 .greeting
-  Dear #{@customer.name},
+  = t('mailers.delivery_note.greeting', customer_name: @customer.name)
 
 .main-message
-  We've attached #{@delivery_notes.count} delivery notes for the services provided. Please review the details and confirm receipt by signing and returning each delivery note.
+  = t('mailers.delivery_note.bulk_main_message', count: @delivery_notes.count)
 
 .document-list
-  %h5 Delivery Notes:
+  %h5= t('mailers.delivery_note.bulk_document_list_title')
   - @delivery_notes.each do |delivery_note|
     .document-highlight.mb-3
       .document-number
-        Delivery Note #{delivery_note.document_number}
+        = t('mailers.delivery_note.document_number', document_number: delivery_note.document_number)
       - if delivery_note.cust_order.present?
         .document-detail
-          Order: #{delivery_note.cust_order}
+          #{t('mailers.delivery_note.order_label')} #{delivery_note.cust_order}
       - if delivery_note.cust_reference.present?
         .document-detail
-          Reference: #{delivery_note.cust_reference}
+          #{t('mailers.delivery_note.reference_label')} #{delivery_note.cust_reference}
       - if delivery_note.delivery_timeframe.present?
         .document-detail
-          Delivery Period: #{delivery_note.delivery_timeframe}
+          #{t('mailers.delivery_note.delivery_period_label')} #{delivery_note.delivery_timeframe}
 
 .instructions
-  %strong Next Steps:
+  %strong= t('mailers.delivery_note.next_steps_title')
   %ol
-    %li Please review each delivery note and verify all details are correct
-    %li Sign each delivery note to confirm acceptance of the delivered services
-    %li Return the signed delivery notes to us via email
+    - t('mailers.delivery_note.bulk_next_steps').each do |step|
+      %li= step
 
 .closing
-  Thank you for your business. We appreciate your continued partnership.
+  = t('mailers.delivery_note.closing')

--- a/app/views/delivery_note_mailer/bulk_customer_email.text.haml
+++ b/app/views/delivery_note_mailer/bulk_customer_email.text.haml
@@ -1,21 +1,20 @@
-Dear #{@customer.name},
+#{t('mailers.delivery_note.greeting', customer_name: @customer.name)}
 \
-We've attached #{@delivery_notes.count} delivery notes for the services provided. Please review the details and confirm receipt by signing and returning each delivery note.
+#{t('mailers.delivery_note.bulk_main_message', count: @delivery_notes.count)}
 \
-Delivery Notes:
+#{t('mailers.delivery_note.bulk_document_list_title')}
 - @delivery_notes.each do |delivery_note|
   \
-  Delivery Note #{delivery_note.document_number}
+  #{t('mailers.delivery_note.document_number', document_number: delivery_note.document_number)}
   - if delivery_note.cust_order.present?
-    Order: #{delivery_note.cust_order}
+    #{t('mailers.delivery_note.order_label')} #{delivery_note.cust_order}
   - if delivery_note.cust_reference.present?
-    Reference: #{delivery_note.cust_reference}
+    #{t('mailers.delivery_note.reference_label')} #{delivery_note.cust_reference}
   - if delivery_note.delivery_timeframe.present?
-    Delivery Period: #{delivery_note.delivery_timeframe}
+    #{t('mailers.delivery_note.delivery_period_label')} #{delivery_note.delivery_timeframe}
 \
-Next Steps:
-1. Please review each delivery note and verify all details are correct
-2. Sign each delivery note to confirm acceptance of the delivered services
-3. Return the signed delivery notes to us via email
+#{t('mailers.delivery_note.next_steps_title')}
+- t('mailers.delivery_note.bulk_next_steps').each_with_index do |step, index|
+  #{index + 1}. #{step}
 \
-Thank you for your business. We appreciate your continued partnership.
+#{t('mailers.delivery_note.closing')}

--- a/app/views/delivery_note_mailer/customer_email.html.haml
+++ b/app/views/delivery_note_mailer/customer_email.html.haml
@@ -1,30 +1,29 @@
-- content_for :title, "Delivery Note #{@delivery_note.document_number}"
+- content_for :title, t('mailers.delivery_note.document_number', document_number: @delivery_note.document_number)
 
 .greeting
-  Dear #{@delivery_note.customer.name},
+  = t('mailers.delivery_note.greeting', customer_name: @delivery_note.customer.name)
 
 .main-message
-  We've attached your delivery note for the services provided. Please review the details and confirm receipt by signing and returning the delivery note.
+  = t('mailers.delivery_note.main_message')
 
 .document-highlight
   .document-number
-    Delivery Note #{@delivery_note.document_number}
+    = t('mailers.delivery_note.document_number', document_number: @delivery_note.document_number)
   - if @delivery_note.cust_order.present?
     .document-detail
-      Order: #{@delivery_note.cust_order}
+      #{t('mailers.delivery_note.order_label')} #{@delivery_note.cust_order}
   - if @delivery_note.cust_reference.present?
     .document-detail
-      Reference: #{@delivery_note.cust_reference}
+      #{t('mailers.delivery_note.reference_label')} #{@delivery_note.cust_reference}
   - if @delivery_note.delivery_timeframe.present?
     .document-detail
-      Delivery Period: #{@delivery_note.delivery_timeframe}
+      #{t('mailers.delivery_note.delivery_period_label')} #{@delivery_note.delivery_timeframe}
 
 .instructions
-  %strong Next Steps:
+  %strong= t('mailers.delivery_note.next_steps_title')
   %ol
-    %li Please review the delivery note and verify all details are correct
-    %li Sign the delivery note to confirm acceptance of the delivered services
-    %li Return the signed delivery note to us via email
+    - t('mailers.delivery_note.next_steps').each do |step|
+      %li= step
 
 .closing
-  Thank you for your business. We appreciate your continued partnership.
+  = t('mailers.delivery_note.closing')

--- a/app/views/delivery_note_mailer/customer_email.text.haml
+++ b/app/views/delivery_note_mailer/customer_email.text.haml
@@ -1,18 +1,17 @@
-Dear #{@delivery_note.customer.name},
+#{t('mailers.delivery_note.greeting', customer_name: @delivery_note.customer.name)}
 \
-We've attached your delivery note for the services provided. Please review the details and confirm receipt by signing and returning the delivery note.
+#{t('mailers.delivery_note.main_message')}
 \
-Delivery Note #{@delivery_note.document_number}
+#{t('mailers.delivery_note.document_number', document_number: @delivery_note.document_number)}
 - if @delivery_note.cust_order.present?
-  Order: #{@delivery_note.cust_order}
+  #{t('mailers.delivery_note.order_label')} #{@delivery_note.cust_order}
 - if @delivery_note.cust_reference.present?
-  Reference: #{@delivery_note.cust_reference}
+  #{t('mailers.delivery_note.reference_label')} #{@delivery_note.cust_reference}
 - if @delivery_note.delivery_timeframe.present?
-  Delivery Period: #{@delivery_note.delivery_timeframe}
+  #{t('mailers.delivery_note.delivery_period_label')} #{@delivery_note.delivery_timeframe}
 \
-Next Steps:
-1. Please review the delivery note and verify all details are correct
-2. Sign the delivery note to confirm acceptance of the delivered services
-3. Return the signed delivery note to us via email
+#{t('mailers.delivery_note.next_steps_title')}
+- t('mailers.delivery_note.next_steps').each_with_index do |step, index|
+  #{index + 1}. #{step}
 \
-Thank you for your business. We appreciate your continued partnership.
+#{t('mailers.delivery_note.closing')}

--- a/app/views/invoice_mailer/customer_email.html.haml
+++ b/app/views/invoice_mailer/customer_email.html.haml
@@ -1,22 +1,22 @@
-- content_for :title, "Invoice #{@invoice.document_number}"
+- content_for :title, t('mailers.invoice.document_number', document_number: @invoice.document_number)
 
 .greeting
-  Dear #{@invoice.customer.name},
+  = t('mailers.invoice.greeting', customer_name: @invoice.customer.name)
 
 .main-message
-  We've attached your invoice for the services provided. Please review the details and let us know if you have any questions.
+  = t('mailers.invoice.main_message')
 
 .document-highlight
   .document-number
-    Invoice #{@invoice.document_number}
+    = t('mailers.invoice.document_number', document_number: @invoice.document_number)
   - if @invoice.cust_order.present?
     .document-detail
-      Order: #{@invoice.cust_order}
+      #{t('mailers.invoice.order_label')} #{@invoice.cust_order}
   - if @invoice.cust_reference.present?
     .document-detail
-      Reference: #{@invoice.cust_reference}
+      #{t('mailers.invoice.reference_label')} #{@invoice.cust_reference}
   .due-date
-    Due date: #{@invoice.due_date}
+    #{t('mailers.invoice.due_date_label')} #{@invoice.due_date}
 
 .closing
-  Thank you for your business. We appreciate your continued partnership.
+  = t('mailers.invoice.closing')

--- a/app/views/invoice_mailer/customer_email.text.haml
+++ b/app/views/invoice_mailer/customer_email.text.haml
@@ -1,12 +1,12 @@
-Dear #{@invoice.customer.name},
+#{t('mailers.invoice.greeting', customer_name: @invoice.customer.name)}
 \
-We've attached your invoice for the services provided. Please review the details and let us know if you have any questions.
+#{t('mailers.invoice.main_message')}
 \
-Invoice #{@invoice.document_number}
+#{t('mailers.invoice.document_number', document_number: @invoice.document_number)}
 - if @invoice.cust_order.present?
-  Order: #{@invoice.cust_order}
+  #{t('mailers.invoice.order_label')} #{@invoice.cust_order}
 - if @invoice.cust_reference.present?
-  Reference: #{@invoice.cust_reference}
-Due date: #{@invoice.due_date}
+  #{t('mailers.invoice.reference_label')} #{@invoice.cust_reference}
+#{t('mailers.invoice.due_date_label')} #{@invoice.due_date}
 \
-Thank you for your business. We appreciate your continued partnership.
+#{t('mailers.invoice.closing')}

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,0 +1,33 @@
+de:
+  mailers:
+    invoice:
+      subject: "%{issuer_name} Rechnung %{document_number}"
+      greeting: "Sehr geehrte Damen und Herren,"
+      main_message: "Anbei finden Sie die Rechnung für unsere erbrachten Leistungen. Bei Fragen dazu wenden Sie sich gerne an uns."
+      document_number: "Rechnung %{document_number}"
+      order_label: "Bestellung:"
+      reference_label: "Referenz:"
+      due_date_label: "Fälligkeitsdatum:"
+      closing: "Vielen Dank für Ihr Vertrauen. Wir freuen uns auf die weitere Zusammenarbeit."
+
+    delivery_note:
+      subject: "%{issuer_name} Lieferschein %{document_number}"
+      bulk_subject: "%{issuer_name} Lieferscheine %{document_numbers}"
+      greeting: "Sehr geehrte Damen und Herren,"
+      main_message: "Anbei finden Sie den Lieferschein für unsere erbrachten Leistungen. Bitte prüfen Sie die Lieferung und bestätigen Sie den Erhalt durch Unterzeichnung und Rücksendung des Lieferscheins."
+      bulk_main_message: "Wir haben %{count} Lieferscheine für unsere erbrachten Leistungen beigefügt. Bitte prüfen Sie die Lieferung und bestätigen Sie den Erhalt durch Unterzeichnung und Rücksendung jedes Lieferscheins."
+      bulk_document_list_title: "Lieferscheine:"
+      bulk_next_steps:
+        - "Abnahme der gelieferten Leistungen"
+        - "Bestätitung der Leistungserbringung"
+        - "Rücksendung der unterfertigten Lieferscheine per E-Mail"
+      document_number: "Lieferschein %{document_number}"
+      order_label: "Bestellung:"
+      reference_label: "Referenz:"
+      delivery_period_label: "Lieferzeitraum:"
+      next_steps_title: "Nächste Schritte:"
+      next_steps:
+        - "Abnahme der gelieferten Leistungen"
+        - "Bestätitung der Leistungserbringung"
+        - "Rücksendung des unterfertigten Lieferscheins per E-Mail"
+      closing: "Vielen Dank für Ihr Vertrauen. Wir freuen uns auf die weitere Zusammenarbeit."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,35 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  mailers:
+    invoice:
+      subject: "%{issuer_name} Invoice %{document_number}"
+      greeting: "Dear %{customer_name},"
+      main_message: "We've attached your invoice for the services provided. Please review the details and let us know if you have any questions."
+      document_number: "Invoice %{document_number}"
+      order_label: "Order:"
+      reference_label: "Reference:"
+      due_date_label: "Due date:"
+      closing: "Thank you for your business. We appreciate your continued partnership."
+
+    delivery_note:
+      subject: "%{issuer_name} Delivery Note %{document_number}"
+      bulk_subject: "%{issuer_name} Delivery Notes %{document_numbers}"
+      greeting: "Dear %{customer_name},"
+      main_message: "We've attached your delivery note for the services provided. Please review the details and confirm receipt by signing and returning the delivery note."
+      bulk_main_message: "We've attached %{count} delivery notes for the services provided. Please review the details and confirm receipt by signing and returning each delivery note."
+      bulk_document_list_title: "Delivery Notes:"
+      bulk_next_steps:
+        - "Please review each delivery note and verify all details are correct"
+        - "Sign each delivery note to confirm acceptance of the delivered services"
+        - "Return the signed delivery notes to us via email"
+      document_number: "Delivery Note %{document_number}"
+      order_label: "Order:"
+      reference_label: "Reference:"
+      delivery_period_label: "Delivery Period:"
+      next_steps_title: "Next Steps:"
+      next_steps:
+        - "Please review the delivery note and verify all details are correct"
+        - "Sign the delivery note to confirm acceptance of the delivered services"
+        - "Return the signed delivery note to us via email"
+      closing: "Thank you for your business. We appreciate your continued partnership."

--- a/test/integration/email_translation_test.rb
+++ b/test/integration/email_translation_test.rb
@@ -1,0 +1,87 @@
+require 'test_helper'
+
+class EmailTranslationTest < ActionDispatch::IntegrationTest
+  setup do
+    ActionMailer::Base.deliveries.clear
+  end
+
+  test "invoice email uses English translations for English customers" do
+    english_customer = customers(:good_eu) # Customer with English language
+    invoice = invoices(:published_invoice)
+    invoice.update!(customer: english_customer)
+
+    mail = InvoiceMailer.with(invoice: invoice).customer_email
+
+    # Test subject line uses English
+    assert_includes mail.subject, "Invoice"
+    refute_includes mail.subject, "Rechnung"
+
+    # Test email body uses English
+    assert_includes mail.html_part.body.to_s, "Dear"
+    assert_includes mail.html_part.body.to_s, "We&#39;ve attached your invoice"
+    assert_includes mail.html_part.body.to_s, "Thank you for your business"
+
+    # Should not contain German text
+    refute_includes mail.html_part.body.to_s, "Sehr geehrte"
+    refute_includes mail.html_part.body.to_s, "Vielen Dank für"
+  end
+
+  test "invoice email uses German translations for German customers" do
+    german_customer = customers(:good_eu)
+    german_customer.update!(language: languages(:german))
+    invoice = invoices(:published_invoice)
+    invoice.update!(customer: german_customer)
+
+    mail = InvoiceMailer.with(invoice: invoice).customer_email
+
+    # Test subject line uses German
+    assert_includes mail.subject, "Rechnung"
+    refute_includes mail.subject, " Invoice "
+
+    # Test email body uses German
+    assert_includes mail.html_part.body.to_s, "Sehr geehrte Damen und Herren"
+    assert_includes mail.html_part.body.to_s, "Anbei finden Sie die Rechnung"
+    assert_includes mail.html_part.body.to_s, "Vielen Dank für Ihr Vertrauen"
+
+    # Should not contain English text
+    refute_includes mail.html_part.body.to_s, "Dear"
+    refute_includes mail.html_part.body.to_s, "We&#39;ve attached your invoice"
+    refute_includes mail.html_part.body.to_s, "Thank you for your business"
+  end
+
+  test "delivery note email uses German translations for German customers" do
+    german_customer = customers(:good_eu)
+    german_customer.update!(language: languages(:german))
+    delivery_note = delivery_notes(:published_delivery_note)
+    delivery_note.update!(customer: german_customer)
+
+    mail = DeliveryNoteMailer.with(delivery_note: delivery_note).customer_email
+
+    # Test subject line uses German
+    assert_includes mail.subject, "Lieferschein"
+    refute_includes mail.subject, "Delivery Note"
+
+    # Test email body uses German
+    assert_includes mail.html_part.body.to_s, "Sehr geehrte Damen und Herren"
+    assert_includes mail.html_part.body.to_s, "Anbei finden Sie den Lieferschein"
+    assert_includes mail.html_part.body.to_s, "Vielen Dank für Ihr Vertrauen"
+  end
+
+  test "delivery note email uses English translations for English customers" do
+    english_customer = customers(:good_eu)
+    english_customer.update!(language: languages(:english))
+    delivery_note = delivery_notes(:published_delivery_note)
+    delivery_note.update!(customer: english_customer)
+
+    mail = DeliveryNoteMailer.with(delivery_note: delivery_note).customer_email
+
+    # Test subject line uses English
+    assert_includes mail.subject, "Delivery Note"
+    refute_includes mail.subject, "Lieferschein"
+
+    # Test email body uses English
+    assert_includes mail.html_part.body.to_s, "Dear"
+    assert_includes mail.html_part.body.to_s, "We&#39;ve attached your delivery note"
+    assert_includes mail.html_part.body.to_s, "Thank you for your business"
+  end
+end


### PR DESCRIPTION
Add comprehensive translation support for invoice and delivery note email templates to support German and English customers based on their language preference.

- Add English and German translations for all email template strings in config/locales/
- Update InvoiceMailer and DeliveryNoteMailer to use I18n.with_locale based on customer language
- Convert all email templates (HTML and text) to use translation keys instead of hardcoded strings
- Support for bulk delivery note emails with proper translations

Email templates now automatically use the customer's language (English or German) for subjects, greetings, content, and closing messages.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
