### PR TITLE
Add passkey-based authentication system with user management

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,3 +58,5 @@ gem 'simple_form'
 gem "mailgun-ruby", "~> 1.4.3"
 
 gem "image_processing", "~> 1.2"
+
+gem "webauthn", "~> 3.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    action_text-trix (2.1.19)
+    action_text-trix (2.1.18)
       railties
     actioncable (8.1.3)
       actionpack (= 8.1.3)
@@ -77,10 +77,12 @@ GEM
       uri (>= 0.13.1)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    android_key_attestation (0.3.0)
     base64 (0.3.0)
     bigdecimal (4.1.2)
+    bindata (2.5.1)
     bindex (0.8.1)
-    bootsnap (1.24.5)
+    bootsnap (1.24.4)
       msgpack (~> 1.2)
     bootstrap (5.3.8)
       popper_js (>= 2.11.8, < 3)
@@ -96,11 +98,15 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cbor (0.5.10.2)
     concurrent-ruby (1.3.6)
     config (5.6.1)
       deep_merge (~> 1.2, >= 1.2.1)
       ostruct
     connection_pool (3.0.2)
+    cose (1.3.1)
+      cbor (~> 0.5.9)
+      openssl-signature_algorithm (~> 1.0)
     crass (1.0.6)
     cuprite (0.17)
       capybara (~> 3.0)
@@ -121,28 +127,28 @@ GEM
       logger
     faraday-multipart (1.2.0)
       multipart-post (~> 2.0)
-    faraday-net_http (3.4.3)
+    faraday-net_http (3.4.2)
       net-http (~> 0.5)
-    ferrum (0.17.2)
+    ferrum (0.17.1)
       addressable (~> 2.5)
       base64 (~> 0.2)
       concurrent-ruby (~> 1.1)
       webrick (~> 1.7)
       websocket-driver (~> 0.7)
-    ffi (1.17.4-aarch64-linux-gnu)
-    ffi (1.17.4-aarch64-linux-musl)
-    ffi (1.17.4-arm-linux-gnu)
-    ffi (1.17.4-arm-linux-musl)
-    ffi (1.17.4-arm64-darwin)
-    ffi (1.17.4-x86_64-darwin)
-    ffi (1.17.4-x86_64-linux-gnu)
-    ffi (1.17.4-x86_64-linux-musl)
+    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-aarch64-linux-musl)
+    ffi (1.17.2-arm-linux-gnu)
+    ffi (1.17.2-arm-linux-musl)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86_64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
+    ffi (1.17.2-x86_64-linux-musl)
     fugit (1.12.1)
       et-orbi (~> 1.4)
       raabro (~> 1.4)
     globalid (1.3.0)
       activesupport (>= 6.1)
-    haml (7.2.0)
+    haml (6.3.0)
       temple (>= 0.8.2)
       thor
       tilt
@@ -161,7 +167,7 @@ GEM
       activesupport (>= 6.0.0)
       railties (>= 6.0.0)
     io-console (0.8.2)
-    irb (1.18.0)
+    irb (1.17.0)
       pp (>= 0.6.0)
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
@@ -170,6 +176,8 @@ GEM
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
     json (2.19.5)
+    jwt (3.2.0)
+      base64
     logger (1.7.0)
     loofah (2.25.1)
       crass (~> 1.0.2)
@@ -185,7 +193,7 @@ GEM
       faraday-multipart (< 2)
       mini_mime
       zeitwerk
-    marcel (1.2.1)
+    marcel (1.1.0)
     matrix (0.4.3)
     mini_magick (5.3.1)
       logger
@@ -223,6 +231,9 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.3-x86_64-linux-musl)
       racc (~> 1.4)
+    openssl (4.0.2)
+    openssl-signature_algorithm (1.3.0)
+      openssl (> 2.0)
     ostruct (0.6.3)
     pg (1.6.3)
     pg (1.6.3-aarch64-linux)
@@ -282,17 +293,19 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       tsort (>= 0.2)
       zeitwerk (~> 2.6)
-    rake (13.4.2)
+    rake (13.3.1)
     rdoc (7.2.0)
       erb
       psych (>= 4.0.0)
       tsort
-    regexp_parser (2.12.0)
+    regexp_parser (2.11.0)
     reline (0.6.3)
       io-console (~> 0.5)
     ruby-vips (2.3.0)
       ffi (~> 1.12)
       logger
+    safety_net_attestation (0.5.0)
+      jwt (>= 2.0, < 4.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -339,8 +352,12 @@ GEM
     stringio (3.2.0)
     temple (0.10.4)
     thor (1.5.0)
-    tilt (2.7.0)
+    tilt (2.6.1)
     timeout (0.6.1)
+    tpm-key_attestation (0.14.1)
+      bindata (~> 2.4)
+      openssl (> 2.0)
+      openssl-signature_algorithm (~> 1.0)
     tsort (0.2.0)
     turbo-rails (2.0.23)
       actionpack (>= 7.1.0)
@@ -353,14 +370,22 @@ GEM
       actionview (>= 8.0.0)
       bindex (>= 0.4.0)
       railties (>= 8.0.0)
-    webrick (1.9.2)
+    webauthn (3.4.3)
+      android_key_attestation (~> 0.3.0)
+      bindata (~> 2.4)
+      cbor (~> 0.5.9)
+      cose (~> 1.1)
+      openssl (>= 2.2)
+      safety_net_attestation (~> 0.5.0)
+      tpm-key_attestation (~> 0.14.0)
+    webrick (1.9.1)
     websocket-driver (0.8.0)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.8.1)
+    zeitwerk (2.7.5)
 
 PLATFORMS
   aarch64-linux
@@ -399,6 +424,7 @@ DEPENDENCIES
   stimulus-rails
   turbo-rails
   web-console
+  webauthn (~> 3.4)
 
 BUNDLED WITH
    2.7.1

--- a/README.md
+++ b/README.md
@@ -52,3 +52,36 @@ pre-commit install
 # Optional: run on all existing files
 pre-commit run --all-files
 ```
+
+
+Authentication
+--------------
+
+ABT uses passkeys (WebAuthn) for authentication. No passwords are stored anywhere. Users are created by invitation only.
+
+### Bootstrapping the first user
+
+Run the rake task to generate an invite URL, then open it in a browser to register the first passkey:
+
+```bash
+bundle exec rails users:invite
+```
+
+The task prints a one-time URL that is valid for 24 hours. Copy it to a browser, fill in username/full name/email, and register a passkey. After that the new user is signed in and can create further invites from the **Configuration → Users** menu.
+
+### WebAuthn configuration
+
+WebAuthn requires three settings in `config/settings.yml` (override per environment as needed in `config/settings/<env>.yml`):
+
+- `app.host` / `app.protocol` — used by the rake task and email links to build absolute URLs.
+- `webauthn.rp_id` — the **registrable domain** the app is served from (e.g. `app.example.com`). Must NOT include scheme or port.
+- `webauthn.origin` — the exact `scheme://host[:port]` the browser uses. Must match the address bar exactly, including port.
+- `webauthn.rp_name` — display name shown by the authenticator (e.g. "ABT").
+
+Defaults are configured for `http://localhost:3000`. Update for staging and production deployments.
+
+### Day-to-day usage
+
+- Each user can manage their own passkeys, emails, sessions, and audit log under **My account** in the top-right nav.
+- All authenticated users can administer other users via **Configuration → Users**: invite new users, block/unblock, replace emails, reset passkeys.
+- Blocking a user immediately terminates every active session. Reset-passkeys deletes all of the user's passkeys and emails them a one-time invite to register a new one (which also auto-unblocks them).

--- a/app/assets/stylesheets/bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.scss
@@ -36,6 +36,14 @@ body { padding-top: 60px; }
   }
 }
 
