### PR TITLE
Add background jobs status dashboard

### DIFF
--- a/app/controllers/jobs_status_controller.rb
+++ b/app/controllers/jobs_status_controller.rb
@@ -1,0 +1,37 @@
+class JobsStatusController < ApplicationController
+  STALE_HEARTBEAT_THRESHOLD = 1.minute
+  RECENT_FAILED_LIMIT = 20
+  RECENT_FINISHED_LIMIT = 10
+
+  def show
+    @processes = SolidQueue::Process.order(:kind, :name).to_a
+    @stale_threshold = STALE_HEARTBEAT_THRESHOLD.ago
+
+    @counts = {
+      ready: SolidQueue::ReadyExecution.count,
+      scheduled: SolidQueue::ScheduledExecution.count,
+      claimed: SolidQueue::ClaimedExecution.count,
+      blocked: SolidQueue::BlockedExecution.count,
+      failed: SolidQueue::FailedExecution.count,
+      finished: SolidQueue::Job.finished.count
+    }
+
+    @recurring_tasks = SolidQueue::RecurringTask.order(:key).to_a
+    @next_recurring_runs = SolidQueue::RecurringExecution
+                             .where(task_key: @recurring_tasks.map(&:key))
+                             .group(:task_key)
+                             .minimum(:run_at)
+
+    @failed_jobs = SolidQueue::FailedExecution
+                     .includes(:job)
+                     .order(created_at: :desc)
+                     .limit(RECENT_FAILED_LIMIT)
+
+    @recent_finished_jobs = SolidQueue::Job
+                              .finished
+                              .order(finished_at: :desc)
+                              .limit(RECENT_FINISHED_LIMIT)
+
+    @queue_adapter = Rails.application.config.active_job.queue_adapter
+  end
+end

