### PR TITLE
Validate attachment uploads and harden serving

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -1,10 +1,15 @@
 class AttachmentsController < ApplicationController
+  INLINE_CONTENT_TYPES = %w[application/pdf].freeze
+
   def show
     @attachment = Attachment.find(params[:id])
+    served_type = @attachment.safe_content_type
+    disposition = INLINE_CONTENT_TYPES.include?(served_type) ? 'inline' : 'attachment'
+    response.set_header('X-Content-Type-Options', 'nosniff')
     send_data @attachment.data,
-              :filename => @attachment.filename,
-              :type => @attachment.content_type,
-              :title => @attachment.title
+              filename: @attachment.filename,
+              type: served_type,
+              disposition: disposition
   end
 
   def create
@@ -18,7 +23,7 @@ class AttachmentsController < ApplicationController
       flash[:notice] = "Attachment created."
       redirect_to :action => "index"  # FIXME: do something useful
     else
-      flash[:error] = "Saving attachment failed."
+      flash[:error] = "Saving attachment failed: #{@attachment.errors.full_messages.join(', ')}"
       render :action => "new"
     end
   end

--- a/app/controllers/delivery_notes_controller.rb
+++ b/app/controllers/delivery_notes_controller.rb
@@ -204,6 +204,11 @@ class DeliveryNotesController < ApplicationController
       redirect_to @delivery_note and return
     end
 
+    if uploaded_file.size > Attachment::MAX_SIZE_BYTES
+      flash[:error] = "Acceptance document is too large (maximum is #{Attachment::MAX_SIZE_BYTES / 1.megabyte} MB)."
+      redirect_to @delivery_note and return
+    end
+
     # If there's an existing acceptance attachment, delete it first
     if @delivery_note.acceptance_attachment.present?
       old_attachment = @delivery_note.acceptance_attachment

--- a/app/controllers/delivery_notes_controller.rb
+++ b/app/controllers/delivery_notes_controller.rb
@@ -199,13 +199,14 @@ class DeliveryNotesController < ApplicationController
       redirect_to @delivery_note and return
     end
 
-    if uploaded_file.content_type != 'application/pdf'
-      flash[:error] = "Only PDF files are allowed for acceptance documents."
+    if uploaded_file.size > Attachment::MAX_SIZE_BYTES
+      flash[:error] = "Acceptance document is too large (maximum is #{Attachment::MAX_SIZE_BYTES / 1.megabyte} MB)."
       redirect_to @delivery_note and return
     end
 
-    if uploaded_file.size > Attachment::MAX_SIZE_BYTES
-      flash[:error] = "Acceptance document is too large (maximum is #{Attachment::MAX_SIZE_BYTES / 1.megabyte} MB)."
+    detected_type = Attachment.detect_content_type(uploaded_file.tempfile)
+    if detected_type != 'application/pdf'
+      flash[:error] = "Only PDF files are allowed for acceptance documents (detected: #{detected_type})."
       redirect_to @delivery_note and return
     end
 
@@ -218,7 +219,7 @@ class DeliveryNotesController < ApplicationController
 
     # Create new attachment
     attachment = Attachment.new
-    attachment.set_data uploaded_file.read, uploaded_file.content_type
+    attachment.set_data uploaded_file.read, 'application/pdf'
     attachment.filename = uploaded_file.original_filename
     attachment.title = "Acceptance Document for Delivery Note #{@delivery_note.document_number}"
 

--- a/app/controllers/issuer_companies_controller.rb
+++ b/app/controllers/issuer_companies_controller.rb
@@ -1,4 +1,8 @@
 class IssuerCompaniesController < ApplicationController
+  MAX_LOGO_SIZE_BYTES = 2.megabytes
+  PNG_MAGIC = "\x89PNG\r\n\x1A\n".b.freeze
+  PDF_MAGIC = "%PDF-".b.freeze
+
   before_action :set_issuer_company
 
   def show
@@ -6,6 +10,7 @@ class IssuerCompaniesController < ApplicationController
 
   def png_logo
     if @issuer_company.png_logo.present?
+      response.set_header('X-Content-Type-Options', 'nosniff')
       send_data @issuer_company.png_logo, type: 'image/png', disposition: 'inline'
     else
       head :not_found
@@ -21,14 +26,14 @@ class IssuerCompaniesController < ApplicationController
 
     # Handle PDF logo upload
     if params[:issuer_company][:pdf_logo_file].present?
