### PR TITLE
Track invoice payment date

### DIFF
--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -224,6 +224,34 @@ class InvoicesController < ApplicationController
     end
   end
 
+  def mark_paid
+    @invoice = Invoice.find(params[:id])
+    return unless check_published
+
+    paid_date = params[:paid_at].presence
+    @invoice.paid_at = paid_date ? Date.parse(paid_date) : Date.current
+    @invoice.save!
+
+    respond_to do |format|
+      format.html { redirect_to @invoice, notice: "Invoice marked as paid on #{helpers.format_date(@invoice.paid_at)}." }
+      format.json { render json: @invoice, status: :ok, location: @invoice }
+    end
+  rescue ArgumentError
+    redirect_to @invoice, alert: 'Invalid date.'
+  end
+
+  def mark_unpaid
+    @invoice = Invoice.find(params[:id])
+    return unless check_published
+
+    @invoice.update!(paid_at: nil)
+
+    respond_to do |format|
+      format.html { redirect_to @invoice, notice: 'Invoice marked as unpaid.' }
+      format.json { render json: @invoice, status: :ok, location: @invoice }
+    end
+  end
+
   def bulk_send_emails
     invoice_ids = params[:invoice_ids] || []
     invoice_ids = invoice_ids.reject(&:blank?)

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -7,7 +7,7 @@ class InvoicesController < ApplicationController
   def index
     # Get the selected year from params, default to current year
     @selected_year = params[:year]&.to_i || Date.current.year
-    @email_filter = params[:email_filter] || 'all'
+    @filter = params[:filter] || 'all'
 
     # Filter invoices by selected year, including draft invoices (date = nil) for current year
     year_start = Date.new(@selected_year, 1, 1)
@@ -23,9 +23,11 @@ class InvoicesController < ApplicationController
                         .reorder(Arel.sql('document_number DESC NULLS FIRST'))
     end
 
-    case @email_filter
+    case @filter
     when 'unsent'
       @invoices = @invoices.email_unsent.published
+    when 'unpaid'
+      @invoices = @invoices.unpaid.published
     end
 
     # Get available years for pagination (years that have invoices)

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -9,6 +9,8 @@ class Invoice < ApplicationRecord
     .where("customers.email IS NOT NULL AND customers.email != '' OR customers.invoice_email_auto_enabled = true")
   }
   scope :published, -> { where(published: true) }
+  scope :paid, -> { where.not(paid_at: nil) }
+  scope :unpaid, -> { where(paid_at: nil) }
 
   after_initialize :set_defaults
 
@@ -28,6 +30,10 @@ class Invoice < ApplicationRecord
 
   def has_items?
     self.invoice_lines.any? { |line| line.is_item? }
+  end
+
+  def paid?
+    self.paid_at.present?
   end
 
   def validate_lines_for_booking

--- a/app/views/invoices/index.html.haml
+++ b/app/views/invoices/index.html.haml
@@ -4,19 +4,20 @@
 .bulk-select-container{data: { controller: 'bulk-select' }}
   = form_with url: bulk_send_emails_invoices_path, method: :post, local: true, id: 'bulk-email-form' do |form|
     .btn-toolbar.mb-3{:role=>"toolbar", "aria-label"=>"List toolbar"}
