### PR TITLE
Add Solid Queue background job worker with overdue invoices report

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,8 +15,9 @@ gem "stimulus-rails"
 gem "jbuilder"
 
 
-# Use database-backed adapter
+# Use database-backed adapters
 gem "solid_cache"
+gem "solid_queue"
 
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,8 @@ GEM
     drb (2.2.3)
     erb (6.0.4)
     erubi (1.13.1)
+    et-orbi (1.4.0)
+      tzinfo
     faraday (2.14.2)
       faraday-net_http (>= 2.0, < 3.5)
       json
@@ -135,6 +137,9 @@ GEM
     ffi (1.17.2-x86_64-darwin)
     ffi (1.17.2-x86_64-linux-gnu)
     ffi (1.17.2-x86_64-linux-musl)
+    fugit (1.12.1)
+      et-orbi (~> 1.4)
+      raabro (~> 1.4)
     globalid (1.3.0)
       activesupport (>= 6.1)
     haml (6.3.0)
@@ -232,6 +237,7 @@ GEM
     public_suffix (7.0.5)
     puma (8.0.1)
       nio4r (~> 2.0)
+    raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.6)
     rack-session (2.1.2)
@@ -297,6 +303,13 @@ GEM
       activejob (>= 7.2)
       activerecord (>= 7.2)
       railties (>= 7.2)
+    solid_queue (1.4.0)
+      activejob (>= 7.1)
+      activerecord (>= 7.1)
+      concurrent-ruby (>= 1.3.1)
+      fugit (~> 1.11)
+      railties (>= 7.1)
+      thor (>= 1.3.1)
     sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
       logger
@@ -372,6 +385,7 @@ DEPENDENCIES
   sass-rails
   simple_form
   solid_cache
+  solid_queue
   sqlite3 (>= 2.1)
   stimulus-rails
   turbo-rails

--- a/app/jobs/overdue_invoices_report_job.rb
+++ b/app/jobs/overdue_invoices_report_job.rb
@@ -1,0 +1,14 @@
+class OverdueInvoicesReportJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    overdue = Invoice.published.unpaid
+                     .where("due_date < ?", Date.current)
+                     .includes(:customer)
+                     .order(:due_date)
+
+    return if overdue.empty?
+
+    OverdueInvoicesMailer.with(invoices: overdue).overdue_report.deliver_now
+  end
+end

--- a/app/mailers/overdue_invoices_mailer.rb
+++ b/app/mailers/overdue_invoices_mailer.rb
@@ -1,0 +1,19 @@
+class OverdueInvoicesMailer < ApplicationMailer
+  def overdue_report
+    @invoices = params[:invoices]
+    @today = Date.current
+
+    recipient = @issuer.document_email_auto_bcc.presence
+    return if recipient.blank?
+
+    I18n.with_locale(I18n.default_locale) do
+      mail(
+        to: recipient,
+        from: "\"#{@issuer.short_name}\" <#{@issuer.document_email_from}>",
+        subject: I18n.t('mailers.overdue_invoices.subject',
+                        issuer_name: @issuer.short_name,
+                        count: @invoices.size)
+      )
+    end
+  end
+end