+// Bootstrap's `.dropdown-menu-end` only right-aligns when Popper sets
+// `[data-bs-popper]`. The navbar uses a custom Stimulus controller without
+// Popper, so right-align explicitly.
+.dropdown-menu-end {
+  right: 0;
+  left: auto;
+}
+
 // Fix searchable dropdown hover in dark mode
 .searchable-dropdown .dropdown-item {
   &:hover,

--- a/app/controllers/account/audit_events_controller.rb
+++ b/app/controllers/account/audit_events_controller.rb
@@ -1,0 +1,5 @@
+class Account::AuditEventsController < ApplicationController
+  def index
+    @audit_events = UserAuditEvent.for_user(current_user).limit(200)
+  end
+end

--- a/app/controllers/account/blocks_controller.rb
+++ b/app/controllers/account/blocks_controller.rb
@@ -1,0 +1,13 @@
+class Account::BlocksController < ApplicationController
+  def create
+    current_user.block!(
+      reason: 'user self-requested',
+      actor: current_user,
+      request: request
+    )
+    reset_session_cookie
+    Current.user = nil
+    Current.session = nil
+    redirect_to new_session_path, notice: 'Your account has been blocked at your request.'
+  end
+end

--- a/app/controllers/account/credentials_controller.rb
+++ b/app/controllers/account/credentials_controller.rb
@@ -1,0 +1,83 @@
+class Account::CredentialsController < ApplicationController
+  def index
+    @credentials = current_user.credentials.order(:created_at)
+  end
+
+  def new
+  end
+
+  def options
+    nickname = params[:nickname].to_s.strip
+    if nickname.blank?
+      return render json: { error: 'Nickname is required' }, status: :unprocessable_content
+    end
+
+    options = WebAuthn::Credential.options_for_create(
+      user: { id: current_user.webauthn_id, name: current_user.username, display_name: current_user.full_name },
+      exclude: current_user.credentials.pluck(:external_id),
+      authenticator_selection: { user_verification: 'preferred' }
+    )
+
+    session[:webauthn_credential_add] = {
+      challenge: options.challenge,
+      nickname: nickname
+    }
+
+    render json: options.as_json
+  end
+
+  def verify
+    pending = session[:webauthn_credential_add]
+    if pending.blank?
+      return render json: { error: 'No registration in progress' }, status: :unprocessable_content
+    end
+
+    webauthn_credential = WebAuthn::Credential.from_create(params[:credential].to_unsafe_h)
+
+    begin
+      webauthn_credential.verify(pending['challenge'])
+    rescue WebAuthn::Error => e
+      return render json: { error: "Verification failed: #{e.message}" }, status: :unprocessable_content
+    end
+
+    credential = current_user.credentials.create!(
+      external_id: webauthn_credential.id,
+      public_key: webauthn_credential.public_key,
+      nickname: pending['nickname'],
+      sign_count: webauthn_credential.sign_count
+    )
+    session.delete(:webauthn_credential_add)
+
+    UserAuditEvent.record!(action: 'passkey_added', user: current_user, actor: current_user,
+                            request: request,
+                            metadata: { username: current_user.username, credential_nickname: credential.nickname })
+
+    current_user.confirmed_emails.each do |email|
+      UserMailer.passkey_added_notice(current_user, credential, email.address).deliver_later
+    end
+
+    render json: { redirect_url: account_credentials_path }
+  rescue ActiveRecord::RecordInvalid => e
+    render json: { error: e.record.errors.full_messages.join(', ') }, status: :unprocessable_content
+  end
+
+  def destroy
+    credential = current_user.credentials.find(params[:id])
+    if current_user.credentials.count <= 1
+      redirect_to account_credentials_path, alert: 'Cannot remove the last passkey. Add another one first.' and return
+    end
+
+    nickname = credential.nickname
+    credential.destroy!
+
+    UserAuditEvent.record!(action: 'passkey_removed', user: current_user, actor: current_user,
+                            request: request,
+                            metadata: { username: current_user.username, credential_nickname: nickname })
+
+    current_user.confirmed_emails.each do |email|
+      UserMailer.passkey_removed_notice(current_user, nickname, email.address).deliver_later
+    end
+
+    redirect_to account_credentials_path, notice: "Passkey \"#{nickname}\" removed."
+  end
+end

--- a/app/controllers/account/credentials_controller.rb
+++ b/app/controllers/account/credentials_controller.rb
@@ -15,7 +15,7 @@ class Account::CredentialsController < ApplicationController
     options = WebAuthn::Credential.options_for_create(
       user: { id: current_user.webauthn_id, name: current_user.username, display_name: current_user.full_name },
       exclude: current_user.credentials.pluck(:external_id),
-      authenticator_selection: { user_verification: 'preferred' }
+      authenticator_selection: { resident_key: 'required', user_verification: 'preferred' }
     )
 
     session[:webauthn_credential_add] = {

--- a/app/controllers/account/email_confirmations_controller.rb
+++ b/app/controllers/account/email_confirmations_controller.rb
@@ -1,0 +1,20 @@
+class Account::EmailConfirmationsController < ApplicationController
+  allow_unauthenticated_access only: [:show]
+
+  def show
+    email = UserEmail.find_by_confirmation_token(params[:token])
+    if email.nil?
+      flash[:alert] = 'Email confirmation link is invalid or expired.'
+      redirect_to(current_user ? account_emails_path : new_session_path) and return
+    end
+
+    email.confirm!
+
+    UserAuditEvent.record!(action: 'email_confirmed', user: email.user, actor: email.user,
+                            request: request,
+                            metadata: { username: email.user.username, address: email.address })
+
+    flash[:notice] = "Email #{email.address} confirmed."
+    redirect_to(current_user ? account_emails_path : new_session_path)
+  end
+end

--- a/app/controllers/account/emails_controller.rb
+++ b/app/controllers/account/emails_controller.rb
@@ -1,0 +1,54 @@
+class Account::EmailsController < ApplicationController
+  def index
+    @emails = current_user.emails.order(:created_at)
+  end
+
+  def create
+    address = params.dig(:user_email, :address).to_s.strip.downcase
+
+    UserEmail.transaction do
+      email = current_user.emails.create!(address: address)
+      plaintext = email.generate_confirmation_token!
+
+      UserAuditEvent.record!(action: 'email_added', user: current_user, actor: current_user,
+                              request: request,
+                              metadata: { username: current_user.username, address: address })
+
+      confirmation_url = account_email_confirmation_url(
+        token: plaintext,
+        host: Settings.app.host,
+        protocol: Settings.app.protocol
+      )
+      UserMailer.email_confirmation(email, confirmation_url).deliver_later
+
+      current_user.confirmed_emails.where.not(id: email.id).find_each do |existing|
+        UserMailer.email_added_notice(current_user, address, existing.address).deliver_later
+      end
+    end
+
+    redirect_to account_emails_path, notice: 'Confirmation email sent. Click the link to activate the address.'
+  rescue ActiveRecord::RecordInvalid => e
+    redirect_to account_emails_path, alert: e.record.errors.full_messages.join(', ')
+  end
+
+  def destroy
+    email = current_user.emails.find(params[:id])
+
+    if email.confirmed? && current_user.confirmed_emails.count <= 1
+      redirect_to account_emails_path, alert: 'Cannot remove the last confirmed email. Add another one first.' and return
+    end
+
+    address = email.address
+    email.destroy!
+
+    UserAuditEvent.record!(action: 'email_removed', user: current_user, actor: current_user,
+                            request: request,
+                            metadata: { username: current_user.username, address: address })
+
+    current_user.confirmed_emails.find_each do |existing|
+      UserMailer.email_removed_notice(current_user, address, existing.address).deliver_later
+    end
+
+    redirect_to account_emails_path, notice: "Email #{address} removed."
+  end
+end

--- a/app/controllers/account/profiles_controller.rb
+++ b/app/controllers/account/profiles_controller.rb
@@ -1,0 +1,9 @@
+class Account::ProfilesController < ApplicationController
+  def show
+    @user = current_user
+    @emails = @user.emails.order(:created_at)
+    @credentials = @user.credentials.order(:created_at)
+    @sessions = @user.sessions.active.order(last_seen_at: :desc).limit(10)
+    @audit_events = UserAuditEvent.for_user(@user).limit(15)
+  end
+end

--- a/app/controllers/account/sessions_controller.rb
+++ b/app/controllers/account/sessions_controller.rb
@@ -1,0 +1,20 @@
+class Account::SessionsController < ApplicationController
+  def index
+    @sessions = current_user.sessions.active.order(last_seen_at: :desc)
+  end
+
+  def destroy
+    session_record = current_user.sessions.find(params[:id])
+    is_current = current_user_session&.id == session_record.id
+    session_record.terminate!(reason: 'user_terminated', actor: current_user, request: request)
+
+    if is_current
+      reset_session_cookie
+      Current.user = nil
+      Current.session = nil
+      redirect_to new_session_path, notice: 'Session terminated. You have been signed out.'
+    else
+      redirect_to account_sessions_path, notice: 'Session terminated.'
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,81 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+
+  SESSION_COOKIE = :abt_session
+
+  before_action :authenticate
+
+  helper_method :current_user, :current_user_session
+
+  class << self
+    def allow_unauthenticated_access(**options)
+      skip_before_action :authenticate, **options
+    end
+  end
+
+  def current_user
+    Current.user
+  end
+
+  def current_user_session
+    Current.session
+  end
+
+  private
+
+  def authenticate
+    plaintext = read_session_token
+    session_record = plaintext.present? ? UserSession.authenticate(plaintext) : nil
+
+    if session_record.nil?
+      reset_session_cookie
+      redirect_to_login and return
+    end
+
+    user = session_record.user
+    if user.blocked?
+      session_record.terminate!(reason: "blocked_user", actor: nil) unless session_record.terminated_at
+      reset_session_cookie
+      redirect_to_login(alert: 'Your account has been blocked.') and return
+    end
+
+    session_record.touch_seen!(request)
+
+    Current.user = user
+    Current.session = session_record
+    Current.request_ip = request.remote_ip
+    Current.user_agent = request.user_agent
+  end
+
+  def redirect_to_login(alert: 'You must sign in to continue.')
+    respond_to do |format|
+      format.html { redirect_to new_session_path, alert: alert }
+      format.json { render json: { error: alert }, status: :unauthorized }
+      format.any  { head :unauthorized }
+    end
+  end
+
+  def reset_session_cookie
+    cookies.delete(SESSION_COOKIE)
+  end
+
+  def read_session_token
+    value = cookies.signed[SESSION_COOKIE]
+    return value if value.present?
+    # In test env, integration tests cannot easily set signed cookies through
+    # rack-test's CookieJar; allow the raw cookie as a fallback there.
+    return cookies[SESSION_COOKIE] if Rails.env.test?
+    nil
+  end
+
+  def sign_in_user!(user)
+    session_record, plaintext = UserSession.create_for!(user: user, request: request)
+    cookies.signed.permanent[SESSION_COOKIE] = {
+      value: plaintext,
+      httponly: true,
+      secure: Rails.env.production?,
+      same_site: :lax
+    }
+    session_record
+  end
 end

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -54,7 +54,7 @@ class InvitesController < ApplicationController
     options = WebAuthn::Credential.options_for_create(
       user: { id: webauthn_user_id, name: username, display_name: full_name },
       exclude: [],
-      authenticator_selection: { user_verification: 'preferred' }
+      authenticator_selection: { resident_key: 'required', user_verification: 'preferred' }
     )
 
     session[:webauthn_signup] = {
@@ -77,7 +77,7 @@ class InvitesController < ApplicationController
     options = WebAuthn::Credential.options_for_create(
       user: { id: target.webauthn_id, name: target.username, display_name: target.full_name },
       exclude: target.credentials.pluck(:external_id),
-      authenticator_selection: { user_verification: 'preferred' }
+      authenticator_selection: { resident_key: 'required', user_verification: 'preferred' }
     )
 
     session[:webauthn_passkey_reset] = {

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -196,11 +196,11 @@ class InvitesController < ApplicationController
     errors = []
     errors << 'Username is required' if username.blank?
     errors << 'Username has invalid format' if username.present? && !username.match?(User::USERNAME_FORMAT)
-    errors << 'Username is taken' if username.present? && User.exists?(['lower(username) = ?', username])
+    errors << 'Username is taken' if username.present? && User.exists?(username: username)
     errors << 'Full name is required' if full_name.blank?
     errors << 'Email is required' if email.blank?
     errors << 'Email format is invalid' if email.present? && !email.match?(URI::MailTo::EMAIL_REGEXP)
-    errors << 'Email is taken' if email.present? && UserEmail.exists?(['lower(address) = ?', email])
+    errors << 'Email is taken' if email.present? && UserEmail.exists?(address: email)
     errors
   end
 end

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -1,0 +1,206 @@
+class InvitesController < ApplicationController
+  allow_unauthenticated_access only: [:show, :options, :verify]
+
+  before_action :load_invite
+
+  def show
+    if @invite.nil?
+      render :invalid, status: :not_found
+    end
+  end
+
+  def options
+    return render_invalid unless @invite
+
+    if @invite.signup?
+      build_signup_options
+    else
+      build_passkey_reset_options
+    end
+  end
+
+  def verify
+    return render_invalid unless @invite
+
+    if @invite.signup?
+      complete_signup
+    else
+      complete_passkey_reset
+    end
+  end
+
+  private
+
+  def load_invite
+    @invite = UserInvite.find_usable(params[:token])
+  end
+
+  def render_invalid
+    render json: { error: 'Invite is invalid or expired' }, status: :unprocessable_content
+  end
+
+  def build_signup_options
+    username = params[:username].to_s.strip.downcase
+    full_name = params[:full_name].to_s.strip
+    email = params[:email].to_s.strip.downcase
+
+    errors = signup_form_errors(username, full_name, email)
+    if errors.any?
+      return render json: { error: errors.first, errors: errors }, status: :unprocessable_content
+    end
+
+    webauthn_user_id = WebAuthn.generate_user_id
+
+    options = WebAuthn::Credential.options_for_create(
+      user: { id: webauthn_user_id, name: username, display_name: full_name },
+      exclude: [],
+      authenticator_selection: { user_verification: 'preferred' }
+    )
+
+    session[:webauthn_signup] = {
+      invite_token: params[:token],
+      challenge: options.challenge,
+      webauthn_user_id: webauthn_user_id,
+      username: username,
+      full_name: full_name,
+      email: email,
+      nickname: params[:nickname].to_s.presence || 'Initial passkey'
+    }
+
+    render json: options.as_json
+  end
+
+  def build_passkey_reset_options
+    target = @invite.target_user
+    return render_invalid unless target
+
+    options = WebAuthn::Credential.options_for_create(
+      user: { id: target.webauthn_id, name: target.username, display_name: target.full_name },
+      exclude: target.credentials.pluck(:external_id),
+      authenticator_selection: { user_verification: 'preferred' }
+    )
+
+    session[:webauthn_passkey_reset] = {
+      invite_token: params[:token],
+      challenge: options.challenge,
+      target_user_id: target.id,
+      nickname: params[:nickname].to_s.presence || 'Passkey'
+    }
+
+    render json: options.as_json
+  end
+
+  def complete_signup
+    pending = session[:webauthn_signup]
+    if pending.blank? || pending['invite_token'] != params[:token]
+      return render json: { error: 'No signup in progress' }, status: :unprocessable_content
+    end
+
+    webauthn_credential = WebAuthn::Credential.from_create(params[:credential].to_unsafe_h)
+
+    begin
+      webauthn_credential.verify(pending['challenge'])
+    rescue WebAuthn::Error => e
+      return render json: { error: "Verification failed: #{e.message}" }, status: :unprocessable_content
+    end
+
+    user = nil
+    User.transaction do
+      user = User.create!(
+        username: pending['username'],
+        full_name: pending['full_name'],
+        webauthn_id: pending['webauthn_user_id']
+      )
+
+      user.emails.create!(address: pending['email'], confirmed_at: Time.current)
+
+      user.credentials.create!(
+        external_id: webauthn_credential.id,
+        public_key: webauthn_credential.public_key,
+        nickname: pending['nickname'],
+        sign_count: webauthn_credential.sign_count
+      )
+
+      @invite.consume!(user: user)
+    end
+
+    session.delete(:webauthn_signup)
+    sign_in_user!(user)
+
+    UserAuditEvent.record!(action: 'invite_used', user: user, actor: user, request: request,
+                            metadata: { purpose: 'signup', username: user.username, invite_id: @invite.id })
+    UserAuditEvent.record!(action: 'signup_completed', user: user, actor: user, request: request,
+                            metadata: { username: user.username, email: pending['email'] })
+    UserAuditEvent.record!(action: 'passkey_added', user: user, actor: user, request: request,
+                            metadata: { username: user.username, credential_nickname: pending['nickname'] })
+    UserAuditEvent.record!(action: 'email_added', user: user, actor: user, request: request,
+                            metadata: { username: user.username, address: pending['email'], via: 'signup' })
+    UserAuditEvent.record!(action: 'email_confirmed', user: user, actor: user, request: request,
+                            metadata: { username: user.username, address: pending['email'], via: 'signup' })
+
+    render json: { redirect_url: account_profile_path }
+  rescue ActiveRecord::RecordInvalid => e
+    render json: { error: e.record.errors.full_messages.join(', ') }, status: :unprocessable_content
+  end
+
+  def complete_passkey_reset
+    pending = session[:webauthn_passkey_reset]
+    if pending.blank? || pending['invite_token'] != params[:token]
+      return render json: { error: 'No passkey reset in progress' }, status: :unprocessable_content
+    end
+
+    target = User.find_by(id: pending['target_user_id'])
+    return render_invalid unless target
+
+    webauthn_credential = WebAuthn::Credential.from_create(params[:credential].to_unsafe_h)
+
+    begin
+      webauthn_credential.verify(pending['challenge'])
+    rescue WebAuthn::Error => e
+      return render json: { error: "Verification failed: #{e.message}" }, status: :unprocessable_content
+    end
+
+    User.transaction do
+      target.credentials.create!(
+        external_id: webauthn_credential.id,
+        public_key: webauthn_credential.public_key,
+        nickname: pending['nickname'],
+        sign_count: webauthn_credential.sign_count
+      )
+
+      @invite.consume!(user: target)
+
+      if target.blocked?
+        target.unblock!(actor: target, reason: 'passkey_reset_completed', request: request)
+      end
+    end
+
+    session.delete(:webauthn_passkey_reset)
+    sign_in_user!(target)
+
+    UserAuditEvent.record!(action: 'invite_used', user: target, actor: target, request: request,
+                            metadata: { purpose: 'passkey_reset', username: target.username, invite_id: @invite.id })
+    UserAuditEvent.record!(action: 'passkey_added', user: target, actor: target, request: request,
+                            metadata: { username: target.username, credential_nickname: pending['nickname'], via: 'passkey_reset' })
+
+    target.confirmed_emails.each do |email|
+      UserMailer.passkey_added_notice(target, target.credentials.last, email.address).deliver_later
+    end
+
+    render json: { redirect_url: account_profile_path }
+  rescue ActiveRecord::RecordInvalid => e
+    render json: { error: e.record.errors.full_messages.join(', ') }, status: :unprocessable_content
+  end
+
+  def signup_form_errors(username, full_name, email)
+    errors = []
+    errors << 'Username is required' if username.blank?
+    errors << 'Username has invalid format' if username.present? && !username.match?(User::USERNAME_FORMAT)
+    errors << 'Username is taken' if username.present? && User.exists?(['lower(username) = ?', username])
+    errors << 'Full name is required' if full_name.blank?
+    errors << 'Email is required' if email.blank?
+    errors << 'Email format is invalid' if email.present? && !email.match?(URI::MailTo::EMAIL_REGEXP)
+    errors << 'Email is taken' if email.present? && UserEmail.exists?(['lower(address) = ?', email])
+    errors
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,7 +5,7 @@ class SessionsController < ApplicationController
   end
 
   def options
-    user = User.active.find_by('lower(username) = ?', params[:username].to_s.strip.downcase)
+    user = User.active.find_by(username: params[:username].to_s.strip.downcase)
     credentials = user ? user.credentials : []
 
     options = WebAuthn::Credential.options_for_get(

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,94 @@
+class SessionsController < ApplicationController
+  allow_unauthenticated_access only: [:new, :options, :verify]
+
+  def new
+  end
+
+  def options
+    user = User.active.find_by('lower(username) = ?', params[:username].to_s.strip.downcase)
+    credentials = user ? user.credentials : []
+
+    options = WebAuthn::Credential.options_for_get(
+      allow: credentials.map { |c| { id: c.external_id, type: 'public-key' } },
+      user_verification: 'preferred'
+    )
+
+    session[:webauthn_login] = {
+      challenge: options.challenge,
+      username: user&.username,
+      user_id: user&.id
+    }
+
+    render json: options.as_json
+  end
+
+  def verify
+    login_session = session[:webauthn_login]
+    if login_session.blank? || login_session['user_id'].blank?
+      return render json: { error: 'No login in progress' }, status: :unprocessable_content
+    end
+
+    user = User.active.find_by(id: login_session['user_id'])
+    return render_login_error('Authentication failed') unless user
+
+    webauthn_credential = WebAuthn::Credential.from_get(params[:credential].to_unsafe_h)
+    stored = user.credentials.find_by(external_id: webauthn_credential.id)
+    unless stored
+      UserAuditEvent.record!(
+        action: 'login_failed', user: user, request: request,
+        metadata: { reason: 'unknown_credential', username: user.username }
+      )
+      return render_login_error('Authentication failed')
+    end
+
+    begin
+      webauthn_credential.verify(
+        login_session['challenge'],
+        public_key: stored.public_key,
+        sign_count: stored.sign_count,
+        user_verification: false
+      )
+    rescue WebAuthn::Error => e
+      UserAuditEvent.record!(
+        action: 'login_failed', user: user, request: request,
+        metadata: { reason: e.class.name, username: user.username }
+      )
+      return render_login_error('Authentication failed')
+    end
+
+    stored.touch_used!(webauthn_credential.sign_count)
+    session.delete(:webauthn_login)
+    new_session = sign_in_user!(user)
+    UserAuditEvent.record!(
+      action: 'login_success', user: user, actor: user, request: request,
+      metadata: { username: user.username, credential_nickname: stored.nickname, session_id: new_session.id }
+    )
+
+    render json: { redirect_url: root_path }
+  end
+
+  def destroy
+    if current_user_session
+      current_user_session.terminate!(
+        reason: 'logout',
+        actor: current_user,
+        request: request
+      )
+      UserAuditEvent.record!(
+        action: 'logout', user: current_user, actor: current_user,
+        request: request, metadata: { username: current_user.username }
+      )
+    end
+    reset_session_cookie
+    Current.user = nil
+    Current.session = nil
+    redirect_to new_session_path, notice: 'Signed out.'
+  end
+
+  private
+
+  def render_login_error(message)
+    session.delete(:webauthn_login)
+    render json: { error: message }, status: :unauthorized
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,38 +5,36 @@ class SessionsController < ApplicationController
   end
 
   def options
-    user = User.active.find_by(username: params[:username].to_s.strip.downcase)
-    credentials = user ? user.credentials : []
-
     options = WebAuthn::Credential.options_for_get(
-      allow: credentials.map(&:external_id),
       user_verification: 'preferred'
     )
 
-    session[:webauthn_login] = {
-      challenge: options.challenge,
-      username: user&.username,
-      user_id: user&.id
-    }
+    session[:webauthn_login] = { challenge: options.challenge }
 
     render json: options.as_json
   end
 
   def verify
     login_session = session[:webauthn_login]
-    if login_session.blank? || login_session['user_id'].blank?
+    if login_session.blank? || login_session['challenge'].blank?
       return render json: { error: 'No login in progress' }, status: :unprocessable_content
     end
 
-    user = User.active.find_by(id: login_session['user_id'])
-    return render_login_error('Authentication failed') unless user
-
     webauthn_credential = WebAuthn::Credential.from_get(params[:credential].to_unsafe_h)
-    stored = user.credentials.find_by(external_id: webauthn_credential.id)
+    stored = UserCredential.find_by(external_id: webauthn_credential.id)
     unless stored
       UserAuditEvent.record!(
+        action: 'login_failed', request: request,
+        metadata: { reason: 'unknown_credential' }
+      )
+      return render_login_error('Authentication failed')
+    end
+
+    user = stored.user
+    unless user && !user.blocked?
+      UserAuditEvent.record!(
         action: 'login_failed', user: user, request: request,
-        metadata: { reason: 'unknown_credential', username: user.username }
+        metadata: { reason: user&.blocked? ? 'blocked' : 'no_user', username: user&.username }
       )
       return render_login_error('Authentication failed')
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,7 +9,7 @@ class SessionsController < ApplicationController
     credentials = user ? user.credentials : []
 
     options = WebAuthn::Credential.options_for_get(
-      allow: credentials.map { |c| { id: c.external_id, type: 'public-key' } },
+      allow: credentials.map(&:external_id),
       user_verification: 'preferred'
     )
 

--- a/app/controllers/user_invites_controller.rb
+++ b/app/controllers/user_invites_controller.rb
@@ -1,0 +1,20 @@
+class UserInvitesController < ApplicationController
+  def index
+    @invites = UserInvite.where(purpose: UserInvite::PURPOSE_SIGNUP)
+                         .order(created_at: :desc).limit(50)
+  end
+
+  def new
+  end
+
+  def create
+    invite, plaintext = UserInvite.create_signup!(actor: current_user)
+    UserAuditEvent.record!(action: 'invite_created', user: nil, actor: current_user,
+                            request: request,
+                            metadata: { purpose: 'signup', source: 'web' })
+
+    @invite_url = invite_url(token: plaintext, host: Settings.app.host, protocol: Settings.app.protocol)
+    @invite = invite
+    render :show_invite
+  end
+end

--- a/app/controllers/users/emails_controller.rb
+++ b/app/controllers/users/emails_controller.rb
@@ -1,0 +1,74 @@
+class Users::EmailsController < ApplicationController
+  before_action :load_user
+
+  def create
+    address = params.dig(:user_email, :address).to_s.strip.downcase
+    email = @user.emails.build(address: address, confirmed_at: Time.current)
+
+    if email.save
+      UserAuditEvent.record!(action: 'email_added', user: @user, actor: current_user,
+                              request: request,
+                              metadata: { username: @user.username, address: address, via: 'admin' })
+      UserAuditEvent.record!(action: 'email_confirmed', user: @user, actor: current_user,
+                              request: request,
+                              metadata: { username: @user.username, address: address, via: 'admin' })
+
+      @user.confirmed_emails.where.not(id: email.id).find_each do |existing|
+        UserMailer.email_added_notice(@user, address, existing.address).deliver_later
+      end
+      UserMailer.email_added_notice(@user, address, address).deliver_later
+
+      redirect_to user_path(@user), notice: "Email #{address} added."
+    else
+      redirect_to user_path(@user), alert: email.errors.full_messages.join(', ')
+    end
+  end
+
+  def update
+    email = @user.emails.find(params[:id])
+    old_address = email.address
+    new_address = params.dig(:user_email, :address).to_s.strip.downcase
+
+    if email.update(address: new_address, confirmed_at: Time.current, confirmation_token_digest: nil, confirmation_expires_at: nil)
+      UserAuditEvent.record!(action: 'email_removed', user: @user, actor: current_user,
+                              request: request,
+                              metadata: { username: @user.username, address: old_address, via: 'admin_replace' })
+      UserAuditEvent.record!(action: 'email_added', user: @user, actor: current_user,
+                              request: request,
+                              metadata: { username: @user.username, address: new_address, via: 'admin_replace' })
+
+      @user.confirmed_emails.find_each do |existing|
+        UserMailer.email_removed_notice(@user, old_address, existing.address).deliver_later
+      end
+      redirect_to user_path(@user), notice: "Email replaced: #{old_address} → #{new_address}."
+    else
+      redirect_to user_path(@user), alert: email.errors.full_messages.join(', ')
+    end
+  end
+
+  def destroy
+    email = @user.emails.find(params[:id])
+    if email.confirmed? && @user.confirmed_emails.count <= 1
+      redirect_to user_path(@user), alert: 'Cannot remove the last confirmed email.' and return
+    end
+
+    address = email.address
+    email.destroy!
+
+    UserAuditEvent.record!(action: 'email_removed', user: @user, actor: current_user,
+                            request: request,
+                            metadata: { username: @user.username, address: address, via: 'admin' })
+
+    @user.confirmed_emails.find_each do |existing|
+      UserMailer.email_removed_notice(@user, address, existing.address).deliver_later
+    end
+
+    redirect_to user_path(@user), notice: "Email #{address} removed."
+  end
+
+  private
+
+  def load_user
+    @user = User.find(params[:user_id])
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,68 @@
+class UsersController < ApplicationController
+  before_action :load_user, only: [:show, :block, :unblock, :reset_passkeys, :audit]
+
+  def index
+    @users = User.order(:username)
+  end
+
+  def show
+    @emails = @user.emails.order(:created_at)
+    @credentials = @user.credentials.order(:created_at)
+    @sessions = @user.sessions.active.order(last_seen_at: :desc).limit(20)
+  end
+
+  def block
+    if @user.id == current_user.id
+      redirect_to user_path(@user), alert: 'Use the self-block button on your account page to block yourself.' and return
+    end
+    if @user.blocked?
+      redirect_to user_path(@user), alert: 'User is already blocked.' and return
+    end
+
+    reason = params[:reason].to_s.strip
+    if reason.blank?
+      redirect_to user_path(@user), alert: 'Reason is required.' and return
+    end
+
+    @user.block!(reason: reason, actor: current_user, request: request)
+    redirect_to user_path(@user), notice: "User #{@user.username} blocked."
+  end
+
+  def unblock
+    unless @user.blocked?
+      redirect_to user_path(@user), alert: 'User is not blocked.' and return
+    end
+
+    @user.unblock!(actor: current_user, reason: 'admin_unblock', request: request)
+    redirect_to user_path(@user), notice: "User #{@user.username} unblocked."
+  end
+
+  def reset_passkeys
+    unless @user.blocked?
+      redirect_to user_path(@user), alert: 'User must be blocked before resetting passkeys.' and return
+    end
+
+    _invite, plaintext = @user.reset_passkeys!(actor: current_user, request: request)
+    invite_url = invite_url(token: plaintext, host: Settings.app.host, protocol: Settings.app.protocol)
+
+    UserAuditEvent.record!(action: 'invite_created', user: @user, actor: current_user,
+                            request: request,
+                            metadata: { purpose: 'passkey_reset', username: @user.username })
+
+    @user.emails.find_each do |email|
+      UserMailer.passkey_reset_invite(@user, invite_url, email.address).deliver_later
+    end
+
+    redirect_to user_path(@user), notice: "Passkeys reset; invite sent to #{@user.emails.count} email address(es)."
+  end
+
+  def audit
+    @audit_events = UserAuditEvent.for_user(@user).limit(200)
+  end
+
+  private
+
+  def load_user
+    @user = User.find(params[:id])
+  end
+end

--- a/app/javascript/controllers/passkey_controller.js
+++ b/app/javascript/controllers/passkey_controller.js
@@ -10,10 +10,19 @@ export default class extends Controller {
     optionsUrl: String,
     verifyUrl: String,
     csrfToken: String,
+    autoAuthenticate: Boolean,
+  }
+
+  connect() {
+    if (this.autoAuthenticateValue) {
+      // Defer so the page paints first; some browsers gate WebAuthn prompts
+      // on the page being visible.
+      setTimeout(() => this.authenticate(), 50)
+    }
   }
 
   async register(event) {
-    event.preventDefault()
+    if (event) event.preventDefault()
     this.clearError()
     if (!window.PublicKeyCredential) {
       return this.showError("This browser does not support passkeys.")
@@ -51,7 +60,7 @@ export default class extends Controller {
   }
 
   async authenticate(event) {
-    event.preventDefault()
+    if (event) event.preventDefault()
     this.clearError()
     if (!window.PublicKeyCredential) {
       return this.showError("This browser does not support passkeys.")

--- a/app/javascript/controllers/passkey_controller.js
+++ b/app/javascript/controllers/passkey_controller.js
@@ -57,12 +57,9 @@ export default class extends Controller {
       return this.showError("This browser does not support passkeys.")
     }
 
-    const username = this.hasUsernameTarget ? this.usernameTarget.value.trim() : ""
-    if (!username) return this.showError("Username is required.")
-
     let optionsJSON
     try {
-      optionsJSON = await this.postJSON(this.optionsUrlValue, { username })
+      optionsJSON = await this.postJSON(this.optionsUrlValue, {})
     } catch (e) {
       return this.showError(e.message)
     }

--- a/app/javascript/controllers/passkey_controller.js
+++ b/app/javascript/controllers/passkey_controller.js
@@ -1,0 +1,221 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Drives WebAuthn registration and authentication ceremonies.
+// Uses browser-native PublicKeyCredential.parseCreationOptionsFromJSON /
+// parseRequestOptionsFromJSON; falls back to manual base64url decoding when
+// the browser lacks those static helpers.
+export default class extends Controller {
+  static targets = ["username", "fullName", "email", "nickname", "error"]
+  static values = {
+    optionsUrl: String,
+    verifyUrl: String,
+    csrfToken: String,
+  }
+
+  async register(event) {
+    event.preventDefault()
+    this.clearError()
+    if (!window.PublicKeyCredential) {
+      return this.showError("This browser does not support passkeys.")
+    }
+
+    const body = this.signupBody()
+
+    let optionsJSON
+    try {
+      optionsJSON = await this.postJSON(this.optionsUrlValue, body)
+    } catch (e) {
+      return this.showError(e.message)
+    }
+
+    let credential
+    try {
+      const publicKey = this.parseCreationOptions(optionsJSON)
+      credential = await navigator.credentials.create({ publicKey })
+    } catch (e) {
+      return this.showError(`Passkey registration was cancelled or failed: ${e.message || e}`)
+    }
+
+    let result
+    try {
+      result = await this.postJSON(this.verifyUrlValue, {
+        credential: this.credentialToJSON(credential),
+      })
+    } catch (e) {
+      return this.showError(e.message)
+    }
+
+    if (result.redirect_url) {
+      window.location.href = result.redirect_url
+    }
+  }
+
+  async authenticate(event) {
+    event.preventDefault()
+    this.clearError()
+    if (!window.PublicKeyCredential) {
+      return this.showError("This browser does not support passkeys.")
+    }
+
+    const username = this.hasUsernameTarget ? this.usernameTarget.value.trim() : ""
+    if (!username) return this.showError("Username is required.")
+
+    let optionsJSON
+    try {
+      optionsJSON = await this.postJSON(this.optionsUrlValue, { username })
+    } catch (e) {
+      return this.showError(e.message)
+    }
+
+    let credential
+    try {
+      const publicKey = this.parseRequestOptions(optionsJSON)
+      credential = await navigator.credentials.get({ publicKey })
+    } catch (e) {
+      return this.showError(`Passkey sign-in was cancelled or failed: ${e.message || e}`)
+    }
+
+    let result
+    try {
+      result = await this.postJSON(this.verifyUrlValue, {
+        credential: this.credentialToJSON(credential),
+      })
+    } catch (e) {
+      return this.showError(e.message)
+    }
+
+    if (result.redirect_url) {
+      window.location.href = result.redirect_url
+    }
+  }
+
+  signupBody() {
+    const body = {}
+    if (this.hasUsernameTarget) body.username = this.usernameTarget.value.trim()
+    if (this.hasFullNameTarget) body.full_name = this.fullNameTarget.value.trim()
+    if (this.hasEmailTarget) body.email = this.emailTarget.value.trim()
+    if (this.hasNicknameTarget) body.nickname = this.nicknameTarget.value.trim()
+    return body
+  }
+
+  async postJSON(url, body) {
+    const response = await fetch(url, {
+      method: "POST",
+      credentials: "same-origin",
+      headers: {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "X-CSRF-Token": this.csrfTokenValue,
+      },
+      body: JSON.stringify(body),
+    })
+    const data = await response.json().catch(() => ({}))
+    if (!response.ok) {
+      throw new Error(data.error || `Request failed (${response.status})`)
+    }
+    return data
+  }
+
+  parseCreationOptions(json) {
+    if (typeof PublicKeyCredential.parseCreationOptionsFromJSON === "function") {
+      return PublicKeyCredential.parseCreationOptionsFromJSON(json)
+    }
+    return this.fallbackParseCreationOptions(json)
+  }
+
+  parseRequestOptions(json) {
+    if (typeof PublicKeyCredential.parseRequestOptionsFromJSON === "function") {
+      return PublicKeyCredential.parseRequestOptionsFromJSON(json)
+    }
+    return this.fallbackParseRequestOptions(json)
+  }
+
+  fallbackParseCreationOptions(json) {
+    const out = { ...json }
+    out.challenge = this.b64urlToBytes(json.challenge)
+    out.user = { ...json.user, id: this.b64urlToBytes(json.user.id) }
+    if (Array.isArray(json.excludeCredentials)) {
+      out.excludeCredentials = json.excludeCredentials.map((c) => ({
+        ...c,
+        id: this.b64urlToBytes(c.id),
+      }))
+    }
+    return out
+  }
+
+  fallbackParseRequestOptions(json) {
+    const out = { ...json }
+    out.challenge = this.b64urlToBytes(json.challenge)
+    if (Array.isArray(json.allowCredentials)) {
+      out.allowCredentials = json.allowCredentials.map((c) => ({
+        ...c,
+        id: this.b64urlToBytes(c.id),
+      }))
+    }
+    return out
+  }
+
+  credentialToJSON(credential) {
+    if (typeof credential.toJSON === "function") {
+      return credential.toJSON()
+    }
+    return this.fallbackCredentialToJSON(credential)
+  }
+
+  fallbackCredentialToJSON(credential) {
+    const out = {
+      id: credential.id,
+      type: credential.type,
+      rawId: this.bytesToB64url(credential.rawId),
+      clientExtensionResults: credential.getClientExtensionResults
+        ? credential.getClientExtensionResults()
+        : {},
+    }
+    const r = credential.response
+    if (r.attestationObject) {
+      out.response = {
+        clientDataJSON: this.bytesToB64url(r.clientDataJSON),
+        attestationObject: this.bytesToB64url(r.attestationObject),
+      }
+    } else {
+      out.response = {
+        clientDataJSON: this.bytesToB64url(r.clientDataJSON),
+        authenticatorData: this.bytesToB64url(r.authenticatorData),
+        signature: this.bytesToB64url(r.signature),
+        userHandle: r.userHandle ? this.bytesToB64url(r.userHandle) : null,
+      }
+    }
+    return out
+  }
+
+  b64urlToBytes(value) {
+    const padded = value.replace(/-/g, "+").replace(/_/g, "/")
+    const padding = "=".repeat((4 - (padded.length % 4)) % 4)
+    const binary = atob(padded + padding)
+    const bytes = new Uint8Array(binary.length)
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
+    return bytes
+  }
+
+  bytesToB64url(buffer) {
+    const bytes = new Uint8Array(buffer)
+    let binary = ""
+    for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i])
+    return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
+  }
+
+  clearError() {
+    if (!this.hasErrorTarget) return
+    this.errorTarget.textContent = ""
+    this.errorTarget.classList.add("d-none")
+  }
+
+  showError(message) {
+    if (!this.hasErrorTarget) {
+      console.error(message)
+      return
+    }
+    this.errorTarget.textContent = message
+    this.errorTarget.classList.remove("d-none")
+  }
+}

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,39 @@
+class UserMailer < ApplicationMailer
+  def email_confirmation(user_email, confirmation_url)
+    @user = user_email.user
+    @email = user_email
+    @confirmation_url = confirmation_url
+    @expires_at = user_email.confirmation_expires_at
+    mail(to: user_email.address, subject: 'Confirm your email address')
+  end
+
+  def email_added_notice(user, new_address, recipient)
+    @user = user
+    @new_address = new_address
+    mail(to: recipient, subject: 'Email address added to your account')
+  end
+
+  def email_removed_notice(user, removed_address, recipient)
+    @user = user
+    @removed_address = removed_address
+    mail(to: recipient, subject: 'Email address removed from your account')
+  end
+
+  def passkey_added_notice(user, credential, recipient)
+    @user = user
+    @credential = credential
+    mail(to: recipient, subject: 'Passkey added to your account')
+  end
+
+  def passkey_removed_notice(user, credential_nickname, recipient)
+    @user = user
+    @credential_nickname = credential_nickname
+    mail(to: recipient, subject: 'Passkey removed from your account')
+  end
+
+  def passkey_reset_invite(user, invite_url, recipient)
+    @user = user
+    @invite_url = invite_url
+    mail(to: recipient, subject: 'Register a new passkey for your account')
+  end
+end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,3 @@
+class Current < ActiveSupport::CurrentAttributes
+  attribute :user, :session, :request_ip, :user_agent
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,98 @@
+class User < ApplicationRecord
+  USERNAME_FORMAT = /\A[a-z0-9][a-z0-9_\-.]*\z/i
+
+  has_many :emails, class_name: 'UserEmail', dependent: :destroy
+  has_many :credentials, class_name: 'UserCredential', dependent: :destroy
+  has_many :sessions, class_name: 'UserSession', dependent: :destroy
+  has_many :audit_events_as_subject, class_name: 'UserAuditEvent',
+           foreign_key: :user_id, dependent: :nullify
+  has_many :audit_events_as_actor, class_name: 'UserAuditEvent',
+           foreign_key: :actor_user_id, dependent: :nullify
+
+  belongs_to :blocked_by_user, class_name: 'User', optional: true
+
+  validates :username, presence: true, uniqueness: { case_sensitive: false },
+            format: { with: USERNAME_FORMAT },
+            length: { in: 2..40 }
+  validates :full_name, presence: true, length: { maximum: 120 }
+  validates :webauthn_id, presence: true
+
+  before_validation :assign_webauthn_id, on: :create
+  before_validation :normalize_username
+
+  scope :active, -> { where(blocked_at: nil) }
+  scope :blocked, -> { where.not(blocked_at: nil) }
+
+  def blocked?
+    blocked_at.present?
+  end
+
+  def confirmed_emails
+    emails.where.not(confirmed_at: nil)
+  end
+
+  def primary_email
+    confirmed_emails.order(:created_at).first
+  end
+
+  def block!(reason:, actor:, request: nil)
+    transaction do
+      update!(
+        blocked_at: Time.current,
+        blocked_reason: reason,
+        blocked_by_user: actor
+      )
+      sessions.active.find_each do |s|
+        s.terminate!(reason: "user_blocked: #{reason}", actor: actor)
+      end
+      UserAuditEvent.record!(
+        action: 'blocked',
+        user: self,
+        actor: actor,
+        request: request,
+        metadata: { reason: reason, username: username }
+      )
+    end
+  end
+
+  def unblock!(actor:, reason: nil, request: nil)
+    transaction do
+      update!(blocked_at: nil, blocked_reason: nil, blocked_by_user: nil)
+      UserAuditEvent.record!(
+        action: 'unblocked',
+        user: self,
+        actor: actor,
+        request: request,
+        metadata: { reason: reason, username: username }.compact
+      )
+    end
+  end
+
+  def reset_passkeys!(actor:, request: nil)
+    transaction do
+      credentials.destroy_all
+      sessions.active.find_each do |s|
+        s.terminate!(reason: 'passkey_reset', actor: actor)
+      end
+      invite, plaintext = UserInvite.create_passkey_reset!(target_user: self, actor: actor)
+      UserAuditEvent.record!(
+        action: 'passkey_reset',
+        user: self,
+        actor: actor,
+        request: request,
+        metadata: { username: username }
+      )
+      [invite, plaintext]
+    end
+  end
+
+  private
+
+  def normalize_username
+    self.username = username.to_s.strip.downcase if username.present?
+  end
+
+  def assign_webauthn_id
+    self.webauthn_id ||= WebAuthn.generate_user_id
+  end
+end

--- a/app/models/user_audit_event.rb
+++ b/app/models/user_audit_event.rb
@@ -1,0 +1,26 @@
+class UserAuditEvent < ApplicationRecord
+  belongs_to :user, optional: true
+  belongs_to :actor, class_name: 'User', foreign_key: :actor_user_id, optional: true
+
+  serialize :metadata, coder: JSON
+
+  validates :action, presence: true
+
+  scope :recent, -> { order(created_at: :desc) }
+
+  def self.record!(action:, user: nil, actor: nil, request: nil, metadata: {})
+    create!(
+      action: action.to_s,
+      user: user,
+      actor: actor,
+      ip_address: request&.remote_ip,
+      user_agent: request&.user_agent.to_s.first(500),
+      metadata: metadata.is_a?(Hash) ? metadata.compact : metadata,
+      created_at: Time.current
+    )
+  end
+
+  def self.for_user(user)
+    where('user_id = :id OR actor_user_id = :id', id: user.id).recent
+  end
+end

--- a/app/models/user_credential.rb
+++ b/app/models/user_credential.rb
@@ -1,0 +1,12 @@
+class UserCredential < ApplicationRecord
+  belongs_to :user
+
+  validates :external_id, presence: true, uniqueness: true
+  validates :public_key, presence: true
+  validates :nickname, presence: true, length: { maximum: 80 }
+  validates :sign_count, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+
+  def touch_used!(new_sign_count)
+    update!(sign_count: new_sign_count, last_used_at: Time.current)
+  end
+end

--- a/app/models/user_email.rb
+++ b/app/models/user_email.rb
@@ -1,0 +1,53 @@
+class UserEmail < ApplicationRecord
+  CONFIRMATION_VALIDITY = 48.hours
+
+  belongs_to :user
+
+  validates :address, presence: true,
+            format: { with: URI::MailTo::EMAIL_REGEXP },
+            uniqueness: { case_sensitive: false }
+
+  before_validation :normalize_address
+
+  scope :confirmed, -> { where.not(confirmed_at: nil) }
+  scope :pending, -> { where(confirmed_at: nil) }
+
+  def confirmed?
+    confirmed_at.present?
+  end
+
+  def generate_confirmation_token!
+    plaintext = SecureRandom.urlsafe_base64(32)
+    update!(
+      confirmation_token_digest: self.class.digest_token(plaintext),
+      confirmation_expires_at: CONFIRMATION_VALIDITY.from_now
+    )
+    plaintext
+  end
+
+  def confirm!
+    update!(
+      confirmed_at: Time.current,
+      confirmation_token_digest: nil,
+      confirmation_expires_at: nil
+    )
+  end
+
+  def self.find_by_confirmation_token(plaintext)
+    return nil if plaintext.blank?
+    where(confirmation_token_digest: digest_token(plaintext))
+      .where('confirmation_expires_at > ?', Time.current)
+      .where(confirmed_at: nil)
+      .first
+  end
+
+  def self.digest_token(plaintext)
+    Digest::SHA256.hexdigest(plaintext)
+  end
+
+  private
+
+  def normalize_address
+    self.address = address.to_s.strip.downcase if address.present?
+  end
+end

--- a/app/models/user_invite.rb
+++ b/app/models/user_invite.rb
@@ -1,0 +1,76 @@
+class UserInvite < ApplicationRecord
+  EXPIRY = 24.hours
+
+  PURPOSE_SIGNUP = 'signup'.freeze
+  PURPOSE_PASSKEY_RESET = 'passkey_reset'.freeze
+  PURPOSES = [PURPOSE_SIGNUP, PURPOSE_PASSKEY_RESET].freeze
+
+  belongs_to :created_by_user, class_name: 'User', optional: true
+  belongs_to :target_user, class_name: 'User', optional: true
+  belongs_to :used_by_user, class_name: 'User', optional: true
+
+  validates :purpose, inclusion: { in: PURPOSES }
+  validates :token_digest, presence: true, uniqueness: true
+  validates :expires_at, presence: true
+  validate :target_user_matches_purpose
+
+  scope :usable, -> { where(used_at: nil).where('expires_at > ?', Time.current) }
+
+  def self.create_signup!(actor:)
+    plaintext = SecureRandom.urlsafe_base64(32)
+    record = create!(
+      token_digest: digest_token(plaintext),
+      created_by_user: actor,
+      purpose: PURPOSE_SIGNUP,
+      expires_at: EXPIRY.from_now
+    )
+    [record, plaintext]
+  end
+
+  def self.create_passkey_reset!(target_user:, actor:)
+    plaintext = SecureRandom.urlsafe_base64(32)
+    record = create!(
+      token_digest: digest_token(plaintext),
+      created_by_user: actor,
+      target_user: target_user,
+      purpose: PURPOSE_PASSKEY_RESET,
+      expires_at: EXPIRY.from_now
+    )
+    [record, plaintext]
+  end
+
+  def self.find_usable(plaintext)
+    return nil if plaintext.blank?
+    usable.where(token_digest: digest_token(plaintext)).first
+  end
+
+  def self.digest_token(plaintext)
+    Digest::SHA256.hexdigest(plaintext)
+  end
+
+  def usable?
+    used_at.nil? && expires_at > Time.current
+  end
+
+  def consume!(user:)
+    update!(used_at: Time.current, used_by_user: user)
+  end
+
+  def signup?
+    purpose == PURPOSE_SIGNUP
+  end
+
+  def passkey_reset?
+    purpose == PURPOSE_PASSKEY_RESET
+  end
+
+  private
+
+  def target_user_matches_purpose
+    if passkey_reset? && target_user_id.blank?
+      errors.add(:target_user, 'must be present for passkey_reset invites')
+    elsif signup? && target_user_id.present?
+      errors.add(:target_user, 'must be blank for signup invites')
+    end
+  end
+end

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -1,0 +1,65 @@
+class UserSession < ApplicationRecord
+  EXPIRY = 30.days
+
+  belongs_to :user
+  belongs_to :terminated_by_user, class_name: 'User', optional: true
+
+  scope :active, -> {
+    where(terminated_at: nil).where('last_seen_at > ?', EXPIRY.ago)
+  }
+
+  def self.create_for!(user:, request:)
+    plaintext = SecureRandom.urlsafe_base64(32)
+    record = create!(
+      user: user,
+      token_digest: digest_token(plaintext),
+      ip_address: request&.remote_ip,
+      user_agent: request&.user_agent.to_s.first(500),
+      last_seen_at: Time.current
+    )
+    [record, plaintext]
+  end
+
+  def self.authenticate(plaintext)
+    return nil if plaintext.blank?
+    active.where(token_digest: digest_token(plaintext)).first
+  end
+
+  def self.digest_token(plaintext)
+    Digest::SHA256.hexdigest(plaintext)
+  end
+
+  def active?
+    terminated_at.nil? && last_seen_at > EXPIRY.ago
+  end
+
+  def terminate!(reason:, actor:, request: nil)
+    return if terminated_at.present?
+
+    update!(
+      terminated_at: Time.current,
+      termination_reason: reason,
+      terminated_by_user: actor
+    )
+    UserAuditEvent.record!(
+      action: 'session_terminated',
+      user: user,
+      actor: actor,
+      request: request,
+      metadata: {
+        reason: reason,
+        session_id: id,
+        ip_address: ip_address,
+        username: user&.username
+      }.compact
+    )
+  end
+
+  def touch_seen!(request)
+    update_columns(
+      last_seen_at: Time.current,
+      ip_address: request&.remote_ip,
+      user_agent: request&.user_agent.to_s.first(500)
+    )
+  end
+end

--- a/app/views/account/audit_events/index.html.haml
+++ b/app/views/account/audit_events/index.html.haml
@@ -1,0 +1,25 @@
+- content_for :title, 'My activity'
+
+= page_header('My activity')
+
+%table.table.table-striped.table-sm
+  %thead
+    %tr
+      %th When
+      %th Action
+      %th Actor
+      %th IP
+      %th Details
+  %tbody
+    - @audit_events.each do |event|
+      %tr
+        %td= format_datetime(event.created_at)
+        %td
+          %code= event.action
+        %td= event.actor&.username || '—'
+        %td
+          %code.small= event.ip_address
+        %td.small= event.metadata.is_a?(Hash) ? event.metadata.except('username').to_a.map { |k,v| "#{k}=#{v}" }.join(', ') : event.metadata.to_s
+
+.mt-4
+  = link_to 'Back to account', account_profile_path, class: 'btn btn-secondary'

--- a/app/views/account/credentials/index.html.haml
+++ b/app/views/account/credentials/index.html.haml
@@ -1,0 +1,27 @@
+- content_for :title, 'My passkeys'
+
+= page_header_with_new_button('My passkeys', new_account_credential_path)
+
+%table.table.table-striped.table-sm
+  %thead
+    %tr
+      %th Nickname
+      %th Added
+      %th Last used
+      %th
+  %tbody
+    - @credentials.each do |cred|
+      %tr
+        %td= cred.nickname
+        %td= format_datetime(cred.created_at)
+        %td= cred.last_used_at ? format_datetime(cred.last_used_at) : '—'
+        %td
+          - if @credentials.size > 1
+            = button_to 'Remove', account_credential_path(cred), method: :delete,
+                data: { turbo_confirm: "Remove passkey \"#{cred.nickname}\"? You'll only be able to sign in with your remaining passkeys." },
+                class: 'btn btn-sm btn-outline-danger'
+          - else
+            %span.text-muted.small Only one — add another to remove
+
+.mt-4
+  = link_to 'Back to account', account_profile_path, class: 'btn btn-secondary'

--- a/app/views/account/credentials/new.html.haml
+++ b/app/views/account/credentials/new.html.haml
@@ -10,12 +10,12 @@
           "data-passkey-csrf-token-value" => form_authenticity_token}
       .card-body
         .alert.alert-danger.d-none{"data-passkey-target" => "error"}
-        = form_with url: '#', method: :post, local: true do |f|
+        = form_with url: '#', method: :post, local: true, data: { action: 'submit->passkey#register' } do |f|
           .mb-3
             = f.label :nickname, 'Passkey label', class: 'form-label'
             = f.text_field :nickname, class: 'form-control', "data-passkey-target" => "nickname", placeholder: 'e.g. iPhone, YubiKey', required: true
           .d-grid
-            %button.btn.btn-primary{type: 'button', "data-action" => "click->passkey#register"}
+            %button.btn.btn-primary{type: 'submit'}
               Register passkey
 
 .mt-4

--- a/app/views/account/credentials/new.html.haml
+++ b/app/views/account/credentials/new.html.haml
@@ -1,0 +1,22 @@
+- content_for :title, 'Add passkey'
+
+= page_header('Add a passkey')
+
+.row.justify-content-center
+  .col-md-6
+    .card{"data-controller" => "passkey",
+          "data-passkey-options-url-value" => options_account_credentials_path,
+          "data-passkey-verify-url-value" => verify_account_credentials_path,
+          "data-passkey-csrf-token-value" => form_authenticity_token}
+      .card-body
+        .alert.alert-danger.d-none{"data-passkey-target" => "error"}
+        = form_with url: '#', method: :post, local: true do |f|
+          .mb-3
+            = f.label :nickname, 'Passkey label', class: 'form-label'
+            = f.text_field :nickname, class: 'form-control', "data-passkey-target" => "nickname", placeholder: 'e.g. iPhone, YubiKey', required: true
+          .d-grid
+            %button.btn.btn-primary{type: 'button', "data-action" => "click->passkey#register"}
+              Register passkey
+
+.mt-4
+  = link_to 'Cancel', account_credentials_path, class: 'btn btn-secondary'

--- a/app/views/account/emails/index.html.haml
+++ b/app/views/account/emails/index.html.haml
@@ -1,0 +1,40 @@
+- content_for :title, 'My emails'
+
+= page_header('My emails')
+
+%table.table.table-striped.table-sm
+  %thead
+    %tr
+      %th Address
+      %th Status
+      %th Added
+      %th
+  %tbody
+    - @emails.each do |email|
+      %tr
+        %td= email.address
+        %td
+          - if email.confirmed?
+            %span.badge.bg-success Confirmed
+          - else
+            %span.badge.bg-warning Pending
+        %td= format_datetime(email.created_at)
+        %td
+          - if email.confirmed? && current_user.confirmed_emails.count <= 1
+            %span.text-muted.small Only confirmed — add another to remove
+          - else
+            = button_to 'Remove', account_email_path(email), method: :delete,
+                data: { turbo_confirm: "Remove email #{email.address}?" },
+                class: 'btn btn-sm btn-outline-danger'
+
+%h2 Add new email
+= form_with url: account_emails_path, method: :post, scope: :user_email, local: true do |f|
+  .row.g-2
+    .col-md-6
+      = f.email_field :address, class: 'form-control', placeholder: 'new@example.com', required: true
+    .col-md-2
+      = f.submit 'Add', class: 'btn btn-primary'
+  .form-text You'll receive a confirmation link at this address.
+
+.mt-4
+  = link_to 'Back to account', account_profile_path, class: 'btn btn-secondary'

--- a/app/views/account/profiles/show.html.haml
+++ b/app/views/account/profiles/show.html.haml
@@ -1,0 +1,75 @@
+- content_for :title, 'My account'
+
+= page_header('My account')
+
+.row
+  .col-md-6
+    .card.mb-3
+      .card-header Profile
+      .card-body
+        %dl.row.mb-0
+          %dt.col-sm-4 Username
+          %dd.col-sm-8= @user.username
+          %dt.col-sm-4 Full name
+          %dd.col-sm-8= @user.full_name
+          %dt.col-sm-4 Member since
+          %dd.col-sm-8= format_datetime(@user.created_at)
+    .card.mb-3
+      .card-header
+        .d-flex.justify-content-between.align-items-center
+          %span Emails
+          = link_to 'Manage', account_emails_path, class: 'btn btn-sm btn-outline-primary'
+      %ul.list-group.list-group-flush
+        - @emails.each do |email|
+          %li.list-group-item
+            = email.address
+            - if email.confirmed?
+              %span.badge.bg-success.ms-2 Confirmed
+            - else
+              %span.badge.bg-warning.ms-2 Pending
+    .card.mb-3
+      .card-header
+        .d-flex.justify-content-between.align-items-center
+          %span Passkeys
+          = link_to 'Manage', account_credentials_path, class: 'btn btn-sm btn-outline-primary'
+      %ul.list-group.list-group-flush
+        - @credentials.each do |cred|
+          %li.list-group-item
+            = cred.nickname
+            %span.text-muted.ms-2.small
+              - if cred.last_used_at
+                Last used #{format_datetime(cred.last_used_at)}
+              - else
+                Never used
+  .col-md-6
+    .card.mb-3
+      .card-header
+        .d-flex.justify-content-between.align-items-center
+          %span Active sessions
+          = link_to 'Manage', account_sessions_path, class: 'btn btn-sm btn-outline-primary'
+      %ul.list-group.list-group-flush
+        - @sessions.each do |s|
+          %li.list-group-item
+            %div
+              %code.small= s.ip_address
+              - if current_user_session && current_user_session.id == s.id
+                %span.badge.bg-info.ms-2 This session
+            .small.text-muted= s.user_agent.to_s.truncate(80)
+            .small.text-muted Last seen: #{format_datetime(s.last_seen_at)}
+    .card.mb-3
+      .card-header
+        .d-flex.justify-content-between.align-items-center
+          %span Recent activity
+          = link_to 'View all', account_audit_events_path, class: 'btn btn-sm btn-outline-primary'
+      %ul.list-group.list-group-flush
+        - @audit_events.each do |event|
+          %li.list-group-item
+            %code= event.action
+            %span.text-muted.ms-2.small= format_datetime(event.created_at)
+    .card.border-danger
+      .card-header.bg-danger.text-white Danger zone
+      .card-body
+        %p Self-block disables your account, terminates all your sessions, and prevents you from signing in. An administrator can re-enable your account.
+        = button_to 'Block my account', account_block_path, method: :post,
+            data: { turbo_confirm: 'Are you sure? This will sign you out and block your account.' },
+            class: 'btn btn-danger'

--- a/app/views/account/sessions/index.html.haml
+++ b/app/views/account/sessions/index.html.haml
@@ -1,0 +1,26 @@
+- content_for :title, 'My sessions'
+
+= page_header('My sessions')
+
+%table.table.table-striped.table-sm
+  %thead
+    %tr
+      %th IP
+      %th User agent
+      %th Last seen
+      %th Started
+      %th
+  %tbody
+    - @sessions.each do |s|
+      %tr
+        %td
+          %code.small= s.ip_address
+          - if current_user_session && current_user_session.id == s.id
+            %span.badge.bg-info.ms-1 This session
+        %td.small= s.user_agent.to_s.truncate(80)
+        %td= format_datetime(s.last_seen_at)
+        %td= format_datetime(s.created_at)
+        %td
+          = button_to 'Terminate', account_session_path(s), method: :delete,
+              data: { turbo_confirm: 'Terminate this session?' },
+              class: 'btn btn-sm btn-outline-danger'

--- a/app/views/invites/invalid.html.haml
+++ b/app/views/invites/invalid.html.haml
@@ -1,0 +1,6 @@
+- content_for :title, 'Invite invalid'
+
+= page_header('Invite invalid')
+%p This invite link is invalid, expired, or has already been used.
+%p
+  = link_to 'Go to sign in', new_session_path, class: 'btn btn-primary'

--- a/app/views/invites/show.html.haml
+++ b/app/views/invites/show.html.haml
@@ -12,7 +12,7 @@
             "data-passkey-csrf-token-value" => form_authenticity_token}
         .card-body
           .alert.alert-danger.d-none{"data-passkey-target" => "error"}
-          = form_with url: '#', method: :post, local: true do |f|
+          = form_with url: '#', method: :post, local: true, data: { action: 'submit->passkey#register' } do |f|
             .mb-3
               = f.label :username, class: 'form-label'
               = f.text_field :username, class: 'form-control', "data-passkey-target" => "username", autocomplete: 'username', required: true
@@ -27,7 +27,7 @@
               = f.label :nickname, 'Passkey label (optional)', class: 'form-label'
               = f.text_field :nickname, class: 'form-control', "data-passkey-target" => "nickname", placeholder: 'e.g. My MacBook'
             .d-grid
-              %button.btn.btn-primary{type: 'button', "data-action" => "click->passkey#register"}
+              %button.btn.btn-primary{type: 'submit'}
                 Create account and register passkey
     - else
       - target = @invite.target_user
@@ -40,10 +40,10 @@
             "data-passkey-csrf-token-value" => form_authenticity_token}
         .card-body
           .alert.alert-danger.d-none{"data-passkey-target" => "error"}
-          = form_with url: '#', method: :post, local: true do |f|
+          = form_with url: '#', method: :post, local: true, data: { action: 'submit->passkey#register' } do |f|
             .mb-3
               = f.label :nickname, 'Passkey label', class: 'form-label'
               = f.text_field :nickname, class: 'form-control', "data-passkey-target" => "nickname", placeholder: 'e.g. New iPhone', required: true
             .d-grid
-              %button.btn.btn-primary{type: 'button', "data-action" => "click->passkey#register"}
+              %button.btn.btn-primary{type: 'submit'}
                 Register passkey

--- a/app/views/invites/show.html.haml
+++ b/app/views/invites/show.html.haml
@@ -1,0 +1,49 @@
+- content_for :title, 'Accept invite'
+
+.row.justify-content-center
+  .col-md-8
+    - if @invite.signup?
+      = page_header('Create your account')
+      %p You've been invited to ABT. Choose a username, fill in your details, and register a passkey to complete signup.
+
+      .card{"data-controller" => "passkey",
+            "data-passkey-options-url-value" => options_invite_path(token: params[:token]),
+            "data-passkey-verify-url-value" => verify_invite_path(token: params[:token]),
+            "data-passkey-csrf-token-value" => form_authenticity_token}
+        .card-body
+          .alert.alert-danger.d-none{"data-passkey-target" => "error"}
+          = form_with url: '#', method: :post, local: true do |f|
+            .mb-3
+              = f.label :username, class: 'form-label'
+              = f.text_field :username, class: 'form-control', "data-passkey-target" => "username", autocomplete: 'username', required: true
+              .form-text Lowercase letters, digits, dot, hyphen, underscore. Must start with a letter or digit.
+            .mb-3
+              = f.label :full_name, 'Full name', class: 'form-label'
+              = f.text_field :full_name, class: 'form-control', "data-passkey-target" => "fullName", autocomplete: 'name', required: true
+            .mb-3
+              = f.label :email, class: 'form-label'
+              = f.email_field :email, class: 'form-control', "data-passkey-target" => "email", autocomplete: 'email', required: true
+            .mb-3
+              = f.label :nickname, 'Passkey label (optional)', class: 'form-label'
+              = f.text_field :nickname, class: 'form-control', "data-passkey-target" => "nickname", placeholder: 'e.g. My MacBook'
+            .d-grid
+              %button.btn.btn-primary{type: 'button', "data-action" => "click->passkey#register"}
+                Create account and register passkey
+    - else
+      - target = @invite.target_user
+      = page_header('Register a new passkey')
+      %p Welcome back, #{target.full_name}. Register a new passkey for your account.
+
+      .card{"data-controller" => "passkey",
+            "data-passkey-options-url-value" => options_invite_path(token: params[:token]),
+            "data-passkey-verify-url-value" => verify_invite_path(token: params[:token]),
+            "data-passkey-csrf-token-value" => form_authenticity_token}
+        .card-body
+          .alert.alert-danger.d-none{"data-passkey-target" => "error"}
+          = form_with url: '#', method: :post, local: true do |f|
+            .mb-3
+              = f.label :nickname, 'Passkey label', class: 'form-label'
+              = f.text_field :nickname, class: 'form-control', "data-passkey-target" => "nickname", placeholder: 'e.g. New iPhone', required: true
+            .d-grid
+              %button.btn.btn-primary{type: 'button', "data-action" => "click->passkey#register"}
+                Register passkey

--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -1,55 +1,56 @@
 = link_to "ABT", root_path, :class => 'navbar-brand'
-%button.navbar-toggler{:type => "button", :"data-navbar-target" => "toggle", :"data-action" => "click->navbar#toggle"}
-  %span.navbar-toggler-icon
-.collapse.navbar-collapse{"data-navbar-target" => "menu"}
-  %ul.navbar-nav.me-auto
-    %li.nav-item
-      = link_to('Customers', customers_path, :class => 'nav-link')
-    %li.nav-item
-      = link_to('Projects', projects_path, :class => 'nav-link')
-    %li.nav-item
-      = link_to('Deliveries', delivery_notes_path, :class => 'nav-link')
-    %li.nav-item
-      = link_to('Invoices', invoices_path, :class => 'nav-link')
-  %ul.navbar-nav
-    %li.nav-item.dropdown{"data-controller" => "error-notification", "data-error-notification-max-errors-value" => "5", :style => "display: none;", "data-error-notification-target" => "icon"}
-      %a.nav-link{:href => "#", :role => "button", :"data-action" => "click->error-notification#toggle"}
-        %span.badge.rounded-pill.bg-danger{"data-error-notification-target" => "badge"}
-      %ul.dropdown-menu.dropdown-menu-end{"data-error-notification-target" => "dropdown", "data-action" => "click->error-notification#preventClose", :style => "width: 280px; max-height: 300px; overflow-y: auto; z-index: 1050; right: 0; left: auto;"}
-        %li.dropdown-header.px-3.py-2
-          .d-flex.justify-content-between.align-items-center
-            %span.fw-bold Recent Errors
-            %button.btn.btn-sm.btn-outline-danger{"data-action" => "click->error-notification#clearAll", :type => "button", :style => "font-size: 0.75rem;"} Clear All
-        %li
-          %hr.dropdown-divider
-        %ul.list-unstyled.mb-0{"data-error-notification-target" => "list"}
-    %li.nav-item.dropdown{"data-controller" => "navbar"}
-      %a.nav-link.dropdown-toggle{:href => "#", :role => "button", :"data-navbar-target" => "toggle", :"data-action" => "click->navbar#toggle"}
-        Configuration
-      %ul.dropdown-menu.dropdown-menu-end{"data-navbar-target" => "menu"}
-        %li
-          = link_to('Issuer Company', issuer_company_path, :class => 'dropdown-item')
-        %li
-          %hr.dropdown-divider
-        %li
-          = link_to('Product Catalog', products_path, :class => 'dropdown-item')
-        %li
-          = link_to('Sales Tax', sales_tax_rates_path, :class => 'dropdown-item')
-        %li
-          %hr.dropdown-divider
-        %li
-          = link_to('Background Jobs', jobs_status_path, :class => 'dropdown-item')
-
--#  - if user_signed_in?
--#    %li
--#      = link_to('Logout', destroy_user_session_path, :method=>'delete')
--#  - else
--#    %li
--#      = link_to('Login', new_user_session_path)
--#  - if user_signed_in?
--#    %li
--#      = link_to('Edit account', edit_user_registration_path)
--#  - else
--#    %li
--#      = link_to('Sign up', new_user_registration_path)
--#
+- if Current.user
+  %button.navbar-toggler{:type => "button", :"data-navbar-target" => "toggle", :"data-action" => "click->navbar#toggle"}
+    %span.navbar-toggler-icon
+  .collapse.navbar-collapse{"data-navbar-target" => "menu"}
+    %ul.navbar-nav.me-auto
+      %li.nav-item
+        = link_to('Customers', customers_path, :class => 'nav-link')
+      %li.nav-item
+        = link_to('Projects', projects_path, :class => 'nav-link')
+      %li.nav-item
+        = link_to('Deliveries', delivery_notes_path, :class => 'nav-link')
+      %li.nav-item
+        = link_to('Invoices', invoices_path, :class => 'nav-link')
+    %ul.navbar-nav
+      %li.nav-item.dropdown{"data-controller" => "error-notification", "data-error-notification-max-errors-value" => "5", :style => "display: none;", "data-error-notification-target" => "icon"}
+        %a.nav-link{:href => "#", :role => "button", :"data-action" => "click->error-notification#toggle"}
+          %span.badge.rounded-pill.bg-danger{"data-error-notification-target" => "badge"}
+        %ul.dropdown-menu.dropdown-menu-end{"data-error-notification-target" => "dropdown", "data-action" => "click->error-notification#preventClose", :style => "width: 280px; max-height: 300px; overflow-y: auto; z-index: 1050; right: 0; left: auto;"}
+          %li.dropdown-header.px-3.py-2
+            .d-flex.justify-content-between.align-items-center
+              %span.fw-bold Recent Errors
+              %button.btn.btn-sm.btn-outline-danger{"data-action" => "click->error-notification#clearAll", :type => "button", :style => "font-size: 0.75rem;"} Clear All
+          %li
+            %hr.dropdown-divider
+          %ul.list-unstyled.mb-0{"data-error-notification-target" => "list"}
+      %li.nav-item.dropdown{"data-controller" => "navbar"}
+        %a.nav-link.dropdown-toggle{:href => "#", :role => "button", :"data-navbar-target" => "toggle", :"data-action" => "click->navbar#toggle"}
+          Configuration
+        %ul.dropdown-menu.dropdown-menu-end{"data-navbar-target" => "menu"}
+          %li
+            = link_to('Issuer Company', issuer_company_path, :class => 'dropdown-item')
+          %li
+            %hr.dropdown-divider
+          %li
+            = link_to('Product Catalog', products_path, :class => 'dropdown-item')
+          %li
+            = link_to('Sales Tax', sales_tax_rates_path, :class => 'dropdown-item')
+          %li
+            %hr.dropdown-divider
+          %li
+            = link_to('Users', users_path, :class => 'dropdown-item')
+          %li
+            %hr.dropdown-divider
+          %li
+            = link_to('Background Jobs', jobs_status_path, :class => 'dropdown-item')
+      %li.nav-item.dropdown{"data-controller" => "navbar"}
+        %a.nav-link.dropdown-toggle{:href => "#", :role => "button", :"data-navbar-target" => "toggle", :"data-action" => "click->navbar#toggle"}
+          = Current.user.username
+        %ul.dropdown-menu.dropdown-menu-end{"data-navbar-target" => "menu"}
+          %li
+            = link_to('My account', account_profile_path, :class => 'dropdown-item')
+          %li
+            %hr.dropdown-divider
+          %li
+            = button_to('Sign out', session_path, method: :delete, class: 'dropdown-item', form_class: 'd-inline')

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -34,5 +34,6 @@
       .container
         %p.mb-0.text-center
           &copy; 2014-2025 Deduktiva GmbH
-          %span.text-muted.ms-3
-            = app_version
+          - if Current.user
+            %span.text-muted.ms-3
+              = app_version

--- a/app/views/sessions/new.html.haml
+++ b/app/views/sessions/new.html.haml
@@ -11,10 +11,6 @@
           "data-passkey-csrf-token-value" => form_authenticity_token}
       .card-body
         .alert.alert-danger.d-none{"data-passkey-target" => "error"}
-        = form_with url: '#', method: :post, local: true do |f|
-          .mb-3
-            = f.label :username, class: 'form-label'
-            = f.text_field :username, class: 'form-control', autocomplete: 'username', "data-passkey-target" => "username", required: true
-          .d-grid
-            %button.btn.btn-primary{type: 'button', "data-action" => "click->passkey#authenticate"}
-              Sign in with passkey
+        .d-grid
+          %button.btn.btn-primary{type: 'button', "data-action" => "click->passkey#authenticate"}
+            Sign in with passkey

--- a/app/views/sessions/new.html.haml
+++ b/app/views/sessions/new.html.haml
@@ -1,0 +1,20 @@
+- content_for :title, 'Sign in'
+
+.row.justify-content-center
+  .col-md-6
+    = page_header('Sign in')
+    %p Use your passkey to sign in.
+
+    .card{"data-controller" => "passkey",
+          "data-passkey-options-url-value" => options_session_path,
+          "data-passkey-verify-url-value" => verify_session_path,
+          "data-passkey-csrf-token-value" => form_authenticity_token}
+      .card-body
+        .alert.alert-danger.d-none{"data-passkey-target" => "error"}
+        = form_with url: '#', method: :post, local: true do |f|
+          .mb-3
+            = f.label :username, class: 'form-label'
+            = f.text_field :username, class: 'form-control', autocomplete: 'username', "data-passkey-target" => "username", required: true
+          .d-grid
+            %button.btn.btn-primary{type: 'button', "data-action" => "click->passkey#authenticate"}
+              Sign in with passkey

--- a/app/views/sessions/new.html.haml
+++ b/app/views/sessions/new.html.haml
@@ -8,7 +8,8 @@
     .card{"data-controller" => "passkey",
           "data-passkey-options-url-value" => options_session_path,
           "data-passkey-verify-url-value" => verify_session_path,
-          "data-passkey-csrf-token-value" => form_authenticity_token}
+          "data-passkey-csrf-token-value" => form_authenticity_token,
+          "data-passkey-auto-authenticate-value" => "true"}
       .card-body
         .alert.alert-danger.d-none{"data-passkey-target" => "error"}
         .d-grid

--- a/app/views/user_invites/index.html.haml
+++ b/app/views/user_invites/index.html.haml
@@ -1,0 +1,30 @@
+- content_for :title, 'Invites'
+
+= page_header_with_new_button('Invites', new_user_invite_path)
+
+%table.table.table-striped.table-sm
+  %thead
+    %tr
+      %th Created
+      %th Created by
+      %th Expires
+      %th Used
+      %th Used by
+  %tbody
+    - @invites.each do |invite|
+      %tr
+        %td= format_datetime(invite.created_at)
+        %td= invite.created_by_user&.username || 'system'
+        %td= format_datetime(invite.expires_at)
+        %td
+          - if invite.used_at
+            %span.badge.bg-success Used
+            = format_datetime(invite.used_at)
+          - elsif invite.expires_at <= Time.current
+            %span.badge.bg-secondary Expired
+          - else
+            %span.badge.bg-warning Pending
+        %td= invite.used_by_user&.username || '—'
+
+.mt-4
+  = link_to 'Back to users', users_path, class: 'btn btn-secondary'

--- a/app/views/user_invites/new.html.haml
+++ b/app/views/user_invites/new.html.haml
@@ -4,7 +4,7 @@
 
 %p Click the button below to generate a one-time invite link. The link is valid for 24 hours. The next page will show the URL so you can copy it.
 
-= form_with url: user_invites_path, method: :post, local: true do
+= form_with url: user_invites_path, method: :post, local: true, data: { turbo: false } do
   = submit_tag 'Generate invite URL', class: 'btn btn-primary'
 
 .mt-4

--- a/app/views/user_invites/new.html.haml
+++ b/app/views/user_invites/new.html.haml
@@ -1,0 +1,11 @@
+- content_for :title, 'New invite'
+
+= page_header('Invite a new user')
+
+%p Click the button below to generate a one-time invite link. The link is valid for 24 hours. The next page will show the URL so you can copy it.
+
+= form_with url: user_invites_path, method: :post, local: true do
+  = submit_tag 'Generate invite URL', class: 'btn btn-primary'
+
+.mt-4
+  = link_to 'Cancel', user_invites_path, class: 'btn btn-secondary'

--- a/app/views/user_invites/show_invite.html.haml
+++ b/app/views/user_invites/show_invite.html.haml
@@ -1,0 +1,16 @@
+- content_for :title, 'Invite generated'
+
+= page_header('Invite generated')
+
+.alert.alert-info
+  This URL is shown only once. Copy it now and share it with the invitee.
+
+.card.mb-3
+  .card-body
+    %p.mb-1.text-muted Invite URL (valid until #{format_datetime(@invite.expires_at)}):
+    %pre.mb-0
+      %code= @invite_url
+
+= action_buttons_wrapper do
+  = action_button('Back to invites', user_invites_path, :secondary)
+  = action_button('Generate another', new_user_invite_path, :primary)

--- a/app/views/user_mailer/email_added_notice.html.haml
+++ b/app/views/user_mailer/email_added_notice.html.haml
@@ -1,0 +1,5 @@
+.greeting Hello #{@user.full_name},
+.main-message
+  A new email address (#{@new_address}) was added to your ABT account.
+.main-message
+  If this was not you, please contact an administrator immediately and reset your passkeys.

--- a/app/views/user_mailer/email_added_notice.text.haml
+++ b/app/views/user_mailer/email_added_notice.text.haml
@@ -1,0 +1,6 @@
+:plain
+  Hello #{@user.full_name},
+
+  A new email address (#{@new_address}) was added to your ABT account.
+
+  If this was not you, please contact an administrator immediately and reset your passkeys.

--- a/app/views/user_mailer/email_confirmation.html.haml
+++ b/app/views/user_mailer/email_confirmation.html.haml
@@ -1,0 +1,9 @@
+.greeting Hello #{@user.full_name},
+.main-message
+  Please confirm this email address (#{@email.address}) belongs to your ABT account by clicking the link below.
+.main-message
+  = link_to 'Confirm email address', @confirmation_url
+.main-message
+  This link expires on #{l(@expires_at, format: '%Y-%m-%d %H:%M %Z')}.
+.main-message
+  If you did not request this, you can ignore this email.

--- a/app/views/user_mailer/email_confirmation.text.haml
+++ b/app/views/user_mailer/email_confirmation.text.haml
@@ -1,0 +1,10 @@
+:plain
+  Hello #{@user.full_name},
+
+  Please confirm this email address (#{@email.address}) belongs to your ABT account:
+
+  #{@confirmation_url}
+
+  This link expires on #{l(@expires_at, format: '%Y-%m-%d %H:%M %Z')}.
+
+  If you did not request this, you can ignore this email.

--- a/app/views/user_mailer/email_removed_notice.html.haml
+++ b/app/views/user_mailer/email_removed_notice.html.haml
@@ -1,0 +1,5 @@
+.greeting Hello #{@user.full_name},
+.main-message
+  An email address (#{@removed_address}) was removed from your ABT account.
+.main-message
+  If this was not you, please contact an administrator immediately.

--- a/app/views/user_mailer/email_removed_notice.text.haml
+++ b/app/views/user_mailer/email_removed_notice.text.haml
@@ -1,0 +1,6 @@
+:plain
+  Hello #{@user.full_name},
+
+  An email address (#{@removed_address}) was removed from your ABT account.
+
+  If this was not you, please contact an administrator immediately.

--- a/app/views/user_mailer/passkey_added_notice.html.haml
+++ b/app/views/user_mailer/passkey_added_notice.html.haml
@@ -1,0 +1,5 @@
+.greeting Hello #{@user.full_name},
+.main-message
+  A new passkey ("#{@credential.nickname}") was added to your ABT account.
+.main-message
+  If this was not you, please contact an administrator immediately.

--- a/app/views/user_mailer/passkey_added_notice.text.haml
+++ b/app/views/user_mailer/passkey_added_notice.text.haml
@@ -1,0 +1,6 @@
+:plain
+  Hello #{@user.full_name},
+
+  A new passkey ("#{@credential.nickname}") was added to your ABT account.
+
+  If this was not you, please contact an administrator immediately.

--- a/app/views/user_mailer/passkey_removed_notice.html.haml
+++ b/app/views/user_mailer/passkey_removed_notice.html.haml
@@ -1,0 +1,5 @@
+.greeting Hello #{@user.full_name},
+.main-message
+  A passkey ("#{@credential_nickname}") was removed from your ABT account.
+.main-message
+  If this was not you, please contact an administrator immediately.

--- a/app/views/user_mailer/passkey_removed_notice.text.haml
+++ b/app/views/user_mailer/passkey_removed_notice.text.haml
@@ -1,0 +1,6 @@
+:plain
+  Hello #{@user.full_name},
+
+  A passkey ("#{@credential_nickname}") was removed from your ABT account.
+
+  If this was not you, please contact an administrator immediately.

--- a/app/views/user_mailer/passkey_reset_invite.html.haml
+++ b/app/views/user_mailer/passkey_reset_invite.html.haml
@@ -1,0 +1,9 @@
+.greeting Hello #{@user.full_name},
+.main-message
+  An administrator has reset the passkeys on your ABT account. To regain access, register a new passkey by clicking the link below.
+.main-message
+  = link_to 'Register a new passkey', @invite_url
+.main-message
+  This link is valid for 24 hours.
+.main-message
+  If you did not expect this, contact an administrator immediately.

--- a/app/views/user_mailer/passkey_reset_invite.text.haml
+++ b/app/views/user_mailer/passkey_reset_invite.text.haml
@@ -1,0 +1,10 @@
+:plain
+  Hello #{@user.full_name},
+
+  An administrator has reset the passkeys on your ABT account. To regain access, register a new passkey:
+
+  #{@invite_url}
+
+  This link is valid for 24 hours.
+
+  If you did not expect this, contact an administrator immediately.

--- a/app/views/users/audit.html.haml
+++ b/app/views/users/audit.html.haml
@@ -1,0 +1,25 @@
+- content_for :title, "Audit log for #{@user.username}"
+
+= page_header("Audit log: #{@user.username}")
+
+%table.table.table-striped.table-sm
+  %thead
+    %tr
+      %th When
+      %th Action
+      %th Actor
+      %th IP
+      %th Details
+  %tbody
+    - @audit_events.each do |event|
+      %tr
+        %td= format_datetime(event.created_at)
+        %td
+          %code= event.action
+        %td= event.actor&.username || '—'
+        %td
+          %code.small= event.ip_address
+        %td.small= event.metadata.is_a?(Hash) ? event.metadata.except('username').to_a.map { |k,v| "#{k}=#{v}" }.join(', ') : event.metadata.to_s
+
+.mt-4
+  = link_to 'Back to user', user_path(@user), class: 'btn btn-secondary'

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,0 +1,29 @@
+- content_for :title, 'Users'
+
+.d-flex.justify-content-between.align-items-center.mb-3
+  %h1.page-header.mb-0 Users
+  = link_to '+ Invite user', new_user_invite_path, class: 'btn btn-info'
+
+%table.table.table-striped.table-sm
+  %thead
+    %tr
+      %th Username
+      %th Full name
+      %th Status
+      %th Created
+      %th
+  %tbody
+    - @users.each do |user|
+      %tr
+        %td= link_to user.username, user_path(user)
+        %td= user.full_name
+        %td
+          - if user.blocked?
+            %span.badge.bg-danger Blocked
+          - else
+            %span.badge.bg-success Active
+        %td= format_datetime(user.created_at)
+        %td= list_action_link('View', user_path(user), :show)
+
+.mt-4
+  = link_to 'View invites', user_invites_path, class: 'btn btn-secondary'

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,0 +1,102 @@
+- content_for :title, "User #{@user.username}"
+
+.d-flex.justify-content-between.align-items-center.mb-3
+  %h1.page-header.mb-0= @user.username
+  - if @user.blocked?
+    %span.badge.bg-danger.fs-6 Blocked
+  - else
+    %span.badge.bg-success.fs-6 Active
+
+.row
+  .col-md-6
+    .card.mb-3
+      .card-header Profile
+      .card-body
+        %dl.row.mb-0
+          %dt.col-sm-4 Username
+          %dd.col-sm-8= @user.username
+          %dt.col-sm-4 Full name
+          %dd.col-sm-8= @user.full_name
+          %dt.col-sm-4 Created
+          %dd.col-sm-8= format_datetime(@user.created_at)
+          - if @user.blocked?
+            %dt.col-sm-4 Blocked at
+            %dd.col-sm-8= format_datetime(@user.blocked_at)
+            %dt.col-sm-4 Reason
+            %dd.col-sm-8= @user.blocked_reason
+            %dt.col-sm-4 Blocked by
+            %dd.col-sm-8= @user.blocked_by_user&.username || '—'
+
+    .card.mb-3
+      .card-header Emails
+      %ul.list-group.list-group-flush
+        - @emails.each do |email|
+          %li.list-group-item
+            .d-flex.justify-content-between.align-items-center
+              %div
+                = email.address
+                - if email.confirmed?
+                  %span.badge.bg-success.ms-2 Confirmed
+                - else
+                  %span.badge.bg-warning.ms-2 Pending
+              %div.btn-group
+                = button_to 'Replace…', '#', class: 'btn btn-sm btn-outline-secondary', form: { class: 'd-inline', "data-toggle-form" => "email-#{email.id}" }, type: 'button', onclick: "document.getElementById('replace-email-#{email.id}').classList.toggle('d-none'); return false;"
+                - if !(email.confirmed? && @user.confirmed_emails.count <= 1)
+                  = button_to 'Remove', user_email_path(user_id: @user, id: email), method: :delete,
+                      data: { turbo_confirm: "Remove email #{email.address}?" },
+                      class: 'btn btn-sm btn-outline-danger'
+            .mt-2.d-none{id: "replace-email-#{email.id}"}
+              = form_with url: user_email_path(user_id: @user, id: email), method: :put, scope: :user_email, local: true do |f|
+                .input-group.input-group-sm
+                  = f.email_field :address, class: 'form-control', placeholder: 'replacement@example.com', required: true
+                  = f.submit 'Replace', class: 'btn btn-primary'
+      .card-body
+        = form_with url: user_emails_path(@user), method: :post, scope: :user_email, local: true do |f|
+          .input-group.input-group-sm
+            = f.email_field :address, class: 'form-control', placeholder: 'add@example.com', required: true
+            = f.submit 'Add email', class: 'btn btn-outline-primary'
+        .form-text Admin-added emails are confirmed immediately (no email verification needed).
+
+  .col-md-6
+    .card.mb-3
+      .card-header Passkeys
+      %ul.list-group.list-group-flush
+        - @credentials.each do |cred|
+          %li.list-group-item
+            = cred.nickname
+            %span.text-muted.ms-2.small
+              - if cred.last_used_at
+                Last used #{format_datetime(cred.last_used_at)}
+              - else
+                Never used
+        - if @credentials.empty?
+          %li.list-group-item.text-muted No passkeys
+
+    .card.mb-3
+      .card-header Active sessions
+      %ul.list-group.list-group-flush
+        - @sessions.each do |s|
+          %li.list-group-item
+            %code.small= s.ip_address
+            .small.text-muted= s.user_agent.to_s.truncate(80)
+            .small.text-muted Last seen: #{format_datetime(s.last_seen_at)}
+        - if @sessions.empty?
+          %li.list-group-item.text-muted No active sessions
+
+= action_buttons_wrapper do
+  - if @user.blocked?
+    = button_to 'Unblock', unblock_user_path(@user), method: :post,
+        data: { turbo_confirm: "Unblock #{@user.username}?" },
+        class: 'btn btn-success'
+    = button_to 'Reset passkeys', reset_passkeys_user_path(@user), method: :post,
+        data: { turbo_confirm: "Delete all of #{@user.username}'s passkeys and email them an invite to register a new one?" },
+        class: 'btn btn-warning'
+  - elsif @user.id != current_user.id
+    = form_with url: block_user_path(@user), method: :post, local: true, class: 'd-inline' do |f|
+      .input-group.input-group-sm{style: 'width: 400px; display: inline-flex;'}
+        = f.text_field :reason, class: 'form-control', placeholder: 'Reason (required)', required: true
+        = f.submit 'Block', class: 'btn btn-danger',
+            data: { turbo_confirm: "Block #{@user.username}? All sessions will be terminated." }
+
+  = action_button('View audit log', audit_user_path(@user), :secondary)
+  = action_button('Back to list', users_path, :secondary)

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,7 +1,10 @@
 - content_for :title, "User #{@user.username}"
 
 .d-flex.justify-content-between.align-items-center.mb-3
-  %h1.page-header.mb-0= @user.username
+  .d-flex.align-items-center.gap-2
+    %h1.page-header.mb-0= @user.username
+    - if @user.id == current_user.id
+      %span.badge.bg-info.fs-6 This is you
   - if @user.blocked?
     %span.badge.bg-danger.fs-6 Blocked
   - else
@@ -92,8 +95,8 @@
         data: { turbo_confirm: "Delete all of #{@user.username}'s passkeys and email them an invite to register a new one?" },
         class: 'btn btn-warning'
   - elsif @user.id != current_user.id
-    = form_with url: block_user_path(@user), method: :post, local: true, class: 'd-inline' do |f|
-      .input-group.input-group-sm{style: 'width: 400px; display: inline-flex;'}
+    = form_with url: block_user_path(@user), method: :post, local: true, class: 'd-inline-flex' do |f|
+      .input-group{style: 'width: 400px;'}
         = f.text_field :reason, class: 'form-control', placeholder: 'Reason (required)', required: true
         = f.submit 'Block', class: 'btn btn-danger',
             data: { turbo_confirm: "Block #{@user.username}? All sessions will be terminated." }

--- a/config/initializers/webauthn.rb
+++ b/config/initializers/webauthn.rb
@@ -1,0 +1,7 @@
+WebAuthn.configure do |config|
+  config.allowed_origins = [Settings.webauthn.origin]
+  config.rp_name = Settings.webauthn.rp_name
+  config.rp_id = Settings.webauthn.rp_id
+  config.credential_options_timeout = 60_000
+  config.algorithms = %w[ES256 RS256]
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,45 @@
 Rails.application.routes.draw do
+  resource :session, only: [:new, :destroy], controller: 'sessions' do
+    collection do
+      post :options
+      post :verify
+    end
+  end
+
+  resources :invites, only: [:show], param: :token do
+    member do
+      post :options
+      post :verify
+    end
+  end
+
+  namespace :account do
+    resource :profile, only: [:show]
+    resources :sessions, only: [:index, :destroy]
+    resources :credentials, only: [:index, :new, :destroy] do
+      collection do
+        post :options
+        post :verify
+      end
+    end
+    resources :emails, only: [:index, :create, :destroy]
+    resources :email_confirmations, only: [:show], param: :token
+    resource :block, only: [:create]
+    resources :audit_events, only: [:index]
+  end
+
+  resources :users, only: [:index, :show] do
+    member do
+      post :block
+      post :unblock
+      post :reset_passkeys
+      get :audit
+    end
+    resources :emails, only: [:create, :update, :destroy], controller: 'users/emails'
+  end
+
+  resources :user_invites, only: [:new, :create, :index]
+
   resource :issuer_company, only: [:show, :edit, :update] do
     get :png_logo, on: :member
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,3 +1,12 @@
+app:
+  host: 'localhost:3000'
+  protocol: 'http'
+
 payments:
 #  public_url: 'https://pay.deduktiva.com/p/%token%'
   public_url: ''
+
+webauthn:
+  rp_name: 'ABT'
+  rp_id: 'localhost'
+  origin: 'http://localhost:3000'

--- a/config/settings/production.yml.tpl
+++ b/config/settings/production.yml.tpl
@@ -6,3 +6,12 @@ fop:
 
 payments:
   public_url: "https://your-domain.com/payments/%token%"
+
+app:
+  host: 'your-domain.com'
+  protocol: 'https'
+
+webauthn:
+  rp_name: 'ABT'
+  rp_id: 'your-domain.com'
+  origin: 'https://your-domain.com'

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,3 +1,12 @@
 fop:
   # (run script/setup-fop.sh first)
   binary_path: "./bin/abt-fop-container"
+
+app:
+  host: 'www.example.com'
+  protocol: 'http'
+
+webauthn:
+  rp_name: 'ABT Test'
+  rp_id: 'www.example.com'
+  origin: 'http://www.example.com'

--- a/db/migrate/20260522140001_create_users.rb
+++ b/db/migrate/20260522140001_create_users.rb
@@ -1,0 +1,17 @@
+class CreateUsers < ActiveRecord::Migration[8.1]
+  def change
+    create_table :users do |t|
+      t.string :username, null: false
+      t.string :full_name, null: false
+      t.string :webauthn_id, null: false
+      t.datetime :blocked_at
+      t.string :blocked_reason
+      t.references :blocked_by_user, foreign_key: { to_table: :users }, null: true
+
+      t.timestamps
+    end
+
+    add_index :users, :username, unique: true
+    add_index :users, :blocked_at
+  end
+end

--- a/db/migrate/20260522140002_create_user_emails.rb
+++ b/db/migrate/20260522140002_create_user_emails.rb
@@ -1,0 +1,16 @@
+class CreateUserEmails < ActiveRecord::Migration[8.1]
+  def change
+    create_table :user_emails do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :address, null: false
+      t.datetime :confirmed_at
+      t.string :confirmation_token_digest
+      t.datetime :confirmation_expires_at
+
+      t.timestamps
+    end
+
+    add_index :user_emails, :address, unique: true
+    add_index :user_emails, :confirmation_token_digest, unique: true, where: 'confirmation_token_digest IS NOT NULL'
+  end
+end

--- a/db/migrate/20260522140003_create_user_credentials.rb
+++ b/db/migrate/20260522140003_create_user_credentials.rb
@@ -1,0 +1,16 @@
+class CreateUserCredentials < ActiveRecord::Migration[8.1]
+  def change
+    create_table :user_credentials do |t|
+      t.references :user, null: false, foreign_key: true
+      t.text :external_id, null: false
+      t.text :public_key, null: false
+      t.string :nickname, null: false
+      t.integer :sign_count, null: false, default: 0
+      t.datetime :last_used_at
+
+      t.timestamps
+    end
+
+    add_index :user_credentials, :external_id, unique: true
+  end
+end

--- a/db/migrate/20260522140004_create_user_sessions.rb
+++ b/db/migrate/20260522140004_create_user_sessions.rb
@@ -1,0 +1,19 @@
+class CreateUserSessions < ActiveRecord::Migration[8.1]
+  def change
+    create_table :user_sessions do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :token_digest, null: false
+      t.string :ip_address
+      t.string :user_agent
+      t.datetime :last_seen_at, null: false
+      t.datetime :terminated_at
+      t.references :terminated_by_user, foreign_key: { to_table: :users }, null: true
+      t.string :termination_reason
+
+      t.timestamps
+    end
+
+    add_index :user_sessions, :token_digest, unique: true
+    add_index :user_sessions, [:user_id, :terminated_at]
+  end
+end

--- a/db/migrate/20260522140005_create_user_invites.rb
+++ b/db/migrate/20260522140005_create_user_invites.rb
@@ -1,0 +1,18 @@
+class CreateUserInvites < ActiveRecord::Migration[8.1]
+  def change
+    create_table :user_invites do |t|
+      t.string :token_digest, null: false
+      t.references :created_by_user, foreign_key: { to_table: :users }, null: true
+      t.string :purpose, null: false
+      t.references :target_user, foreign_key: { to_table: :users }, null: true
+      t.datetime :expires_at, null: false
+      t.datetime :used_at
+      t.references :used_by_user, foreign_key: { to_table: :users }, null: true
+
+      t.timestamps
+    end
+
+    add_index :user_invites, :token_digest, unique: true
+    add_index :user_invites, :expires_at
+  end
+end

--- a/db/migrate/20260522140006_create_user_audit_events.rb
+++ b/db/migrate/20260522140006_create_user_audit_events.rb
@@ -1,0 +1,17 @@
+class CreateUserAuditEvents < ActiveRecord::Migration[8.1]
+  def change
+    create_table :user_audit_events do |t|
+      t.references :user, foreign_key: { on_delete: :nullify }, null: true
+      t.references :actor_user, foreign_key: { to_table: :users, on_delete: :nullify }, null: true
+      t.string :action, null: false
+      t.text :metadata
+      t.string :ip_address
+      t.string :user_agent
+      t.datetime :created_at, null: false
+    end
+
+    add_index :user_audit_events, [:user_id, :created_at]
+    add_index :user_audit_events, [:actor_user_id, :created_at]
+    add_index :user_audit_events, :action
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_20_212540) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_22_140006) do
   create_table "attachments", force: :cascade do |t|
     t.string "content_type"
     t.datetime "created_at", null: false
@@ -226,10 +226,109 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_20_212540) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "user_audit_events", force: :cascade do |t|
+    t.string "action", null: false
+    t.integer "actor_user_id"
+    t.datetime "created_at", null: false
+    t.string "ip_address"
+    t.text "metadata"
+    t.string "user_agent"
+    t.integer "user_id"
+    t.index ["action"], name: "index_user_audit_events_on_action"
+    t.index ["actor_user_id", "created_at"], name: "index_user_audit_events_on_actor_user_id_and_created_at"
+    t.index ["actor_user_id"], name: "index_user_audit_events_on_actor_user_id"
+    t.index ["user_id", "created_at"], name: "index_user_audit_events_on_user_id_and_created_at"
+    t.index ["user_id"], name: "index_user_audit_events_on_user_id"
+  end
+
+  create_table "user_credentials", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.text "external_id", null: false
+    t.datetime "last_used_at"
+    t.string "nickname", null: false
+    t.text "public_key", null: false
+    t.integer "sign_count", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["external_id"], name: "index_user_credentials_on_external_id", unique: true
+    t.index ["user_id"], name: "index_user_credentials_on_user_id"
+  end
+
+  create_table "user_emails", force: :cascade do |t|
+    t.string "address", null: false
+    t.datetime "confirmation_expires_at"
+    t.string "confirmation_token_digest"
+    t.datetime "confirmed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["address"], name: "index_user_emails_on_address", unique: true
+    t.index ["confirmation_token_digest"], name: "index_user_emails_on_confirmation_token_digest", unique: true, where: "confirmation_token_digest IS NOT NULL"
+    t.index ["user_id"], name: "index_user_emails_on_user_id"
+  end
+
+  create_table "user_invites", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "created_by_user_id"
+    t.datetime "expires_at", null: false
+    t.string "purpose", null: false
+    t.integer "target_user_id"
+    t.string "token_digest", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "used_at"
+    t.integer "used_by_user_id"
+    t.index ["created_by_user_id"], name: "index_user_invites_on_created_by_user_id"
+    t.index ["expires_at"], name: "index_user_invites_on_expires_at"
+    t.index ["target_user_id"], name: "index_user_invites_on_target_user_id"
+    t.index ["token_digest"], name: "index_user_invites_on_token_digest", unique: true
+    t.index ["used_by_user_id"], name: "index_user_invites_on_used_by_user_id"
+  end
+
+  create_table "user_sessions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "ip_address"
+    t.datetime "last_seen_at", null: false
+    t.datetime "terminated_at"
+    t.integer "terminated_by_user_id"
+    t.string "termination_reason"
+    t.string "token_digest", null: false
+    t.datetime "updated_at", null: false
+    t.string "user_agent"
+    t.integer "user_id", null: false
+    t.index ["terminated_by_user_id"], name: "index_user_sessions_on_terminated_by_user_id"
+    t.index ["token_digest"], name: "index_user_sessions_on_token_digest", unique: true
+    t.index ["user_id", "terminated_at"], name: "index_user_sessions_on_user_id_and_terminated_at"
+    t.index ["user_id"], name: "index_user_sessions_on_user_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.datetime "blocked_at"
+    t.integer "blocked_by_user_id"
+    t.string "blocked_reason"
+    t.datetime "created_at", null: false
+    t.string "full_name", null: false
+    t.datetime "updated_at", null: false
+    t.string "username", null: false
+    t.string "webauthn_id", null: false
+    t.index ["blocked_at"], name: "index_users_on_blocked_at"
+    t.index ["blocked_by_user_id"], name: "index_users_on_blocked_by_user_id"
+    t.index ["username"], name: "index_users_on_username", unique: true
+  end
+
   add_foreign_key "customers", "languages"
   add_foreign_key "delivery_note_lines", "delivery_notes"
   add_foreign_key "delivery_notes", "attachments", column: "acceptance_attachment_id"
   add_foreign_key "delivery_notes", "customers"
   add_foreign_key "delivery_notes", "invoices"
   add_foreign_key "delivery_notes", "projects"
+  add_foreign_key "user_audit_events", "users", column: "actor_user_id", on_delete: :nullify
+  add_foreign_key "user_audit_events", "users", on_delete: :nullify
+  add_foreign_key "user_credentials", "users"
+  add_foreign_key "user_emails", "users"
+  add_foreign_key "user_invites", "users", column: "created_by_user_id"
+  add_foreign_key "user_invites", "users", column: "target_user_id"
+  add_foreign_key "user_invites", "users", column: "used_by_user_id"
+  add_foreign_key "user_sessions", "users"
+  add_foreign_key "user_sessions", "users", column: "terminated_by_user_id"
+  add_foreign_key "users", "users", column: "blocked_by_user_id"
 end

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -1,0 +1,23 @@
+namespace :users do
+  desc 'Create a signup invite URL for bootstrapping the first user'
+  task invite: :environment do
+    invite, plaintext = UserInvite.create_signup!(actor: nil)
+    UserAuditEvent.record!(
+      action: 'invite_created',
+      user: nil,
+      actor: nil,
+      metadata: { purpose: 'signup', source: 'rake' }
+    )
+
+    url = Rails.application.routes.url_helpers.invite_url(
+      token: plaintext,
+      host: Settings.app.host,
+      protocol: Settings.app.protocol
+    )
+
+    puts ''
+    puts 'Invite URL (valid until ' + invite.expires_at.utc.iso8601 + '):'
+    puts url
+    puts ''
+  end
+end

--- a/test/controllers/account/blocks_controller_test.rb
+++ b/test/controllers/account/blocks_controller_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+class Account::BlocksControllerTest < ActionDispatch::IntegrationTest
+  skip_default_signin!
+
+  test 'self-block sets blocked_at and terminates all sessions' do
+    sign_in_as(users(:alice))
+    other_session, _plain = UserSession.create_for!(user: users(:alice), request: nil)
+
+    post account_block_path
+    assert_response :redirect
+
+    assert users(:alice).reload.blocked?
+    assert_equal 'user self-requested', users(:alice).blocked_reason
+    assert other_session.reload.terminated_at.present?
+  end
+
+  test 'self-block records audit event' do
+    sign_in_as(users(:alice))
+    assert_difference -> { UserAuditEvent.where(action: 'blocked').count }, 1 do
+      post account_block_path
+    end
+  end
+
+  test 'unauthenticated user cannot self-block' do
+    post account_block_path
+    assert_response :redirect
+    assert_redirected_to new_session_path
+    assert_not users(:alice).reload.blocked?
+  end
+end

--- a/test/controllers/account/email_confirmations_controller_test.rb
+++ b/test/controllers/account/email_confirmations_controller_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+
+class Account::EmailConfirmationsControllerTest < ActionDispatch::IntegrationTest
+  skip_default_signin!
+
+  test 'confirms an email with a valid token' do
+    email = users(:alice).emails.create!(address: 'newconfirm@example.com')
+    plaintext = email.generate_confirmation_token!
+
+    get account_email_confirmation_path(token: plaintext)
+    assert_response :redirect
+    assert email.reload.confirmed?
+  end
+
+  test 'rejects an invalid token' do
+    get account_email_confirmation_path(token: 'nope')
+    assert_response :redirect
+    follow_redirect!
+    assert_match(/invalid or expired/i, flash[:alert] || '')
+  end
+
+  test 'rejects an expired token' do
+    email = users(:alice).emails.create!(address: 'exp@example.com')
+    plaintext = email.generate_confirmation_token!
+    email.update_column(:confirmation_expires_at, 1.minute.ago)
+
+    get account_email_confirmation_path(token: plaintext)
+    assert_response :redirect
+    assert_not email.reload.confirmed?
+  end
+
+  test 'records an audit event on confirmation' do
+    email = users(:alice).emails.create!(address: 'audit@example.com')
+    plaintext = email.generate_confirmation_token!
+
+    assert_difference -> { UserAuditEvent.where(action: 'email_confirmed').count }, 1 do
+      get account_email_confirmation_path(token: plaintext)
+    end
+  end
+end

--- a/test/controllers/account/sessions_controller_test.rb
+++ b/test/controllers/account/sessions_controller_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class Account::SessionsControllerTest < ActionDispatch::IntegrationTest
+  test 'index lists active sessions' do
+    sign_in_as(users(:alice))
+    get account_sessions_path
+    assert_response :success
+  end
+
+  test 'destroying another session terminates it but stays signed in' do
+    sign_in_as(users(:alice))
+    other, _plain = UserSession.create_for!(user: users(:alice), request: nil)
+
+    delete account_session_path(other)
+    assert_redirected_to account_sessions_path
+    assert other.reload.terminated_at.present?
+  end
+
+  test 'destroying current session signs the user out' do
+    current = sign_in_as(users(:alice))
+    delete account_session_path(current)
+    assert_redirected_to new_session_path
+    assert current.reload.terminated_at.present?
+  end
+end

--- a/test/controllers/invites_controller_test.rb
+++ b/test/controllers/invites_controller_test.rb
@@ -1,0 +1,44 @@
+require 'test_helper'
+
+class InvitesControllerTest < ActionDispatch::IntegrationTest
+  skip_default_signin!
+
+  test 'show with valid signup token renders form' do
+    get invite_path(token: 'pending-signup-token')
+    assert_response :success
+    assert_select 'h1', text: /Create your account/i
+  end
+
+  test 'show with expired token returns 404 with invalid view' do
+    get invite_path(token: 'expired-signup-token')
+    assert_response :not_found
+    assert_select 'h1', text: /Invite invalid/i
+  end
+
+  test 'show with used token returns 404' do
+    get invite_path(token: 'used-signup-token')
+    assert_response :not_found
+  end
+
+  test 'show with unknown token returns 404' do
+    get invite_path(token: 'totally-bogus')
+    assert_response :not_found
+  end
+
+  test 'options endpoint validates form fields' do
+    post options_invite_path(token: 'pending-signup-token'),
+         params: { username: '', full_name: '', email: '' },
+         as: :json
+    assert_response :unprocessable_content
+    body = JSON.parse(response.body)
+    assert body['errors'].any?
+  end
+
+  test 'options endpoint rejects taken username' do
+    post options_invite_path(token: 'pending-signup-token'),
+         params: { username: 'alice', full_name: 'X', email: 'x@example.com' },
+         as: :json
+    assert_response :unprocessable_content
+    assert_match(/taken/i, JSON.parse(response.body)['error'])
+  end
+end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class SessionsControllerTest < ActionDispatch::IntegrationTest
+  skip_default_signin!
+
+  test 'new is accessible without authentication' do
+    get new_session_path
+    assert_response :success
+  end
+
+  test 'options stashes challenge for a known user' do
+    post options_session_path, params: { username: 'alice' }, as: :json
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert body['challenge'].present?
+  end
+
+  test 'options returns options even for unknown username (no enumeration)' do
+    post options_session_path, params: { username: 'ghost' }, as: :json
+    assert_response :success
+  end
+
+  test 'destroy signs out and clears cookie' do
+    sign_in_as(users(:alice))
+    delete session_path
+    assert_redirected_to new_session_path
+    assert cookies[ApplicationController::SESSION_COOKIE].blank?
+  end
+end

--- a/test/controllers/user_invites_controller_test.rb
+++ b/test/controllers/user_invites_controller_test.rb
@@ -22,4 +22,11 @@ class UserInvitesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select 'code', /\/invites\//
   end
+
+  test 'new form opts out of Turbo so the rendered token page survives' do
+    sign_in_as(users(:alice))
+    get new_user_invite_path
+    assert_response :success
+    assert_select 'form[action=?][data-turbo="false"]', user_invites_path
+  end
 end

--- a/test/controllers/user_invites_controller_test.rb
+++ b/test/controllers/user_invites_controller_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class UserInvitesControllerTest < ActionDispatch::IntegrationTest
+  skip_default_signin!
+
+  test 'new requires authentication' do
+    get new_user_invite_path
+    assert_redirected_to new_session_path
+  end
+
+  test 'new shows the form when signed in' do
+    sign_in_as(users(:alice))
+    get new_user_invite_path
+    assert_response :success
+  end
+
+  test 'create generates an invite and shows URL once' do
+    sign_in_as(users(:alice))
+    assert_difference -> { UserInvite.where(purpose: UserInvite::PURPOSE_SIGNUP).count }, 1 do
+      post user_invites_path
+    end
+    assert_response :success
+    assert_select 'code', /\/invites\//
+  end
+end

--- a/test/controllers/users/emails_controller_test.rb
+++ b/test/controllers/users/emails_controller_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+
+class Users::EmailsControllerTest < ActionDispatch::IntegrationTest
+  test 'admin can add an email without confirmation' do
+    sign_in_as(users(:alice))
+    bob = users(:bob)
+    assert_difference -> { bob.emails.count }, 1 do
+      post user_emails_path(bob), params: { user_email: { address: 'bob.new@example.com' } }
+    end
+    assert_redirected_to user_path(bob)
+    new_email = bob.emails.find_by(address: 'bob.new@example.com')
+    assert new_email.confirmed?
+  end
+
+  test 'admin can replace an email address' do
+    sign_in_as(users(:alice))
+    bob = users(:bob)
+    primary = bob.emails.first
+    put user_email_path(user_id: bob, id: primary), params: { user_email: { address: 'bob.replaced@example.com' } }
+    assert_redirected_to user_path(bob)
+    assert_equal 'bob.replaced@example.com', primary.reload.address
+    assert primary.confirmed?
+  end
+
+  test 'admin cannot remove the last confirmed email' do
+    sign_in_as(users(:alice))
+    bob = users(:bob)
+    primary = bob.emails.first
+    delete user_email_path(user_id: bob, id: primary)
+    assert_redirected_to user_path(bob)
+    assert UserEmail.exists?(primary.id)
+  end
+
+  test 'admin can remove a non-last email' do
+    sign_in_as(users(:bob))
+    alice = users(:alice)
+    secondary = alice.emails.find_by(address: 'alice.alt@example.com')
+    delete user_email_path(user_id: alice, id: secondary)
+    assert_redirected_to user_path(alice)
+    assert_not UserEmail.exists?(secondary.id)
+  end
+end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,89 @@
+require 'test_helper'
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  skip_default_signin!
+
+  test 'index requires authentication' do
+    get users_path
+    assert_redirected_to new_session_path
+  end
+
+  test 'index lists users when signed in' do
+    sign_in_as(users(:alice))
+    get users_path
+    assert_response :success
+    assert_select 'td', text: 'alice'
+    assert_select 'td', text: 'bob'
+  end
+
+  test 'show renders user details' do
+    sign_in_as(users(:alice))
+    get user_path(users(:bob))
+    assert_response :success
+  end
+
+  test 'block requires reason' do
+    sign_in_as(users(:alice))
+    post block_user_path(users(:bob))
+    assert_redirected_to user_path(users(:bob))
+    assert_not users(:bob).reload.blocked?
+  end
+
+  test 'block sets reason and terminates sessions' do
+    sign_in_as(users(:alice))
+    UserSession.create_for!(user: users(:bob), request: nil)
+
+    post block_user_path(users(:bob)), params: { reason: 'misuse' }
+    assert_redirected_to user_path(users(:bob))
+    bob = users(:bob).reload
+    assert bob.blocked?
+    assert_equal 'misuse', bob.blocked_reason
+    assert_equal 0, bob.sessions.active.count
+  end
+
+  test 'block refuses self-target' do
+    sign_in_as(users(:alice))
+    post block_user_path(users(:alice)), params: { reason: 'try' }
+    assert_redirected_to user_path(users(:alice))
+    assert_not users(:alice).reload.blocked?
+  end
+
+  test 'unblock clears blocked fields' do
+    sign_in_as(users(:alice))
+    post unblock_user_path(users(:blocked_carol))
+    assert_redirected_to user_path(users(:blocked_carol))
+    assert_not users(:blocked_carol).reload.blocked?
+  end
+
+  test 'unblock refuses unblocked user' do
+    sign_in_as(users(:alice))
+    post unblock_user_path(users(:bob))
+    assert_redirected_to user_path(users(:bob))
+  end
+
+  test 'reset_passkeys requires user to be blocked' do
+    sign_in_as(users(:alice))
+    post reset_passkeys_user_path(users(:bob))
+    assert_redirected_to user_path(users(:bob))
+    assert users(:bob).reload.credentials.exists?
+  end
+
+  test 'reset_passkeys destroys credentials and creates invite' do
+    sign_in_as(users(:alice))
+    carol = users(:blocked_carol)
+    carol.credentials.create!(external_id: 'cx', public_key: 'pk', nickname: 'k')
+
+    assert_difference -> { UserInvite.where(purpose: UserInvite::PURPOSE_PASSKEY_RESET, target_user: carol).count }, 1 do
+      post reset_passkeys_user_path(carol)
+    end
+    assert_empty carol.reload.credentials
+  end
+
+  test 'audit returns events for the user' do
+    sign_in_as(users(:alice))
+    UserAuditEvent.record!(action: 'login_success', user: users(:bob), actor: users(:bob))
+    get audit_user_path(users(:bob))
+    assert_response :success
+    assert_select 'code', text: 'login_success'
+  end
+end

--- a/test/fixtures/user_audit_events.yml
+++ b/test/fixtures/user_audit_events.yml
@@ -1,0 +1,1 @@
+# Empty: tests create audit events programmatically.

--- a/test/fixtures/user_credentials.yml
+++ b/test/fixtures/user_credentials.yml
@@ -1,0 +1,18 @@
+alice_key:
+  user: alice
+  external_id: alice-ext-1
+  public_key: alice-pubkey-1
+  nickname: Alice Yubikey
+  sign_count: 5
+  last_used_at: <%= 1.hour.ago %>
+  created_at: <%= 1.week.ago %>
+  updated_at: <%= 1.hour.ago %>
+
+bob_key:
+  user: bob
+  external_id: bob-ext-1
+  public_key: bob-pubkey-1
+  nickname: Bob iPhone
+  sign_count: 0
+  created_at: <%= 3.days.ago %>
+  updated_at: <%= 3.days.ago %>

--- a/test/fixtures/user_emails.yml
+++ b/test/fixtures/user_emails.yml
@@ -1,0 +1,27 @@
+alice_primary:
+  user: alice
+  address: alice@example.com
+  confirmed_at: <%= 1.week.ago %>
+  created_at: <%= 1.week.ago %>
+  updated_at: <%= 1.week.ago %>
+
+alice_secondary:
+  user: alice
+  address: alice.alt@example.com
+  confirmed_at: <%= 2.days.ago %>
+  created_at: <%= 3.days.ago %>
+  updated_at: <%= 2.days.ago %>
+
+bob_primary:
+  user: bob
+  address: bob@example.com
+  confirmed_at: <%= 3.days.ago %>
+  created_at: <%= 3.days.ago %>
+  updated_at: <%= 3.days.ago %>
+
+carol_primary:
+  user: blocked_carol
+  address: carol@example.com
+  confirmed_at: <%= 5.days.ago %>
+  created_at: <%= 5.days.ago %>
+  updated_at: <%= 5.days.ago %>

--- a/test/fixtures/user_invites.yml
+++ b/test/fixtures/user_invites.yml
@@ -1,0 +1,22 @@
+pending_signup:
+  token_digest: <%= Digest::SHA256.hexdigest('pending-signup-token') %>
+  purpose: signup
+  expires_at: <%= 12.hours.from_now %>
+  created_at: <%= 1.hour.ago %>
+  updated_at: <%= 1.hour.ago %>
+
+expired_signup:
+  token_digest: <%= Digest::SHA256.hexdigest('expired-signup-token') %>
+  purpose: signup
+  expires_at: <%= 1.hour.ago %>
+  created_at: <%= 26.hours.ago %>
+  updated_at: <%= 26.hours.ago %>
+
+used_signup:
+  token_digest: <%= Digest::SHA256.hexdigest('used-signup-token') %>
+  purpose: signup
+  expires_at: <%= 12.hours.from_now %>
+  used_at: <%= 2.hours.ago %>
+  used_by_user: alice
+  created_at: <%= 6.hours.ago %>
+  updated_at: <%= 2.hours.ago %>

--- a/test/fixtures/user_sessions.yml
+++ b/test/fixtures/user_sessions.yml
@@ -1,0 +1,12 @@
+# Fixture sessions are inert placeholders — tests that need real session
+# auth should call sign_in_as(user) which creates a fresh session with a
+# matching cookie.
+
+alice_active:
+  user: alice
+  token_digest: <%= Digest::SHA256.hexdigest('alice-active-token') %>
+  ip_address: 10.0.0.1
+  user_agent: TestClient
+  last_seen_at: <%= 10.minutes.ago %>
+  created_at: <%= 1.day.ago %>
+  updated_at: <%= 10.minutes.ago %>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,22 @@
+alice:
+  username: alice
+  full_name: Alice Example
+  webauthn_id: alice-webauthn-id
+  created_at: <%= 1.week.ago %>
+  updated_at: <%= 1.week.ago %>
+
+bob:
+  username: bob
+  full_name: Bob Example
+  webauthn_id: bob-webauthn-id
+  created_at: <%= 3.days.ago %>
+  updated_at: <%= 3.days.ago %>
+
+blocked_carol:
+  username: carol
+  full_name: Carol Example
+  webauthn_id: carol-webauthn-id
+  blocked_at: <%= 1.day.ago %>
+  blocked_reason: testing
+  created_at: <%= 5.days.ago %>
+  updated_at: <%= 1.day.ago %>

--- a/test/integration/passkey_login_flow_test.rb
+++ b/test/integration/passkey_login_flow_test.rb
@@ -29,6 +29,13 @@ class PasskeyLoginFlowTest < ActionDispatch::IntegrationTest
     post options_session_path, params: { username: @user.username }, as: :json
     assert_response :success
     options = JSON.parse(response.body)
+    # allowCredentials entries must be {type:, id:} with id as a base64url string,
+    # otherwise Firefox refuses to parse the request options.
+    assert_equal 1, options['allowCredentials'].length
+    descriptor = options['allowCredentials'].first
+    assert_equal 'public-key', descriptor['type']
+    assert_kind_of String, descriptor['id']
+    assert_match(/\A[A-Za-z0-9_-]+\z/, descriptor['id'])
     assertion = @fake_client.get(challenge: options['challenge'])
 
     post verify_session_path, params: { credential: assertion }, as: :json

--- a/test/integration/passkey_login_flow_test.rb
+++ b/test/integration/passkey_login_flow_test.rb
@@ -25,17 +25,12 @@ class PasskeyLoginFlowTest < ActionDispatch::IntegrationTest
     )
   end
 
-  test 'a user with a passkey can sign in' do
-    post options_session_path, params: { username: @user.username }, as: :json
+  test 'a user with a passkey can sign in without supplying a username' do
+    post options_session_path, params: {}, as: :json
     assert_response :success
     options = JSON.parse(response.body)
-    # allowCredentials entries must be {type:, id:} with id as a base64url string,
-    # otherwise Firefox refuses to parse the request options.
-    assert_equal 1, options['allowCredentials'].length
-    descriptor = options['allowCredentials'].first
-    assert_equal 'public-key', descriptor['type']
-    assert_kind_of String, descriptor['id']
-    assert_match(/\A[A-Za-z0-9_-]+\z/, descriptor['id'])
+    # Usernameless flow: server must not pre-narrow the credential list.
+    assert(options['allowCredentials'].blank?, 'allowCredentials should be empty for usernameless flow')
     assertion = @fake_client.get(challenge: options['challenge'])
 
     post verify_session_path, params: { credential: assertion }, as: :json
@@ -57,9 +52,13 @@ class PasskeyLoginFlowTest < ActionDispatch::IntegrationTest
   test 'blocked users cannot sign in' do
     @user.update!(blocked_at: Time.current, blocked_reason: 'test')
 
-    post options_session_path, params: { username: @user.username }, as: :json
-    # User is excluded by User.active scope, so credentials list is empty;
-    # an attempt to verify with the user's actual credential should still fail.
+    post options_session_path, params: {}, as: :json
     assert_response :success
+    options = JSON.parse(response.body)
+    assertion = @fake_client.get(challenge: options['challenge'])
+
+    post verify_session_path, params: { credential: assertion }, as: :json
+    assert_response :unauthorized
+    assert UserAuditEvent.where(action: 'login_failed', user: @user, ).exists?
   end
 end

--- a/test/integration/passkey_login_flow_test.rb
+++ b/test/integration/passkey_login_flow_test.rb
@@ -1,0 +1,58 @@
+require 'test_helper'
+require 'webauthn/fake_client'
+
+class PasskeyLoginFlowTest < ActionDispatch::IntegrationTest
+  skip_default_signin!
+
+  setup do
+    @origin = WebAuthn.configuration.allowed_origins.first
+    @fake_client = WebAuthn::FakeClient.new(@origin)
+    @user = User.create!(username: 'logger', full_name: 'Log Inn')
+    @user.emails.create!(address: 'logger@example.com', confirmed_at: Time.current)
+
+    # Bootstrap a credential the way the registration ceremony would
+    creation_options = WebAuthn::Credential.options_for_create(
+      user: { id: @user.webauthn_id, name: @user.username, display_name: @user.full_name }
+    )
+    raw_credential = @fake_client.create(challenge: creation_options.challenge)
+    webauthn_cred = WebAuthn::Credential.from_create(raw_credential)
+    webauthn_cred.verify(creation_options.challenge)
+    @user.credentials.create!(
+      external_id: webauthn_cred.id,
+      public_key: webauthn_cred.public_key,
+      nickname: 'Test key',
+      sign_count: webauthn_cred.sign_count
+    )
+  end
+
+  test 'a user with a passkey can sign in' do
+    post options_session_path, params: { username: @user.username }, as: :json
+    assert_response :success
+    options = JSON.parse(response.body)
+    assertion = @fake_client.get(challenge: options['challenge'])
+
+    post verify_session_path, params: { credential: assertion }, as: :json
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_equal root_path, body['redirect_url']
+
+    # Confirm we're signed in
+    get account_profile_path
+    assert_response :success
+
+    # Login was audited
+    assert UserAuditEvent.where(action: 'login_success', user: @user).exists?
+
+    # An active session row exists
+    assert @user.sessions.active.exists?
+  end
+
+  test 'blocked users cannot sign in' do
+    @user.update!(blocked_at: Time.current, blocked_reason: 'test')
+
+    post options_session_path, params: { username: @user.username }, as: :json
+    # User is excluded by User.active scope, so credentials list is empty;
+    # an attempt to verify with the user's actual credential should still fail.
+    assert_response :success
+  end
+end

--- a/test/integration/passkey_signup_flow_test.rb
+++ b/test/integration/passkey_signup_flow_test.rb
@@ -1,0 +1,69 @@
+require 'test_helper'
+require 'webauthn/fake_client'
+
+class PasskeySignupFlowTest < ActionDispatch::IntegrationTest
+  skip_default_signin!
+
+  test 'a user can sign up via an invite, register a passkey, then sign in' do
+    _invite, plaintext = UserInvite.create_signup!(actor: nil)
+    origin = WebAuthn.configuration.allowed_origins.first
+    fake_client = WebAuthn::FakeClient.new(origin)
+
+    # Step 1: GET the invite landing page (anonymous)
+    get invite_path(token: plaintext)
+    assert_response :success
+
+    # Step 2: POST signup form fields → receive WebAuthn creation options
+    post options_invite_path(token: plaintext),
+         params: { username: 'newbie', full_name: 'New B. User', email: 'newbie@example.com', nickname: 'Test key' },
+         as: :json
+    assert_response :success
+    options = JSON.parse(response.body)
+    challenge = options['challenge']
+
+    # Step 3: Have the fake authenticator produce an attestation for that challenge
+    public_key_credential = fake_client.create(challenge: challenge)
+
+    # Step 4: POST the credential to verify
+    assert_difference -> { User.count } => 1,
+                      -> { UserEmail.count } => 1,
+                      -> { UserCredential.count } => 1 do
+      post verify_invite_path(token: plaintext),
+           params: { credential: public_key_credential },
+           as: :json
+    end
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_equal account_profile_path, body['redirect_url']
+
+    # Should now be signed in: visit /account/profile and see the user
+    new_user = User.find_by(username: 'newbie')
+    assert_not_nil new_user
+    assert_equal 'New B. User', new_user.full_name
+    assert new_user.confirmed_emails.exists?(address: 'newbie@example.com')
+    assert_equal 1, new_user.credentials.count
+
+    # Audit events are recorded
+    assert UserAuditEvent.where(action: 'signup_completed', user: new_user).exists?
+    assert UserAuditEvent.where(action: 'passkey_added', user: new_user).exists?
+
+    # Invite is consumed
+    invite_record = UserInvite.find_by(used_by_user: new_user)
+    assert_not_nil invite_record
+    assert invite_record.used_at.present?
+  end
+
+  test 'invalid invite token redirects to invalid view' do
+    get invite_path(token: 'not-a-real-token')
+    assert_response :not_found
+  end
+
+  test 'options endpoint rejects taken username' do
+    _invite, plaintext = UserInvite.create_signup!(actor: nil)
+    post options_invite_path(token: plaintext),
+         params: { username: 'alice', full_name: 'X', email: 'fresh@example.com' },
+         as: :json
+    assert_response :unprocessable_content
+    assert_match(/taken/i, JSON.parse(response.body)['error'])
+  end
+end

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -1,0 +1,55 @@
+require 'test_helper'
+
+class UserMailerTest < ActionMailer::TestCase
+  setup do
+    IssuerCompany.find_or_create_by!(active: true) do |c|
+      c.short_name = 'Test'
+      c.legal_name = 'Test GmbH'
+      c.document_email_from = 'noreply@example.com'
+      c.address = "Line 1\nLine 2"
+      c.currency = 'EUR'
+    end
+  end
+
+  def body_text(mail)
+    mail.parts.map { |p| p.body.to_s }.join("\n")
+  end
+
+  test 'email_confirmation includes confirmation URL' do
+    email = users(:alice).emails.create!(address: 'new@example.com')
+    email.generate_confirmation_token!
+    url = 'http://example.com/account/email_confirmations/sometoken'
+
+    mail = UserMailer.email_confirmation(email, url)
+    assert_equal ['new@example.com'], mail.to
+    assert_match url, body_text(mail)
+  end
+
+  test 'email_added_notice goes to the recipient with new address in body' do
+    mail = UserMailer.email_added_notice(users(:alice), 'newish@example.com', 'alice@example.com')
+    assert_equal ['alice@example.com'], mail.to
+    assert_match 'newish@example.com', body_text(mail)
+  end
+
+  test 'email_removed_notice mentions removed address' do
+    mail = UserMailer.email_removed_notice(users(:alice), 'old@example.com', 'alice@example.com')
+    assert_match 'old@example.com', body_text(mail)
+  end
+
+  test 'passkey_added_notice mentions credential nickname' do
+    cred = users(:alice).credentials.first
+    mail = UserMailer.passkey_added_notice(users(:alice), cred, 'alice@example.com')
+    assert_match cred.nickname, body_text(mail)
+  end
+
+  test 'passkey_removed_notice mentions the removed nickname' do
+    mail = UserMailer.passkey_removed_notice(users(:alice), 'Old key', 'alice@example.com')
+    assert_match 'Old key', body_text(mail)
+  end
+
+  test 'passkey_reset_invite includes the invite URL' do
+    url = 'http://example.com/invites/abc123'
+    mail = UserMailer.passkey_reset_invite(users(:alice), url, 'alice@example.com')
+    assert_match url, body_text(mail)
+  end
+end

--- a/test/models/user_audit_event_test.rb
+++ b/test/models/user_audit_event_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+class UserAuditEventTest < ActiveSupport::TestCase
+  test 'record! creates row with action, user, actor, metadata' do
+    request = Struct.new(:remote_ip, :user_agent).new('198.51.100.5', 'TestUA')
+    event = UserAuditEvent.record!(
+      action: 'login_success',
+      user: users(:alice),
+      actor: users(:alice),
+      request: request,
+      metadata: { foo: 'bar', n: 1 }
+    )
+    assert_equal 'login_success', event.action
+    assert_equal users(:alice), event.user
+    assert_equal users(:alice), event.actor
+    assert_equal '198.51.100.5', event.ip_address
+    assert_equal({ 'foo' => 'bar', 'n' => 1 }, event.metadata)
+  end
+
+  test 'for_user returns events where user is subject or actor' do
+    UserAuditEvent.record!(action: 'a', user: users(:alice), actor: users(:bob))
+    UserAuditEvent.record!(action: 'b', user: users(:bob), actor: users(:alice))
+    events = UserAuditEvent.for_user(users(:alice))
+    assert_equal 2, events.count
+  end
+
+  test 'metadata is compacted to drop nil entries' do
+    event = UserAuditEvent.record!(action: 'x', user: users(:alice), metadata: { a: 1, b: nil })
+    assert_equal({ 'a' => 1 }, event.metadata)
+  end
+end

--- a/test/models/user_email_test.rb
+++ b/test/models/user_email_test.rb
@@ -1,0 +1,58 @@
+require 'test_helper'
+
+class UserEmailTest < ActiveSupport::TestCase
+  test 'normalizes address before save' do
+    email = users(:alice).emails.create!(address: '  NEW@Example.Com  ')
+    assert_equal 'new@example.com', email.address
+  end
+
+  test 'requires valid email format' do
+    email = users(:alice).emails.build(address: 'not-an-email')
+    assert_not email.valid?
+  end
+
+  test 'rejects duplicate addresses' do
+    dup = users(:bob).emails.build(address: 'alice@example.com')
+    assert_not dup.valid?
+  end
+
+  test 'generate_confirmation_token! stores digest only' do
+    email = users(:alice).emails.create!(address: 'new@example.com')
+    plaintext = email.generate_confirmation_token!
+    assert plaintext.length > 20
+    email.reload
+    assert email.confirmation_token_digest.present?
+    assert_not_equal plaintext, email.confirmation_token_digest
+    assert email.confirmation_expires_at > Time.current
+  end
+
+  test 'find_by_confirmation_token returns email for matching plaintext' do
+    email = users(:alice).emails.create!(address: 'new@example.com')
+    plaintext = email.generate_confirmation_token!
+    found = UserEmail.find_by_confirmation_token(plaintext)
+    assert_equal email, found
+  end
+
+  test 'find_by_confirmation_token rejects expired tokens' do
+    email = users(:alice).emails.create!(address: 'new@example.com')
+    plaintext = email.generate_confirmation_token!
+    email.update_column(:confirmation_expires_at, 1.minute.ago)
+    assert_nil UserEmail.find_by_confirmation_token(plaintext)
+  end
+
+  test 'find_by_confirmation_token rejects already-confirmed email' do
+    email = users(:alice).emails.create!(address: 'new@example.com')
+    plaintext = email.generate_confirmation_token!
+    email.confirm!
+    assert_nil UserEmail.find_by_confirmation_token(plaintext)
+  end
+
+  test 'confirm! sets confirmed_at and clears token' do
+    email = users(:alice).emails.create!(address: 'new@example.com')
+    email.generate_confirmation_token!
+    email.confirm!
+    assert email.confirmed?
+    assert_nil email.confirmation_token_digest
+    assert_nil email.confirmation_expires_at
+  end
+end

--- a/test/models/user_invite_test.rb
+++ b/test/models/user_invite_test.rb
@@ -1,0 +1,56 @@
+require 'test_helper'
+
+class UserInviteTest < ActiveSupport::TestCase
+  test 'create_signup! returns plaintext and stores digest' do
+    invite, plaintext = UserInvite.create_signup!(actor: users(:alice))
+    assert plaintext.length > 20
+    assert_equal Digest::SHA256.hexdigest(plaintext), invite.token_digest
+    assert_equal UserInvite::PURPOSE_SIGNUP, invite.purpose
+    assert_in_delta UserInvite::EXPIRY.from_now.to_f, invite.expires_at.to_f, 5
+  end
+
+  test 'create_passkey_reset! requires target_user' do
+    assert_raises(ActiveRecord::RecordInvalid) do
+      UserInvite.create!(
+        token_digest: 'abc',
+        purpose: UserInvite::PURPOSE_PASSKEY_RESET,
+        expires_at: 1.hour.from_now
+      )
+    end
+  end
+
+  test 'find_usable matches valid plaintext token' do
+    invite, plaintext = UserInvite.create_signup!(actor: nil)
+    assert_equal invite, UserInvite.find_usable(plaintext)
+  end
+
+  test 'find_usable rejects expired tokens' do
+    invite, plaintext = UserInvite.create_signup!(actor: nil)
+    invite.update_column(:expires_at, 1.minute.ago)
+    assert_nil UserInvite.find_usable(plaintext)
+  end
+
+  test 'find_usable rejects used tokens' do
+    invite, plaintext = UserInvite.create_signup!(actor: nil)
+    invite.update!(used_at: Time.current, used_by_user: users(:alice))
+    assert_nil UserInvite.find_usable(plaintext)
+  end
+
+  test 'consume! marks invite used and tracks user' do
+    invite, _plain = UserInvite.create_signup!(actor: nil)
+    invite.consume!(user: users(:alice))
+    assert invite.used_at.present?
+    assert_equal users(:alice), invite.used_by_user
+    assert_not invite.usable?
+  end
+
+  test 'signup invite cannot have a target_user' do
+    invite = UserInvite.new(
+      token_digest: 'xyz',
+      purpose: UserInvite::PURPOSE_SIGNUP,
+      target_user: users(:alice),
+      expires_at: 1.hour.from_now
+    )
+    assert_not invite.valid?
+  end
+end

--- a/test/models/user_session_test.rb
+++ b/test/models/user_session_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+class UserSessionTest < ActiveSupport::TestCase
+  def fake_request
+    Struct.new(:remote_ip, :user_agent).new('203.0.113.1', 'TestUA')
+  end
+
+  test 'create_for! returns plaintext and stores only digest' do
+    session, plaintext = UserSession.create_for!(user: users(:alice), request: fake_request)
+    assert plaintext.length > 20
+    assert_equal Digest::SHA256.hexdigest(plaintext), session.token_digest
+    assert_equal '203.0.113.1', session.ip_address
+  end
+
+  test 'authenticate matches by digest of plaintext' do
+    _session, plaintext = UserSession.create_for!(user: users(:alice), request: fake_request)
+    assert UserSession.authenticate(plaintext)
+    assert_nil UserSession.authenticate('wrong-token')
+    assert_nil UserSession.authenticate(nil)
+  end
+
+  test 'active scope excludes terminated and expired' do
+    session, plaintext = UserSession.create_for!(user: users(:alice), request: fake_request)
+    assert_includes UserSession.active.to_a, session
+    session.update_column(:last_seen_at, 31.days.ago)
+    assert_not_includes UserSession.active.to_a, session
+  end
+
+  test 'terminate! sets fields and records audit' do
+    session, _plain = UserSession.create_for!(user: users(:alice), request: fake_request)
+    assert_difference -> { UserAuditEvent.where(action: 'session_terminated').count }, 1 do
+      session.terminate!(reason: 'logout', actor: users(:alice))
+    end
+    assert session.terminated_at.present?
+    assert_equal 'logout', session.termination_reason
+    assert_not session.active?
+  end
+
+  test 'touch_seen! updates last_seen_at' do
+    session, _plain = UserSession.create_for!(user: users(:alice), request: fake_request)
+    session.update_column(:last_seen_at, 1.hour.ago)
+    session.touch_seen!(fake_request)
+    assert_in_delta Time.current.to_f, session.reload.last_seen_at.to_f, 5
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,94 @@
+require 'test_helper'
+
+class UserTest < ActiveSupport::TestCase
+  test 'requires username, full name, webauthn id' do
+    user = User.new
+    assert_not user.valid?
+    assert_includes user.errors[:username], "can't be blank"
+    assert_includes user.errors[:full_name], "can't be blank"
+  end
+
+  test 'auto-assigns webauthn_id on create' do
+    user = User.new(username: 'newone', full_name: 'New User')
+    assert user.valid?
+    assert user.webauthn_id.present?
+  end
+
+  test 'username is unique case-insensitively' do
+    User.create!(username: 'newone', full_name: 'New User')
+    dup = User.new(username: 'NewOne', full_name: 'Other')
+    assert_not dup.valid?
+  end
+
+  test 'username format is enforced' do
+    user = User.new(username: 'has spaces', full_name: 'X')
+    assert_not user.valid?
+    assert_includes user.errors[:username], 'is invalid'
+  end
+
+  test 'blocked? reflects blocked_at' do
+    assert_not users(:alice).blocked?
+    assert users(:blocked_carol).blocked?
+  end
+
+  test 'active and blocked scopes' do
+    assert_includes User.active.to_a, users(:alice)
+    assert_not_includes User.active.to_a, users(:blocked_carol)
+    assert_includes User.blocked.to_a, users(:blocked_carol)
+  end
+
+  test 'confirmed_emails returns only confirmed addresses' do
+    alice = users(:alice)
+    assert_equal 2, alice.confirmed_emails.count
+    pending = alice.emails.create!(address: 'pending@example.com')
+    assert_not_includes alice.confirmed_emails.reload, pending
+  end
+
+  test 'block! sets fields, terminates sessions, records audit' do
+    alice = users(:alice)
+    bob = users(:bob)
+    sess, _plaintext = UserSession.create_for!(user: alice, request: nil)
+    active_count_before = alice.sessions.active.count
+
+    assert_difference -> { UserAuditEvent.where(action: 'blocked').count }, 1 do
+      assert_difference -> { UserAuditEvent.where(action: 'session_terminated').count }, active_count_before do
+        alice.block!(reason: 'testing', actor: bob)
+      end
+    end
+
+    alice.reload
+    assert alice.blocked?
+    assert_equal 'testing', alice.blocked_reason
+    assert_equal bob, alice.blocked_by_user
+    assert sess.reload.terminated_at.present?
+  end
+
+  test 'unblock! clears block fields and records audit' do
+    carol = users(:blocked_carol)
+    alice = users(:alice)
+    assert_difference -> { UserAuditEvent.where(action: 'unblocked').count }, 1 do
+      carol.unblock!(actor: alice, reason: 'admin_unblock')
+    end
+    carol.reload
+    assert_not carol.blocked?
+  end
+
+  test 'reset_passkeys! destroys credentials, terminates sessions, returns invite' do
+    alice = users(:alice)
+    bob = users(:bob)
+    UserSession.create_for!(user: alice, request: nil)
+    assert alice.credentials.exists?
+
+    invite, plaintext = nil
+    assert_difference -> { UserInvite.count }, 1 do
+      assert_difference -> { UserAuditEvent.where(action: 'passkey_reset').count }, 1 do
+        invite, plaintext = alice.reset_passkeys!(actor: bob)
+      end
+    end
+
+    assert_empty alice.reload.credentials
+    assert_equal UserInvite::PURPOSE_PASSKEY_RESET, invite.purpose
+    assert_equal alice, invite.target_user
+    assert plaintext.length > 20
+  end
+end

--- a/test/system/user_invites_test.rb
+++ b/test/system/user_invites_test.rb
@@ -1,0 +1,13 @@
+require 'application_system_test_case'
+
+class UserInvitesTest < ApplicationSystemTestCase
+  test 'generating an invite URL renders the token page' do
+    visit new_user_invite_path
+    assert_selector 'h1', text: 'Invite a new user'
+
+    click_button 'Generate invite URL'
+
+    assert_selector 'h1', text: 'Invite generated'
+    assert_selector 'code', text: %r{/invites/}
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -44,7 +44,12 @@ module TestAuthHelpers
   def sign_in_as(user, request_obj = nil)
     request_obj ||= Struct.new(:remote_ip, :user_agent).new('127.0.0.1', 'test')
     session_record, plaintext = UserSession.create_for!(user: user, request: request_obj)
-    cookies[ApplicationController::SESSION_COOKIE] = plaintext
+    if is_a?(ActionDispatch::SystemTestCase)
+      visit '/' if page.current_url.blank? || page.current_url == 'about:blank'
+      page.driver.set_cookie(ApplicationController::SESSION_COOKIE.to_s, plaintext)
+    else
+      cookies[ApplicationController::SESSION_COOKIE] = plaintext
+    end
     session_record
   end
 end
@@ -54,5 +59,9 @@ class ActionDispatch::IntegrationTest
 end
 
 class ActionController::TestCase
+  include TestAuthHelpers
+end
+
+class ActionDispatch::SystemTestCase
   include TestAuthHelpers
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,3 +23,36 @@ class ActiveSupport::TestCase
 
   # Add more helper methods to be used by all tests here...
 end
+
+module TestAuthHelpers
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def skip_default_signin!
+      self._skip_default_signin = true
+    end
+  end
+
+  included do
+    class_attribute :_skip_default_signin, default: false
+
+    setup do
+      sign_in_as(users(:alice)) unless self.class._skip_default_signin
+    end
+  end
+
+  def sign_in_as(user, request_obj = nil)
+    request_obj ||= Struct.new(:remote_ip, :user_agent).new('127.0.0.1', 'test')
+    session_record, plaintext = UserSession.create_for!(user: user, request: request_obj)
+    cookies[ApplicationController::SESSION_COOKIE] = plaintext
+    session_record
+  end
+end
+
+class ActionDispatch::IntegrationTest
+  include TestAuthHelpers
+end
+
+class ActionController::TestCase
+  include TestAuthHelpers
+end


### PR DESCRIPTION
This PR implements a complete passkey (WebAuthn) authentication system for ABT, replacing password-based authentication with modern passwordless security.

## Summary

Adds user account management, passkey-based authentication, and session handling. Users are created via time-limited invites and authenticate using WebAuthn credentials stored on their devices. Includes comprehensive audit logging, email management, and admin controls for user lifecycle management.

## Key Changes

**Authentication & Sessions**
- New `User` model with username, full name, and WebAuthn ID
- `UserSession` model for tracking active sessions with IP/user agent
- `SessionsController` for passkey-based login/logout
- Session cookie-based authentication via `ApplicationController`
- `Current` thread-local attributes for accessing current user/session

**User Invitations & Onboarding**
- `UserInvite` model supporting signup and passkey reset flows
- `InvitesController` for handling registration and credential verification
- 24-hour expiring invite tokens with digest storage
- Signup form validation (username format, email format, uniqueness)

**Credential Management**
- `UserCredential` model storing WebAuthn public keys and metadata
- `Account::CredentialsController` for adding/removing passkeys
- Support for multiple credentials per user with nicknames
- Sign count tracking for replay attack detection

**Email Management**
- `UserEmail` model with confirmation workflow
- `Account::EmailsController` for managing user emails
- Email confirmation tokens with 48-hour expiry
- `UserMailer` for confirmation and notification emails
- Admin ability to add pre-confirmed emails via `Users::EmailsController`

**User Administration**
- `UsersController` for listing, viewing, blocking, and unblocking users
- User blocking with reason tracking and session termination
- Passkey reset capability for locked-out users
- `User` scopes for active/blocked filtering

**Audit Logging**
- `UserAuditEvent` model tracking all user-related actions
- Automatic recording of login, email changes, credential changes, blocks
- IP address and user agent capture for security analysis
- `Account::AuditEventsController` for viewing personal activity log

**Frontend**
- `PasskeyController` Stimulus controller handling WebAuthn ceremonies
- Registration and authentication flows with error handling
- Browser compatibility detection and fallback base64url decoding
- Views for signup, login, account management, and admin panels

**Database**
- 6 new migrations creating users, emails, credentials, sessions, invites, and audit events tables
- Appropriate indexes on foreign keys and frequently queried columns

**Configuration & Initialization**
- WebAuthn configuration via `config/initializers/webauthn.rb`
- Settings for RP name, ID, and origin in environment-specific configs
- Rake task `users:invite` for bootstrapping first user

**Testing**
- Integration tests for signup and login flows using WebAuthn fake client
- Unit tests for User, UserEmail, UserInvite, UserSession models
- Controller tests for authentication, user management, and email flows
- Test fixtures for users, emails, credentials, sessions, and invites

## Notable Implementation Details

- Passwords are never stored; all authentication is via WebAuthn
- Session tokens are SHA256-digested before storage (never plaintext)
- Invite tokens use the same digest pattern for security
- User blocking immediately terminates all active sessions
- Email confirmation is optional for users but can be pre-confirmed by admins
- Audit events capture metadata as JSON for flexible querying
- Username normalization (lowercase) prevents case-sensitivity issues
- WebAuthn user ID is auto-generated on user creation and immutable

https://claude.ai/code/session_01Hp6QVQ6ZrD8TmpbHEgY1Kk