-      .btn-group.btn-group-sm.me-2.email-filter{:role=>"group", "aria-label"=>"E-Mail status"}
-        = link_to 'All', invoices_path(year: @selected_year, email_filter: 'all'), class: (@email_filter == 'all' ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
-        = link_to 'Unsent', invoices_path(year: @selected_year, email_filter: 'unsent'), class: (@email_filter == 'unsent' ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
+      .btn-group.btn-group-sm.me-2.invoice-filter{:role=>"group", "aria-label"=>"Filter"}
+        = link_to 'All', invoices_path(year: @selected_year, filter: 'all'), class: (@filter == 'all' ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
+        = link_to 'Unsent', invoices_path(year: @selected_year, filter: 'unsent'), class: (@filter == 'unsent' ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
+        = link_to 'Unpaid', invoices_path(year: @selected_year, filter: 'unpaid'), class: (@filter == 'unpaid' ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
 
-      - if @email_filter == 'unsent'
+      - if @filter == 'unsent'
         = form.submit 'Send Selected Emails', class: 'btn btn-warning btn-sm me-2 align-self-start', disabled: true, data: { confirm: 'Are you sure you want to send emails for the selected invoices?', 'bulk-select-target': 'submitButton' }
 
       - if @available_years.any?
         .btn-group.btn-group-sm.ms-auto.year-pagination{:role=>"group", "aria-label"=>"Year navigation"}
           - @available_years.each do |year|
-            = link_to year, invoices_path(year: year, email_filter: @email_filter), class: (@selected_year == year ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
+            = link_to year, invoices_path(year: year, filter: @filter), class: (@selected_year == year ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
 
-  - if @email_filter == 'unsent' && @invoices.any?
+  - if @filter == 'unsent' && @invoices.any?
     %table.table.table-striped.table-sm
       %tr
         %th

--- a/app/views/invoices/index.html.haml
+++ b/app/views/invoices/index.html.haml
@@ -62,6 +62,7 @@
         %th Date
         %th Cust Reference
         %th Cust Order No
+        %th Payment
         %th{:width => "3%"}
 
       - @invoices.each do |invoice|
@@ -73,6 +74,12 @@
           %td= format_date(invoice.date)
           %td= invoice.cust_reference
           %td= invoice.cust_order
+          %td
+            - if invoice.published?
+              - if invoice.paid?
+                %span.badge.bg-success Paid #{format_date(invoice.paid_at)}
+              - else
+                %span.badge.bg-warning Unpaid
           %td
             - if invoice.published? and not invoice.attachment.nil?
               = link_to 'PDF', attachment_path(invoice.attachment), target: '_blank', data: { turbo: false }, class: 'btn btn-sm btn-outline-success py-0'

--- a/app/views/invoices/show.html.haml
+++ b/app/views/invoices/show.html.haml
@@ -46,6 +46,15 @@
               - else
                 %span.badge.bg-secondary No Email Address
 
+          .row.mb-2
+            .col-sm-4
+              %strong Payment Status:
+            .col-sm-8
+              - if @invoice.paid?
+                %span.badge.bg-success Paid #{format_date(@invoice.paid_at)}
+              - else
+                %span.badge.bg-warning Unpaid
+
         - if @invoice.delivery_note
           .row.mb-2
             .col-sm-4
@@ -170,6 +179,13 @@
     - unless @invoice.published
       = button_to 'Test Booking', book_invoice_path(@invoice, :save => false), method: :post, class: 'btn btn-warning'
       = destroy_link(@invoice, "Are you sure you want to delete invoice \"#{@invoice.document_number || "##{@invoice.id}"}\"?")
+    - if @invoice.published?
+      - if @invoice.paid?
+        = button_to 'Mark Unpaid', mark_unpaid_invoice_path(@invoice), method: :post, class: 'btn btn-outline-secondary', data: { 'turbo-confirm': 'Mark this invoice as unpaid?' }
+      - else
+        = form_with url: mark_paid_invoice_path(@invoice), method: :post, local: true, class: 'd-flex gap-1 align-items-center' do |f|
+          = f.date_field :paid_at, value: Date.current, class: 'form-control form-control-sm', style: 'width: auto;'
+          = f.submit 'Mark Paid', class: 'btn btn-success'
 
   // Email Preview Modal
   .modal.d-none{"data-email-preview-target" => "modal", "data-action" => "click->email-preview#closeOnBackdrop keydown@window->email-preview#closeOnEscape", "style" => "position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); z-index: 1050; display: flex; align-items: center; justify-content: center;"}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
       get 'book'
       post 'book'
       post 'send_email'
+      post 'mark_paid'
+      post 'mark_unpaid'
     end
     collection do
       post 'bulk_send_emails'

--- a/db/migrate/20260520212540_add_paid_at_to_invoices.rb
+++ b/db/migrate/20260520212540_add_paid_at_to_invoices.rb
@@ -1,0 +1,6 @@
+class AddPaidAtToInvoices < ActiveRecord::Migration[8.0]
+  def change
+    add_column :invoices, :paid_at, :date
+    add_index :invoices, :paid_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_20_204232) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_20_212540) do
   create_table "attachments", force: :cascade do |t|
     t.string "content_type"
     t.datetime "created_at", null: false
@@ -134,6 +134,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_20_204232) do
     t.string "document_number"
     t.date "due_date"
     t.datetime "email_sent_at"
+    t.date "paid_at"
     t.integer "payment_terms_days", default: 30, null: false
     t.text "prelude"
     t.integer "project_id"
@@ -145,6 +146,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_20_204232) do
     t.datetime "updated_at", null: false
     t.index ["date"], name: "index_invoices_on_date"
     t.index ["document_number"], name: "index_invoices_on_document_number", unique: true
+    t.index ["paid_at"], name: "index_invoices_on_paid_at"
     t.index ["published", "date"], name: "index_invoices_on_published_and_date"
     t.index ["published"], name: "index_invoices_on_published"
   end

--- a/test/controllers/invoices_controller_email_test.rb
+++ b/test/controllers/invoices_controller_email_test.rb
@@ -141,13 +141,13 @@ class InvoicesControllerEmailTest < ActionDispatch::IntegrationTest
 
   test "index filters invoices by email status" do
     # Test unsent filter
-    get invoices_path(email_filter: 'unsent')
+    get invoices_path(filter: 'unsent')
     assert_response :success
-    assert_select '.email-filter .active', text: 'Unsent'
+    assert_select '.invoice-filter .active', text: 'Unsent'
   end
 
   test "unsent filter shows bulk send form" do
-    get invoices_path(email_filter: 'unsent')
+    get invoices_path(filter: 'unsent')
     assert_response :success
     assert_select 'form#bulk-email-form'
     assert_select 'input[type="submit"][value="Send Selected Emails"]'

--- a/test/controllers/invoices_controller_paid_test.rb
+++ b/test/controllers/invoices_controller_paid_test.rb
@@ -104,4 +104,27 @@ class InvoicesControllerPaidTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select 'strong', text: 'Payment Status:', count: 0
   end
+
+  test "index unpaid filter shows only unpaid published invoices" do
+    unpaid = invoices(:published_invoice)
+    unpaid.update!(paid_at: nil)
+    paid = invoices(:auto_email_invoice)
+    paid.update!(paid_at: Date.current)
+    draft = invoices(:draft_invoice)
+
+    get invoices_path(filter: 'unpaid', year: Date.current.year)
+
+    assert_response :success
+    assert_select '.invoice-filter .active', text: 'Unpaid'
+    assert_select 'a', text: unpaid.document_number
+    assert_select 'a', text: paid.document_number, count: 0
+    assert_select 'a', text: "Draft ##{draft.id}", count: 0
+  end
+
+  test "index has Unpaid filter button" do
+    get invoices_path
+
+    assert_response :success
+    assert_select '.invoice-filter a', text: 'Unpaid'
+  end
 end

--- a/test/controllers/invoices_controller_paid_test.rb
+++ b/test/controllers/invoices_controller_paid_test.rb
@@ -1,0 +1,107 @@
+require 'test_helper'
+
+class InvoicesControllerPaidTest < ActionDispatch::IntegrationTest
+  test "published invoice defaults to unpaid" do
+    invoice = invoices(:published_invoice)
+    assert_nil invoice.paid_at
+    assert_not invoice.paid?
+  end
+
+  test "mark_paid sets paid_at to today by default" do
+    invoice = invoices(:published_invoice)
+
+    post mark_paid_invoice_path(invoice)
+
+    assert_redirected_to invoice
+    invoice.reload
+    assert_equal Date.current, invoice.paid_at
+    assert invoice.paid?
+  end
+
+  test "mark_paid accepts a specific date" do
+    invoice = invoices(:published_invoice)
+    paid_on = Date.current - 5.days
+
+    post mark_paid_invoice_path(invoice), params: { paid_at: paid_on.to_s }
+
+    assert_redirected_to invoice
+    invoice.reload
+    assert_equal paid_on, invoice.paid_at
+  end
+
+  test "mark_paid rejects draft invoices" do
+    invoice = invoices(:draft_invoice)
+
+    post mark_paid_invoice_path(invoice)
+
+    assert_redirected_to invoice
+    assert_equal 'Draft invoices can not be used for this action.', flash[:error]
+    invoice.reload
+    assert_nil invoice.paid_at
+  end
+
+  test "mark_paid handles invalid date" do
+    invoice = invoices(:published_invoice)
+
+    post mark_paid_invoice_path(invoice), params: { paid_at: 'not-a-date' }
+
+    assert_redirected_to invoice
+    assert_equal 'Invalid date.', flash[:alert]
+    invoice.reload
+    assert_nil invoice.paid_at
+  end
+
+  test "mark_unpaid clears paid_at" do
+    invoice = invoices(:published_invoice)
+    invoice.update!(paid_at: Date.current)
+
+    post mark_unpaid_invoice_path(invoice)
+
+    assert_redirected_to invoice
+    invoice.reload
+    assert_nil invoice.paid_at
+    assert_not invoice.paid?
+  end
+
+  test "mark_unpaid rejects draft invoices" do
+    invoice = invoices(:draft_invoice)
+
+    post mark_unpaid_invoice_path(invoice)
+
+    assert_redirected_to invoice
+    assert_equal 'Draft invoices can not be used for this action.', flash[:error]
+  end
+
+  test "show page exposes unpaid status with mark paid form for booked invoice" do
+    invoice = invoices(:published_invoice)
+    invoice.update!(paid_at: nil)
+
+    get invoice_path(invoice)
+
+    assert_response :success
+    assert_select '.badge.bg-warning', text: 'Unpaid'
+    assert_select "form[action=\"#{mark_paid_invoice_path(invoice)}\"]"
+    assert_select "input[type='date'][name='paid_at']"
+    assert_select 'input[type="submit"][value="Mark Paid"]'
+  end
+
+  test "show page exposes paid status with mark unpaid button when paid" do
+    invoice = invoices(:published_invoice)
+    invoice.update!(paid_at: Date.current)
+
+    get invoice_path(invoice)
+
+    assert_response :success
+    assert_select '.badge.bg-success', text: /Paid/
+    assert_select "form[action=\"#{mark_unpaid_invoice_path(invoice)}\"]"
+  end
+
+  test "show page does not show payment status for draft invoices" do
+    invoice = invoices(:draft_invoice)
+
+    get invoice_path(invoice)
+
+    assert_response :success
+    assert_select 'strong', text: 'Payment Status:', count: 0
+  end
+end


### PR DESCRIPTION
Adds paid_at date field to invoices. Booked invoices start out unpaid
and can be marked paid (optionally with a specific date) or back to
unpaid from the show page.

- New paid_at date column with index, defaults to NULL (unpaid)
- mark_paid and mark_unpaid member actions, published-only
- Show page exposes Payment Status with action buttons/form
- Index list adds a Payment column

https://claude.ai/code/session_0172AtB5eZZuvUbTN4ngn4Yc