--- a/app/views/overdue_invoices_mailer/overdue_report.html.haml
+++ b/app/views/overdue_invoices_mailer/overdue_report.html.haml
@@ -1,0 +1,47 @@
+- content_for :title, t('mailers.overdue_invoices.title', count: @invoices.size)
+
+:css
+  table.overdue {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 20px 0;
+    font-size: 14px;
+  }
+  table.overdue th, table.overdue td {
+    border: 1px solid #dee2e6;
+    padding: 8px 10px;
+    text-align: left;
+  }
+  table.overdue th {
+    background-color: #f8f9fa;
+    font-weight: 600;
+  }
+  table.overdue td.numeric {
+    text-align: right;
+    white-space: nowrap;
+  }
+
+.greeting
+  = t('mailers.overdue_invoices.heading', date: @today.strftime('%d.%m.%Y'))
+
+.main-message
+  = t('mailers.overdue_invoices.main_message', count: @invoices.size)
+
+%table.overdue
+  %thead
+    %tr
+      %th= t('mailers.overdue_invoices.columns.invoice_number')
+      %th= t('mailers.overdue_invoices.columns.customer')
+      %th= t('mailers.overdue_invoices.columns.invoice_date')
+      %th= t('mailers.overdue_invoices.columns.due_date')
+      %th.numeric= t('mailers.overdue_invoices.columns.gross_amount')
+      %th.numeric= t('mailers.overdue_invoices.columns.days_overdue')
+  %tbody
+    - @invoices.each do |invoice|
+      %tr
+        %td= invoice.document_number
+        %td= invoice.customer.matchcode
+        %td= invoice.date&.strftime('%d.%m.%Y')
+        %td= invoice.due_date&.strftime('%d.%m.%Y')
+        %td.numeric= sprintf('%.2f', invoice.sum_total)
+        %td.numeric= (@today - invoice.due_date).to_i

--- a/app/views/overdue_invoices_mailer/overdue_report.text.haml
+++ b/app/views/overdue_invoices_mailer/overdue_report.text.haml
@@ -1,0 +1,7 @@
+= t('mailers.overdue_invoices.heading', date: @today.strftime('%d.%m.%Y'))
+\
+= t('mailers.overdue_invoices.main_message', count: @invoices.size)
+\
+- @invoices.each do |invoice|
+  - days_overdue = (@today - invoice.due_date).to_i
+  = "#{invoice.document_number}  #{invoice.customer.matchcode}  #{t('mailers.overdue_invoices.short.invoice_date')} #{invoice.date&.strftime('%d.%m.%Y')}  #{t('mailers.overdue_invoices.short.due_date')} #{invoice.due_date&.strftime('%d.%m.%Y')}  #{sprintf('%.2f', invoice.sum_total)}  #{t('mailers.overdue_invoices.short.days_overdue', days: days_overdue)}"

--- a/bin/jobs
+++ b/bin/jobs
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+require_relative "../config/environment"
+require "solid_queue/cli"
+
+SolidQueue::Cli.start(ARGV)

--- a/config/database.yml.sample
+++ b/config/database.yml.sample
@@ -13,6 +13,10 @@ development:
     <<: *primary_development
     database: db/development_cache.sqlite3
     migrations_paths: db/cache_migrate
+  queue:
+    <<: *primary_development
+    database: db/development_queue.sqlite3
+    migrations_paths: db/queue_migrate
 
 development_postgres:
   primary: &primary_development_postgres
@@ -28,6 +32,10 @@ development_postgres:
     <<: *primary_development_postgres
     database: abt_development_cache
     migrations_paths: db/cache_migrate
+  queue:
+    <<: *primary_development_postgres
+    database: abt_development_queue
+    migrations_paths: db/queue_migrate
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
@@ -42,6 +50,10 @@ test:
     <<: *primary_test
     database: db/test_cache.sqlite3
     migrations_paths: db/cache_migrate
+  queue:
+    <<: *primary_test
+    database: db/test_queue.sqlite3
+    migrations_paths: db/queue_migrate
 
 production:
   primary: &primary_production
@@ -57,3 +69,7 @@ production:
     <<: *primary_production
     database: abt_production_cache
     migrations_paths: db/cache_migrate
+  queue:
+    <<: *primary_production
+    database: abt_production_queue
+    migrations_paths: db/queue_migrate

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,7 +61,8 @@ Rails.application.configure do
   config.cache_store = :solid_cache_store
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
-  # config.active_job.queue_adapter = :resque
+  config.active_job.queue_adapter = :solid_queue
+  config.solid_queue.connects_to = { database: { writing: :queue } }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,5 +1,22 @@
 de:
   mailers:
+    overdue_invoices:
+      subject: "[%{issuer_name}] %{count} überfällige Rechnung(en)"
+      title: "Bericht über überfällige Rechnungen"
+      heading: "Überfällige Rechnungen am %{date}"
+      main_message: "Es gibt %{count} unbezahlte Rechnung(en), deren Fälligkeitsdatum überschritten ist."
+      columns:
+        invoice_number: "Rechnungsnr."
+        customer: "Kunde"
+        invoice_date: "Rechnungsdatum"
+        due_date: "Fälligkeitsdatum"
+        gross_amount: "Bruttobetrag"
+        days_overdue: "Tage überfällig"
+      short:
+        invoice_date: "Datum:"
+        due_date: "Fällig:"
+        days_overdue: "%{days} Tage überfällig"
+
     invoice:
       subject: "%{issuer_name} Rechnung %{document_number}"
       greeting: "Sehr geehrte Damen und Herren,"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,23 @@
 
 en:
   mailers:
+    overdue_invoices:
+      subject: "[%{issuer_name}] %{count} overdue invoice(s)"
+      title: "Overdue invoices report"
+      heading: "Overdue invoices as of %{date}"
+      main_message: "There are %{count} unpaid invoice(s) past their due date."
+      columns:
+        invoice_number: "Invoice no."
+        customer: "Customer"
+        invoice_date: "Invoice date"
+        due_date: "Due date"
+        gross_amount: "Gross amount"
+        days_overdue: "Days overdue"
+      short:
+        invoice_date: "Date:"
+        due_date: "Due:"
+        days_overdue: "%{days} days overdue"
+
     invoice:
       subject: "%{issuer_name} Invoice %{document_number}"
       greeting: "Dear %{customer_name},"

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -1,0 +1,18 @@
+default: &default
+  dispatchers:
+    - polling_interval: 1
+      batch_size: 500
+  workers:
+    - queues: "*"
+      threads: 3
+      processes: <%= ENV.fetch("JOB_CONCURRENCY", 1) %>
+      polling_interval: 0.1
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -1,0 +1,19 @@
+# examples:
+#   periodic_cleanup:
+#     class: CleanSoftDeletedRecordsJob
+#     queue: background
+#     args: [ 1000, { batch_size: 500 } ]
+#     schedule: every hour
+#   periodic_cleanup_with_command:
+#     command: "SoftDeletedRecord.due.delete_all"
+#     priority: 2
+#     schedule: at 5am every day
+
+production:
+  clear_solid_queue_finished_jobs:
+    command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
+    schedule: every hour at minute 12
+  overdue_invoices_report:
+    class: OverdueInvoicesReportJob
+    queue: default
+    schedule: "0 8 */2 * *"