-      file = params[:issuer_company][:pdf_logo_file]
-      params_hash[:pdf_logo] = file.read
+      data = read_validated_logo(params[:issuer_company][:pdf_logo_file], PDF_MAGIC, 'PDF') or return
+      params_hash[:pdf_logo] = data
     end
 
     # Handle PNG logo upload
     if params[:issuer_company][:png_logo_file].present?
-      file = params[:issuer_company][:png_logo_file]
-      params_hash[:png_logo] = file.read
+      data = read_validated_logo(params[:issuer_company][:png_logo_file], PNG_MAGIC, 'PNG') or return
+      params_hash[:png_logo] = data
     end
 
     if @issuer_company.update(params_hash)
@@ -39,6 +44,21 @@ class IssuerCompaniesController < ApplicationController
   end
 
   private
+
+  def read_validated_logo(file, magic, label)
+    if file.size > MAX_LOGO_SIZE_BYTES
+      redirect_to edit_issuer_company_path,
+                  alert: "#{label} logo is too large (maximum is #{MAX_LOGO_SIZE_BYTES / 1.megabyte} MB)."
+      return nil
+    end
+    data = file.read
+    unless data.byteslice(0, magic.bytesize) == magic
+      redirect_to edit_issuer_company_path,
+                  alert: "#{label} logo: file content does not match a #{label} file."
+      return nil
+    end
+    data
+  end
 
   def set_issuer_company
     @issuer_company = IssuerCompany.get_the_issuer! || IssuerCompany.new

--- a/app/controllers/issuer_companies_controller.rb
+++ b/app/controllers/issuer_companies_controller.rb
@@ -1,7 +1,5 @@
 class IssuerCompaniesController < ApplicationController
   MAX_LOGO_SIZE_BYTES = 2.megabytes
-  PNG_MAGIC = "\x89PNG\r\n\x1A\n".b.freeze
-  PDF_MAGIC = "%PDF-".b.freeze
 
   before_action :set_issuer_company
 
@@ -26,13 +24,13 @@ class IssuerCompaniesController < ApplicationController
 
     # Handle PDF logo upload
     if params[:issuer_company][:pdf_logo_file].present?
-      data = read_validated_logo(params[:issuer_company][:pdf_logo_file], PDF_MAGIC, 'PDF') or return
+      data = read_validated_logo(params[:issuer_company][:pdf_logo_file], 'application/pdf', 'PDF') or return
       params_hash[:pdf_logo] = data
     end
 
     # Handle PNG logo upload
     if params[:issuer_company][:png_logo_file].present?
-      data = read_validated_logo(params[:issuer_company][:png_logo_file], PNG_MAGIC, 'PNG') or return
+      data = read_validated_logo(params[:issuer_company][:png_logo_file], 'image/png', 'PNG') or return
       params_hash[:png_logo] = data
     end
 
@@ -45,19 +43,19 @@ class IssuerCompaniesController < ApplicationController
 
   private
 
-  def read_validated_logo(file, magic, label)
+  def read_validated_logo(file, expected_type, label)
     if file.size > MAX_LOGO_SIZE_BYTES
       redirect_to edit_issuer_company_path,
                   alert: "#{label} logo is too large (maximum is #{MAX_LOGO_SIZE_BYTES / 1.megabyte} MB)."
       return nil
     end
-    data = file.read
-    unless data.byteslice(0, magic.bytesize) == magic
+    detected = Attachment.detect_content_type(file.tempfile)
+    if detected != expected_type
       redirect_to edit_issuer_company_path,
-                  alert: "#{label} logo: file content does not match a #{label} file."
+                  alert: "#{label} logo: file content is not #{expected_type} (detected: #{detected})."
       return nil
     end
-    data
+    file.read
   end
 
   def set_issuer_company

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -1,5 +1,11 @@
 class Attachment < ApplicationRecord
-  validates :title, :presence => true
+  MAX_SIZE_BYTES = 25.megabytes
+  SAFE_CONTENT_TYPES = %w[application/pdf image/png image/jpeg].freeze
+  DEFAULT_CONTENT_TYPE = 'application/octet-stream'.freeze
+
+  validates :title, presence: true
+  validate :data_size_within_limit
+  validate :content_type_in_safelist
 
   def uploaded_file=(incoming_file)
     self.filename = incoming_file.original_filename
@@ -16,11 +22,32 @@ class Attachment < ApplicationRecord
     write_attribute("filename", sanitize_filename(new_filename))
   end
 
+  # Returns a safelisted content type, or octet-stream for unknown values.
+  # Used when serving attachment data to neuter XSS via a crafted Content-Type.
+  def safe_content_type
+    SAFE_CONTENT_TYPES.include?(content_type) ? content_type : DEFAULT_CONTENT_TYPE
+  end
+
   private
