### PR TITLE
Use WebAuthn Conditional Mediation for passkey autoprompt

### DIFF
--- a/app/javascript/controllers/passkey_controller.js
+++ b/app/javascript/controllers/passkey_controller.js
@@ -14,10 +14,73 @@ export default class extends Controller {
   }
 
   connect() {
+    this.cachedPublicKey = null
+    this.conditionalAbortController = null
     if (this.autoAuthenticateValue) {
-      // Defer so the page paints first; some browsers gate WebAuthn prompts
-      // on the page being visible.
-      setTimeout(() => this.authenticate(), 50)
+      this.startConditionalMediation()
+    }
+  }
+
+  disconnect() {
+    this.abortConditional()
+  }
+
+  abortConditional() {
+    if (this.conditionalAbortController && !this.conditionalAbortController.signal.aborted) {
+      this.conditionalAbortController.abort()
+    }
+    this.conditionalAbortController = null
+  }
+
+  async fetchOptions() {
+    if (this.cachedPublicKey) return this.cachedPublicKey
+    const optionsJSON = await this.postJSON(this.optionsUrlValue, {})
+    this.cachedPublicKey = this.parseRequestOptions(optionsJSON)
+    return this.cachedPublicKey
+  }
+
+  async startConditionalMediation() {
+    if (!window.PublicKeyCredential) return
+    if (typeof PublicKeyCredential.isConditionalMediationAvailable !== "function") return
+    try {
+      if (!(await PublicKeyCredential.isConditionalMediationAvailable())) return
+    } catch (_) {
+      return
+    }
+
+    let publicKey
+    try {
+      publicKey = await this.fetchOptions()
+    } catch (e) {
+      return this.showError(e.message)
+    }
+
+    this.conditionalAbortController = new AbortController()
+    let credential
+    try {
+      credential = await navigator.credentials.get({
+        publicKey,
+        mediation: "conditional",
+        signal: this.conditionalAbortController.signal,
+      })
+    } catch (e) {
+      // Silent: our own abort (button click / disconnect) and ambient
+      // user dismissals of the autofill chip should not surface as errors.
+      if (e && (e.name === "AbortError" || e.name === "NotAllowedError")) return
+      return this.showError(`Passkey sign-in failed: ${e.message || e}`)
+    }
+
+    let result
+    try {
+      result = await this.postJSON(this.verifyUrlValue, {
+        credential: this.credentialToJSON(credential),
+      })
+    } catch (e) {
+      return this.showError(e.message)
+    }
+
+    if (result.redirect_url) {
+      window.location.href = result.redirect_url
     }
   }
 
@@ -66,19 +129,23 @@ export default class extends Controller {
       return this.showError("This browser does not support passkeys.")
     }
 
-    let optionsJSON
+    this.abortConditional()
+
+    let publicKey
     try {
-      optionsJSON = await this.postJSON(this.optionsUrlValue, {})
+      publicKey = await this.fetchOptions()
     } catch (e) {
       return this.showError(e.message)
     }
 
     let credential
     try {
-      const publicKey = this.parseRequestOptions(optionsJSON)
       credential = await navigator.credentials.get({ publicKey })
     } catch (e) {
-      return this.showError(`Passkey sign-in was cancelled or failed: ${e.message || e}`)
+      if (e && e.name === "NotAllowedError") {
+        return this.showError("Passkey sign-in cancelled.")
+      }
+      return this.showError(`Passkey sign-in failed: ${e.message || e}`)
     }
 
     let result

--- a/app/views/sessions/new.html.haml
+++ b/app/views/sessions/new.html.haml
@@ -12,6 +12,14 @@
           "data-passkey-auto-authenticate-value" => "true"}
       .card-body
         .alert.alert-danger.d-none{"data-passkey-target" => "error"}
+        .mb-3
+          = label_tag :username, 'Username', class: 'form-label'
+          %input.form-control#username{type: 'text',
+                                       name: 'username',
+                                       autocomplete: 'username webauthn',
+                                       autofocus: true}
+          %small.form-text.text-muted
+            Pick a passkey from the autofill suggestions, or use the button.
         .d-grid
           %button.btn.btn-primary{type: 'button', "data-action" => "click->passkey#authenticate"}
             Sign in with passkey

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -8,6 +8,12 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test 'new renders username input with webauthn conditional-mediation autocomplete' do
+    get new_session_path
+    assert_response :success
+    assert_select 'input[name=username][autocomplete="username webauthn"]'
+  end
+
   test 'options stashes challenge for a known user' do
     post options_session_path, params: { username: 'alice' }, as: :json
     assert_response :success


### PR DESCRIPTION
Safari rejects modal navigator.credentials.get() calls without transient
user activation, so the existing setTimeout-based autoprompt on the
sign-in page failed with NotAllowedError / "page is not focused". Switch
the autoprompt to mediation: 'conditional', anchored to a username input
tagged autocomplete="username webauthn".

- Add username input on sessions/new as the autofill anchor; value is
  not sent (usernameless discoverable-credential flow).
- Feature-detect via PublicKeyCredential.isConditionalMediationAvailable
  and silently no-op if unavailable.
- Share one challenge per page load between the CMA call and the
  button-driven modal call (only one ever resolves; the other is
  aborted before verify).
- AbortController cancels CMA on button click and on Stimulus
  disconnect (Turbo navigation cleanup).
- Soften NotAllowedError on the click path to "Passkey sign-in
  cancelled."; silence aborts and CMA dismissals.

https://claude.ai/code/session_01EHkpHbGEvsERQU5WvoBvu4