--- a/db/queue_schema.rb
+++ b/db/queue_schema.rb
@@ -1,0 +1,141 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.1].define(version: 1) do
+  create_table "solid_queue_blocked_executions", force: :cascade do |t|
+    t.string "concurrency_key", null: false
+    t.datetime "created_at", null: false
+    t.datetime "expires_at", null: false
+    t.bigint "job_id", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "queue_name", null: false
+    t.index ["concurrency_key", "priority", "job_id"], name: "index_solid_queue_blocked_executions_for_release"
+    t.index ["expires_at", "concurrency_key"], name: "index_solid_queue_blocked_executions_for_maintenance"
+    t.index ["job_id"], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_claimed_executions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "job_id", null: false
+    t.bigint "process_id"
+    t.index ["job_id"], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
+    t.index ["process_id", "job_id"], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
+  end
+
+  create_table "solid_queue_failed_executions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.text "error"
+    t.bigint "job_id", null: false
+    t.index ["job_id"], name: "index_solid_queue_failed_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_jobs", force: :cascade do |t|
+    t.string "active_job_id"
+    t.text "arguments"
+    t.string "class_name", null: false
+    t.string "concurrency_key"
+    t.datetime "created_at", null: false
+    t.datetime "finished_at"
+    t.integer "priority", default: 0, null: false
+    t.string "queue_name", null: false
+    t.datetime "scheduled_at"
+    t.datetime "updated_at", null: false
+    t.index ["active_job_id"], name: "index_solid_queue_jobs_on_active_job_id"
+    t.index ["class_name"], name: "index_solid_queue_jobs_on_class_name"
+    t.index ["finished_at"], name: "index_solid_queue_jobs_on_finished_at"
+    t.index ["queue_name", "finished_at"], name: "index_solid_queue_jobs_for_filtering"
+    t.index ["scheduled_at", "finished_at"], name: "index_solid_queue_jobs_for_alerting"
+  end
+
+  create_table "solid_queue_pauses", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "queue_name", null: false
+    t.index ["queue_name"], name: "index_solid_queue_pauses_on_queue_name", unique: true
+  end
+
+  create_table "solid_queue_processes", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "hostname"
+    t.string "kind", null: false
+    t.datetime "last_heartbeat_at", null: false
+    t.text "metadata"
+    t.string "name", null: false
+    t.integer "pid", null: false
+    t.bigint "supervisor_id"
+    t.index ["last_heartbeat_at"], name: "index_solid_queue_processes_on_last_heartbeat_at"
+    t.index ["name", "supervisor_id"], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
+    t.index ["supervisor_id"], name: "index_solid_queue_processes_on_supervisor_id"
+  end
+
+  create_table "solid_queue_ready_executions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "job_id", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "queue_name", null: false
+    t.index ["job_id"], name: "index_solid_queue_ready_executions_on_job_id", unique: true
+    t.index ["priority", "job_id"], name: "index_solid_queue_poll_all"
+    t.index ["queue_name", "priority", "job_id"], name: "index_solid_queue_poll_by_queue"
+  end
+
+  create_table "solid_queue_recurring_executions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "job_id", null: false
+    t.datetime "run_at", null: false
+    t.string "task_key", null: false
+    t.index ["job_id"], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
+    t.index ["task_key", "run_at"], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
+  end
+
+  create_table "solid_queue_recurring_tasks", force: :cascade do |t|
+    t.text "arguments"
+    t.string "class_name"
+    t.string "command", limit: 2048
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.string "key", null: false
+    t.integer "priority", default: 0
+    t.string "queue_name"
+    t.string "schedule", null: false
+    t.boolean "static", default: true, null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_solid_queue_recurring_tasks_on_key", unique: true
+    t.index ["static"], name: "index_solid_queue_recurring_tasks_on_static"
+  end
+
+  create_table "solid_queue_scheduled_executions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "job_id", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "queue_name", null: false
+    t.datetime "scheduled_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
+    t.index ["scheduled_at", "priority", "job_id"], name: "index_solid_queue_dispatch_all"
+  end
+
+  create_table "solid_queue_semaphores", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "expires_at", null: false
+    t.string "key", null: false
+    t.datetime "updated_at", null: false
+    t.integer "value", default: 1, null: false
+    t.index ["expires_at"], name: "index_solid_queue_semaphores_on_expires_at"
+    t.index ["key", "value"], name: "index_solid_queue_semaphores_on_key_and_value"
+    t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
+  end
+
+  add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+end

--- a/script/production-update
+++ b/script/production-update
@@ -157,6 +157,26 @@ restart_apache() {
     fi
 }
 
