### PR TITLE
Regenerate schema.rb with Rails 8.1

### DIFF
--- a/db/cache_schema.rb
+++ b/db/cache_schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 1) do
+ActiveRecord::Schema[8.1].define(version: 1) do
   create_table "solid_cache_entries", force: :cascade do |t|
-    t.binary "key", limit: 1024, null: false
-    t.binary "value", limit: 536870912, null: false
-    t.datetime "created_at", null: false
-    t.integer "key_hash", limit: 8, null: false
     t.integer "byte_size", limit: 4, null: false
+    t.datetime "created_at", null: false
+    t.binary "key", limit: 1024, null: false
+    t.integer "key_hash", limit: 8, null: false
+    t.binary "value", limit: 536870912, null: false
     t.index ["byte_size"], name: "index_solid_cache_entries_on_byte_size"
     t.index ["key_hash", "byte_size"], name: "index_solid_cache_entries_on_key_hash_and_byte_size"
     t.index ["key_hash"], name: "index_solid_cache_entries_on_key_hash", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,66 +10,66 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_10_173512) do
+ActiveRecord::Schema[8.1].define(version: 2025_08_10_173512) do
   create_table "attachments", force: :cascade do |t|
-    t.string "title"
-    t.string "filename"
     t.string "content_type"
-    t.binary "data"
     t.datetime "created_at", null: false
+    t.binary "data"
+    t.string "filename"
+    t.string "title"
     t.datetime "updated_at", null: false
   end
 
   create_table "customers", force: :cascade do |t|
+    t.boolean "active", default: true, null: false
+    t.text "address"
+    t.datetime "created_at", null: false
+    t.string "email"
+    t.boolean "invoice_email_auto_enabled", default: false, null: false
+    t.string "invoice_email_auto_subject_template", default: "", null: false
+    t.string "invoice_email_auto_to", default: "", null: false
+    t.integer "language_id", null: false
     t.string "matchcode"
     t.text "name"
-    t.text "address"
     t.text "notes"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "sales_tax_customer_class_id"
-    t.text "vat_id"
-    t.text "supplier_number"
-    t.string "email"
     t.integer "payment_terms_days", default: 30, null: false
-    t.string "invoice_email_auto_to", default: "", null: false
-    t.string "invoice_email_auto_subject_template", default: "", null: false
-    t.boolean "invoice_email_auto_enabled", default: false, null: false
-    t.boolean "active", default: true, null: false
-    t.integer "language_id", null: false
+    t.integer "sales_tax_customer_class_id"
+    t.text "supplier_number"
+    t.datetime "updated_at", null: false
+    t.text "vat_id"
     t.index ["language_id"], name: "index_customers_on_language_id"
     t.index ["name"], name: "index_customers_on_name"
   end
 
   create_table "delivery_note_lines", force: :cascade do |t|
-    t.integer "delivery_note_id", null: false
-    t.integer "position"
-    t.text "type"
-    t.text "title"
-    t.text "description"
-    t.float "quantity"
     t.datetime "created_at", null: false
+    t.integer "delivery_note_id", null: false
+    t.text "description"
+    t.integer "position"
+    t.float "quantity"
+    t.text "title"
+    t.text "type"
     t.datetime "updated_at", null: false
     t.index ["delivery_note_id"], name: "index_delivery_note_lines_on_delivery_note_id"
     t.index ["position"], name: "index_delivery_note_lines_on_position"
   end
 
   create_table "delivery_notes", force: :cascade do |t|
-    t.string "document_number"
-    t.boolean "published"
-    t.integer "customer_id", null: false
-    t.integer "project_id", null: false
     t.integer "acceptance_attachment_id"
-    t.date "date"
-    t.string "cust_reference"
+    t.datetime "created_at", null: false
     t.string "cust_order"
-    t.text "prelude"
+    t.string "cust_reference"
+    t.integer "customer_id", null: false
+    t.date "date"
+    t.date "delivery_end_date"
+    t.date "delivery_start_date"
+    t.string "document_number"
     t.datetime "email_sent_at"
     t.integer "invoice_id"
