### PR TITLE
Persist payment terms snapshot on invoice

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -128,6 +128,7 @@ private
     self.customer_vat_id = self.customer.vat_id
     self.customer.sales_tax_customer_class.reload
     self.tax_note = self.customer.sales_tax_customer_class.invoice_note
+    self.payment_terms_days = self.customer.payment_terms_days
   end
 
   def line_addedremoved(changed_item)

--- a/app/services/invoice_booker.rb
+++ b/app/services/invoice_booker.rb
@@ -31,7 +31,7 @@ class InvoiceBooker
     if @invoice.date.nil?
       @invoice.date = Date.today
     end
-    @invoice.due_date = @invoice.date + @invoice.customer.payment_terms_days.days
+    @invoice.due_date = @invoice.date + @invoice.payment_terms_days.days
 
     error 'no customer name' if empty_or_nil @invoice.customer_name
     error 'no customer address' if empty_or_nil @invoice.customer_address

--- a/app/services/invoice_renderer.rb
+++ b/app/services/invoice_renderer.rb
@@ -52,6 +52,7 @@ class InvoiceRenderer
       xml_root.number @invoice.document_number
       xml_root.tag! 'issue-date', @invoice.date
       xml_root.tag! 'due-date', @invoice.due_date
+      xml_root.tag! 'payment-terms-days', @invoice.payment_terms_days
       if @invoice.published
         if @invoice.token.nil?
           payment_url = ''

--- a/app/views/invoices/show.html.haml
+++ b/app/views/invoices/show.html.haml
@@ -21,6 +21,18 @@
             %strong Customer:
           .col-sm-8
             = @invoice.customer_name || @invoice.customer.name
+        .row.mb-2
+          .col-sm-4
+            %strong Payment Terms:
+          .col-sm-8
+            = @invoice.payment_terms_days
+            days net
+        - if @invoice.due_date
+          .row.mb-2
+            .col-sm-4
+              %strong Due Date:
+            .col-sm-8
+              = format_date(@invoice.due_date)
 
         - if @invoice.published?
           .row.mb-2

--- a/db/migrate/20260520204232_add_payment_terms_days_to_invoices.rb
+++ b/db/migrate/20260520204232_add_payment_terms_days_to_invoices.rb
@@ -1,0 +1,38 @@
+class AddPaymentTermsDaysToInvoices < ActiveRecord::Migration[8.0]
+  def up
+    add_column :invoices, :payment_terms_days, :integer
+
+    # Backfill values for existing invoices in Ruby so it works for both SQLite and PostgreSQL.
+    say_with_time "Backfilling invoices.payment_terms_days" do
+      conn = ActiveRecord::Base.connection
+      rows = conn.exec_query(<<~SQL).rows
+        SELECT invoices.id, invoices.date, invoices.due_date, customers.payment_terms_days
+        FROM invoices
+        LEFT JOIN customers ON customers.id = invoices.customer_id
+      SQL
+
+      rows.each do |id, date_val, due_date_val, customer_terms|
+        date = date_val.is_a?(Date) ? date_val : (Date.parse(date_val.to_s) rescue nil)
+        due_date = due_date_val.is_a?(Date) ? due_date_val : (Date.parse(due_date_val.to_s) rescue nil)
+
+        terms = if date && due_date
+                  (due_date - date).to_i
+                else
+                  customer_terms
+                end
+        terms ||= 30
+
+        conn.exec_update(
+          "UPDATE invoices SET payment_terms_days = #{conn.quote(terms)} WHERE id = #{conn.quote(id)}"
+        )
+      end
+    end
+
+    change_column_null :invoices, :payment_terms_days, false
+    change_column_default :invoices, :payment_terms_days, 30
+  end
+
+  def down
+    remove_column :invoices, :payment_terms_days
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_08_10_173512) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_20_204232) do
   create_table "attachments", force: :cascade do |t|
     t.string "content_type"
     t.datetime "created_at", null: false
@@ -134,6 +134,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_08_10_173512) do
     t.string "document_number"
     t.date "due_date"
     t.datetime "email_sent_at"