+
   def sanitize_filename(filename)
     # get only the filename, not the whole path (from IE)
     just_filename = File.basename(filename)
     # replace all non-alphanumeric, underscore or periods with underscores
     just_filename.gsub(/[^\w\.\-]/, '_')
+  end
+
+  def data_size_within_limit
+    return if data.blank?
+    if data.bytesize > MAX_SIZE_BYTES
+      errors.add(:data, "is too large (maximum is #{MAX_SIZE_BYTES / 1.megabyte} MB)")
+    end
+  end
+
+  def content_type_in_safelist
+    return if content_type.blank?
+    unless SAFE_CONTENT_TYPES.include?(content_type)
+      errors.add(:content_type, "must be one of: #{SAFE_CONTENT_TYPES.join(', ')}")
+    end
   end
 end

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -7,10 +7,21 @@ class Attachment < ApplicationRecord
   validate :data_size_within_limit
   validate :content_type_in_safelist
 
+  # Detect MIME type from the binary content using Marcel (magic-byte sniffer
+  # used by ActiveStorage). Trusting the client-supplied Content-Type would
+  # let a user-supplied HTML file be served as e.g. application/pdf, which
+  # the safelist on `content_type` is meant to prevent.
+  def self.detect_content_type(io)
+    detected = Marcel::MimeType.for(io)
+    io.rewind if io.respond_to?(:rewind)
+    detected
+  end
+
   def uploaded_file=(incoming_file)
     self.filename = incoming_file.original_filename
-    self.content_type = incoming_file.content_type
-    self.data = incoming_file.read
+    io = incoming_file.respond_to?(:tempfile) ? incoming_file.tempfile : incoming_file
+    self.content_type = self.class.detect_content_type(io)
+    self.data = io.read
   end
 
   def set_data(data, content_type)

--- a/test/controllers/attachments_controller_test.rb
+++ b/test/controllers/attachments_controller_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class AttachmentsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @attachment = attachments(:invoice_pdf)
+  end
+
+  test 'show serves a PDF inline with nosniff header' do
+    get attachment_url(@attachment)
+    assert_response :success
+    assert_equal 'application/pdf', response.media_type
+    assert_match(/inline/, response.headers['Content-Disposition'].to_s)
+    assert_equal 'nosniff', response.headers['X-Content-Type-Options']
+  end
+
+  test 'show forces attachment disposition and octet-stream for non-safelisted content types' do
+    @attachment.update_column(:content_type, 'text/html')
+    get attachment_url(@attachment)
+    assert_response :success
+    assert_equal 'application/octet-stream', response.media_type
+    assert_match(/attachment/, response.headers['Content-Disposition'].to_s)
+    assert_equal 'nosniff', response.headers['X-Content-Type-Options']
+  end
+
+  test 'create rejects oversized uploads' do
+    big = Rack::Test::UploadedFile.new(
+      StringIO.new('x' * (Attachment::MAX_SIZE_BYTES + 1)),
+      'application/pdf',
+      original_filename: 'big.pdf'
+    )
+    assert_no_difference -> { Attachment.count } do
+      post attachments_url, params: { attachment: { attachment: big, title: 'big' } }
+    end
+    assert_match(/too large/, flash[:error])
+  end
+
+  test 'create rejects disallowed content types' do
+    bad = Rack::Test::UploadedFile.new(
+      StringIO.new('<script>alert(1)</script>'),
+      'text/html',
+      original_filename: 'evil.html'
+    )
+    assert_no_difference -> { Attachment.count } do
+      post attachments_url, params: { attachment: { attachment: bad, title: 'evil' } }
+    end
+    assert_match(/Content type/, flash[:error])
+  end
+end

--- a/test/controllers/issuer_companies_controller_test.rb
+++ b/test/controllers/issuer_companies_controller_test.rb
@@ -42,6 +42,56 @@ class IssuerCompaniesControllerTest < ActionDispatch::IntegrationTest
     assert_select 'form'
   end
 
