### PR TITLE
Fix bin/jobs boot when dev bundle is excluded

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,9 @@ gem "bootsnap", require: false
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
+  # `require: false` so the app still boots in environments where the
+  # development/test bundle isn't installed (e.g. production running bin/jobs).
+  gem "debug", platforms: %i[ mri windows ], require: false
 
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
   gem "brakeman", require: false

--- a/script/production-update.md
+++ b/script/production-update.md
@@ -114,6 +114,14 @@ The worker connects to the dedicated `queue` database defined in `config/databas
    systemctl --user enable --now abt-jobs.service
    ```
 
+### Running manually
+
+If you need to run the worker by hand (e.g. for a one-off test before systemd is set up), always pass `RAILS_ENV=production`. Without it `bin/jobs` boots in development mode and Bundler tries to load gems that production deployments don't install:
+
+```bash
+RAILS_ENV=production bin/jobs
+```
+
 ### Verifying the worker
 
 ```bash


### PR DESCRIPTION
## Summary

`bin/jobs` (the Solid Queue worker introduced in #251) crashed at boot on production hosts:

```
Gem Load Error is: cannot load such file -- debug/prelude
```

Cause: `bin/jobs` doesn't set `RAILS_ENV`, so it defaults to `development`. Bundler then tries to require gems from the `:development, :test` group, but `script/production-update` runs `bundle install --without development:test`, so `debug` isn't installed.

Fix: switch the `debug` gem to `require: false` so it isn't auto-loaded at boot. Developers who want `binding.b` to work without a prior `require "debug"` can add one themselves; everyone else gets a clean boot in any environment. Documented the `RAILS_ENV=production` expectation for manual `bin/jobs` invocations in `script/production-update.md` (the systemd unit already sets it).

## Test plan

- [x] `BUNDLE_WITHOUT=development:test bin/jobs --help` now prints help instead of crashing
- [x] `bundle exec rails test` (216 runs, all green)
- [ ] Run `bin/jobs` on the production host after merge to confirm the worker starts

https://claude.ai/code/session_01YakPXmhCcs4nuPYJHXouzK

---
_Generated by [Claude Code](https://claude.ai/code/session_01YakPXmhCcs4nuPYJHXouzK)_