### PR TITLE
Add SessionStart hook to set up FOP in Claude Code sandbox

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# SessionStart hook for Claude Code on the web.
+#
+# Sets up Apache FOP natively (no Docker), since the sandbox doesn't
+# expose a container runtime. The dev/test Rails config expects a FOP
+# binary at ./bin/abt-fop-container — we create a thin wrapper there
+# that runs the Debian/Ubuntu fop package with Saxon on the classpath.
+set -euo pipefail
+
+# Only run inside the remote sandbox; local dev should use script/setup-fop.sh.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+echo "== Installing system packages (fop, saxon, java-wrappers) =="
+export DEBIAN_FRONTEND=noninteractive
+if ! dpkg -s fop libsaxonb-java java-wrappers openjdk-21-jre-headless >/dev/null 2>&1; then
+  # Disable broken third-party PPAs that block apt-get update in the sandbox.
+  for f in /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources; do
+    [ -e "$f" ] || continue
+    case "$f" in
+      *deadsnakes*|*ondrej*) mv "$f" "$f.disabled" ;;
+    esac
+  done
+  apt-get update -qq
+  apt-get install -y -qq --no-install-recommends \
+    fop \
+    libsaxonb-java \
+    java-wrappers \
+    openjdk-21-jre-headless
+fi
+
+echo "== Installing Ruby gems =="
+bundle install --quiet
+
+echo "== Creating FOP wrapper at ./bin/abt-fop-container =="
+mkdir -p bin
+cat > bin/abt-fop-container << 'WRAPPER'
+#!/bin/sh
+# FOP wrapper for the Claude Code sandbox.
+# Runs the system fop (Debian/Ubuntu package) with Saxon-B injected as
+# the XSLT TransformerFactory so XSLT 2.0 stylesheets work.
+. /usr/lib/java-wrappers/java-wrappers.sh
+
+JAVA_ARGS="-Dfop.skipDynamicClasspath=true -Djava.awt.headless=true -Djavax.xml.transform.TransformerFactory=net.sf.saxon.TransformerFactoryImpl"
+
+find_java_runtime
+find_jars saxonb fop fop-core fop-events fop-util fop-transcoder /usr/share/fop/fop-hyph.jar
+find_jars commons-io commons-logging xmlgraphics-commons xercesImpl xml-apis xml-apis-ext fontbox2 batik-all
+
+if [ -n "${FOP_EXTRA_JAR_PATH:-}" ]; then
+  find_jars "$FOP_EXTRA_JAR_PATH"/*.jar
+fi
+
+run_java org.apache.fop.cli.Main "$@"
+WRAPPER
+chmod +x bin/abt-fop-container
+
+echo "== Verifying FOP wrapper =="
+./bin/abt-fop-container -version
+
+echo "== FOP setup complete =="

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Makes Apache FOP work out of the box in Claude Code on the web sessions.

The existing `script/setup-fop.sh` flow builds `Dockerfile.fop` and runs it via Podman/Docker. The Claude sandbox has the docker CLI but no running daemon, so that path doesn't work. This PR installs FOP natively (apt) and creates the `./bin/abt-fop-container` wrapper that `config/settings/development.yml` and `config/settings/test.yml` already point at — so no app config needs to change.

### Changes

- `.claude/hooks/session-start.sh` — installs `fop`, `libsaxonb-java`, `java-wrappers`, `openjdk-21-jre-headless`; runs `bundle install`; writes a wrapper at `bin/abt-fop-container` that runs the Ubuntu/Debian `fop` package with Saxon-B as the `javax.xml.transform.TransformerFactory` (so XSLT 2.0 stylesheets work) and `-Dfop.skipDynamicClasspath=true` (so the FOP 2.8 CLI doesn't try to walk the project dir looking for `fop.jar`).
- `.claude/settings.json` — registers the hook on `SessionStart`.
- Guarded by `CLAUDE_CODE_REMOTE=true`, so local dev keeps using `script/setup-fop.sh`.

### Validation

- `bundle exec rails test test/integration/fop_installation_test.rb` → 3 runs, 7 assertions, 0 failures
- `bundle exec rails test test/services/fop_renderer_test.rb` → 2 runs, 9 assertions, 0 failures
- `npm run lint` → no Stimulus issues
- `pre-commit run --files .claude/...` → all hooks pass

## Test plan

- [ ] Start a fresh Claude Code on the web session; confirm the hook completes and `./bin/abt-fop-container -version` prints `FOP Version 2.8`
- [ ] Run `bundle exec rails test test/integration/fop_installation_test.rb` and `test/services/fop_renderer_test.rb` in the sandbox
- [ ] Confirm local dev (`CLAUDE_CODE_REMOTE` unset) is unaffected — hook exits early


---
_Generated by [Claude Code](https://claude.ai/code/session_014KPymqJe1nGUtmdZiVZLbk)_