+  test "should reject oversized png logo upload" do
+    big = Rack::Test::UploadedFile.new(
+      StringIO.new('x' * (IssuerCompaniesController::MAX_LOGO_SIZE_BYTES + 1)),
+      'image/png',
+      original_filename: 'big.png'
+    )
+    patch issuer_company_url, params: {
+      issuer_company: { png_logo_file: big }
+    }
+    assert_redirected_to edit_issuer_company_url
+    follow_redirect!
+    assert_select '.alert-danger', text: /too large/
+  end
+
+  test "should reject png upload that is not a real png" do
+    fake = Rack::Test::UploadedFile.new(
+      StringIO.new('<script>alert(1)</script>'),
+      'image/png',
+      original_filename: 'evil.png'
+    )
+    patch issuer_company_url, params: {
+      issuer_company: { png_logo_file: fake }
+    }
+    assert_redirected_to edit_issuer_company_url
+    follow_redirect!
+    assert_select '.alert-danger', text: /does not match/
+  end
+
+  test "should accept a valid png upload" do
+    png_data = "\x89PNG\r\n\x1A\n".b + ("\x00" * 32).b
+    valid = Rack::Test::UploadedFile.new(
+      StringIO.new(png_data),
+      'image/png',
+      original_filename: 'logo.png'
+    )
+    patch issuer_company_url, params: {
+      issuer_company: { png_logo_file: valid }
+    }
+    assert_redirected_to issuer_company_url
+    @issuer_company.reload
+    assert_equal png_data, @issuer_company.png_logo
+  end
+
+  test "png_logo response sets nosniff header" do
+    @issuer_company.update!(png_logo: "\x89PNG\r\n\x1A\n".b + "rest".b)
+    get png_logo_issuer_company_url
+    assert_response :success
+    assert_equal 'nosniff', response.headers['X-Content-Type-Options']
+  end
+
   test "should preserve whitespace in contact lines on show page" do
     # Update the fixture to have explicit whitespace
     @issuer_company.update!(

--- a/test/controllers/issuer_companies_controller_test.rb
+++ b/test/controllers/issuer_companies_controller_test.rb
@@ -67,7 +67,7 @@ class IssuerCompaniesControllerTest < ActionDispatch::IntegrationTest
     }
     assert_redirected_to edit_issuer_company_url
     follow_redirect!
-    assert_select '.alert-danger', text: /does not match/
+    assert_select '.alert-danger', text: /not image\/png/
   end
 
   test "should accept a valid png upload" do

--- a/test/functional/delivery_notes_controller_test.rb
+++ b/test/functional/delivery_notes_controller_test.rb
@@ -250,7 +250,7 @@ class DeliveryNotesControllerTest < ActionController::TestCase
 
     # Upload a replacement
     second_pdf = Rack::Test::UploadedFile.new(
-      StringIO.new('replacement pdf content'),
+      Rails.root.join('test', 'fixtures', 'files', 'example_logo.pdf'),
       'application/pdf',
       original_filename: 'replacement.pdf'
     )

--- a/test/models/attachment_test.rb
+++ b/test/models/attachment_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+class AttachmentTest < ActiveSupport::TestCase
+  test 'valid attachment with pdf content type saves' do
+    attachment = Attachment.new(title: 'OK', filename: 'a.pdf',
+                                 content_type: 'application/pdf', data: 'pdf')
+    assert attachment.valid?
+  end
+
+  test 'rejects content type outside safelist' do
+    attachment = Attachment.new(title: 'XSS', filename: 'a.html',
+                                 content_type: 'text/html', data: '<script>')
+    assert_not attachment.valid?
+    assert_includes attachment.errors[:content_type].first, 'must be one of'
+  end
+
+  test 'rejects data larger than MAX_SIZE_BYTES' do
+    attachment = Attachment.new(title: 'big', filename: 'a.pdf',
+                                 content_type: 'application/pdf',
+                                 data: 'x' * (Attachment::MAX_SIZE_BYTES + 1))
+    assert_not attachment.valid?
+    assert_includes attachment.errors[:data].first, 'too large'
+  end
+
+  test 'safe_content_type returns whitelisted content type for safe values' do
+    attachment = Attachment.new(content_type: 'application/pdf')
+    assert_equal 'application/pdf', attachment.safe_content_type
+  end
+
+  test 'safe_content_type returns octet-stream for unsafe values' do
+    attachment = attachments(:invoice_pdf)
+    attachment.update_column(:content_type, 'text/html')
+    assert_equal 'application/octet-stream', attachment.reload.safe_content_type
+  end
+end


### PR DESCRIPTION
Reject attachment uploads outside a small content-type safelist
(application/pdf, image/png, image/jpeg) and cap size at 25 MB. Serve
attachments with X-Content-Type-Options: nosniff, force download for
anything other than PDF, and normalise unknown content types to
application/octet-stream so a crafted upload cannot be served as HTML.

Cap issuer logo uploads at 2 MB and check PNG/PDF magic bytes before
storing. Set nosniff on the inline png_logo response. Mirror the size
cap on delivery-note acceptance PDF uploads.

Addresses #262, #265.