### PR TITLE
Fix removeLine button for single line invoices

### DIFF
--- a/app/javascript/controllers/base_lines_controller.js
+++ b/app/javascript/controllers/base_lines_controller.js
@@ -61,7 +61,7 @@ export default class extends Controller {
 
   removeLine(event) {
     const line = event.target.closest('[data-line-index]')
-    if (line && this.containerTarget.children.length > 1) {
+    if (line) {
       // Check if this is a persisted record (has an ID field)
       const idField = line.querySelector('input[name*="[id]"]')
 

--- a/test/system/line_management_test.rb
+++ b/test/system/line_management_test.rb
@@ -278,4 +278,51 @@ class LineManagementTest < ApplicationSystemTestCase
     line_total = new_line.find('[data-line-total]').text
     assert_equal '€60.00', line_total  # 3 × 20.00
   end
+
+  # Test removing the last line
+  test "can remove the last line from invoice and delivery note" do
+    # Test with invoice: Add one line, then remove it
+    visit edit_invoice_path(@invoice)
+
+    # Remove existing lines to get down to single line scenario
+    initial_count = all('[data-line-index]').count
+    all('[data-line-index]')[1..-1].each do |line|
+      within line do
+        click_button "🗑"
+      end
+    end
+
+    # Should have one line left
+    assert_selector '[data-line-index]', count: 1
+
+    # Remove the last line - should work now
+    within first('[data-line-index]') do
+      click_button "🗑"
+    end
+
+    # Persisted line should be hidden but marked for destruction
+    hidden_line = first('[data-line-index]', visible: false)
+    destroy_field = hidden_line.find('input[name*="[_destroy]"]', visible: false)
+    assert_equal '1', destroy_field.value
+
+    # Test with delivery note: similar scenario
+    visit edit_delivery_note_path(@delivery_note)
+
+    # Remove all but one line
+    all('[data-line-index]')[1..-1].each do |line|
+      within line do
+        click_button "🗑"
+      end
+    end
+
+    # Remove the last line - should work now
+    within first('[data-line-index]') do
+      click_button "🗑"
+    end
+
+    # Should be marked for destruction
+    hidden_line = first('[data-line-index]', visible: false)
+    destroy_field = hidden_line.find('input[name*="[_destroy]"]', visible: false)
+    assert_equal '1', destroy_field.value
+  end
 end


### PR DESCRIPTION
## Summary
Resolves #167

Fixes the issue where the removeLine button did nothing on unbooked invoices with a single line. The button now correctly removes the last line as expected.

## Changes Made
- Modified `base_lines_controller.js` to remove the `length > 1` restriction that prevented removing the last line
- Added comprehensive system test covering single line removal for both invoices and delivery notes
- All 189 tests pass, JavaScript linting passes

## Technical Details
The bug was caused by a defensive check that prevented any action when only one line remained. This check was removed to allow removal of the last line.

🤖 Generated with [Claude Code](https://claude.ai/code)