### PR TITLE
CC customer contact when invoice email auto recipient is set

### DIFF
--- a/app/helpers/email_preview_helper.rb
+++ b/app/helpers/email_preview_helper.rb
@@ -10,6 +10,7 @@ module EmailPreviewHelper
       attachments: extract_attachments_info(mail)
     }
 
+    data[:cc] = mail.cc&.join(', ') if mail.cc&.any?
     data[:bcc] = mail.bcc&.join(', ') if mail.bcc&.any?
     data
   end

--- a/app/javascript/controllers/generic_email_preview_controller.js
+++ b/app/javascript/controllers/generic_email_preview_controller.js
@@ -225,6 +225,17 @@ export default class extends Controller {
                 </div>
               </div>
 
+              ${data.cc ? `
+                <div class="row mb-2">
+                  <div class="col-sm-2">
+                    <strong>CC:</strong>
+                  </div>
+                  <div class="col-sm-10">
+                    ${data.cc}
+                  </div>
+                </div>
+              ` : ''}
+
               ${data.bcc ? `
                 <div class="row mb-2">
                   <div class="col-sm-2">

--- a/app/mailers/invoice_mailer.rb
+++ b/app/mailers/invoice_mailer.rb
@@ -9,9 +9,11 @@ class InvoiceMailer < ApplicationMailer
 
     # Set locale based on customer language
     I18n.with_locale(@invoice.customer.language.iso_code) do
+      cc = nil
       if @invoice.customer.invoice_email_auto_enabled
         subject = @invoice.customer.invoice_email_auto_subject_template.gsub('$CUST_ORDER$', @invoice.cust_order).gsub('$CUST_REF$', @invoice.cust_reference)
         to = @invoice.customer.invoice_email_auto_to
+        cc = @invoice.customer.email if @invoice.customer.email.present? && @invoice.customer.email != to
       elsif @invoice.customer.email
         subject = I18n.t('mailers.invoice.subject', issuer_name: @issuer.short_name, document_number: @invoice.document_number)
         to = @invoice.customer.email
@@ -22,6 +24,7 @@ class InvoiceMailer < ApplicationMailer
       unless to.nil?
         mail(
           to: to,
+          cc: cc,
           from: "\"#{@issuer.short_name}\" <#{@issuer.document_email_from}>",
           bcc: @issuer.document_email_auto_bcc,
           subject: subject

--- a/test/mailers/invoice_mailer_test.rb
+++ b/test/mailers/invoice_mailer_test.rb
@@ -11,6 +11,7 @@ class InvoiceMailerTest < ActionMailer::TestCase
 
     assert_not_nil mail
     assert_equal ["customer@good-company.co.uk"], mail.to
+    assert_nil mail.cc
     assert_equal ["from@example.com"], mail.from  # from issuer fixture
     assert_equal ["bcc@example.com"], mail.bcc    # from issuer fixture
     assert_equal "My Example Invoice INV-2024-001", mail.subject
@@ -22,12 +23,13 @@ class InvoiceMailerTest < ActionMailer::TestCase
     assert_equal "application/pdf", attachment.content_type
   end
 
-  test "customer_email with auto email configuration" do
+  test "customer_email with auto email configuration ccs the regular customer email" do
     invoice = invoices(:auto_email_invoice)
     mail = InvoiceMailer.with(invoice: invoice).customer_email
 
     assert_not_nil mail
     assert_equal ["billing@autoemail.com"], mail.to
+    assert_equal ["customer@autoemail.com"], mail.cc
     assert_equal ["from@example.com"], mail.from
     assert_equal ["bcc@example.com"], mail.bcc
     assert_equal "Invoice AUTO-ORDER-111 - Ref: AUTO-REF-999", mail.subject
@@ -36,6 +38,28 @@ class InvoiceMailerTest < ActionMailer::TestCase
     assert_equal 1, mail.attachments.size
     attachment = mail.attachments.first
     assert_equal "auto_invoice.pdf", attachment.filename
+  end
+
+  test "customer_email with auto email but no regular customer email omits cc" do
+    customer = customers(:auto_email_customer)
+    customer.update!(email: nil)
+    invoice = invoices(:auto_email_invoice)
+
+    mail = InvoiceMailer.with(invoice: invoice).customer_email
+
+    assert_equal ["billing@autoemail.com"], mail.to
+    assert_nil mail.cc
+  end
+
+  test "customer_email with auto email matching regular customer email omits cc" do
+    customer = customers(:auto_email_customer)
+    customer.update!(email: customer.invoice_email_auto_to)
+    invoice = invoices(:auto_email_invoice)
+
+    mail = InvoiceMailer.with(invoice: invoice).customer_email
+
+    assert_equal ["billing@autoemail.com"], mail.to
+    assert_nil mail.cc
   end
 
   test "customer_email with customer without email returns NullMail" do


### PR DESCRIPTION
When a customer has invoice_email_auto_enabled with a separate
invoice_email_auto_to address, also CC the customer's regular email
so the normal contact stays in the loop.

- Mailer adds cc when customer.email is present and differs from to
- Email preview helper exposes cc; preview UI renders a CC row
- Tests cover cc presence, missing customer.email, and matching addresses