--- a/app/views/jobs_status/show.html.haml
+++ b/app/views/jobs_status/show.html.haml
@@ -1,0 +1,161 @@
+= page_header('Background Jobs')
+
+- if @queue_adapter != :solid_queue
+  .alert.alert-warning
+    The Active Job queue adapter for this environment is
+    %code= @queue_adapter || 'default'
+    so jobs are not being routed through Solid Queue. The figures below
+    only reflect data persisted in the queue database.
+
+.row.mb-3
+  .col-md-2.col-6.mb-2
+    .card.text-center
+      .card-body.py-3
+        .h3.mb-0= @counts[:ready]
+        .small.text-muted Ready
+  .col-md-2.col-6.mb-2
+    .card.text-center
+      .card-body.py-3
+        .h3.mb-0= @counts[:scheduled]
+        .small.text-muted Scheduled
+  .col-md-2.col-6.mb-2
+    .card.text-center
+      .card-body.py-3
+        .h3.mb-0= @counts[:claimed]
+        .small.text-muted In progress
+  .col-md-2.col-6.mb-2
+    .card.text-center
+      .card-body.py-3
+        .h3.mb-0= @counts[:blocked]
+        .small.text-muted Blocked
+  .col-md-2.col-6.mb-2
+    .card.text-center.border-danger{class: ('text-danger' if @counts[:failed].positive?)}
+      .card-body.py-3
+        .h3.mb-0= @counts[:failed]
+        .small Failed
+  .col-md-2.col-6.mb-2
+    .card.text-center
+      .card-body.py-3
+        .h3.mb-0= @counts[:finished]
+        .small.text-muted Finished
+
+.card.mb-4
+  .card-header
+    Worker Processes
+  .card-body
+    - if @processes.empty?
+      %p.text-danger.mb-0
+        No worker processes registered. The
+        %code bin/jobs
+        worker may not be running.
+    - else
+      .table-responsive
+        %table.table.table-sm.mb-0
+          %thead
+            %tr
+              %th Kind
+              %th Name
+              %th Hostname
+              %th PID
+              %th Last heartbeat
+              %th Status
+          %tbody
+            - @processes.each do |process|
+              - stale = process.last_heartbeat_at < @stale_threshold
+              %tr
+                %td= process.kind
+                %td= process.name
+                %td= process.hostname
+                %td= process.pid
+                %td
+                  = format_datetime(process.last_heartbeat_at)
+                  %small.text-muted
+                    \(#{time_ago_in_words(process.last_heartbeat_at)} ago)
+                %td
+                  - if stale
+                    %span.badge.bg-danger Stale
+                  - else
+                    %span.badge.bg-success Alive
+
+.card.mb-4
+  .card-header
+    Recurring Tasks
+  .card-body
+    - if @recurring_tasks.empty?
+      %p.text-muted.mb-0 No recurring tasks registered.
+    - else
+      .table-responsive
+        %table.table.table-sm.mb-0
+          %thead
+            %tr
+              %th Key
+              %th Schedule
+              %th Class / Command
+              %th Queue
+              %th Next run
+          %tbody
+            - @recurring_tasks.each do |task|
+              %tr
+                %td
+                  %code= task.key
+                %td= task.schedule
+                %td
+                  - if task.class_name.present?
+                    = task.class_name
+                  - elsif task.command.present?
+                    %code= task.command
+                %td= task.queue_name || 'default'
+                %td
+                  - next_run = @next_recurring_runs[task.key]
+                  - if next_run
+                    = format_datetime(next_run)
+                  - else
+                    %span.text-muted —
+
+.card.mb-4
+  .card-header
+    Recently Failed Jobs
+  .card-body
+    - if @failed_jobs.empty?
+      %p.text-muted.mb-0 No failed jobs.
+    - else
+      .table-responsive
+        %table.table.table-sm.mb-0
+          %thead
+            %tr
+              %th Job
+              %th Queue
+              %th Error
+              %th Failed at
+          %tbody
+            - @failed_jobs.each do |failed|
+              %tr
+                %td= failed.job&.class_name
+                %td= failed.job&.queue_name
+                %td
+                  %div
+                    %strong= failed.exception_class
+                  %div.small.text-muted{style: 'max-width: 480px; word-break: break-word;'}
+                    = failed.message
+                %td= format_datetime(failed.created_at)
+
+.card
+  .card-header
+    Recently Finished Jobs
+  .card-body
+    - if @recent_finished_jobs.empty?
+      %p.text-muted.mb-0 No finished jobs.
+    - else
+      .table-responsive
+        %table.table.table-sm.mb-0
+          %thead
+            %tr
+              %th Job
+              %th Queue
+              %th Finished at
+          %tbody
+            - @recent_finished_jobs.each do |job|
+              %tr
+                %td= job.class_name
+                %td= job.queue_name
+                %td= format_datetime(job.finished_at)

--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -33,6 +33,8 @@
           = link_to('Product Catalog', products_path, :class => 'dropdown-item')
         %li
           = link_to('Sales Tax', sales_tax_rates_path, :class => 'dropdown-item')
+        %li
+          = link_to('Background Jobs', jobs_status_path, :class => 'dropdown-item')
 
 -#  - if user_signed_in?
 -#    %li

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,9 @@ module Abt
 
     config.action_mailer.delivery_method = :mailgun
     config.action_mailer.mailgun_settings = Rails.application.credentials.mailgun
+
+    # Route Solid Queue's ActiveRecord models to the dedicated queue database
+    # in all environments so the jobs status page can read them.
+    config.solid_queue.connects_to = { database: { writing: :queue } }
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,6 +58,10 @@ Rails.application.configure do
   # Highlight code that enqueued background job in logs.
   config.active_job.verbose_enqueue_logs = true
 
+  # Use Solid Queue (database-backed) in development so bin/jobs can process
+  # enqueued work locally and the Background Jobs status page is meaningful.
+  config.active_job.queue_adapter = :solid_queue
+
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -62,7 +62,6 @@ Rails.application.configure do
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
   config.active_job.queue_adapter = :solid_queue
-  config.solid_queue.connects_to = { database: { writing: :queue } }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,5 +43,7 @@ Rails.application.routes.draw do
   resources :sales_tax_product_classes
   resources :sales_tax_rates
 
+  resource :jobs_status, only: [:show], controller: 'jobs_status'
+
   root to: "home#index"
 end

--- a/test/controllers/jobs_status_controller_test.rb
+++ b/test/controllers/jobs_status_controller_test.rb
@@ -1,0 +1,76 @@
+require "test_helper"
+
+class JobsStatusControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    SolidQueue::FailedExecution.delete_all
+    SolidQueue::ReadyExecution.delete_all
+    SolidQueue::ScheduledExecution.delete_all
+    SolidQueue::ClaimedExecution.delete_all
+    SolidQueue::BlockedExecution.delete_all
+    SolidQueue::RecurringExecution.delete_all
+    SolidQueue::Job.delete_all
+    SolidQueue::RecurringTask.delete_all
+    SolidQueue::Process.delete_all
+  end
+
+  test "renders an empty status page" do
+    get jobs_status_path
+    assert_response :success
+    assert_select 'h1', text: 'Background Jobs'
+    assert_select '.card-header', text: 'Worker Processes'
+    assert_select '.card-header', text: 'Recurring Tasks'
+    assert_select '.card-header', text: 'Recently Failed Jobs'
+    assert_select '.card-header', text: 'Recently Finished Jobs'
+    assert_select 'p.text-danger', text: /No worker processes registered/
+  end
+
+  test "renders worker process rows with alive and stale badges" do
+    SolidQueue::Process.create!(
+      kind: 'Worker', name: 'worker-fresh', hostname: 'h1', pid: 1,
+      last_heartbeat_at: 10.seconds.ago
+    )
+    SolidQueue::Process.create!(
+      kind: 'Worker', name: 'worker-stale', hostname: 'h2', pid: 2,
+      last_heartbeat_at: 5.minutes.ago
+    )
+
+    get jobs_status_path
+    assert_response :success
+    assert_select 'td', text: 'worker-fresh'
+    assert_select 'td', text: 'worker-stale'
+    assert_select '.badge.bg-success', text: 'Alive'
+    assert_select '.badge.bg-danger', text: 'Stale'
+  end
+
+  test "shows recurring tasks with class and command entries" do
+    SolidQueue::RecurringTask.create!(
+      key: 'my_class_task', schedule: '0 8 */2 * *',
+      class_name: 'OverdueInvoicesReportJob', queue_name: 'default', static: true
+    )
+    SolidQueue::RecurringTask.create!(
+      key: 'my_command_task', schedule: 'every hour',
+      command: 'SolidQueue::Job.clear_finished_in_batches', static: true
+    )
+
+    get jobs_status_path
+    assert_response :success
+    assert_select 'code', text: 'my_class_task'
+    assert_select 'code', text: 'my_command_task'
+    assert_select 'td', text: 'OverdueInvoicesReportJob'
+    assert_select 'code', text: 'SolidQueue::Job.clear_finished_in_batches'
+  end
+
+  test "lists recently failed jobs with error class and message" do
+    job = SolidQueue::Job.create!(class_name: 'BoomJob', queue_name: 'default', arguments: '[]')
+    SolidQueue::FailedExecution.create!(
+      job: job,
+      error: { exception_class: 'RuntimeError', message: 'kaboom', backtrace: [] }
+    )
+
+    get jobs_status_path
+    assert_response :success
+    assert_select 'td', text: 'BoomJob'
+    assert_select 'strong', text: 'RuntimeError'
+    assert_select 'div.small.text-muted', text: /kaboom/
+  end
+end


### PR DESCRIPTION
Adds a new dashboard page for monitoring Solid Queue background jobs, worker processes, and recurring tasks.

## Changes

- **New controller**: `JobsStatusController` displays queue statistics, worker process health, recurring tasks, and recent job history
- **New view**: `jobs_status/show.html.haml` renders job counts in cards, worker process table with heartbeat monitoring, recurring tasks schedule, and failed/finished job logs
- **New route**: `resource :jobs_status, only: [:show]` mounted at `/jobs_status`
- **Navigation**: Added "Background Jobs" link to admin dropdown menu
- **Configuration**: 
  - Moved `solid_queue.connects_to` configuration from production-only to `application.rb` so the queue database is accessible in all environments
  - Enabled Solid Queue as the Active Job adapter in development for meaningful status page data
  - Removed duplicate `solid_queue.connects_to` from production config

## Implementation Details

- Worker processes display with "Alive" (green) or "Stale" (red) badges based on heartbeat freshness (1 minute threshold)
- Queue statistics show counts for ready, scheduled, in-progress, blocked, failed, and finished jobs
- Failed jobs display exception class and message with word-wrapping for readability
- Recurring tasks show schedule, class/command, queue, and next run time
- Warning alert displays when queue adapter is not Solid Queue, indicating data may be incomplete
- Tests verify empty state rendering, worker process status badges, recurring task display, and failed job details

https://claude.ai/code/session_016KqhNCCrDqwe8QTFLCB48o