### PR TITLE
Show Overdue badge for unpaid invoices past due date

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -36,6 +36,10 @@ class Invoice < ApplicationRecord
     self.paid_at.present?
   end
 
+  def overdue?
+    self.published? && !self.paid? && self.due_date.present? && self.due_date < Date.current
+  end
+
   def validate_lines_for_booking
     errors = []
     log = []

--- a/app/views/invoices/index.html.haml
+++ b/app/views/invoices/index.html.haml
@@ -79,6 +79,8 @@
             - if invoice.published?
               - if invoice.paid?
                 %span.badge.bg-success Paid #{format_date(invoice.paid_at)}
+              - elsif invoice.overdue?
+                %span.badge.bg-danger Overdue
               - else
                 %span.badge.bg-warning Unpaid
           %td

--- a/app/views/invoices/show.html.haml
+++ b/app/views/invoices/show.html.haml
@@ -52,6 +52,8 @@
             .col-sm-8
               - if @invoice.paid?
                 %span.badge.bg-success Paid #{format_date(@invoice.paid_at)}
+              - elsif @invoice.overdue?
+                %span.badge.bg-danger Overdue
               - else
                 %span.badge.bg-warning Unpaid
 

--- a/test/controllers/invoices_controller_paid_test.rb
+++ b/test/controllers/invoices_controller_paid_test.rb
@@ -127,4 +127,47 @@ class InvoicesControllerPaidTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select '.invoice-filter a', text: 'Unpaid'
   end
+
+  test "index shows Overdue label for unpaid invoices past due date" do
+    invoice = invoices(:published_invoice)
+    invoice.update!(paid_at: nil, due_date: Date.current - 1.day)
+
+    get invoices_path(year: Date.current.year)
+
+    assert_response :success
+    assert_select '.badge.bg-danger', text: 'Overdue'
+  end
+
+  test "index shows Unpaid label for unpaid invoices not yet past due date" do
+    invoice = invoices(:published_invoice)
+    invoice.update!(paid_at: nil, due_date: Date.current + 1.day)
+
+    get invoices_path(year: Date.current.year)
+
+    assert_response :success
+    assert_select '.badge.bg-warning', text: 'Unpaid'
+    assert_select '.badge.bg-danger', text: 'Overdue', count: 0
+  end
+
+  test "show page shows Overdue label for unpaid invoices past due date" do
+    invoice = invoices(:published_invoice)
+    invoice.update!(paid_at: nil, due_date: Date.current - 1.day)
+
+    get invoice_path(invoice)
+
+    assert_response :success
+    assert_select '.badge.bg-danger', text: 'Overdue'
+    assert_select '.badge.bg-warning', text: 'Unpaid', count: 0
+  end
+
+  test "unpaid filter includes overdue invoices" do
+    invoice = invoices(:published_invoice)
+    invoice.update!(paid_at: nil, due_date: Date.current - 5.days)
+
+    get invoices_path(filter: 'unpaid', year: Date.current.year)
+
+    assert_response :success
+    assert_select 'a', text: invoice.document_number
+    assert_select '.badge.bg-danger', text: 'Overdue'
+  end
 end


### PR DESCRIPTION
Replaces the Unpaid badge with a red Overdue badge on the invoice list
and detail page when an unpaid published invoice is past its due_date.

- Adds Invoice#overdue? helper
- Unpaid filter unchanged (overdue invoices remain in the unpaid scope)