+# Function to restart the Solid Queue jobs worker
+restart_jobs_worker() {
+    print_status "Restarting Solid Queue jobs worker..."
+
+    if ! command -v systemctl >/dev/null 2>&1; then
+        print_warning "systemctl not available; please restart the jobs worker manually."
+        return 0
+    fi
+
+    if systemctl --user cat abt-jobs.service >/dev/null 2>&1; then
+        if systemctl --user restart abt-jobs.service; then
+            print_success "Solid Queue jobs worker restarted."
+        else
+            print_warning "systemctl --user restart abt-jobs.service failed; please restart manually."
+        fi
+    else
+        print_warning "abt-jobs.service is not installed; see script/production-update.md for setup."
+    fi
+}
+
 # Main deployment function
 main() {
     echo "========================================"
@@ -172,6 +192,7 @@ main() {
     precompile_assets
     migrate_database
     restart_apache
+    restart_jobs_worker
 
     echo
     print_success "Production deployment completed successfully!"
@@ -182,6 +203,7 @@ main() {
     echo "  ✓ Precompiled assets for production"
     echo "  ✓ Ran database migrations"
     echo "  ✓ Triggered application restart"
+    echo "  ✓ Restarted Solid Queue jobs worker"
     echo
     print_status "The application should now be running the latest version."
 }

--- a/script/production-update.md
+++ b/script/production-update.md
@@ -37,6 +37,9 @@ The script sets `RAILS_ENV=production` for the entire session and performs the f
 6. **Application Restart**
    - Creates `tmp/restart.txt` for Passenger to restart the app
 
+7. **Jobs Worker Restart**
+   - Runs `systemctl --user restart abt-jobs.service` to restart the Solid Queue worker so it picks up new code and updated recurring schedules. See "Solid Queue jobs worker" below for one-time setup.
+
 ### Requirements
 
 - Must be run as the application user (user with write access to the app directory)
@@ -64,3 +67,69 @@ The script provides colored output:
 ### Application Restart
 
 The script creates `tmp/restart.txt` which tells Passenger to restart the application automatically. This handles the restart without requiring elevated privileges.
+
+## Solid Queue jobs worker
+
+ABT uses Solid Queue (database-backed Active Job adapter) for background work and scheduled jobs. The worker process is `bin/jobs`, which runs the queue worker, dispatcher, and recurring-job scheduler together. It is required for:
+
+- Emails enqueued via `deliver_later`.
+- The `overdue_invoices_report` recurring job (sends a bi-daily overdue-invoice report to the issuer's `document_email_auto_bcc` address; configured in `config/recurring.yml`).
+
+The worker connects to the dedicated `queue` database defined in `config/database.yml`. The schema is in `db/queue_schema.rb` and is loaded automatically by `bin/rails db:prepare`.
+
+### One-time setup (per host, as the application user)
+
+1. **Enable user lingering** so user-level systemd services keep running after logout. This must be done once by an administrator with `sudo` access (the `production-update` script does not call `sudo`):
+
+   ```bash
+   sudo loginctl enable-linger <app-user>
+   ```
+
+2. **Create the systemd user unit** at `~/.config/systemd/user/abt-jobs.service`:
+
+   ```ini
+   [Unit]
+   Description=ABT Solid Queue jobs worker
+   After=network.target
+
+   [Service]
+   Type=simple
+   WorkingDirectory=%h/abt
+   Environment=RAILS_ENV=production
+   Environment=PATH=%h/.rbenv/shims:/usr/local/bin:/usr/bin:/bin
+   ExecStart=%h/abt/bin/jobs
+   Restart=always
+   RestartSec=5
+
+   [Install]
+   WantedBy=default.target
+   ```
+
+   Adjust `WorkingDirectory` and `Environment=PATH` to match the host (Ruby version manager, app path).
+
+3. **Enable and start the service**:
+
+   ```bash
+   systemctl --user daemon-reload
+   systemctl --user enable --now abt-jobs.service
+   ```
+
+### Verifying the worker
+
+```bash
+systemctl --user status abt-jobs.service
+journalctl --user -u abt-jobs.service -n 50
+```
+
+Confirm the recurring task is registered (after the worker has started at least once):
+
+```bash
+RAILS_ENV=production bundle exec rails runner \
+  'puts SolidQueue::RecurringTask.pluck(:key, :schedule).inspect'
+```
+
+You should see `overdue_invoices_report` in the output alongside any other recurring tasks.
+
+### Updates and restarts
+
+The `production-update` script calls `systemctl --user restart abt-jobs.service` after the application restart. It is tolerant of the unit not being installed yet (prints a warning and continues) so the first deploy that introduces the worker does not abort. Once the unit is installed, every subsequent deploy restarts the worker so it picks up code changes and any updates to `config/recurring.yml`.

--- a/test/jobs/overdue_invoices_report_job_test.rb
+++ b/test/jobs/overdue_invoices_report_job_test.rb
@@ -1,0 +1,63 @@
+require "test_helper"
+
+class OverdueInvoicesReportJobTest < ActiveJob::TestCase
+  include ActiveJob::TestHelper
+  include ActionMailer::TestHelper
+
+  def setup
+    ActionMailer::Base.deliveries.clear
+    # Ensure no other fixture invoices are accidentally overdue.
+    Invoice.update_all(paid_at: Date.current)
+  end
+
+  test "sends a single report email when overdue unpaid invoices exist" do
+    overdue = invoices(:published_invoice)
+    overdue.update_columns(published: true, due_date: 5.days.ago.to_date, paid_at: nil)
+
+    assert_emails 1 do
+      OverdueInvoicesReportJob.perform_now
+    end
+
+    delivered = ActionMailer::Base.deliveries.last
+    assert_match overdue.document_number, delivered.html_part.body.to_s
+  end
+
+  test "sends nothing when there are no overdue invoices" do
+    assert_emails 0 do
+      OverdueInvoicesReportJob.perform_now
+    end
+  end
+
+  test "ignores draft invoices" do
+    draft = invoices(:draft_invoice)
+    draft.update_columns(published: false, due_date: 5.days.ago.to_date, paid_at: nil)
+
+    assert_emails 0 do
+      OverdueInvoicesReportJob.perform_now
+    end
+  end
+
+  test "ignores paid invoices" do
+    paid = invoices(:published_invoice)
+    paid.update_columns(published: true, due_date: 5.days.ago.to_date, paid_at: 1.day.ago.to_date)
+
+    assert_emails 0 do
+      OverdueInvoicesReportJob.perform_now
+    end
+  end
+
+  test "ignores invoices whose due_date is today or later" do
+    not_yet_due = invoices(:published_invoice)
+    not_yet_due.update_columns(published: true, due_date: Date.current, paid_at: nil)
+
+    assert_emails 0 do
+      OverdueInvoicesReportJob.perform_now
+    end
+  end
+
+  test "can be queued" do
+    assert_enqueued_jobs 1, only: OverdueInvoicesReportJob do
+      OverdueInvoicesReportJob.perform_later
+    end
+  end
+end

--- a/test/mailers/overdue_invoices_mailer_test.rb
+++ b/test/mailers/overdue_invoices_mailer_test.rb
@@ -1,0 +1,65 @@
+require "test_helper"
+
+class OverdueInvoicesMailerTest < ActionMailer::TestCase
+  def setup
+    ActionMailer::Base.deliveries.clear
+
+    @overdue_a = invoices(:published_invoice)
+    @overdue_a.update_columns(due_date: 10.days.ago.to_date, paid_at: nil)
+
+    @overdue_b = invoices(:auto_email_invoice)
+    @overdue_b.update_columns(due_date: 3.days.ago.to_date, paid_at: nil)
+  end
+
+  test "overdue_report builds an email to the issuer's auto BCC address" do
+    invoices = [@overdue_a, @overdue_b]
+
+    mail = OverdueInvoicesMailer.with(invoices: invoices).overdue_report
+
+    assert_equal ["bcc@example.com"], mail.to
+    assert_equal ["from@example.com"], mail.from
+    assert_match(/My Example/, mail.subject)
+    assert_match(/2 overdue/, mail.subject)
+  end
+
+  test "overdue_report HTML body contains every required field per invoice" do
+    invoices = [@overdue_a, @overdue_b]
+
+    mail = OverdueInvoicesMailer.with(invoices: invoices).overdue_report
+    html = mail.html_part.body.to_s
+
+    invoices.each do |inv|
+      assert_match inv.document_number, html
+      assert_match inv.customer.matchcode, html
+      assert_match inv.date.strftime('%d.%m.%Y'), html
+      assert_match inv.due_date.strftime('%d.%m.%Y'), html
+      assert_match sprintf('%.2f', inv.sum_total), html
+
+      days_overdue = (Date.current - inv.due_date).to_i
+      assert_match days_overdue.to_s, html
+    end
+  end
+
+  test "overdue_report text body contains every required field per invoice" do
+    invoices = [@overdue_a]
+
+    mail = OverdueInvoicesMailer.with(invoices: invoices).overdue_report
+    text = mail.text_part.body.to_s
+
+    assert_match @overdue_a.document_number, text
+    assert_match @overdue_a.customer.matchcode, text
+    assert_match @overdue_a.date.strftime('%d.%m.%Y'), text
+    assert_match @overdue_a.due_date.strftime('%d.%m.%Y'), text
+    assert_match sprintf('%.2f', @overdue_a.sum_total), text
+    assert_match "10 days overdue", text
+  end
+
+  test "overdue_report returns NullMail when issuer has no auto BCC address" do
+    issuer_companies(:one).update!(document_email_auto_bcc: "")
+
+    mail = OverdueInvoicesMailer.with(invoices: [@overdue_a]).overdue_report
+
+    assert_instance_of ActionMailer::Parameterized::MessageDelivery, mail
+    assert_instance_of ActionMailer::Base::NullMail, mail.message
+  end
+end


### PR DESCRIPTION
## Summary

Introduces Solid Queue as the Active Job adapter for background job processing and scheduled tasks. Implements an automated bi-daily overdue invoices report that emails issuers about unpaid invoices past their due date.

## Key Changes

- **Solid Queue Integration**
  - Added `solid_queue` gem and configured it as the Active Job adapter in production
  - Created dedicated `queue` database with schema in `db/queue_schema.rb`
  - Added `config/queue.yml` for worker, dispatcher, and polling configuration
  - Updated `config/database.yml.sample` to include queue database configuration for all environments

- **Jobs Worker Process**
  - Created `bin/jobs` executable to run the Solid Queue CLI (worker, dispatcher, and recurring scheduler)
  - Added systemd user service setup documentation and one-time setup instructions in `script/production-update.md`
  - Updated `script/production-update` to restart the jobs worker on each deployment

- **Overdue Invoices Report**
  - Implemented `OverdueInvoicesReportJob` that finds unpaid, published invoices past their due date and sends a report email
  - Created `OverdueInvoicesMailer` with `overdue_report` action that emails the issuer's `document_email_auto_bcc` address
  - Added HTML and text email templates (`overdue_report.html.haml` and `overdue_report.text.haml`) with invoice details table
  - Configured recurring task in `config/recurring.yml` to run the report every 2 days at 8 AM
  - Added German and English i18n translations for the mailer

- **Testing**
  - Added comprehensive test suite for `OverdueInvoicesReportJob` covering job enqueueing, filtering logic (draft/paid/not-yet-due invoices), and email delivery
  - Added test suite for `OverdueInvoicesMailer` covering email content, HTML/text rendering, and NullMail behavior when no BCC address is configured

## Implementation Details

- The queue database is separate from the primary database, allowing independent scaling and backup strategies
- The worker process runs continuously and handles both immediate job processing and recurring task scheduling
- The overdue report respects the issuer's configured auto-BCC email address and uses the issuer's document email sender address
- Report emails are sent in the default locale (English) regardless of user preferences
- The production deployment script gracefully handles the case where the systemd service is not yet installed on first deploy

https://claude.ai/code/session_01YakPXmhCcs4nuPYJHXouzK