### PR TITLE
Fix production-update jobs-worker restart from non-login shells

### DIFF
--- a/script/production-update
+++ b/script/production-update
@@ -166,14 +166,30 @@ restart_jobs_worker() {
         return 0
     fi
 
-    if systemctl --user cat abt-jobs.service >/dev/null 2>&1; then
+    # systemctl --user needs XDG_RUNTIME_DIR pointing at the user's systemd
+    # runtime directory. Non-login shells (deploys, cron, scripted ssh) don't
+    # inherit it from PAM. With `loginctl enable-linger` configured (see
+    # script/production-update.md), /run/user/<uid> persists for the user.
+    export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+
+    if [[ ! -S "${XDG_RUNTIME_DIR}/bus" ]]; then
+        print_warning "Cannot reach user systemd: ${XDG_RUNTIME_DIR}/bus is missing."
+        print_warning "Ensure 'loginctl enable-linger $(whoami)' has been run (see script/production-update.md)."
+        return 0
+    fi
+
+    local cat_output
+    if cat_output=$(systemctl --user cat abt-jobs.service 2>&1); then
         if systemctl --user restart abt-jobs.service; then
             print_success "Solid Queue jobs worker restarted."
         else
             print_warning "systemctl --user restart abt-jobs.service failed; please restart manually."
         fi
-    else
+    elif echo "$cat_output" | grep -qi "no .*unit\|not loaded\|not.found\|could not be found"; then
         print_warning "abt-jobs.service is not installed; see script/production-update.md for setup."
+    else
+        print_warning "systemctl --user cat abt-jobs.service failed:"
+        echo "$cat_output" | sed 's/^/    /'
     fi
 }
 

--- a/script/production-update.md
+++ b/script/production-update.md
@@ -79,11 +79,13 @@ The worker connects to the dedicated `queue` database defined in `config/databas
 
 ### One-time setup (per host, as the application user)
 
-1. **Enable user lingering** so user-level systemd services keep running after logout. This must be done once by an administrator with `sudo` access (the `production-update` script does not call `sudo`):
+1. **Enable user lingering** so user-level systemd services keep running after logout *and* so `/run/user/<uid>` exists for non-login shells (deploys, cron). The `production-update` script relies on this to find the user systemd bus — without it, `systemctl --user` from the deploy shell will fail with "Failed to connect to bus" and the script will warn that the unit cannot be reached. Run this once as an administrator with `sudo`:
 
    ```bash
    sudo loginctl enable-linger <app-user>
    ```
+
+   Verify with `loginctl show-user <app-user> | grep Linger=yes` and confirm `/run/user/$(id -u <app-user>)/bus` exists.
 
 2. **Create the systemd user unit** at `~/.config/systemd/user/abt-jobs.service`:
 


### PR DESCRIPTION
## Summary

`script/production-update` always reported `abt-jobs.service is not installed` even when the service was healthy. Verified by hand: `sudo systemctl --machine=abt@.host --user status abt-jobs.service` worked, so the unit was running fine — the deploy script just couldn't reach the user systemd manager.

Root cause: when the abt user runs the deploy from a non-PAM shell (cron, scripted ssh, etc.), `XDG_RUNTIME_DIR` isn't inherited, so `systemctl --user` fails to connect to the user bus. The previous code swallowed that error with `2>&1 >/dev/null` and mis-reported it as "not installed".

## Changes

- `script/production-update`: export `XDG_RUNTIME_DIR=/run/user/$(id -u)` before any `systemctl --user` call; this path is persistent once `loginctl enable-linger` has been run (already required by the docs).
- Pre-flight the user bus socket at `${XDG_RUNTIME_DIR}/bus` and print a clear, actionable warning if it's missing.
- Capture stderr from `systemctl --user cat …` and only report "unit not installed" when the output actually says so; surface other errors verbatim.
- `script/production-update.md`: spell out that lingering is what makes `/run/user/<uid>/bus` exist for non-login shells, with a verification snippet.

## Test plan

- [x] `bash -n script/production-update` (syntax)
- [ ] Run `./script/production-update` on the production host as the abt user — confirm it now reports `✓ Restarted Solid Queue jobs worker` instead of the false "not installed" warning.
- [ ] Sanity-check the "really not installed" path by temporarily renaming the unit file and re-running.

https://claude.ai/code/session_01YakPXmhCcs4nuPYJHXouzK

---
_Generated by [Claude Code](https://claude.ai/code/session_01YakPXmhCcs4nuPYJHXouzK)_