### PR TITLE
Enable strict CSP and Permissions-Policy headers

### DIFF
--- a/app/assets/stylesheets/utilities.css.scss
+++ b/app/assets/stylesheets/utilities.css.scss
@@ -1,0 +1,123 @@
+// Utility / scoped classes that replace inline style="..." attributes so
+// the app can run under a strict CSP without 'unsafe-inline' for style-src.
+
+// --- Reusable utilities ---
+
+.text-pre-wrap {
+  white-space: pre-wrap;
+}
+
+.initially-hidden {
+  // Use a class rather than inline style="display: none;" for initial state.
+  // Not !important so JS can override with element.style.display = '...'
+  display: none;
+}
+
+// --- Fixed-width form helpers ---
+
+.w-fixed-400 { width: 400px; }
+.w-fixed-250 { width: 250px; }
+
+// --- Searchable dropdown scrollable content ---
+// (used by app/views/shared/_searchable_dropdown.html.haml etc.)
+.searchable-dropdown,
+.customer-dropdown,
+.project-dropdown {
+  .dropdown-content {
+    max-height: 300px;
+    overflow-y: auto;
+  }
+}
+
+// --- Document line tables (invoices show, delivery notes show) ---
+
+.document-lines-table {
+  th.col-description { width: 55%; }
+  th.col-quantity    { width: 10%; }
+  th.col-rate        { width: 15%; }
+  th.col-tax-class   { width: 10%; }
+  th.col-amount      { width: 15%; }
+
+  td.document-section-row { padding: 12px 8px; }
+  td.document-text-row    { padding: 8px; }
+
+  .document-line-comment { margin-left: 20px; }
+}
+
+// --- Email preview modal & iframe (invoices/show, delivery_notes/show) ---
+
+.email-preview-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1050;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.email-preview-modal-dialog {
+  max-width: 800px;
+  width: 90%;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.email-preview-iframe {
+  width: 100%;
+  height: 400px;
+  border: 1px solid #dee2e6;
+  border-radius: 0.375rem;
+}
+
+// --- Error notification dropdown (layout/_navigation) ---
+
+.error-notification-dropdown {
+  width: 280px;
+  max-height: 300px;
+  overflow-y: auto;
+  z-index: 1050;
+  right: 0;
+  left: auto;
+}
+
+.error-notification-clear-all {
+  font-size: 0.75rem;
+}
+
+.error-notification-error-text {
+  min-width: 0;
+}
+
+.error-notification-error-message {
+  word-break: break-word;
+}
+
+.error-notification-clear-button {
+  min-width: 24px;
+}
+
+// --- Dashboard ---
+
+.dashboard-issuer-logo {
+  max-height: 80px;
+  max-width: 200px;
+}
+
+.text-issuer-accent {
+  color: var(--issuer-accent-color) !important;
+}
+
+.badge-issuer-accent {
+  background-color: var(--issuer-accent-color);
+}
+
+// --- Jobs status ---
+
+.job-row-description {
+  max-width: 480px;
+  word-break: break-word;
+}

--- a/app/javascript/controllers/base_lines_controller.js
+++ b/app/javascript/controllers/base_lines_controller.js
@@ -180,9 +180,7 @@ export default class extends Controller {
 
   toggleProductDropdownForLine(line) {
     const dropdown = line.querySelector('[data-product-dropdown]')
-
-    const isVisible = dropdown.style.display !== 'none'
-    dropdown.style.display = isVisible ? 'none' : 'block'
+    dropdown.classList.toggle('d-none')
   }
 
   toggleProductDropdown(event) {

--- a/app/javascript/controllers/clear_input_controller.js
+++ b/app/javascript/controllers/clear_input_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["field"]
+
+  clear(event) {
+    event.preventDefault()
+    if (this.hasFieldTarget) {
+      this.fieldTarget.value = ""
+      this.fieldTarget.dispatchEvent(new Event("input", { bubbles: true }))
+      this.fieldTarget.dispatchEvent(new Event("change", { bubbles: true }))
+    }
+  }
+}

--- a/app/javascript/controllers/error_notification_controller.js
+++ b/app/javascript/controllers/error_notification_controller.js
@@ -161,12 +161,12 @@ export default class extends Controller {
       this.listTarget.innerHTML = this.errors.map(error => `
         <li class="dropdown-item-text small py-2 px-3" data-error-id="${error.id}">
           <div class="d-flex justify-content-between align-items-start">
-            <div class="flex-grow-1 me-2" style="min-width: 0;">
-              <div class="fw-bold text-danger text-wrap" style="word-break: break-word;">${error.message}</div>
+            <div class="flex-grow-1 me-2 error-notification-error-text">
+              <div class="fw-bold text-danger text-wrap error-notification-error-message">${error.message}</div>
               <div class="text-muted small">${this.formatTimestamp(error.timestamp)}</div>
             </div>
-            <button type="button" class="btn btn-sm btn-outline-secondary flex-shrink-0"
-                    data-action="click->error-notification#clearError" style="min-width: 24px;">×</button>
+            <button type="button" class="btn btn-sm btn-outline-secondary flex-shrink-0 error-notification-clear-button"
+                    data-action="click->error-notification#clearError">×</button>
           </div>
         </li>
       `).join('')

--- a/app/javascript/controllers/generic_email_preview_controller.js
+++ b/app/javascript/controllers/generic_email_preview_controller.js
@@ -188,7 +188,7 @@ export default class extends Controller {
 
     const textContentSection = data.text_body ? `
       <div class="card-body email-preview-content d-none" data-format-content="text">
-        <pre class="mb-0" style="white-space: pre-wrap; font-family: monospace;">${data.text_body}</pre>
+        <pre class="mb-0 font-monospace text-pre-wrap">${data.text_body}</pre>
       </div>
     ` : ''
 
@@ -266,7 +266,7 @@ export default class extends Controller {
             </div>
             <div class="card-body email-preview-content" data-format-content="html">
               ${data.html_body ? `
-                <iframe src="${iframeContent}" style="width: 100%; height: 400px; border: 1px solid #dee2e6; border-radius: 0.375rem;"></iframe>
+                <iframe class="email-preview-iframe" src="${iframeContent}"></iframe>
               ` : '<p class="text-muted"><i>No HTML content available</i></p>'}
             </div>
 

--- a/app/javascript/controllers/invoice_lines_controller.js
+++ b/app/javascript/controllers/invoice_lines_controller.js
@@ -63,7 +63,7 @@ export default class extends BaseLinesController {
 
       // Hide the dropdown
       const dropdown = line.querySelector('[data-product-dropdown]')
-      dropdown.style.display = 'none'
+      dropdown.classList.add('d-none')
 
       // Update totals
       this.updateTotal()

--- a/app/javascript/controllers/toggle_visibility_controller.js
+++ b/app/javascript/controllers/toggle_visibility_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["panel"]
+
+  toggle(event) {
+    event.preventDefault()
+    if (this.hasPanelTarget) {
+      this.panelTarget.classList.toggle("d-none")
+    }
+  }
+}

--- a/app/middleware/permissions_policy_header.rb
+++ b/app/middleware/permissions_policy_header.rb
@@ -1,0 +1,29 @@
+# Rails 8 still emits the deprecated `Feature-Policy` header for
+# `config.permissions_policy`. Modern browsers expect the renamed
+# `Permissions-Policy` header (different syntax: `name=(allow-list)`),
+# so this middleware emits it alongside Rails's output.
+#
+# Keep the directive list in sync with config/initializers/permissions_policy.rb.
+class PermissionsPolicyHeader
+  POLICY = [
+    "camera=()",
+    "microphone=()",
+    "geolocation=()",
+    "gyroscope=()",
+    "magnetometer=()",
+    "accelerometer=()",
+    "usb=()",
+    "payment=()",
+    "fullscreen=(self)"
+  ].join(", ").freeze
+
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    status, headers, body = @app.call(env)
+    headers["Permissions-Policy"] ||= POLICY
+    [status, headers, body]
+  end
+end

--- a/app/models/issuer_company.rb
+++ b/app/models/issuer_company.rb
@@ -1,6 +1,9 @@
 class IssuerCompany < ApplicationRecord
   validates :short_name, presence: true
   validates :legal_name, presence: true
+  validates :document_accent_color,
+            format: { with: /\A#[0-9a-fA-F]{3,8}\z/, message: 'must be a hex color like #rrggbb' },
+            allow_blank: true
 
   # This app requires that there is exactly *one* issuer_company in the database.
   def self.get_the_issuer!

--- a/app/views/delivery_notes/_form.html.haml
+++ b/app/views/delivery_notes/_form.html.haml
@@ -35,7 +35,7 @@
                 .dropdown-menu{ id: 'customer-dropdown-menu', data: { searchable_dropdown_target: 'dropdown' } }
                   .p-2.border-bottom
                     %input.form-control.form-control-sm{ type: 'text', placeholder: 'Search customers...', data: { searchable_dropdown_target: 'search' } }
-                  .dropdown-content{ style: 'max-height: 300px; overflow-y: auto;' }
+                  .dropdown-content
                     .dropdown-item.text-muted Loading...
         .col-sm-4
           .mb-3
@@ -65,7 +65,7 @@
                 .dropdown-menu{ id: 'project-dropdown-menu', data: { searchable_dropdown_target: 'dropdown' } }
                   .p-2.border-bottom
                     %input.form-control.form-control-sm{ type: 'text', placeholder: 'Search projects...', data: { searchable_dropdown_target: 'search' } }
-                  .dropdown-content{ style: 'max-height: 300px; overflow-y: auto;' }
+                  .dropdown-content
                     .dropdown-item.text-muted Loading...
         .col-sm-4.order-sm-3
           .mb-3
@@ -74,9 +74,9 @@
           .d-sm-none
             .mb-3
               %label.form-label Delivery End Date
-              .input-group
-                = f.date_field :delivery_end_date, class: 'form-control'
-                %button.btn.btn-outline-secondary{type: 'button', onclick: 'this.previousElementSibling.value = ""', title: 'Clear date'}
+              .input-group{data: {controller: 'clear-input'}}
+                = f.date_field :delivery_end_date, class: 'form-control', data: { 'clear-input-target': 'field' }
+                %button.btn.btn-outline-secondary{type: 'button', data: { action: 'click->clear-input#clear' }, title: 'Clear date'}
                   ×
               .form-text.text-muted Leave empty if same as start date
 
@@ -92,9 +92,9 @@
         .col-sm-4.order-sm-3.d-none.d-sm-block
           .mb-3
             %label.form-label Delivery End Date
-            .input-group
-              = f.date_field :delivery_end_date, class: 'form-control'
-              %button.btn.btn-outline-secondary{type: 'button', onclick: 'this.previousElementSibling.value = ""', title: 'Clear date'}
+            .input-group{data: {controller: 'clear-input'}}
+              = f.date_field :delivery_end_date, class: 'form-control', data: { 'clear-input-target': 'field' }
+              %button.btn.btn-outline-secondary{type: 'button', data: { action: 'click->clear-input#clear' }, title: 'Clear date'}
                 ×
             .form-text.text-muted Leave empty if same as start date
 

--- a/app/views/delivery_notes/preview_email.html.haml
+++ b/app/views/delivery_notes/preview_email.html.haml
@@ -52,12 +52,12 @@
         Email Content
       .card-body.email-preview-content{"data-format-content" => "html"}
         - if @email_body_html.present?
-          %iframe{"src" => preview_email_raw_delivery_note_path(@delivery_note), "style" => "width: 100%; height: 400px; border: 1px solid #dee2e6; border-radius: 0.375rem;"}
+          %iframe.email-preview-iframe{"src" => preview_email_raw_delivery_note_path(@delivery_note)}
         - else
           %p.text-muted
             %i No HTML content available
 
       - if @email_body_text
         .card-body.email-preview-content.d-none{"data-format-content" => "text"}
-          %pre.mb-0{style: "white-space: pre-wrap; font-family: monospace;"}
+          %pre.mb-0.font-monospace.text-pre-wrap
             = @email_body_text

--- a/app/views/delivery_notes/show.html.haml
+++ b/app/views/delivery_notes/show.html.haml
@@ -90,13 +90,13 @@
             .d-flex.gap-2
               = form_with url: upload_acceptance_delivery_note_path(@delivery_note), method: :post, multipart: true, local: true, class: 'd-flex align-items-center', data: { controller: 'file-upload-validation' } do |form|
                 .me-2
-                  = form.file_field :acceptance_pdf, accept: 'application/pdf', class: 'form-control form-control-sm', style: 'width: 250px;', data: { file_upload_validation_target: 'fileInput' }
+                  = form.file_field :acceptance_pdf, accept: 'application/pdf', class: 'form-control form-control-sm w-fixed-250', data: { file_upload_validation_target: 'fileInput' }
                 = form.submit 'Replace', class: 'btn btn-warning btn-sm', data: { file_upload_validation_target: 'submitButton' }
               = button_to 'Delete', delete_acceptance_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-outline-danger btn-sm', confirm: 'Are you sure you want to delete the acceptance document?'
           - else
             = form_with url: upload_acceptance_delivery_note_path(@delivery_note), method: :post, multipart: true, local: true, class: 'd-flex align-items-center', data: { controller: 'file-upload-validation' } do |form|
               .me-3
-                = form.file_field :acceptance_pdf, accept: 'application/pdf', class: 'form-control', style: 'width: auto;', data: { file_upload_validation_target: 'fileInput' }
+                = form.file_field :acceptance_pdf, accept: 'application/pdf', class: 'form-control w-auto', data: { file_upload_validation_target: 'fileInput' }
               = form.submit 'Upload PDF', class: 'btn btn-primary btn-sm', data: { file_upload_validation_target: 'submitButton' }
             %small.text-muted.d-block.mt-2
               Upload the signed acceptance document (PDF only)
@@ -108,10 +108,10 @@
           = simple_format(@delivery_note.prelude)
 
   .document-lines.mb-2
-    %table.table.table-bordered
+    %table.table.table-bordered.document-lines-table
       %thead
         %tr
-          %th.text-end{style: "width: 10%"} Quantity
+          %th.text-end.col-quantity Quantity
           %th Description
       %tbody
         - @delivery_note.delivery_note_lines.each do |line|
@@ -128,17 +128,17 @@
                 =#line.delivery_time
           - when 'subheading'
             %tr
-              %td.fw-bold.table-secondary{colspan: 5, style: "padding: 12px 8px;"}
+              %td.fw-bold.table-secondary.document-section-row{colspan: 5}
                 = line.title
           - when 'text', 'plain'
             %tr
-              %td{colspan: 5, style: "padding: 8px;"}
+              %td.document-text-row{colspan: 5}
                 - if line.title.present?
                   %div= line.title
                 - if line.description.present?
-                  %div.text-muted{style: "margin-left: 20px;"}
+                  %div.text-muted.document-line-comment
                     - if line.type == 'plain'
-                      %pre.mb-0{style: "font-family: monospace; white-space: pre-wrap;"}= line.description
+                      %pre.mb-0.font-monospace.text-pre-wrap= line.description
                     - else
                       = simple_format(line.description)
 
@@ -161,8 +161,8 @@
       = destroy_link(@delivery_note, "Are you sure you want to delete delivery note \"#{@delivery_note.document_number || "##{@delivery_note.id}"}\"?")
 
   // Email Preview Modal
-  .modal.d-none{"data-delivery-note-email-preview-target" => "modal", "data-action" => "click->delivery-note-email-preview#closeOnBackdrop keydown@window->delivery-note-email-preview#closeOnEscape", "style" => "position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); z-index: 1050; display: flex; align-items: center; justify-content: center;"}
-    .modal-dialog.modal-lg{"style" => "max-width: 800px; width: 90%; max-height: 90vh; overflow-y: auto;"}
+  .modal.d-none.email-preview-modal{"data-delivery-note-email-preview-target" => "modal", "data-action" => "click->delivery-note-email-preview#closeOnBackdrop keydown@window->delivery-note-email-preview#closeOnEscape"}
+    .modal-dialog.modal-lg.email-preview-modal-dialog
       .modal-content
         .modal-header.d-flex.justify-content-between.align-items-center
           %h5.modal-title.mb-0

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -37,10 +37,15 @@
       .card-body
         - if @data[:issuer_company].png_logo.present?
           .mb-3.text-center
-            = image_tag png_logo_issuer_company_path, alt: @data[:issuer_company].legal_name, style: 'max-height: 80px; max-width: 200px;'
+            = image_tag png_logo_issuer_company_path, alt: @data[:issuer_company].legal_name, class: 'dashboard-issuer-logo'
 
-        %h6.text-primary{:style => "color: #{@data[:issuer_company].document_accent_color} !important"}
-          = @data[:issuer_company].legal_name
+        - if @data[:issuer_company].document_accent_color.present?
+          = tag.style ":root { --issuer-accent-color: #{@data[:issuer_company].document_accent_color}; }".html_safe, nonce: true
+          %h6.text-issuer-accent
+            = @data[:issuer_company].legal_name
+        - else
+          %h6.text-primary
+            = @data[:issuer_company].legal_name
 
         .mb-2
           %strong Address:

--- a/app/views/invoices/_form.html.haml
+++ b/app/views/invoices/_form.html.haml
@@ -35,7 +35,7 @@
                 .dropdown-menu{ id: 'customer-dropdown-menu', data: { searchable_dropdown_target: 'dropdown' } }
                   .p-2.border-bottom
                     %input.form-control.form-control-sm{ type: 'text', placeholder: 'Search customers...', data: { searchable_dropdown_target: 'search' } }
-                  .dropdown-content{ style: 'max-height: 300px; overflow-y: auto;' }
+                  .dropdown-content
                     .dropdown-item.text-muted Loading...
         .col-sm-4
           .mb-3
@@ -65,7 +65,7 @@
                 .dropdown-menu{ id: 'project-dropdown-menu', data: { searchable_dropdown_target: 'dropdown' } }
                   .p-2.border-bottom
                     %input.form-control.form-control-sm{ type: 'text', placeholder: 'Search projects...', data: { searchable_dropdown_target: 'search' } }
-                  .dropdown-content{ style: 'max-height: 300px; overflow-y: auto;' }
+                  .dropdown-content
                     .dropdown-item.text-muted Loading...
         .col-sm-4
           .mb-3

--- a/app/views/invoices/_invoice_line_fields.html.haml
+++ b/app/views/invoices/_invoice_line_fields.html.haml
@@ -20,7 +20,7 @@
           %button.btn.btn-sm.btn-secondary{type: 'button', data: {action: 'click->invoice-lines#moveLineDown'}} ▼
           %button.btn.btn-sm.btn-danger{type: 'button', data: {action: 'click->invoice-lines#removeLine'}} 🗑
 
-    .row.mt-2{data: {product_dropdown: true}, style: 'display: none;'}
+    .row.mt-2.d-none{data: {product_dropdown: true}}
       .col-sm-11
         .input-group.mb-3
           %select.form-select{data: {product_select: true}}

--- a/app/views/invoices/preview_email.html.haml
+++ b/app/views/invoices/preview_email.html.haml
@@ -52,12 +52,12 @@
         Email Content
       .card-body.email-preview-content{"data-format-content" => "html"}
         - if @email_body_html.present?
-          %iframe{"src" => preview_email_raw_invoice_path(@invoice), "style" => "width: 100%; height: 400px; border: 1px solid #dee2e6; border-radius: 0.375rem;"}
+          %iframe.email-preview-iframe{"src" => preview_email_raw_invoice_path(@invoice)}
         - else
           %p.text-muted
             %i No HTML content available
 
       - if @email_body_text
         .card-body.email-preview-content.d-none{"data-format-content" => "text"}
-          %pre.mb-0{style: "white-space: pre-wrap; font-family: monospace;"}
+          %pre.mb-0.font-monospace.text-pre-wrap
             = @email_body_text

--- a/app/views/invoices/show.html.haml
+++ b/app/views/invoices/show.html.haml
@@ -101,14 +101,14 @@
           = simple_format(@invoice.prelude)
 
   .document-lines.mb-2
-    %table.table.table-bordered
+    %table.table.table-bordered.document-lines-table
       %thead
         %tr
-          %th{style: "width: 55%"} Description
-          %th.text-end{style: "width: 10%"} Quantity
-          %th.text-end{style: "width: 15%"} Rate
-          %th.text-center{style: "width: 10%"} Tax Class
-          %th.text-end{style: "width: 15%"} Amount
+          %th.col-description Description
+          %th.text-end.col-quantity Quantity
+          %th.text-end.col-rate Rate
+          %th.text-center.col-tax-class Tax Class
+          %th.text-end.col-amount Amount
       %tbody
         - @invoice.invoice_lines.each do |line|
           - case line.type
@@ -129,17 +129,17 @@
                 %strong= format_currency(line.amount || (line.quantity * line.rate))
           - when 'subheading'
             %tr
-              %td.fw-bold.table-secondary{colspan: 5, style: "padding: 12px 8px;"}
+              %td.fw-bold.table-secondary.document-section-row{colspan: 5}
                 = line.title
           - when 'text', 'plain'
             %tr
-              %td{colspan: 5, style: "padding: 8px;"}
+              %td.document-text-row{colspan: 5}
                 - if line.title.present?
                   %div= line.title
                 - if line.description.present?
-                  %div.text-muted{style: "margin-left: 20px;"}
+                  %div.text-muted.document-line-comment
                     - if line.type == 'plain'
-                      %pre.mb-0{style: "font-family: monospace; white-space: pre-wrap;"}= line.description
+                      %pre.mb-0.font-monospace.text-pre-wrap= line.description
                     - else
                       = simple_format(line.description)
 
@@ -186,12 +186,12 @@
         = button_to 'Mark Unpaid', mark_unpaid_invoice_path(@invoice), method: :post, class: 'btn btn-outline-secondary', data: { 'turbo-confirm': 'Mark this invoice as unpaid?' }
       - else
         = form_with url: mark_paid_invoice_path(@invoice), method: :post, local: true, class: 'd-flex gap-1 align-items-center' do |f|
-          = f.date_field :paid_at, value: Date.current, class: 'form-control form-control-sm', style: 'width: auto;'
+          = f.date_field :paid_at, value: Date.current, class: 'form-control form-control-sm w-auto'
           = f.submit 'Mark Paid', class: 'btn btn-success'
 
   // Email Preview Modal
-  .modal.d-none{"data-email-preview-target" => "modal", "data-action" => "click->email-preview#closeOnBackdrop keydown@window->email-preview#closeOnEscape", "style" => "position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); z-index: 1050; display: flex; align-items: center; justify-content: center;"}
-    .modal-dialog.modal-lg{"style" => "max-width: 800px; width: 90%; max-height: 90vh; overflow-y: auto;"}
+  .modal.d-none.email-preview-modal{"data-email-preview-target" => "modal", "data-action" => "click->email-preview#closeOnBackdrop keydown@window->email-preview#closeOnEscape"}
+    .modal-dialog.modal-lg.email-preview-modal-dialog
       .modal-content
         .modal-header.d-flex.justify-content-between.align-items-center
           %h5.modal-title.mb-0

--- a/app/views/issuer_companies/show.html.haml
+++ b/app/views/issuer_companies/show.html.haml
@@ -78,13 +78,13 @@
           .col-sm-4
             %strong Contact Line 1:
           .col-sm-8
-            %span{style: "white-space: pre-wrap"}= @issuer_company.document_contact_line1
+            %span.text-pre-wrap= @issuer_company.document_contact_line1
 
         .row.mb-2
           .col-sm-4
             %strong Contact Line 2:
           .col-sm-8
-            %span{style: "white-space: pre-wrap"}= @issuer_company.document_contact_line2
+            %span.text-pre-wrap= @issuer_company.document_contact_line2
 
         .row.mb-2
           .col-sm-4
@@ -103,7 +103,8 @@
             %strong Accent Color:
           .col-sm-8
             - if @issuer_company.document_accent_color.present?
-              %span.badge{style: "background-color: #{@issuer_company.document_accent_color}"}
+              = tag.style ":root { --issuer-accent-color: #{@issuer_company.document_accent_color}; }".html_safe, nonce: true
+              %span.badge.badge-issuer-accent
                 = @issuer_company.document_accent_color
             - else
               %em Not set

--- a/app/views/jobs_status/show.html.haml
+++ b/app/views/jobs_status/show.html.haml
@@ -135,7 +135,7 @@
                 %td
                   %div
                     %strong= failed.exception_class
-                  %div.small.text-muted{style: 'max-width: 480px; word-break: break-word;'}
+                  %div.small.text-muted.job-row-description
                     = failed.message
                 %td= format_datetime(failed.created_at)
 

--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -13,14 +13,14 @@
       %li.nav-item
         = link_to('Invoices', invoices_path, :class => 'nav-link')
     %ul.navbar-nav
-      %li.nav-item.dropdown{"data-controller" => "error-notification", "data-error-notification-max-errors-value" => "5", :style => "display: none;", "data-error-notification-target" => "icon"}
+      %li.nav-item.dropdown.initially-hidden{"data-controller" => "error-notification", "data-error-notification-max-errors-value" => "5", "data-error-notification-target" => "icon"}
         %a.nav-link{:href => "#", :role => "button", :"data-action" => "click->error-notification#toggle"}
           %span.badge.rounded-pill.bg-danger{"data-error-notification-target" => "badge"}
-        %ul.dropdown-menu.dropdown-menu-end{"data-error-notification-target" => "dropdown", "data-action" => "click->error-notification#preventClose", :style => "width: 280px; max-height: 300px; overflow-y: auto; z-index: 1050; right: 0; left: auto;"}
+        %ul.dropdown-menu.dropdown-menu-end.error-notification-dropdown{"data-error-notification-target" => "dropdown", "data-action" => "click->error-notification#preventClose"}
           %li.dropdown-header.px-3.py-2
             .d-flex.justify-content-between.align-items-center
               %span.fw-bold Recent Errors
-              %button.btn.btn-sm.btn-outline-danger{"data-action" => "click->error-notification#clearAll", :type => "button", :style => "font-size: 0.75rem;"} Clear All
+              %button.btn.btn-sm.btn-outline-danger.error-notification-clear-all{"data-action" => "click->error-notification#clearAll", :type => "button"} Clear All
           %li
             %hr.dropdown-divider
           %ul.list-unstyled.mb-0{"data-error-notification-target" => "list"}

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,19 +7,20 @@
     = favicon_link_tag 'favicon.svg', type: 'image/svg+xml'
     = stylesheet_link_tag    "application", :media => "all"
     = javascript_importmap_tags
-    :javascript
-      // Automatically use browser's dark mode preference
-      (function() {
-        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        const theme = prefersDark ? 'dark' : 'light';
-        document.documentElement.setAttribute('data-bs-theme', theme);
+    = javascript_tag nonce: true do
+      :plain
+        // Automatically use browser's dark mode preference
+        (function() {
+          const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+          const theme = prefersDark ? 'dark' : 'light';
+          document.documentElement.setAttribute('data-bs-theme', theme);
 
-        // Listen for changes to the browser's color scheme preference
-        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function(e) {
-          const newTheme = e.matches ? 'dark' : 'light';
-          document.documentElement.setAttribute('data-bs-theme', newTheme);
-        });
-      })();
+          // Listen for changes to the browser's color scheme preference
+          window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function(e) {
+            const newTheme = e.matches ? 'dark' : 'light';
+            document.documentElement.setAttribute('data-bs-theme', newTheme);
+          });
+        })();
     = yield :head
   %body.d-flex.flex-column.min-vh-100
     %nav.navbar.navbar-expand-lg.bg-body-tertiary.fixed-top{"data-controller" => "navbar"}

--- a/app/views/shared/_searchable_dropdown.html.haml
+++ b/app/views/shared/_searchable_dropdown.html.haml
@@ -36,5 +36,5 @@
     .dropdown-menu{ id: dropdown_id, data: { searchable_dropdown_target: 'dropdown' } }
       .p-2.border-bottom
         %input.form-control.form-control-sm{ type: 'text', placeholder: "Search #{item_name.pluralize}...", data: { searchable_dropdown_target: 'search' } }
-      .dropdown-content{ style: 'max-height: 300px; overflow-y: auto;' }
+      .dropdown-content
         .dropdown-item.text-muted Loading...

--- a/app/views/shared/_searchable_dropdown_options.turbo_stream.haml
+++ b/app/views/shared/_searchable_dropdown_options.turbo_stream.haml
@@ -8,7 +8,7 @@
 = turbo_stream.update dropdown_id do
   .p-2.border-bottom
     %input.form-control.form-control-sm{ type: 'text', placeholder: search_placeholder, data: { searchable_dropdown_target: 'search' } }
-  .dropdown-content{ style: 'max-height: 300px; overflow-y: auto;' }
+  .dropdown-content
     - if items.empty?
       .dropdown-item.text-muted= "No #{item_name.pluralize} available"
     - else

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -34,7 +34,7 @@
       .card-header Emails
       %ul.list-group.list-group-flush
         - @emails.each do |email|
-          %li.list-group-item
+          %li.list-group-item{data: { controller: 'toggle-visibility' }}
             .d-flex.justify-content-between.align-items-center
               %div
                 = email.address
@@ -43,12 +43,12 @@
                 - else
                   %span.badge.bg-warning.ms-2 Pending
               %div.btn-group
-                = button_to 'Replace…', '#', class: 'btn btn-sm btn-outline-secondary', form: { class: 'd-inline', "data-toggle-form" => "email-#{email.id}" }, type: 'button', onclick: "document.getElementById('replace-email-#{email.id}').classList.toggle('d-none'); return false;"
+                %button.btn.btn-sm.btn-outline-secondary{type: 'button', data: { action: 'click->toggle-visibility#toggle' }} Replace…
                 - if !(email.confirmed? && @user.confirmed_emails.count <= 1)
                   = button_to 'Remove', user_email_path(user_id: @user, id: email), method: :delete,
                       data: { turbo_confirm: "Remove email #{email.address}?" },
                       class: 'btn btn-sm btn-outline-danger'
-            .mt-2.d-none{id: "replace-email-#{email.id}"}
+            .mt-2.d-none{id: "replace-email-#{email.id}", data: { 'toggle-visibility-target': 'panel' }}
               = form_with url: user_email_path(user_id: @user, id: email), method: :put, scope: :user_email, local: true do |f|
                 .input-group.input-group-sm
                   = f.email_field :address, class: 'form-control', placeholder: 'replacement@example.com', required: true
@@ -96,7 +96,7 @@
         class: 'btn btn-warning'
   - elsif @user.id != current_user.id
     = form_with url: block_user_path(@user), method: :post, local: true, class: 'd-inline-flex' do |f|
-      .input-group{style: 'width: 400px;'}
+      .input-group.w-fixed-400
         = f.text_field :reason, class: 'form-control', placeholder: 'Reason (required)', required: true
         = f.submit 'Block', class: 'btn btn-danger',
             data: { turbo_confirm: "Block #{@user.username}? All sessions will be terminated." }

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,10 @@ module Abt
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
 
+    # Modern Permissions-Policy header (Rails 8 still emits Feature-Policy).
+    require_relative "../app/middleware/permissions_policy_header"
+    config.middleware.use PermissionsPolicyHeader
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,30 +1,22 @@
 # Be sure to restart your server when you modify this file.
+#
+# Defines an application-wide Content Security Policy. The policy is strict:
+# no 'unsafe-inline' or 'unsafe-eval'. The few legitimately-inline elements
+# (the layout's theme-detection script and per-page `<style>` blocks for the
+# issuer accent color) are nonced.
 
-# Define an application-wide content security policy
-# For further information see the following documentation
-# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
+Rails.application.config.content_security_policy do |policy|
+  policy.default_src     :self
+  policy.script_src      :self
+  policy.style_src       :self
+  policy.img_src         :self, :data
+  policy.font_src        :self
+  policy.connect_src     :self
+  policy.object_src      :none
+  policy.base_uri        :self
+  policy.form_action     :self
+  policy.frame_ancestors :none
+end
 
-# Rails.application.config.content_security_policy do |policy|
-#   policy.default_src :self, :https
-#   policy.font_src    :self, :https, :data
-#   policy.img_src     :self, :https, :data
-#   policy.object_src  :none
-#   policy.script_src  :self, :https
-#   policy.style_src   :self, :https
-#   # If you are using webpack-dev-server then specify webpack-dev-server host
-#   policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
-
-#   # Specify URI for violation reports
-#   # policy.report_uri "/csp-violation-report-endpoint"
-# end
-
-# If you are using UJS then enable automatic nonce generation
-# Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }
-
-# Set the nonce only to specific directives
-# Rails.application.config.content_security_policy_nonce_directives = %w(script-src)
-
-# Report CSP violations to a specified URI
-# For further information see the following documentation:
-# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
-# Rails.application.config.content_security_policy_report_only = true
+Rails.application.config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
+Rails.application.config.content_security_policy_nonce_directives = %w[script-src style-src]

--- a/config/initializers/permissions_policy.rb
+++ b/config/initializers/permissions_policy.rb
@@ -1,0 +1,17 @@
+# Be sure to restart your server when you modify this file.
+#
+# Defines an application-wide Permissions Policy. Disables sensor / payment /
+# device APIs the invoice app has no use for. `fullscreen` stays self-allowed
+# so the browser's native PDF viewer (and email-preview iframe) can request it.
+
+Rails.application.config.permissions_policy do |policy|
+  policy.camera        :none
+  policy.microphone    :none
+  policy.geolocation   :none
+  policy.gyroscope     :none
+  policy.magnetometer  :none
+  policy.accelerometer :none
+  policy.usb           :none
+  policy.payment       :none
+  policy.fullscreen    :self
+end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,8 +1,18 @@
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :cuprite, using: :chrome, screen_size: [1400, 1400], options: {
+  cuprite_options = {
     js_errors: true,
     headless: ENV['HEADLESS'] != '0'  # Default to headless unless explicitly disabled
   }
+
+  # Allow pointing at a non-standard Chromium binary (e.g. the Playwright build
+  # in /opt/pw-browsers in our sandbox) and add --no-sandbox when running as
+  # root, which Chrome refuses by default.
+  cuprite_options[:browser_path] = ENV['BROWSER_PATH'] if ENV['BROWSER_PATH'].present?
+  if Process.uid.zero? || ENV['CHROME_NO_SANDBOX'] == '1'
+    cuprite_options[:browser_options] = { 'no-sandbox' => nil }
+  end
+
+  driven_by :cuprite, using: :chrome, screen_size: [1400, 1400], options: cuprite_options
 end

--- a/test/controllers/issuer_companies_controller_test.rb
+++ b/test/controllers/issuer_companies_controller_test.rb
@@ -53,7 +53,7 @@ class IssuerCompaniesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     # Check that whitespace is preserved in the rendered HTML
-    assert_select 'span[style*="white-space: pre-wrap"]' do |elements|
+    assert_select 'span.text-pre-wrap' do |elements|
       contact_line1_element = elements.find { |el| el.text.include?("www.example.com      hi@example.com") }
       contact_line2_element = elements.find { |el| el.text.include?("voice + xxx xxxxxx") }
 

--- a/test/integration/csp_inline_handlers_structure_test.rb
+++ b/test/integration/csp_inline_handlers_structure_test.rb
@@ -1,0 +1,108 @@
+require 'test_helper'
+
+# Structural checks that the inline-JS-replacement Stimulus wiring is rendered
+# on the affected pages. Complements the system tests, but does not require a
+# browser so it can run in CI environments without Chrome.
+class CspInlineHandlersStructureTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in_as(users(:alice))
+  end
+
+  test "users/show wires the email-replace toggle via Stimulus, with no inline handler" do
+    get user_path(users(:alice))
+    assert_response :success
+    body = @response.body
+
+    assert_no_match(/onclick=/, body, "inline onclick must be replaced by Stimulus")
+    assert_match(/data-controller=['"][^'"]*toggle-visibility/, body)
+    assert_match(/data-action=['"][^'"]*toggle-visibility#toggle/, body)
+    assert_match(/data-toggle-visibility-target=['"]panel['"]/, body)
+  end
+
+  test "delivery_notes form wires both clear-date buttons via Stimulus" do
+    get edit_delivery_note_path(delivery_notes(:draft_delivery_note))
+    assert_response :success
+    body = @response.body
+
+    assert_no_match(/onclick=/, body, "inline onclick must be replaced by Stimulus")
+    clear_input_controllers = body.scan(/data-controller=['"][^'"]*clear-input/)
+    assert clear_input_controllers.length >= 2,
+      "expected at least 2 clear-input controllers (mobile + desktop), got #{clear_input_controllers.length}"
+    assert_match(/data-action=['"][^'"]*clear-input#clear/, body)
+    assert_match(/data-clear-input-target=['"]field['"]/, body)
+  end
+
+  test "layout theme script carries a CSP nonce" do
+    get root_path
+    body = @response.body
+
+    assert_match(/<script[^>]*\bnonce=['"][^'"]+['"][^>]*>[\s\S]*?prefers-color-scheme/, body,
+      "theme detection inline script must have a CSP nonce")
+  end
+
+  test "Content-Security-Policy header is present and strict" do
+    get root_path
+    csp = @response.headers['Content-Security-Policy']
+
+    assert csp.present?, 'CSP header should be set'
+    assert_no_match(/unsafe-inline/, csp, 'CSP must not allow unsafe-inline')
+    assert_no_match(/unsafe-eval/, csp, 'CSP must not allow unsafe-eval')
+    assert_match(/script-src[^;]*'nonce-[^']+'/, csp, 'script-src must include a nonce')
+    assert_match(/style-src[^;]*'nonce-[^']+'/, csp, 'style-src must include a nonce')
+    assert_match(/object-src 'none'/, csp)
+    assert_match(/frame-ancestors 'none'/, csp)
+  end
+
+  test "Permissions-Policy header is present and disables sensors" do
+    get root_path
+    pp = @response.headers['Permissions-Policy']
+
+    # Debug what headers were actually returned if missing
+    unless pp.present?
+      headers_summary = @response.headers.to_h.keys.sort.join(", ")
+      flunk "Permissions-Policy header missing. Headers present: #{headers_summary}"
+    end
+
+    assert_match(/camera=\(\)/, pp)
+    assert_match(/microphone=\(\)/, pp)
+    assert_match(/geolocation=\(\)/, pp)
+    assert_match(/payment=\(\)/, pp)
+  end
+
+  test "issuer_companies/show carries no inline style attribute and emits nonced accent-color block" do
+    get issuer_company_path
+    body = @response.body
+
+    assert_no_match(/\bstyle=['"]/, body, 'no inline style attributes allowed on issuer companies show')
+    assert_match(/<style[^>]*\bnonce=['"][^'"]+['"][^>]*>[\s\S]*?--issuer-accent-color/, body,
+      'expected a nonced <style> block setting --issuer-accent-color when accent color is configured')
+  end
+
+  test "home dashboard carries no inline style attribute" do
+    get root_path
+    body = @response.body
+
+    assert_no_match(/\bstyle=['"]/, body, 'no inline style attributes allowed on the dashboard')
+  end
+
+  test "invoices show carries no inline style attribute" do
+    get invoice_path(invoices(:published_invoice))
+    body = @response.body
+
+    assert_no_match(/\bstyle=['"]/, body, 'no inline style attributes allowed on invoices show')
+  end
+
+  test "delivery notes show carries no inline style attribute" do
+    get delivery_note_path(delivery_notes(:published_delivery_note))
+    body = @response.body
+
+    assert_no_match(/\bstyle=['"]/, body, 'no inline style attributes allowed on delivery notes show')
+  end
+
+  test "users show carries no inline style attribute" do
+    get user_path(users(:alice))
+    body = @response.body
+
+    assert_no_match(/\bstyle=['"]/, body, 'no inline style attributes allowed on users show')
+  end
+end

--- a/test/system/delivery_notes_form_test.rb
+++ b/test/system/delivery_notes_form_test.rb
@@ -1,0 +1,20 @@
+require 'application_system_test_case'
+
+class DeliveryNotesFormTest < ApplicationSystemTestCase
+  setup do
+    @delivery_note = delivery_notes(:draft_delivery_note)
+  end
+
+  test "clear-date button empties the delivery_end_date field" do
+    visit edit_delivery_note_path(@delivery_note)
+
+    field = find_field('delivery_note[delivery_end_date]', match: :first)
+    assert_not_equal '', field.value, 'fixture should provide a non-empty end date'
+
+    within(field.find(:xpath, '..')) do
+      click_button '×'
+    end
+
+    assert_equal '', find_field('delivery_note[delivery_end_date]', match: :first).value
+  end
+end

--- a/test/system/theme_detection_test.rb
+++ b/test/system/theme_detection_test.rb
@@ -1,0 +1,10 @@
+require 'application_system_test_case'
+
+class ThemeDetectionTest < ApplicationSystemTestCase
+  test "html element has data-bs-theme attribute set after page load" do
+    visit root_path
+
+    attr = page.evaluate_script("document.documentElement.getAttribute('data-bs-theme')")
+    assert_includes %w[light dark], attr, "expected data-bs-theme to be 'light' or 'dark', got #{attr.inspect}"
+  end
+end

--- a/test/system/users_email_replace_test.rb
+++ b/test/system/users_email_replace_test.rb
@@ -1,0 +1,42 @@
+require 'application_system_test_case'
+
+class UsersEmailReplaceTest < ApplicationSystemTestCase
+  setup do
+    @user = users(:alice)
+    @email = user_emails(:alice_primary)
+  end
+
+  test "Replace button reveals replacement form" do
+    visit user_path(@user)
+
+    panel_selector = "#replace-email-#{@email.id}"
+
+    assert_selector "#{panel_selector}.d-none", visible: :all
+    assert_no_selector "#{panel_selector}:not(.d-none)"
+
+    within("li", text: @email.address) do
+      click_button 'Replace…'
+    end
+
+    assert_selector "#{panel_selector}:not(.d-none)"
+    within(panel_selector) do
+      assert_selector "input[type='email']"
+      assert_button 'Replace'
+    end
+  end
+
+  test "Replace button toggles the form closed again" do
+    visit user_path(@user)
+    panel_selector = "#replace-email-#{@email.id}"
+
+    within("li", text: @email.address) do
+      click_button 'Replace…'
+    end
+    assert_selector "#{panel_selector}:not(.d-none)"
+
+    within("li", text: @email.address) do
+      click_button 'Replace…'
+    end
+    assert_selector "#{panel_selector}.d-none", visible: :all
+  end
+end


### PR DESCRIPTION
Replace commented-out CSP boilerplate with a strict policy (no
'unsafe-inline', no 'unsafe-eval') and add a Permissions-Policy that
disables sensor and payment APIs.

- Refactor 3 inline onclick handlers to Stimulus controllers
  (toggle_visibility for the email-replace toggle on users/show,
  clear_input for the two delivery-note date-clear buttons).
- Move the layout's theme-detection inline script to javascript_tag
  with nonce: true so CSP can allow it via 'nonce-...'.
- Remove ~30+ inline style="..." attributes from HAML views and JS
  innerHTML templates by introducing utility/scoped classes in a new
  app/assets/stylesheets/utilities.css.scss (picked up automatically
  by require_tree).
- For the dynamic issuer accent color emit a per-page nonced <style>
  block setting --issuer-accent-color custom property, used by new
  .badge-issuer-accent / .text-issuer-accent classes. Add hex format
  validation to IssuerCompany.document_accent_color to prevent CSS
  injection through the admin form.
- Toggle the invoice-line product dropdown via .d-none classList
  instead of inline display style, so the initial markup carries no
  style attribute.
- Replace the deprecated Feature-Policy header (which Rails 8 still
  emits) with a small Rack middleware that adds modern
  Permissions-Policy syntax.
- Cover the change with structural request tests (no Chrome needed)
  plus durable system tests for the toggle / clear / theme behaviors.

https://claude.ai/code/session_01Kx3QAsubKrq2YMdxM5HgZd