### PR TITLE
Group Configuration menu with dividers

### DIFF
--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -30,9 +30,13 @@
         %li
           = link_to('Issuer Company', issuer_company_path, :class => 'dropdown-item')
         %li
+          %hr.dropdown-divider
+        %li
           = link_to('Product Catalog', products_path, :class => 'dropdown-item')
         %li
           = link_to('Sales Tax', sales_tax_rates_path, :class => 'dropdown-item')
+        %li
+          %hr.dropdown-divider
         %li
           = link_to('Background Jobs', jobs_status_path, :class => 'dropdown-item')
 


### PR DESCRIPTION
## Summary
- Split the Configuration dropdown into three sections separated by `dropdown-divider`s:
  - Issuer Company
  - Product Catalog, Sales Tax
  - Background Jobs

## Test plan
- [ ] Open the Configuration dropdown in the navbar and confirm two horizontal dividers separate the three groups.

https://claude.ai/code/session_016KqhNCCrDqwe8QTFLCB48o

---
_Generated by [Claude Code](https://claude.ai/code/session_016KqhNCCrDqwe8QTFLCB48o)_