-    t.datetime "created_at", null: false
+    t.text "prelude"
+    t.integer "project_id", null: false
+    t.boolean "published"
     t.datetime "updated_at", null: false
-    t.date "delivery_start_date"
-    t.date "delivery_end_date"
     t.index ["acceptance_attachment_id"], name: "index_delivery_notes_on_acceptance_attachment_id"
     t.index ["customer_id"], name: "index_delivery_notes_on_customer_id"
     t.index ["date"], name: "index_delivery_notes_on_date"
@@ -81,67 +81,67 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_10_173512) do
 
   create_table "document_numbers", force: :cascade do |t|
     t.string "code"
-    t.string "format"
-    t.integer "sequence"
-    t.string "last_number"
-    t.date "last_date"
     t.datetime "created_at", null: false
+    t.string "format"
+    t.date "last_date"
+    t.string "last_number"
+    t.integer "sequence"
     t.datetime "updated_at", null: false
   end
 
   create_table "invoice_lines", force: :cascade do |t|
-    t.integer "invoice_id"
-    t.text "type"
-    t.text "title"
-    t.text "description"
-    t.integer "sales_tax_product_class_id"
-    t.text "sales_tax_name"
-    t.text "sales_tax_indicator_code"
-    t.integer "sales_tax_rate"
-    t.float "quantity"
-    t.float "rate"
     t.float "amount"
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.text "description"
+    t.integer "invoice_id"
     t.integer "position"
+    t.float "quantity"
+    t.float "rate"
+    t.text "sales_tax_indicator_code"
+    t.text "sales_tax_name"
+    t.integer "sales_tax_product_class_id"
+    t.integer "sales_tax_rate"
+    t.text "title"
+    t.text "type"
+    t.datetime "updated_at", null: false
   end
 
   create_table "invoice_tax_classes", force: :cascade do |t|
-    t.integer "invoice_id"
-    t.integer "sales_tax_product_class_id"
-    t.string "name"
-    t.string "indicator_code"
-    t.decimal "rate"
-    t.decimal "net"
-    t.decimal "value"
-    t.decimal "total"
     t.datetime "created_at", null: false
+    t.string "indicator_code"
+    t.integer "invoice_id"
+    t.string "name"
+    t.decimal "net"
+    t.decimal "rate"
+    t.integer "sales_tax_product_class_id"
+    t.decimal "total"
     t.datetime "updated_at", null: false
+    t.decimal "value"
   end
 
   create_table "invoices", force: :cascade do |t|
-    t.string "document_number"
-    t.boolean "published"
-    t.integer "customer_id"
     t.integer "attachment_id"
-    t.integer "project_id"
-    t.date "date"
-    t.string "cust_reference"
-    t.string "cust_order"
-    t.text "prelude"
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.text "customer_name"
-    t.text "customer_address"
+    t.string "cust_order"
+    t.string "cust_reference"
     t.text "customer_account_number"
-    t.text "customer_vat_id"
+    t.text "customer_address"
+    t.integer "customer_id"
+    t.text "customer_name"
     t.text "customer_supplier_number"
+    t.text "customer_vat_id"
+    t.date "date"
+    t.string "document_number"
     t.date "due_date"
+    t.datetime "email_sent_at"
+    t.text "prelude"
+    t.integer "project_id"
+    t.boolean "published"
     t.decimal "sum_net"
     t.decimal "sum_total"
-    t.string "token"
     t.text "tax_note"
-    t.datetime "email_sent_at"
+    t.string "token"
+    t.datetime "updated_at", null: false
     t.index ["date"], name: "index_invoices_on_date"
     t.index ["document_number"], name: "index_invoices_on_document_number", unique: true
     t.index ["published", "date"], name: "index_invoices_on_published_and_date"
