### PR TITLE
Stop permitting raw logo blob columns in issuer params

### DIFF
--- a/app/controllers/issuer_companies_controller.rb
+++ b/app/controllers/issuer_companies_controller.rb
@@ -72,7 +72,7 @@ class IssuerCompaniesController < ApplicationController
       :currency,
       :document_email_from,
       :document_email_auto_bcc,
-      :pdf_logo, :pdf_logo_width, :pdf_logo_height, :png_logo
+      :pdf_logo_width, :pdf_logo_height
     )
   end
 end

--- a/test/controllers/issuer_companies_controller_test.rb
+++ b/test/controllers/issuer_companies_controller_test.rb
@@ -92,6 +92,19 @@ class IssuerCompaniesControllerTest < ActionDispatch::IntegrationTest
     assert_equal 'nosniff', response.headers['X-Content-Type-Options']
   end
 
+  test "should ignore direct mass-assignment of pdf_logo and png_logo" do
+    @issuer_company.update!(png_logo: nil, pdf_logo: nil)
+    patch issuer_company_url, params: {
+      issuer_company: {
+        pdf_logo: '<script>alert(1)</script>',
+        png_logo: '<script>alert(1)</script>'
+      }
+    }
+    @issuer_company.reload
+    assert_nil @issuer_company.pdf_logo
+    assert_nil @issuer_company.png_logo
+  end
+
   test "should preserve whitespace in contact lines on show page" do
     # Update the fixture to have explicit whitespace
     @issuer_company.update!(


### PR DESCRIPTION
## Summary

Drop `:pdf_logo` and `:png_logo` from `IssuerCompaniesController#issuer_company_params`. The file-upload branch (which validates size and magic bytes before assigning the blob) still works because it sets these on a plain hash after `params.permit`. A direct form post that tries to mass-assign raw bytes into the logo columns now has nowhere to land.

Adds a regression test that posts `pdf_logo`/`png_logo` directly and asserts both columns stay nil.

Closes #266.

## Test plan

- [x] `bundle exec rails test test/controllers/issuer_companies_controller_test.rb` — 10 runs / 32 assertions
- [x] `bundle exec rails test` — 321 runs / 0 failures
- [x] `brakeman` — 0 warnings

https://claude.ai/code/session_01XRSmWVdjwHGtyrEmyL44yP

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRSmWVdjwHGtyrEmyL44yP)_