+    t.integer "payment_terms_days", default: 30, null: false
     t.text "prelude"
     t.integer "project_id"
     t.boolean "published"

--- a/test/fixtures/invoices.yml
+++ b/test/fixtures/invoices.yml
@@ -6,6 +6,7 @@ published_invoice:
   published: true
   date: <%= Date.current %>
   due_date: <%= 30.days.from_now.to_date %>
+  payment_terms_days: 30
   cust_reference: "REF-12345"
   cust_order: "ORDER-67890"
   prelude: "Thank you for your business."
@@ -20,6 +21,7 @@ auto_email_invoice:
   published: true
   date: <%= Date.current %>
   due_date: <%= 45.days.from_now.to_date %>
+  payment_terms_days: 45
   cust_reference: "AUTO-REF-999"
   cust_order: "AUTO-ORDER-111"
   prelude: "Automated invoice processing."
@@ -34,6 +36,7 @@ no_email_invoice:
   published: true
   date: <%= Date.current %>
   due_date: <%= 14.days.from_now.to_date %>
+  payment_terms_days: 14
   cust_reference: "NOEMAIL-REF"
   cust_order: "NOEMAIL-ORDER"
   sum_net: 75.00

--- a/test/services/invoice_booker_test.rb
+++ b/test/services/invoice_booker_test.rb
@@ -39,4 +39,60 @@ class InvoiceBookerTest < ActiveSupport::TestCase
     # Should get default of 30 days
     assert_equal 30, new_customer.payment_terms_days
   end
+
+  test "draft invoice copies payment_terms_days from customer on save" do
+    customer = customers(:good_eu)
+    customer.update!(payment_terms_days: 60)
+
+    invoice = Invoice.create!(
+      customer: customer,
+      project: projects(:test_project),
+      cust_reference: "SNAPSHOT-1"
+    )
+
+    assert_equal 60, invoice.payment_terms_days
+  end
+
+  test "published invoice keeps its payment_terms_days when customer's value later changes" do
+    customer = customers(:good_eu)
+    customer.update!(payment_terms_days: 30)
+
+    invoice = Invoice.create!(
+      customer: customer,
+      project: projects(:test_project),
+      cust_reference: "SNAPSHOT-2",
+      date: Date.new(2024, 6, 1),
+    )
+
+    # Lock in the snapshot the same way a booked invoice does
+    invoice.update!(published: true)
+
+    assert_equal 30, invoice.payment_terms_days
+
+    # Customer's terms change later - invoice snapshot must not move
+    customer.update!(payment_terms_days: 90)
+    invoice.reload
+
+    assert_equal 30, invoice.payment_terms_days
+  end
+
+  test "booker derives due_date from invoice's persisted payment_terms_days" do
+    customer = customers(:good_eu)
+    customer.update!(payment_terms_days: 21)
+
+    invoice = Invoice.create!(
+      customer: customer,
+      project: projects(:test_project),
+      cust_reference: "SNAPSHOT-3",
+      date: Date.new(2024, 6, 1),
+    )
+
+    # On a draft, the snapshot tracks the customer value
+    assert_equal 21, invoice.payment_terms_days
+
+    booker = InvoiceBooker.new(invoice, issuer_companies(:one))
+    booker.book(false)
+
+    assert_equal Date.new(2024, 6, 22), invoice.due_date
+  end
 end


### PR DESCRIPTION
Customer.payment_terms_days was already in place and editable on the
customer form, but invoices only stored the computed due_date. If a
customer's terms changed later, the original terms in effect at the
time of an old invoice were lost.

- Add payment_terms_days column to invoices, backfilled from
  (due_date - date) for published rows and from the customer otherwise.
- Copy customer.payment_terms_days onto the invoice in update_customer,
  same pattern as the existing customer_name / customer_address fields:
  refreshes on draft save, locks in once published.
- InvoiceBooker now computes due_date from the invoice's snapshot,
  and the value is emitted in the PDF XML and shown on the invoice
  detail page.

https://claude.ai/code/session_01QnFvRzknPKPGS1eVxFX1wp