@@ -150,76 +150,76 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_10_173512) do
 
   create_table "issuer_companies", force: :cascade do |t|
     t.boolean "active"
-    t.string "short_name"
-    t.string "legal_name"
-    t.string "vat_id"
     t.string "address"
     t.string "bankaccount_bank"
     t.string "bankaccount_bic"
     t.string "bankaccount_number"
+    t.datetime "created_at", null: false
+    t.string "currency", default: "EUR", null: false
+    t.string "document_accent_color"
     t.string "document_contact_line1"
     t.string "document_contact_line2"
-    t.string "document_accent_color"
-    t.string "invoice_footer"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "currency", default: "EUR", null: false
-    t.binary "pdf_logo"
-    t.string "pdf_logo_width"
-    t.string "pdf_logo_height"
-    t.binary "png_logo"
-    t.string "document_email_from", default: "from@example.com", null: false
     t.string "document_email_auto_bcc", default: "bcc@example.com", null: false
+    t.string "document_email_from", default: "from@example.com", null: false
+    t.string "invoice_footer"
+    t.string "legal_name"
+    t.binary "pdf_logo"
+    t.string "pdf_logo_height"
+    t.string "pdf_logo_width"
+    t.binary "png_logo"
+    t.string "short_name"
+    t.datetime "updated_at", null: false
+    t.string "vat_id"
     t.index ["active"], name: "index_issuer_companies_on_active", unique: true
   end
 
   create_table "languages", force: :cascade do |t|
+    t.datetime "created_at", null: false
     t.string "iso_code", limit: 2, null: false
     t.string "title", null: false
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["iso_code"], name: "index_languages_on_iso_code", unique: true
   end
 
   create_table "products", force: :cascade do |t|
-    t.string "title"
+    t.datetime "created_at", null: false
     t.text "description"
     t.decimal "rate"
     t.integer "sales_tax_product_class_id"
-    t.datetime "created_at", null: false
+    t.string "title"
     t.datetime "updated_at", null: false
     t.index ["title"], name: "index_products_on_title"
   end
 
   create_table "projects", force: :cascade do |t|
-    t.string "matchcode"
-    t.text "description"
+    t.boolean "active", default: true, null: false
     t.integer "bill_to_customer_id"
     t.datetime "created_at", null: false
+    t.text "description"
+    t.string "matchcode"
     t.datetime "updated_at", null: false
-    t.boolean "active", default: true, null: false
     t.index ["matchcode"], name: "index_projects_on_matchcode"
   end
 
   create_table "sales_tax_customer_classes", force: :cascade do |t|
-    t.string "name"
-    t.text "invoice_note"
     t.datetime "created_at", null: false
+    t.text "invoice_note"
+    t.string "name"
     t.datetime "updated_at", null: false
   end
 
   create_table "sales_tax_product_classes", force: :cascade do |t|
-    t.string "name"
-    t.string "indicator_code"
     t.datetime "created_at", null: false
+    t.string "indicator_code"
+    t.string "name"
     t.datetime "updated_at", null: false
   end
 
   create_table "sales_tax_rates", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.decimal "rate"
     t.integer "sales_tax_customer_class_id"
     t.integer "sales_tax_product_class_id"
-    t.decimal "rate"
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 


### PR DESCRIPTION
## Summary
- Bump `ActiveRecord::Schema` version from `8.0` to `8.1` in `db/schema.rb` and `db/cache_schema.rb`
- Apply Rails 8.1's new alphabetical column ordering in the schema dumps

Generated with `bundle exec rails db:schema:dump` after `db:setup` against the current migrations.

## Test plan
- [x] `bundle exec rails db:setup` succeeds with the new schema
- [x] `bundle exec rails test` — only pre-existing failures remain, all from the missing FOP binary in this environment; no schema-related regressions

https://claude.ai/code/session_01JH7YXLEoRsvy84pNZh34YL

---
_Generated by [Claude Code](https://claude.ai/code/session_01JH7YXLEoRsvy84pNZh34YL)_