### PR TITLE
Add image_processing gem dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,3 +53,5 @@ gem 'haml-rails'
 gem 'simple_form'
 
 gem "mailgun-ruby", "~> 1.4.3"
+
+gem "image_processing", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,9 @@ GEM
       railties (>= 5.1)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
+    image_processing (1.14.0)
+      mini_magick (>= 4.9.5, < 6)
+      ruby-vips (>= 2.0.17, < 3)
     importmap-rails (2.2.3)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
@@ -179,6 +182,8 @@ GEM
       zeitwerk
     marcel (1.1.0)
     matrix (0.4.3)
+    mini_magick (5.3.1)
+      logger
     mini_mime (1.1.5)
     minitest (6.0.6)
       drb (~> 2.0)
@@ -279,6 +284,9 @@ GEM
     regexp_parser (2.11.0)
     reline (0.6.3)
       io-console (~> 0.5)
+    ruby-vips (2.3.0)
+      ffi (~> 1.12)
+      logger
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -363,6 +371,7 @@ DEPENDENCIES
   cuprite
   debug
   haml-rails
+  image_processing (~> 1.2)
   importmap-rails
   jbuilder
   mailgun-ruby (~> 1.4.3)


### PR DESCRIPTION
Adds the `image_processing` gem (~> 1.2) to the project dependencies.

This gem provides a Ruby interface for image processing operations and is commonly used with Active Storage for image transformations and variant generation.

**Changes:**
- Added `gem "image_processing", "~> 1.2"` to Gemfile

https://claude.ai/code/session_01M2weK83tnW5WoGFLeaZfD6