### PR TITLE
Add 7-day cooldown to dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,13 @@ updates:
     commit-message:
       prefix: "deps"
       include: "scope"
+    # Wait 7 days after a release before opening a version-update PR.
+    # Security updates bypass cooldown automatically.
+    cooldown:
+      default-days: 7
+      semver-major-days: 7
+      semver-minor-days: 7
+      semver-patch-days: 7
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
@@ -23,6 +30,11 @@ updates:
     commit-message:
       prefix: "ci"
       include: "scope"
+    cooldown:
+      default-days: 7
+      semver-major-days: 7
+      semver-minor-days: 7
+      semver-patch-days: 7
 
   # Enable version updates for Docker
   - package-ecosystem: "docker"
@@ -35,3 +47,8 @@ updates:
     commit-message:
       prefix: "docker"
       include: "scope"
+    cooldown:
+      default-days: 7
+      semver-major-days: 7
+      semver-minor-days: 7
+      semver-patch-days: 7


### PR DESCRIPTION
Delays bundler, GitHub Actions and Docker version-update PRs by 7 days
after a release. Dependabot security updates bypass cooldown
automatically, so vetted critical security fixes are unaffected.

https://claude.ai/code/session_011oU926hH522Viuxu9TvAVq