### PR TITLE
Add permissions, groups, and teams

### DIFF
--- a/app/controllers/account/audit_events_controller.rb
+++ b/app/controllers/account/audit_events_controller.rb
@@ -1,4 +1,7 @@
 class Account::AuditEventsController < ApplicationController
+  # Self-service: scoped to current_user.
+  allow_without_permission_check
+
   def index
     @audit_events = UserAuditEvent.for_user(current_user).limit(200)
   end

--- a/app/controllers/account/blocks_controller.rb
+++ b/app/controllers/account/blocks_controller.rb
@@ -1,4 +1,7 @@
 class Account::BlocksController < ApplicationController
+  # Self-service: user blocking their own account.
+  allow_without_permission_check
+
   def create
     current_user.block!(
       reason: "user self-requested",

--- a/app/controllers/account/credentials_controller.rb
+++ b/app/controllers/account/credentials_controller.rb
@@ -1,4 +1,7 @@
 class Account::CredentialsController < ApplicationController
+  # Self-service: every action operates on current_user's own credentials.
+  allow_without_permission_check
+
   def index
     @credentials = current_user.credentials.order(:created_at)
   end

--- a/app/controllers/account/emails_controller.rb
+++ b/app/controllers/account/emails_controller.rb
@@ -1,4 +1,7 @@
 class Account::EmailsController < ApplicationController
+  # Self-service: every action operates on current_user's own emails.
+  allow_without_permission_check
+
   def index
     @emails = current_user.emails.order(:created_at)
   end

--- a/app/controllers/account/profiles_controller.rb
+++ b/app/controllers/account/profiles_controller.rb
@@ -1,9 +1,14 @@
 class Account::ProfilesController < ApplicationController
+  # Self-service: every action operates on current_user.
+  allow_without_permission_check
+
   def show
     @user = current_user
     @emails = @user.emails.order(:created_at)
     @credentials = @user.credentials.order(:created_at)
     @sessions = @user.sessions.active.order(last_seen_at: :desc).limit(10)
     @audit_events = UserAuditEvent.for_user(@user).limit(15)
+    @user_groups = @user.groups.ordered
+    @user_teams = @user.teams.ordered
   end
 end

--- a/app/controllers/account/sessions_controller.rb
+++ b/app/controllers/account/sessions_controller.rb
@@ -1,4 +1,7 @@
 class Account::SessionsController < ApplicationController
+  # Self-service: every action operates on current_user's own sessions.
+  allow_without_permission_check
+
   def index
     @sessions = current_user.sessions.active.order(last_seen_at: :desc)
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,12 +4,25 @@ class ApplicationController < ActionController::Base
   AUTH_COOKIE = :abt_auth
 
   before_action :authenticate
+  after_action  :verify_permission_check_performed
 
-  helper_method :current_user, :current_user_session
+  helper_method :current_user, :current_user_session, :available_teams
+
+  class PermissionDenied < StandardError; end
+  class MissingPermissionCheck < StandardError; end
+  rescue_from PermissionDenied, with: :deny_permission
 
   class << self
     def allow_unauthenticated_access(**options)
       skip_before_action :authenticate, **options
+      skip_after_action :verify_permission_check_performed, **options
+    end
+
+    # Mark actions as intentionally not requiring a permission check.
+    # Use for self-service surfaces (account/*) and the dashboard where the
+    # data is already scoped to the current user.
+    def allow_without_permission_check(**options)
+      skip_after_action :verify_permission_check_performed, **options
     end
   end
 
@@ -19,6 +32,59 @@ class ApplicationController < ActionController::Base
 
   def current_user_session
     Current.session
+  end
+
+  def require_permission!(key)
+    @_permission_check_performed = true
+    raise PermissionDenied, key unless current_user&.permission?(key)
+  end
+
+  def deny_permission(exception)
+    Rails.logger.info "Permission denied for user #{current_user&.username.inspect} key=#{exception.message}"
+    respond_to do |format|
+      format.html { redirect_to root_path, alert: "You don't have permission to access that page." }
+      format.json { render json: { error: "permission_denied" }, status: :forbidden }
+      format.turbo_stream { redirect_to root_path, alert: "You don't have permission to access that page." }
+      format.any  { head :forbidden }
+    end
+  end
+
+  # Fails the response if the action never called require_permission!. Any
+  # controller action that handles authenticated user data must either gate
+  # on a permission or explicitly opt out via allow_without_permission_check.
+  # This catches "forgot to add a before_action" bugs at request time rather
+  # than at code review.
+  def verify_permission_check_performed
+    return if @_permission_check_performed
+    msg = "No permission check performed for #{self.class.name}##{action_name}. " \
+          "Add `before_action -> { require_permission!('...') }` or " \
+          "`allow_without_permission_check only: [:#{action_name}]` if intentional."
+    Rails.logger.error "[authorization] #{msg}"
+    raise MissingPermissionCheck, msg
+  end
+
+  # Teams the current user may assign records to. Bypass-scoping users see
+  # every team; everyone else sees only the teams they're a member of.
+  # Used by the customer and project forms.
+  def available_teams
+    @available_teams ||= if current_user&.bypass_team_scoping?
+                           Team.ordered.to_a
+    else
+                           current_user ? current_user.teams.ordered.to_a : []
+    end
+  end
+
+  # Record a privilege-change audit event with the current actor and request.
+  # Used by GroupsController/TeamsController/UsersController to log group
+  # CRUD, team CRUD, and membership changes.
+  def audit_privilege_change!(action, user: nil, metadata: {})
+    UserAuditEvent.record!(
+      action: action,
+      user: user,
+      actor: current_user,
+      request: request,
+      metadata: metadata
+    )
   end
 
   private

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -3,6 +3,8 @@ class AttachmentsController < ApplicationController
 
   def show
     @attachment = Attachment.find(params[:id])
+    authorize_attachment!(@attachment)
+
     served_type = @attachment.safe_content_type
     disposition = INLINE_CONTENT_TYPES.include?(served_type) ? "inline" : "attachment"
     response.set_header("X-Content-Type-Options", "nosniff")
@@ -10,5 +12,20 @@ class AttachmentsController < ApplicationController
               filename: @attachment.filename,
               type: served_type,
               disposition: disposition
+  end
+
+  private
+
+  # An Attachment row is reachable only through a parent record (an Invoice
+  # PDF or a DeliveryNote acceptance document). Mirror the parent's team
+  # visibility so an attacker can't enumerate attachment ids across teams.
+  def authorize_attachment!(attachment)
+    if Invoice.visible_to(current_user).where(attachment_id: attachment.id).exists?
+      return require_permission!("invoices.view")
+    end
+    if DeliveryNote.visible_to(current_user).where(acceptance_attachment_id: attachment.id).exists?
+      return require_permission!("delivery_notes.view")
+    end
+    raise ApplicationController::PermissionDenied, "attachment##{attachment.id}"
   end
 end

--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -1,15 +1,19 @@
 class CustomersController < ApplicationController
+  before_action -> { require_permission!("customers.view") }, only: [ :index, :show ]
+  before_action -> { require_permission!("customers.edit") }, only: [ :new, :create, :edit, :update, :destroy ]
+
   # GET /customers
   def index
     # Show active customers by default
     params[:filter] ||= "active"
+    base = Customer.visible_to(current_user)
     @customers = case params[:filter]
     when "all"
-      Customer.all
+      base
     when "inactive"
-      Customer.inactive
+      base.where(active: false)
     else
-      Customer.active
+      base.where(active: true)
     end
 
     @customers = @customers.order(:matchcode)
@@ -17,22 +21,35 @@ class CustomersController < ApplicationController
     respond_to do |format|
       format.html # index.html.erb
       format.turbo_stream { render :filter_options }
+      format.json {
+        render json: @customers.map { |c|
+          {
+            id: c.id,
+            matchcode: c.matchcode,
+            name: c.name,
+            team_id: c.team_id,
+            team_name: c.team&.name
+          }
+        }
+      }
     end
   end
 
   # GET /customers/1
   def show
-    @customer = Customer.find(params[:id])
+    @customer = Customer.visible_to(current_user).find(params[:id])
   end
 
   # GET /customers/new
   def new
     @customer = Customer.new
+    teams_available = available_teams
+    @customer.team_id = teams_available.first&.id if teams_available.size == 1
   end
 
   # GET /customers/1/edit
   def edit
-    @customer = Customer.find(params[:id])
+    @customer = Customer.visible_to(current_user).find(params[:id])
   end
 
   # POST /customers
@@ -48,7 +65,7 @@ class CustomersController < ApplicationController
 
   # PUT /customers/1
   def update
-    @customer = Customer.find(params[:id])
+    @customer = Customer.visible_to(current_user).find(params[:id])
 
     if @customer.update(customers_params)
       redirect_to @customer, notice: "Customer was successfully updated."
@@ -59,7 +76,7 @@ class CustomersController < ApplicationController
 
   # DELETE /customers/1
   def destroy
-    @customer = Customer.find(params[:id])
+    @customer = Customer.visible_to(current_user).find(params[:id])
 
     if @customer.destroy
       redirect_to customers_url, notice: "Customer was successfully deleted."
@@ -72,7 +89,8 @@ private
   def customers_params
     params.require(:customer).permit(
         :matchcode, :name, :address, :email, :vat_id, :notes, :sales_tax_customer_class_id, :language_id, :payment_terms_days,
-        :invoice_email_auto_to, :invoice_email_auto_subject_template, :invoice_email_auto_enabled, :active
+        :invoice_email_auto_to, :invoice_email_auto_subject_template, :invoice_email_auto_enabled, :active,
+        :team_id
     )
   end
 end

--- a/app/controllers/delivery_notes_controller.rb
+++ b/app/controllers/delivery_notes_controller.rb
@@ -9,6 +9,13 @@ class DeliveryNotesController < ApplicationController
   publishable_document :delivery_note, label: "delivery note"
   document_with_lines line_class: DeliveryNoteLine
 
+  before_action -> { require_permission!("delivery_notes.view") }, only: %i[index show preview preview_email preview_email_raw pdf]
+  before_action -> { require_permission!("delivery_notes.edit") }, only: %i[
+    new create edit update destroy
+    publish unpublish send_email upload_acceptance delete_acceptance
+    convert_to_invoice bulk_send_emails
+  ]
+
   before_action :set_delivery_note, only: %i[show edit update destroy publish preview pdf unpublish upload_acceptance delete_acceptance convert_to_invoice preview_email preview_email_raw send_email]
 
   # Permit the inline <style> blocks and embedded data: images that the
@@ -38,7 +45,8 @@ class DeliveryNotesController < ApplicationController
     @selected_year = params[:year]&.to_i || Date.current.year
     @email_filter = params[:email_filter] || "all"
 
-    @delivery_notes = DeliveryNote.in_year(@selected_year, include_drafts: @selected_year == Date.current.year)
+    @delivery_notes = DeliveryNote.visible_to(current_user)
+                                  .in_year(@selected_year, include_drafts: @selected_year == Date.current.year)
                                   .reorder(Arel.sql("document_number DESC NULLS FIRST"))
 
     case @email_filter
@@ -46,7 +54,7 @@ class DeliveryNotesController < ApplicationController
       @delivery_notes = @delivery_notes.email_unsent.published
     end
 
-    @available_years = DeliveryNote.available_years
+    @available_years = DeliveryNote.visible_to(current_user).available_years
   end
 
   # GET /delivery_notes/1
@@ -311,7 +319,7 @@ class DeliveryNotesController < ApplicationController
 
 protected
   def set_delivery_note
-    @delivery_note = DeliveryNote.find(params[:id])
+    @delivery_note = DeliveryNote.visible_to(current_user).find(params[:id])
   end
 
   def delivery_note_params

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,0 +1,136 @@
+class GroupsController < ApplicationController
+  before_action -> { require_permission!("groups.manage") }
+  before_action :load_group, only: [ :show, :edit, :update, :destroy ]
+
+  def index
+    @groups = Group.ordered
+                   .left_joins(:group_memberships, :group_permissions)
+                   .select('groups.*,
+                            COUNT(DISTINCT group_memberships.id) AS member_count,
+                            COUNT(DISTINCT group_permissions.id) AS permission_count')
+                   .group("groups.id")
+  end
+
+  def show
+    @members = @group.users.order(:username)
+    @permissions = @group.permissions.to_a.sort
+  end
+
+  def new
+    @group = Group.new
+  end
+
+  def edit
+  end
+
+  def create
+    @group = Group.new(group_attributes)
+
+    if @group.save
+      assign_permissions(@group, params.dig(:group, :permission_keys))
+      assign_members(@group, params.dig(:group, :user_ids))
+      audit_privilege_change!("group_created", metadata: { name: @group.name,
+                                          permissions: @group.permissions.to_a,
+                                          bypass_team_scoping: @group.bypass_team_scoping?,
+                                          member_usernames: @group.users.pluck(:username) })
+      redirect_to groups_path, notice: "Group created."
+    else
+      render :new, status: :unprocessable_content
+    end
+  end
+
+  def update
+    before_perms = @group.permissions.dup
+    before_members = @group.user_ids.to_set
+    before_bypass = @group.bypass_team_scoping?
+    if @group.update(group_attributes)
+      assign_permissions(@group, params.dig(:group, :permission_keys)) if params.dig(:group, :permission_keys)
+      assign_members(@group, params.dig(:group, :user_ids)) if params.dig(:group, :user_ids)
+      after_perms = @group.permissions
+      after_members = @group.reload.user_ids.to_set
+      audit_privilege_change!("group_updated", metadata: {
+        name: @group.name,
+        permissions_added: (after_perms - before_perms).to_a,
+        permissions_removed: (before_perms - after_perms).to_a,
+        members_added: User.where(id: (after_members - before_members).to_a).pluck(:username),
+        members_removed: User.where(id: (before_members - after_members).to_a).pluck(:username),
+        bypass_team_scoping_changed: before_bypass != @group.bypass_team_scoping?
+      })
+      redirect_to groups_path, notice: "Group updated."
+    else
+      render :edit, status: :unprocessable_content
+    end
+  end
+
+  def destroy
+    name = @group.name
+    if @group.destroy
+      audit_privilege_change!("group_deleted", metadata: { name: name })
+      redirect_to groups_path, notice: "Group deleted."
+    else
+      redirect_to groups_path, alert: @group.errors.full_messages.join(", ")
+    end
+  end
+
+  private
+
+  def load_group
+    @group = Group.find(params[:id])
+  end
+
+  # bypass_team_scoping is intentionally NOT permitted from user input. It is
+  # the most dangerous flag in the system — set on the Admin group via
+  # migration/seed and nowhere else. Granting it from a web form would let
+  # any `groups.manage` user create a "bypass" group, join it, and read every
+  # team's data. Operators that need another bypass group must do it via a
+  # migration.
+  #
+  # :name is also stripped for built-in groups. Group#admin? identifies the
+  # Admin group by `builtin? && name == "Admin"`, so renaming it would silently
+  # disable the last-admin protection, the admin-only permission validation,
+  # and the permission filter in Group#permissions=. The view marks the field
+  # readonly; this is the server-side counterpart.
+  def group_attributes
+    attrs = params.require(:group).permit(:name, :description)
+    attrs.delete(:name) if @group&.builtin?
+    attrs
+  end
+
+  def assign_permissions(group, keys)
+    return if group.builtin? # cannot modify built-in Admin permissions
+    # Admin-only permissions (users.reset_passkeys, users.auto_confirm_email)
+    # are stripped before assignment so a tampered form submission can't
+    # grant them to a non-Admin group. GroupPermission validation re-checks.
+    keys = Array(keys).reject(&:blank?) - Permission::ADMIN_ONLY_KEYS.to_a
+    group.permissions = keys
+  end
+
+  def assign_members(group, user_ids)
+    new_ids = Array(user_ids).reject(&:blank?).map(&:to_i)
+    new_users = User.where(id: new_ids).to_a
+
+    if group.admin? && new_users.empty?
+      group.errors.add(:base, "Admin group must have at least one member")
+      return
+    end
+
+    # Only existing admins can change the Admin group's membership in either
+    # direction. Without this, a `groups.manage` user could grant themselves
+    # Admin membership (inheriting bypass_team_scoping + the admin-only
+    # credential primitives) OR demote other admins. The remove direction is
+    # the more dangerous primitive: `has_many through` collection assignment
+    # silently swallows `prevent_removing_last_admin`'s `throw :abort`, so a
+    # single PATCH with one admin id in user_ids would otherwise delete every
+    # other admin's GroupMembership without raising.
+    if group.admin? && !current_user.groups.include?(group)
+      added   = new_users.map(&:id) - group.user_ids
+      removed = group.user_ids - new_users.map(&:id)
+      if added.any? || removed.any?
+        group.errors.add(:base, "Only members of the Admin group can change its membership")
+        return
+      end
+    end
+
+    group.users = new_users
+  end
+end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,12 +1,17 @@
 class HomeController < ApplicationController
+  # Dashboard. Data is already scoped to current_user via Invoice.visible_to.
+  allow_without_permission_check only: [ :index ]
+
   def index
     ytd_range = Date.current.beginning_of_year..Date.current
 
+    visible = Invoice.visible_to(current_user)
+
     @stats = {
-      invoices_current_year: Invoice.where(date: ytd_range).count,
-      invoices_ytd_total: Invoice.where(published: true, date: ytd_range).sum(:sum_total),
-      invoices_total_count: Invoice.where(published: true).count,
-      invoices_total_amount: Invoice.where(published: true).sum(:sum_total)
+      invoices_current_year: visible.where(date: ytd_range).count,
+      invoices_ytd_total: visible.where(published: true, date: ytd_range).sum(:sum_total),
+      invoices_total_count: visible.where(published: true).count,
+      invoices_total_amount: visible.where(published: true).sum(:sum_total)
     }
 
     @data = {}

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -8,6 +8,12 @@ class InvoicesController < ApplicationController
   publishable_document :invoice, label: "invoice"
   document_with_lines line_class: InvoiceLine
 
+  before_action -> { require_permission!("invoices.view") }, only: %i[index show preview preview_email preview_email_raw]
+  before_action -> { require_permission!("invoices.edit") }, only: %i[
+    new create edit update destroy
+    book send_email mark_paid mark_unpaid bulk_send_emails
+  ]
+
   before_action :set_invoice, only: %i[show edit update destroy book preview preview_email preview_email_raw send_email mark_paid mark_unpaid]
 
   # Permit the inline <style> blocks and embedded data: images that the
@@ -36,7 +42,8 @@ class InvoicesController < ApplicationController
     @selected_year = params[:year]&.to_i || Date.current.year
     @filter = params[:filter] || "all"
 
-    @invoices = Invoice.in_year(@selected_year, include_drafts: @selected_year == Date.current.year)
+    @invoices = Invoice.visible_to(current_user)
+                       .in_year(@selected_year, include_drafts: @selected_year == Date.current.year)
                        .reorder(Arel.sql("document_number DESC NULLS FIRST"))
 
     case @filter
@@ -46,7 +53,7 @@ class InvoicesController < ApplicationController
       @invoices = @invoices.unpaid.published
     end
 
-    @available_years = Invoice.available_years
+    @available_years = Invoice.visible_to(current_user).available_years
   end
 
   # GET /invoices/1
@@ -211,7 +218,7 @@ class InvoicesController < ApplicationController
 
 protected
   def set_invoice
-    @invoice = Invoice.find(params[:id])
+    @invoice = Invoice.visible_to(current_user).find(params[:id])
   end
 
   def invoice_params

--- a/app/controllers/issuer_companies_controller.rb
+++ b/app/controllers/issuer_companies_controller.rb
@@ -1,6 +1,8 @@
 class IssuerCompaniesController < ApplicationController
   MAX_LOGO_SIZE_BYTES = 2.megabytes
 
+  before_action -> { require_permission!("issuer_company.view") }, only: [ :show, :png_logo ]
+  before_action -> { require_permission!("issuer_company.edit") }, only: [ :edit, :update ]
   before_action :set_issuer_company
 
   def show

--- a/app/controllers/jobs_status_controller.rb
+++ b/app/controllers/jobs_status_controller.rb
@@ -1,4 +1,6 @@
 class JobsStatusController < ApplicationController
+  before_action -> { require_permission!("jobs_status.view") }
+
   STALE_HEARTBEAT_THRESHOLD = 1.minute
   RECENT_FAILED_LIMIT = 20
   RECENT_FINISHED_LIMIT = 10

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,4 +1,7 @@
 class ProductsController < ApplicationController
+  before_action -> { require_permission!("products.view") }, only: [ :index, :show ]
+  before_action -> { require_permission!("products.edit") }, only: [ :new, :create, :edit, :update, :destroy ]
+
   # GET /products
   def index
     @products = Product.order(:title)

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,16 +1,21 @@
 class ProjectsController < ApplicationController
+  before_action -> { require_permission!("projects.view") }, only: [ :index, :show ]
+  before_action -> { require_permission!("projects.edit") }, only: [ :new, :create, :edit, :update, :destroy ]
+  before_action :load_customer_options, only: [ :new, :create, :edit, :update ]
+
   # GET /projects
   # GET /projects.json
   def index
     params[:filter] ||= "active"
 
+    base = Project.visible_to(current_user)
     @projects = case params[:filter]
     when "all"
-      Project.all
+      base
     when "inactive"
-      Project.inactive
+      base.where(active: false)
     else
-      Project.active
+      base.where(active: true)
     end
 
     # Filters for AJAX requests
@@ -39,7 +44,9 @@ class ProjectsController < ApplicationController
             name: project.display_name,
             matchcode: project.matchcode,
             description: project.description,
-            is_reusable: project.bill_to_customer_id.nil?
+            is_reusable: project.bill_to_customer_id.nil?,
+            team_id: project.team_id,
+            team_name: project.team&.name
           }
         }
       }
@@ -48,17 +55,19 @@ class ProjectsController < ApplicationController
 
   # GET /projects/1
   def show
-    @project = Project.find(params[:id])
+    @project = Project.visible_to(current_user).find(params[:id])
   end
 
   # GET /projects/new
   def new
     @project = Project.new
+    teams_available = available_teams
+    @project.team_id = teams_available.first&.id if teams_available.size == 1
   end
 
   # GET /projects/1/edit
   def edit
-    @project = Project.find(params[:id])
+    @project = Project.visible_to(current_user).find(params[:id])
   end
 
   # POST /projects
@@ -74,7 +83,7 @@ class ProjectsController < ApplicationController
 
   # PUT /projects/1
   def update
-    @project = Project.find(params[:id])
+    @project = Project.visible_to(current_user).find(params[:id])
 
     if @project.update(projects_params)
       redirect_to @project, notice: "Project was successfully updated."
@@ -85,7 +94,7 @@ class ProjectsController < ApplicationController
 
   # DELETE /projects/1
   def destroy
-    @project = Project.find(params[:id])
+    @project = Project.visible_to(current_user).find(params[:id])
 
     if @project.destroy
       redirect_to projects_url, notice: "Project was successfully deleted."
@@ -96,6 +105,10 @@ class ProjectsController < ApplicationController
 
 private
   def projects_params
-    params.require(:project).permit(:bill_to_customer_id, :description, :matchcode, :active)
+    params.require(:project).permit(:bill_to_customer_id, :description, :matchcode, :active, :team_id)
+  end
+
+  def load_customer_options
+    @customer_options = Customer.visible_to(current_user).order(:name).to_a
   end
 end

--- a/app/controllers/sales_tax_customer_classes_controller.rb
+++ b/app/controllers/sales_tax_customer_classes_controller.rb
@@ -1,4 +1,7 @@
 class SalesTaxCustomerClassesController < ApplicationController
+  before_action -> { require_permission!("sales_tax.view") }, only: [ :index, :show ]
+  before_action -> { require_permission!("sales_tax.edit") }, only: [ :new, :create, :edit, :update, :destroy ]
+
   # GET /sales_tax_customer_classes
   def index
     @sales_tax_customer_classes = SalesTaxCustomerClass.all

--- a/app/controllers/sales_tax_product_classes_controller.rb
+++ b/app/controllers/sales_tax_product_classes_controller.rb
@@ -1,4 +1,7 @@
 class SalesTaxProductClassesController < ApplicationController
+  before_action -> { require_permission!("sales_tax.view") }, only: [ :index, :show ]
+  before_action -> { require_permission!("sales_tax.edit") }, only: [ :new, :create, :edit, :update, :destroy ]
+
   # GET /sales_tax_product_classes
   def index
     @sales_tax_product_classes = SalesTaxProductClass.all

--- a/app/controllers/sales_tax_rates_controller.rb
+++ b/app/controllers/sales_tax_rates_controller.rb
@@ -1,4 +1,7 @@
 class SalesTaxRatesController < ApplicationController
+  before_action -> { require_permission!("sales_tax.view") }, only: [ :index, :show ]
+  before_action -> { require_permission!("sales_tax.edit") }, only: [ :new, :create, :edit, :update, :destroy ]
+
   # GET /sales_tax_rates
   def index
     @sales_tax_rates = SalesTaxRate.all

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,7 @@
 class SessionsController < ApplicationController
   allow_unauthenticated_access only: [ :new, :options, :verify ]
+  # destroy: signed-in user terminating their own session.
+  allow_without_permission_check only: [ :destroy ]
 
   def new
   end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,0 +1,80 @@
+class TeamsController < ApplicationController
+  before_action -> { require_permission!("teams.manage") }
+  before_action :load_team, only: [ :show, :edit, :update, :destroy ]
+
+  def index
+    @teams = Team.ordered
+                 .left_joins(:team_memberships, :customers, :projects)
+                 .select('teams.*,
+                          COUNT(DISTINCT team_memberships.id) AS member_count,
+                          COUNT(DISTINCT customers.id)        AS customer_count,
+                          COUNT(DISTINCT projects.id)         AS project_count')
+                 .group("teams.id")
+  end
+
+  def show
+    @members  = @team.users.order(:username)
+    @customer_count = @team.customers.count
+    @project_count  = @team.projects.count
+  end
+
+  def new
+    @team = Team.new
+  end
+
+  def edit
+  end
+
+  def create
+    @team = Team.new(team_attributes)
+    if @team.save
+      assign_members(@team, params.dig(:team, :user_ids))
+      audit_privilege_change!("team_created", metadata: { name: @team.name,
+                                         member_usernames: @team.users.pluck(:username) })
+      redirect_to teams_path, notice: "Team created."
+    else
+      render :new, status: :unprocessable_content
+    end
+  end
+
+  def update
+    before_members = @team.user_ids.to_set
+    if @team.update(team_attributes)
+      assign_members(@team, params.dig(:team, :user_ids)) if params.dig(:team, :user_ids)
+      after_members = @team.reload.user_ids.to_set
+      audit_privilege_change!("team_updated", metadata: {
+        name: @team.name,
+        members_added: User.where(id: (after_members - before_members).to_a).pluck(:username),
+        members_removed: User.where(id: (before_members - after_members).to_a).pluck(:username)
+      })
+      redirect_to teams_path, notice: "Team updated."
+    else
+      render :edit, status: :unprocessable_content
+    end
+  end
+
+  def destroy
+    name = @team.name
+    if @team.destroy
+      audit_privilege_change!("team_deleted", metadata: { name: name })
+      redirect_to teams_path, notice: "Team deleted."
+    else
+      redirect_to teams_path, alert: @team.errors.full_messages.join(", ")
+    end
+  end
+
+  private
+
+  def load_team
+    @team = Team.find(params[:id])
+  end
+
+  def team_attributes
+    params.require(:team).permit(:name, :description)
+  end
+
+  def assign_members(team, user_ids)
+    new_ids = Array(user_ids).reject(&:blank?).map(&:to_i)
+    team.users = User.where(id: new_ids).to_a
+  end
+end

--- a/app/controllers/user_invites_controller.rb
+++ b/app/controllers/user_invites_controller.rb
@@ -1,4 +1,6 @@
 class UserInvitesController < ApplicationController
+  before_action -> { require_permission!("user_invites.manage") }
+
   def index
     @invites = UserInvite.where(purpose: UserInvite::PURPOSE_SIGNUP)
                          .order(created_at: :desc).limit(50)

--- a/app/controllers/users/emails_controller.rb
+++ b/app/controllers/users/emails_controller.rb
@@ -1,4 +1,10 @@
 class Users::EmailsController < ApplicationController
+  # Admin-only: this controller adds/replaces emails with confirmed_at set
+  # to Time.current — no out-of-band verification. That's a credential-
+  # issuance primitive (combined with reset_passkeys it's full account
+  # takeover), so it sits behind users.auto_confirm_email which only the
+  # Admin group can hold.
+  before_action -> { require_permission!("users.auto_confirm_email") }
   before_action :load_user
 
   def create

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,11 @@
 class UsersController < ApplicationController
-  before_action :load_user, only: [ :show, :block, :unblock, :reset_passkeys, :audit ]
+  before_action -> { require_permission!("users.view") }, only: [ :index, :show, :audit ]
+  before_action -> { require_permission!("users.block") }, only: [ :block, :unblock ]
+  before_action -> { require_permission!("users.reset_passkeys") }, only: [ :reset_passkeys ]
+  before_action -> { require_permission!("groups.manage") }, only: [ :update_groups ]
+  before_action -> { require_permission!("teams.manage") }, only: [ :update_teams ]
+
+  before_action :load_user, only: [ :show, :block, :unblock, :reset_passkeys, :audit, :update_groups, :update_teams ]
 
   def index
     @users = User.order(:username)
@@ -9,6 +15,8 @@ class UsersController < ApplicationController
     @emails = @user.emails.order(:created_at)
     @credentials = @user.credentials.order(:created_at)
     @sessions = @user.sessions.active.order(last_seen_at: :desc).limit(20)
+    @user_groups = @user.groups.ordered
+    @user_teams = @user.teams.ordered
   end
 
   def block
@@ -58,6 +66,61 @@ class UsersController < ApplicationController
 
   def audit
     @audit_events = UserAuditEvent.for_user(@user).limit(200)
+  end
+
+  def update_groups
+    new_ids = Array(params[:group_ids]).reject(&:blank?).map(&:to_i)
+    new_groups = Group.where(id: new_ids).to_a
+
+    admin_group = Group.admin
+    if admin_group && @user.groups.include?(admin_group) && !new_groups.include?(admin_group)
+      if admin_group.users.where.not(id: @user.id).none?
+        redirect_to user_path(@user), alert: "Cannot remove the last member of the Admin group." and return
+      end
+    end
+
+    # Only admins can change Admin-group membership in either direction.
+    # `groups.manage` alone is insufficient: the add direction is admin
+    # self-promotion (bypass_team_scoping + admin-only credential primitives);
+    # the remove direction lets a non-admin demote any admin (down to the
+    # last-admin floor enforced above), which is unauthorized privilege
+    # modification + an admin-lockout primitive.
+    if admin_group && !current_user.groups.include?(admin_group)
+      adding_admin   = new_groups.include?(admin_group) && !@user.groups.include?(admin_group)
+      removing_admin = @user.groups.include?(admin_group) && !new_groups.include?(admin_group)
+      if adding_admin || removing_admin
+        redirect_to user_path(@user), alert: "Only members of the Admin group can change Admin membership." and return
+      end
+    end
+
+    previous = @user.groups.pluck(:id).to_set
+    @user.groups = new_groups
+    added   = new_ids.to_set - previous
+    removed = previous - new_ids.to_set
+    if added.any? || removed.any?
+      audit_privilege_change!("groups_updated", user: @user, metadata: {
+        username: @user.username,
+        added: Group.where(id: added.to_a).pluck(:name),
+        removed: Group.where(id: removed.to_a).pluck(:name)
+      })
+    end
+    redirect_to user_path(@user), notice: "Group memberships updated."
+  end
+
+  def update_teams
+    new_ids = Array(params[:team_ids]).reject(&:blank?).map(&:to_i)
+    previous = @user.teams.pluck(:id).to_set
+    @user.teams = Team.where(id: new_ids).to_a
+    added   = new_ids.to_set - previous
+    removed = previous - new_ids.to_set
+    if added.any? || removed.any?
+      audit_privilege_change!("teams_updated", user: @user, metadata: {
+        username: @user.username,
+        added: Team.where(id: added.to_a).pluck(:name),
+        removed: Team.where(id: removed.to_a).pluck(:name)
+      })
+    end
+    redirect_to user_path(@user), notice: "Team memberships updated."
   end
 
   private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,10 @@
 module ApplicationHelper
+  # Permission check helper for views. Uses current_user via the controller
+  # (already defined as a helper_method in ApplicationController).
+  def can?(key)
+    !!Current.user&.permission?(key)
+  end
+
   def current_currency
     @current_currency ||= IssuerCompany.get_the_issuer!&.currency || "EUR"
   end
@@ -26,17 +32,23 @@ module ApplicationHelper
     end
   end
 
-  def page_header_with_new_button(title, new_path)
+  # If `permission:` is given, the +New / Edit button is hidden unless the
+  # current user holds that key. The header itself always renders so users
+  # with .view-only access still see the page heading. Controllers gate the
+  # actual action server-side; this just keeps the UI honest.
+  def page_header_with_new_button(title, new_path, permission: nil)
     content_tag :div, class: "d-flex justify-content-between align-items-center mb-3" do
-      content_tag(:h1, title, class: "page-header mb-0") +
-      link_to("+ New", new_path, class: "btn btn-info")
+      header = content_tag(:h1, title, class: "page-header mb-0")
+      button = (permission.nil? || can?(permission)) ? link_to("+ New", new_path, class: "btn btn-info") : "".html_safe
+      header + button
     end
   end
 
-  def page_header_with_edit_button(title, edit_path)
+  def page_header_with_edit_button(title, edit_path, permission: nil)
     content_tag :div, class: "d-flex justify-content-between align-items-center mb-3" do
-      content_tag(:h1, title, class: "page-header mb-0") +
-      link_to("Edit", edit_path, class: "btn btn-primary")
+      header = content_tag(:h1, title, class: "page-header mb-0")
+      button = (permission.nil? || can?(permission)) ? link_to("Edit", edit_path, class: "btn btn-primary") : "".html_safe
+      header + button
     end
   end
 

--- a/app/javascript/controllers/permission_pair_controller.js
+++ b/app/javascript/controllers/permission_pair_controller.js
@@ -1,0 +1,39 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Pairs every <foo>.view / <foo>.edit checkbox so that:
+//  - ticking .edit auto-ticks the matching .view (no .edit without .view)
+//  - unticking .view auto-unticks the matching .edit (same reason)
+// The server treats each permission key independently — without this an
+// admin could assign customers.edit alone, and the user would 403 on the
+// index page they need to reach to use the edit action.
+//
+// Discovery is by id convention: perm_<scope>_view / perm_<scope>_edit
+// (the same id pattern the form uses for label `for=` linking).
+export default class extends Controller {
+  connect() {
+    this.boundOnChange = this.onChange.bind(this)
+    this.element.addEventListener("change", this.boundOnChange)
+  }
+
+  disconnect() {
+    this.element.removeEventListener("change", this.boundOnChange)
+  }
+
+  onChange(event) {
+    const cb = event.target
+    if (!(cb instanceof HTMLInputElement) || cb.type !== "checkbox" || !cb.id) return
+
+    const editMatch = cb.id.match(/^perm_(.+)_edit$/)
+    if (editMatch && cb.checked) {
+      const view = this.element.querySelector(`#perm_${editMatch[1]}_view`)
+      if (view && !view.checked) view.checked = true
+      return
+    }
+
+    const viewMatch = cb.id.match(/^perm_(.+)_view$/)
+    if (viewMatch && !cb.checked) {
+      const edit = this.element.querySelector(`#perm_${viewMatch[1]}_edit`)
+      if (edit && edit.checked) edit.checked = false
+    }
+  }
+}

--- a/app/javascript/controllers/project_team_controller.js
+++ b/app/javascript/controllers/project_team_controller.js
@@ -1,0 +1,83 @@
+import { Controller } from "@hotwired/stimulus"
+
+// When a bill-to customer is selected, replace the team dropdown's options
+// with just the customer's team — that's the only legal choice, so showing
+// the others is misleading (and `pointer-events: none` doesn't reliably
+// disable a <select> in Safari). When the customer is cleared (reusable
+// project), restore the full team list. Server-side `team_must_match_customer`
+// enforces the rule even if JS fails or is bypassed.
+export default class extends Controller {
+  static targets = ["customer", "teamSelect"]
+
+  connect() {
+    this.boundChange = this.onCustomerChange.bind(this)
+    if (this.hasCustomerTarget) {
+      this.customerTarget.addEventListener("change", this.boundChange)
+    }
+    this.cacheOriginalOptions()
+    this.applyLock()
+  }
+
+  disconnect() {
+    if (this.hasCustomerTarget) {
+      this.customerTarget.removeEventListener("change", this.boundChange)
+    }
+  }
+
+  onCustomerChange() {
+    this.applyLock()
+  }
+
+  cacheOriginalOptions() {
+    if (!this.hasTeamSelectTarget) return
+    this.originalOptions = Array.from(this.teamSelectTarget.options).map((opt) => ({
+      value: opt.value,
+      text: opt.textContent,
+    }))
+  }
+
+  applyLock() {
+    if (!this.hasCustomerTarget || !this.hasTeamSelectTarget) return
+
+    const map = this.customerTeamMap()
+    const customerId = this.customerTarget.value
+    const entry = customerId ? map[customerId] : null
+
+    if (entry && entry.team_id != null) {
+      const teamId = String(entry.team_id)
+      const teamName = entry.team_name || `Team ${teamId}`
+      this.setOptions([{ value: teamId, text: teamName }])
+      this.teamSelectTarget.value = teamId
+    } else {
+      this.setOptions(this.originalOptions || [])
+    }
+  }
+
+  setOptions(options) {
+    const current = Array.from(this.teamSelectTarget.options).map((o) => ({
+      value: o.value, text: o.textContent,
+    }))
+    if (current.length === options.length &&
+        current.every((o, i) => o.value === options[i].value && o.text === options[i].text)) {
+      return
+    }
+    this.teamSelectTarget.innerHTML = ""
+    options.forEach(({ value, text }) => {
+      const opt = document.createElement("option")
+      opt.value = value
+      opt.textContent = text
+      this.teamSelectTarget.appendChild(opt)
+    })
+  }
+
+  customerTeamMap() {
+    if (this._map) return this._map
+    try {
+      const raw = this.customerTarget.dataset.customerTeamMap
+      this._map = raw ? JSON.parse(raw) : {}
+    } catch (e) {
+      this._map = {}
+    }
+    return this._map
+  }
+}

--- a/app/models/concerns/scoped_through_customer.rb
+++ b/app/models/concerns/scoped_through_customer.rb
@@ -1,0 +1,36 @@
+module ScopedThroughCustomer
+  extend ActiveSupport::Concern
+
+  # Invoices and delivery notes inherit team visibility from their
+  # customer (they have no team_id of their own). Without this concern a
+  # user with invoices.edit / delivery_notes.edit in team A could mass-
+  # assign `customer_id` (or `project_id`) referencing another team's
+  # records and plant invoices/delivery notes into that team's books.
+  #
+  # Enforcement mirrors TeamOwned#validate_team_assignment: the check
+  # reads Current.user (set by ApplicationController#authenticate on every
+  # authenticated request), so a future controller can't "forget" to
+  # authorize the assignment. System contexts (seeds, console, jobs)
+  # have no Current.user and the check skips.
+  included do
+    validate :customer_must_be_visible_to_current_user, if: :will_save_change_to_customer_id?
+    validate :project_must_be_visible_to_current_user,  if: :will_save_change_to_project_id?
+  end
+
+  private
+
+  def customer_must_be_visible_to_current_user
+    user = Current.user
+    return if user.nil?
+    return if customer_id && Customer.visible_to(user).where(id: customer_id).exists?
+    errors.add(:customer_id, "must be a customer you can access")
+  end
+
+  def project_must_be_visible_to_current_user
+    return if project_id.nil?
+    user = Current.user
+    return if user.nil?
+    return if Project.visible_to(user).where(id: project_id).exists?
+    errors.add(:project_id, "must be a project you can access")
+  end
+end

--- a/app/models/concerns/team_owned.rb
+++ b/app/models/concerns/team_owned.rb
@@ -1,0 +1,36 @@
+module TeamOwned
+  extend ActiveSupport::Concern
+
+  included do
+    belongs_to :team
+
+    # Unconditional once team_id is being written. The check reads
+    # Current.user, which ApplicationController#authenticate sets on every
+    # authenticated request. A new controller that handles a TeamOwned
+    # record therefore can't "forget" to authorize the assignment.
+    validate :validate_team_assignment, if: :will_save_change_to_team_id?
+  end
+
+  class_methods do
+    # Restrict a relation to records the user can see. Bypass-scoping users
+    # see everything; everyone else sees records in teams they're a member of.
+    def visible_to(user)
+      return none if user.nil?
+      return all if user.bypass_team_scoping?
+      where(team_id: user.team_ids)
+    end
+  end
+
+  private
+
+  def validate_team_assignment
+    # Current.user is nil in system contexts (seeds, console, background
+    # jobs); the validation skips and those callers can seed freely. Inside
+    # a request it's always set by the authenticate before_action.
+    user = Current.user
+    return if user.nil?
+    return if user.bypass_team_scoping?
+    return if team_id && user.team_ids.include?(team_id)
+    errors.add(:team_id, "must be a team you are a member of")
+  end
+end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -1,4 +1,6 @@
 class Customer < ApplicationRecord
+  include TeamOwned
+
   validates :matchcode, presence: true
   validates :name, presence: true
 
@@ -20,6 +22,15 @@ class Customer < ApplicationRecord
 
   before_destroy :check_if_used
 
+  # When a customer moves to a different team, cascade the change to every
+  # project that bills to this customer. Project#team_must_match_customer
+  # otherwise leaves the projects in an inconsistent state (immediately
+  # unsaveable, and invisible to members of the new team because their
+  # team_id still points at the old one). update_all is fine here:
+  # team_must_match_customer would pass (we're moving INTO match), and the
+  # write is authorized by the customer-side change.
+  after_update :sync_project_teams, if: :saved_change_to_team_id?
+
   private
 
   def set_default_language
@@ -31,5 +42,9 @@ class Customer < ApplicationRecord
       errors.add(:base, "Cannot delete customer that has been used in invoices")
       throw :abort
     end
+  end
+
+  def sync_project_teams
+    Project.where(bill_to_customer_id: id).update_all(team_id: team_id, updated_at: Time.current)
   end
 end

--- a/app/models/delivery_note.rb
+++ b/app/models/delivery_note.rb
@@ -1,6 +1,7 @@
 class DeliveryNote < ApplicationRecord
   include YearFilterable
   include HasLineItems
+  include ScopedThroughCustomer
 
   has_line_items :delivery_note_lines
 
@@ -16,6 +17,12 @@ class DeliveryNote < ApplicationRecord
     .where("customers.email IS NOT NULL AND customers.email != ''")
   }
   scope :published, -> { where(published: true) }
+
+  def self.visible_to(user)
+    return none if user.nil?
+    return all if user.bypass_team_scoping?
+    where(customer_id: Customer.visible_to(user).select(:id))
+  end
 
   belongs_to :customer
   belongs_to :project

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,76 @@
+class Group < ApplicationRecord
+  # Name of the built-in administrator group. Referenced by Group#admin?,
+  # User#auto_promote_first_user, UsersController#update_groups (last-admin
+  # protection), and the seed migration. The string lives here so any future
+  # rename is a single edit; prevent_name_change_if_builtin keeps the row's
+  # actual name in sync with this constant.
+  ADMIN_NAME = "Admin".freeze
+
+  has_many :group_memberships, dependent: :destroy
+  has_many :users, through: :group_memberships
+  has_many :group_permissions, dependent: :destroy
+
+  validates :name, presence: true, uniqueness: { case_sensitive: false }, length: { maximum: 60 }
+  validates :description, length: { maximum: 200 }
+  validate :prevent_name_change_if_builtin
+
+  before_destroy :prevent_destroy_if_builtin, prepend: true
+
+  scope :ordered, -> { order(:name) }
+
+  def self.admin
+    find_by(builtin: true, name: ADMIN_NAME)
+  end
+
+  def permissions
+    @permissions ||= group_permissions.pluck(:permission).to_set
+  end
+
+  def permission?(key)
+    permissions.include?(key)
+  end
+
+  # Sync the set of permissions assigned to this group.
+  # - Unknown keys are silently dropped.
+  # - Admin-only keys (users.reset_passkeys, users.auto_confirm_email) are
+  #   silently dropped for non-Admin groups; GroupPermission's validation is
+  #   the loud defense-in-depth that catches direct DB-style attempts.
+  def permissions=(keys)
+    keys = Array(keys).select { |k| Permission.valid?(k) }
+    keys -= Permission::ADMIN_ONLY_KEYS.to_a unless admin?
+    keys = keys.to_set
+    transaction do
+      existing = group_permissions.pluck(:permission).to_set
+      (existing - keys).each do |p|
+        group_permissions.where(permission: p).destroy_all
+      end
+      (keys - existing).each do |p|
+        group_permissions.create!(permission: p)
+      end
+    end
+    @permissions = nil
+  end
+
+  def admin?
+    builtin? && name == ADMIN_NAME
+  end
+
+  private
+
+  # Renaming a built-in group would silently break the security model.
+  # admin? checks `builtin? && name == ADMIN_NAME`, so a rename disables the
+  # last-admin protection, admin-only permission validation, and the
+  # permission filter. Block at the model layer so even direct
+  # ActiveRecord updates (console, jobs) can't do it.
+  def prevent_name_change_if_builtin
+    return unless persisted? && builtin? && will_save_change_to_name?
+    errors.add(:name, "of a built-in group cannot be changed")
+  end
+
+  def prevent_destroy_if_builtin
+    if builtin?
+      errors.add(:base, "Cannot delete a built-in group")
+      throw :abort
+    end
+  end
+end

--- a/app/models/group_membership.rb
+++ b/app/models/group_membership.rb
@@ -1,0 +1,18 @@
+class GroupMembership < ApplicationRecord
+  belongs_to :group
+  belongs_to :user
+
+  validates :user_id, uniqueness: { scope: :group_id }
+
+  before_destroy :prevent_removing_last_admin
+
+  private
+
+  def prevent_removing_last_admin
+    return unless group.admin?
+    if group.group_memberships.where.not(id: id).none?
+      errors.add(:base, "Cannot remove the last member of the Admin group")
+      throw :abort
+    end
+  end
+end

--- a/app/models/group_permission.rb
+++ b/app/models/group_permission.rb
@@ -1,0 +1,28 @@
+class GroupPermission < ApplicationRecord
+  belongs_to :group
+
+  validates :permission, presence: true, uniqueness: { scope: :group_id }
+  validate  :permission_must_be_known
+  validate  :admin_only_permission_only_on_admin_group
+
+  private
+
+  def permission_must_be_known
+    return if permission.blank?
+    unless Permission.valid?(permission)
+      errors.add(:permission, "is not a known permission")
+    end
+  end
+
+  # Admin-only permissions (users.reset_passkeys, users.auto_confirm_email)
+  # carry latent admin-equivalent power. They must never be assigned to a
+  # non-Admin group. The seed migration is allowed because it creates the
+  # Admin group itself before this validation fires; from then on this is
+  # the canonical enforcement point.
+  def admin_only_permission_only_on_admin_group
+    return if permission.blank?
+    return unless Permission.admin_only?(permission)
+    return if group&.admin?
+    errors.add(:permission, "#{permission} can only be granted to the built-in Admin group")
+  end
+end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -1,6 +1,7 @@
 class Invoice < ApplicationRecord
   include YearFilterable
   include HasLineItems
+  include ScopedThroughCustomer
 
   has_line_items :invoice_lines
 
@@ -14,6 +15,12 @@ class Invoice < ApplicationRecord
   }
   scope :published, -> { where(published: true) }
   scope :unpaid, -> { where(paid_at: nil) }
+
+  def self.visible_to(user)
+    return none if user.nil?
+    return all if user.bypass_team_scoping?
+    where(customer_id: Customer.visible_to(user).select(:id))
+  end
 
   after_initialize :set_defaults
 

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -1,0 +1,62 @@
+module Permission
+  # admin_only: true means the permission cannot be assigned to any non-Admin
+  # group from the UI or via the model. Used for capabilities that carry
+  # latent admin-equivalent power (issuing/resetting auth credentials,
+  # auto-confirming emails on arbitrary users — see app/controllers/users/
+  # emails_controller.rb and UsersController#reset_passkeys).
+  Entry = Struct.new(:key, :label, :category, :admin_only, keyword_init: true)
+
+  ALL = [
+    # Operations
+    Entry.new(key: "customers.view",      label: "View customers",          category: "Operations"),
+    Entry.new(key: "customers.edit",      label: "Create / edit customers", category: "Operations"),
+    Entry.new(key: "projects.view",       label: "View projects",           category: "Operations"),
+    Entry.new(key: "projects.edit",       label: "Create / edit projects",  category: "Operations"),
+    Entry.new(key: "invoices.view",       label: "View invoices",           category: "Operations"),
+    Entry.new(key: "invoices.edit",       label: "Create / book / send invoices", category: "Operations"),
+    Entry.new(key: "delivery_notes.view", label: "View delivery notes",     category: "Operations"),
+    Entry.new(key: "delivery_notes.edit", label: "Create / publish / send delivery notes", category: "Operations"),
+
+    # Catalog & tax
+    Entry.new(key: "products.view", label: "View product catalog",          category: "Catalog & tax"),
+    Entry.new(key: "products.edit", label: "Create / edit products",        category: "Catalog & tax"),
+    Entry.new(key: "sales_tax.view", label: "View sales tax configuration", category: "Catalog & tax"),
+    Entry.new(key: "sales_tax.edit", label: "Edit sales tax configuration", category: "Catalog & tax"),
+
+    # Company settings
+    Entry.new(key: "issuer_company.view", label: "View issuer company",     category: "Company settings"),
+    Entry.new(key: "issuer_company.edit", label: "Edit issuer company",     category: "Company settings"),
+
+    # Administration
+    Entry.new(key: "users.view",                label: "View users",                          category: "Administration"),
+    Entry.new(key: "users.block",               label: "Block and unblock users",             category: "Administration"),
+    Entry.new(key: "users.reset_passkeys",      label: "Reset user passkeys (Admin only)",    category: "Administration", admin_only: true),
+    Entry.new(key: "users.auto_confirm_email",  label: "Add / replace / remove user emails without verification (Admin only)", category: "Administration", admin_only: true),
+    Entry.new(key: "user_invites.manage",       label: "Create user invites",                 category: "Administration"),
+    Entry.new(key: "groups.manage",             label: "Manage groups and permissions",       category: "Administration"),
+    Entry.new(key: "teams.manage",              label: "Manage teams and team memberships",   category: "Administration"),
+    Entry.new(key: "jobs_status.view",          label: "View background jobs status",         category: "Administration")
+  ].freeze
+
+  ALL_KEYS = ALL.map(&:key).to_set.freeze
+
+  ADMIN_ONLY_KEYS = ALL.select(&:admin_only).map(&:key).to_set.freeze
+
+  CATEGORIES = ALL.map(&:category).uniq.freeze
+
+  def self.grouped
+    @grouped ||= ALL.group_by(&:category).freeze
+  end
+
+  def self.valid?(key)
+    ALL_KEYS.include?(key)
+  end
+
+  def self.admin_only?(key)
+    ADMIN_ONLY_KEYS.include?(key)
+  end
+
+  def self.label_for(key)
+    ALL.find { |e| e.key == key }&.label || key
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,8 +1,11 @@
 class Project < ApplicationRecord
+  include TeamOwned
+
   belongs_to :bill_to_customer, class_name: "Customer", optional: true
   has_many :invoices
 
   validates :matchcode, presence: true
+  validate :team_must_match_customer
 
   # Scopes for filtering
   scope :active, -> { where(active: true) }
@@ -35,6 +38,16 @@ class Project < ApplicationRecord
     if used_in_invoices?
       errors.add(:base, "Cannot delete project that has been used in invoices")
       throw :abort
+    end
+  end
+
+  # Reusable projects (no bill_to_customer) are free to pick any team.
+  # Projects with a customer must share that customer's team.
+  def team_must_match_customer
+    return if bill_to_customer_id.blank?
+    return unless team_id && bill_to_customer && bill_to_customer.team_id
+    if team_id != bill_to_customer.team_id
+      errors.add(:team_id, "must match the team of the bill-to customer (#{bill_to_customer.team&.name})")
     end
   end
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,0 +1,47 @@
+class Team < ApplicationRecord
+  # Initial name of the built-in default team. Only used when seeding/
+  # creating the team; lookups go through Team.default which uses the
+  # dedicated `default` column so the team stays renamable.
+  DEFAULT_NAME = "Default".freeze
+
+  has_many :team_memberships, dependent: :destroy
+  has_many :users, through: :team_memberships
+  has_many :customers
+  has_many :projects
+
+  validates :name, presence: true, uniqueness: { case_sensitive: false }, length: { maximum: 60 }
+  validates :description, length: { maximum: 200 }
+
+  before_destroy :prevent_destroy_if_builtin
+  before_destroy :prevent_destroy_if_used
+
+  scope :ordered, -> { order(:name) }
+
+  # The single team marked `default: true`. Distinct from `builtin?` (which
+  # means "system-managed, can't delete"): the default flag identifies the
+  # team new users auto-join via User#join_default_team. A partial unique
+  # index on `default` enforces at most one default at the DB level.
+  def self.default
+    find_by(default: true)
+  end
+
+  def used?
+    customers.exists? || projects.exists?
+  end
+
+  private
+
+  def prevent_destroy_if_builtin
+    if builtin?
+      errors.add(:base, "Cannot delete a built-in team")
+      throw :abort
+    end
+  end
+
+  def prevent_destroy_if_used
+    if used?
+      errors.add(:base, "Cannot delete a team that owns customers or projects")
+      throw :abort
+    end
+  end
+end

--- a/app/models/team_membership.rb
+++ b/app/models/team_membership.rb
@@ -1,0 +1,6 @@
+class TeamMembership < ApplicationRecord
+  belongs_to :team
+  belongs_to :user
+
+  validates :user_id, uniqueness: { scope: :team_id }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,11 @@ class User < ApplicationRecord
   has_many :audit_events_as_actor, class_name: "UserAuditEvent",
            foreign_key: :actor_user_id, dependent: :nullify
 
+  has_many :group_memberships, dependent: :destroy
+  has_many :groups, through: :group_memberships
+  has_many :team_memberships, dependent: :destroy
+  has_many :teams, through: :team_memberships
+
   belongs_to :blocked_by_user, class_name: "User", optional: true
 
   attribute :webauthn_id, default: -> { WebAuthn.generate_user_id }
@@ -21,8 +26,43 @@ class User < ApplicationRecord
 
   normalizes :username, with: ->(v) { v.strip.downcase }
 
+  after_create_commit :auto_promote_first_user
+  after_create_commit :join_default_team
+
   scope :active, -> { where(blocked_at: nil) }
   scope :blocked, -> { where.not(blocked_at: nil) }
+
+  # Memoized per User instance. Fine for the request/response cycle (each
+  # request rebuilds current_user). If a long-running job ever reuses the
+  # same User object across permission mutations, call `user.reload` (or
+  # rebuild it) to get fresh permissions; this method does not invalidate
+  # on group/group_permission/group_membership changes.
+  def permissions
+    @permissions ||= GroupPermission
+                      .joins(group: :group_memberships)
+                      .where(group_memberships: { user_id: id })
+                      .pluck(:permission)
+                      .to_set
+  end
+
+  def permission?(key)
+    permissions.include?(key)
+  end
+
+  # Same per-instance memoization caveat as #permissions — reload the user
+  # if you mutate group memberships and need to re-check on the same object.
+  def bypass_team_scoping?
+    return @bypass_team_scoping if defined?(@bypass_team_scoping)
+    @bypass_team_scoping = groups.where(bypass_team_scoping: true).exists?
+  end
+
+  def visible_team_ids
+    if bypass_team_scoping?
+      Team.pluck(:id)
+    else
+      team_ids
+    end
+  end
 
   def blocked?
     blocked_at.present?
@@ -81,5 +121,20 @@ class User < ApplicationRecord
       )
       [ invite, plaintext ]
     end
+  end
+
+  private
+
+  def auto_promote_first_user
+    return unless User.count == 1
+    admin = Group.admin
+    return unless admin
+    GroupMembership.find_or_create_by!(group: admin, user: self)
+  end
+
+  def join_default_team
+    default_team = Team.default
+    return unless default_team
+    TeamMembership.find_or_create_by!(team: default_team, user: self)
   end
 end

--- a/app/views/account/profiles/show.html.haml
+++ b/app/views/account/profiles/show.html.haml
@@ -58,6 +58,32 @@
             .small.text-muted Last seen: #{l(s.last_seen_at)}
     .card.mb-3
       .card-header
+        Groups
+        %span.badge.bg-secondary.ms-1= @user_groups.size
+      %ul.list-group.list-group-flush
+        - if @user_groups.empty?
+          %li.list-group-item.text-muted No groups
+        - else
+          - @user_groups.each do |group|
+            %li.list-group-item
+              = group.name
+              - if group.builtin?
+                %span.badge.bg-secondary.ms-1 built-in
+    .card.mb-3
+      .card-header
+        Teams
+        %span.badge.bg-secondary.ms-1= @user_teams.size
+      %ul.list-group.list-group-flush
+        - if @user_teams.empty?
+          %li.list-group-item.text-muted No teams
+        - else
+          - @user_teams.each do |team|
+            %li.list-group-item
+              = team.name
+              - if team.builtin?
+                %span.badge.bg-secondary.ms-1 built-in
+    .card.mb-3
+      .card-header
         .d-flex.justify-content-between.align-items-center
           %span Recent activity
           = link_to 'View all', account_audit_events_path, class: 'btn btn-sm btn-outline-primary'

--- a/app/views/customers/_form.html.haml
+++ b/app/views/customers/_form.html.haml
@@ -20,6 +20,13 @@
           = f.label :active, class: 'form-check-label'
 
     .row.mb-3
+      = f.label :team_id, 'Team', class: 'col-lg-2 col-md-3 col-form-label'
+      .col-sm-5
+        = f.collection_select :team_id, available_teams, :id, :name, { prompt: 'Select team...' }, {:class => 'form-select', :required => true}
+        - if available_teams.empty?
+          .form-text.text-danger You are not a member of any team. Ask an admin to add you to a team before creating customers.
+
+    .row.mb-3
       = f.label :name, class: 'col-lg-2 col-md-3 col-form-label'
       .col-lg-5
         = f.text_area :name, :class => 'form-control', :rows => 2

--- a/app/views/customers/index.html.haml
+++ b/app/views/customers/index.html.haml
@@ -1,4 +1,4 @@
-= page_header_with_new_button('Listing customers', new_customer_path)
+= page_header_with_new_button('Listing customers', new_customer_path, permission: 'customers.edit')
 
 .mb-3
   .btn-toolbar.mb-3{:role=>"toolbar", "aria-label"=>"List toolbar"}
@@ -12,6 +12,7 @@
     %th{:width => "10%"} Matchcode
     %th{:width => "7%"} Status
     %th Name
+    %th{:width => "10%"} Team
     %th{:width => "3%"}
     %th{:width => "3%"}
 
@@ -24,7 +25,10 @@
         - else
           %span.badge.bg-secondary Inactive
       %td= customer.name
-      %td= list_action_link('Edit', edit_customer_path(customer), :edit)
+      %td= customer.team&.name
       %td
-        - if !customer.used_in_invoices?
+        - if can?('customers.edit')
+          = list_action_link('Edit', edit_customer_path(customer), :edit)
+      %td
+        - if can?('customers.edit') && !customer.used_in_invoices?
           = destroy_link(customer, "Are you sure you want to delete customer \"#{customer.matchcode}\" (#{customer.name})?")

--- a/app/views/customers/show.html.haml
+++ b/app/views/customers/show.html.haml
@@ -1,4 +1,4 @@
-= page_header_with_edit_button("Customer #{@customer.matchcode}", edit_customer_path(@customer))
+= page_header_with_edit_button("Customer #{@customer.matchcode}", edit_customer_path(@customer), permission: 'customers.edit')
 
 .row
   .col-md-6
@@ -50,6 +50,12 @@
             %strong Language:
           .col-sm-8
             = @customer.language&.title
+
+        .row.mb-2
+          .col-sm-4
+            %strong Team:
+          .col-sm-8
+            = @customer.team&.name
 
   .col-md-6
     .card
@@ -106,5 +112,5 @@
 
 = action_buttons_wrapper do
   = action_button 'Back', customers_path, :secondary
-  - unless @customer.used_in_invoices?
+  - if can?('customers.edit') && !@customer.used_in_invoices?
     = button_to 'Delete', @customer, method: :delete, class: 'btn btn-danger', data: { 'turbo-confirm': "Are you sure you want to delete customer \"#{@customer.matchcode}\" (#{@customer.name})?" }

--- a/app/views/delivery_notes/index.html.haml
+++ b/app/views/delivery_notes/index.html.haml
@@ -1,4 +1,4 @@
-= page_header_with_new_button('Listing delivery notes', new_delivery_note_path)
+= page_header_with_new_button('Listing delivery notes', new_delivery_note_path, permission: 'delivery_notes.edit')
 
 
 .bulk-select-container{data: { controller: 'bulk-select' }}
@@ -72,5 +72,5 @@
           %td= delivery_note.cust_reference
           %td= delivery_note.cust_order
           %td
-            - unless delivery_note.published?
+            - if !delivery_note.published? && can?('delivery_notes.edit')
               = list_action_link('Edit', edit_delivery_note_path(delivery_note), :edit)

--- a/app/views/delivery_notes/preview_email.html.haml
+++ b/app/views/delivery_notes/preview_email.html.haml
@@ -1,0 +1,63 @@
+.row
+  .col-md-12
+    .card
+      .card-header.d-flex.justify-content-between.align-items-center
+        %h6.mb-0 Email Details
+        .btn-group{"role" => "group", "aria-label" => "Email format"}
+          %button.btn.btn-sm.btn-outline-primary.active{"data-format" => "html"}
+            HTML
+          - if @email_body_text
+            %button.btn.btn-sm.btn-outline-primary{"data-format" => "text"}
+              Text
+      .card-body
+        .row.mb-2
+          .col-sm-2
+            %strong To:
+          .col-sm-10
+            = @email_to || %i{No recipient configured}
+
+        .row.mb-2
+          .col-sm-2
+            %strong From:
+          .col-sm-10
+            = @email_from || %i{No sender configured}
+
+        - if @email_bcc.present?
+          .row.mb-2
+            .col-sm-2
+              %strong BCC:
+            .col-sm-10
+              = @email_bcc
+
+        .row.mb-2
+          .col-sm-2
+            %strong Subject:
+          .col-sm-10
+            = @email_subject || %i{No subject}
+
+        - if @attachments&.any?
+          .row.mb-2
+            .col-sm-2
+              %strong Files:
+            .col-sm-10
+              - @attachments.each do |attachment|
+                .d-flex.align-items-center.mb-1
+                  %span.me-1 📎
+                  %span= attachment[:filename]
+                  %small.text-muted.ms-2
+                    (#{number_to_human_size(attachment[:size])})
+
+    .card.mt-4
+      .card-header
+        Email Content
+      .card-body.email-preview-content{"data-format-content" => "html"}
+        - if @email_body_html.present?
+          %iframe.email-preview-iframe{"src" => preview_email_raw_delivery_note_path(@delivery_note)}
+        - else
+          %p.text-muted
+            %i No HTML content available
+
+      - if @email_body_text
+        .card-body.email-preview-content.d-none{"data-format-content" => "text"}
+          %pre.mb-0.font-monospace.text-pre-wrap
+            = @email_body_text

--- a/app/views/delivery_notes/show.html.haml
+++ b/app/views/delivery_notes/show.html.haml
@@ -142,23 +142,26 @@
                     - else
                       = simple_format(line.description)
 
-.email-delivery_note-preview-wrapper{"data-controller" => "generic-email-preview", "data-generic-email-preview-preview-url-value" => preview_email_delivery_note_path(@delivery_note), "data-generic-email-preview-raw-preview-url-value" => preview_email_raw_delivery_note_path(@delivery_note), "data-generic-email-preview-send-url-value" => send_email_delivery_note_path(@delivery_note)}
+.email-delivery_note-preview-wrapper{"data-controller" => "generic-email-preview", "data-generic-email-preview-preview-url-value" => preview_email_delivery_note_path(@delivery_note), "data-generic-email-preview-send-url-value" => send_email_delivery_note_path(@delivery_note)}
+  - can_edit_dn = can?('delivery_notes.edit')
   = action_buttons_wrapper do
     = action_button 'Back', delivery_notes_path, :secondary
-    - unless @delivery_note.published
+    - if !@delivery_note.published && can_edit_dn
       = action_button 'Edit', edit_delivery_note_path(@delivery_note), :primary
     - if @delivery_note.published?
       = action_button 'PDF', pdf_delivery_note_path(@delivery_note), :success, { target: '_blank', data: { turbo: false } }
-      - if @delivery_note.customer&.email.present?
+      - if can_edit_dn && @delivery_note.customer&.email.present?
         %button.btn.btn-warning{"data-action" => "click->generic-email-preview#open"}
           Send E-Mail
-      - unless @delivery_note.invoice
+      - if can_edit_dn && !@delivery_note.invoice
         = button_to 'Convert to Invoice', convert_to_invoice_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-info', confirm: 'Create an invoice draft from this delivery note?'
-      = button_to 'Unpublish', unpublish_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-outline-secondary', confirm: 'Are you sure you want to revert this delivery note to draft status?'
+      - if can_edit_dn
+        = button_to 'Unpublish', unpublish_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-outline-secondary', confirm: 'Are you sure you want to revert this delivery note to draft status?'
     - else
       = action_button 'Preview', preview_delivery_note_path(@delivery_note), :info, { target: '_blank', data: { turbo: false } }
-      = button_to 'Publish', publish_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-warning'
-      = destroy_link(@delivery_note, "Are you sure you want to delete delivery note \"#{@delivery_note.document_number || "##{@delivery_note.id}"}\"?")
+      - if can_edit_dn
+        = button_to 'Publish', publish_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-warning'
+        = destroy_link(@delivery_note, "Are you sure you want to delete delivery note \"#{@delivery_note.document_number || "##{@delivery_note.id}"}\"?")
 
   // Email Preview Modal
   .modal.d-none.email-preview-modal{"data-generic-email-preview-target" => "modal", "data-action" => "click->generic-email-preview#closeOnBackdrop keydown@window->generic-email-preview#closeOnEscape"}

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -1,0 +1,71 @@
+.fieldset
+  = simple_form_for(@group, :validation => true, :html => {:class => 'form-horizontal'}) do |f|
+    - if @group.errors.any?
+      .alert.alert-danger
+        %h4
+          = pluralize(@group.errors.count, 'error')
+          prohibited saving:
+        %ul
+          - @group.errors.full_messages.each do |msg|
+            %li= msg
+
+    .form-inputs
+      .row.mb-3
+        = f.label :name, class: 'col-lg-2 col-md-3 col-form-label'
+        .col-sm-6
+          = f.text_field :name, {:class => 'form-control', :required => true, :readonly => @group.builtin?}
+          - if @group.builtin?
+            .form-text Built-in group names cannot be edited.
+
+      .row.mb-3
+        = f.label :description, class: 'col-lg-2 col-md-3 col-form-label'
+        .col-sm-9
+          = f.text_field :description, {:class => 'form-control'}
+
+      - if @group.bypass_team_scoping?
+        .row.mb-3
+          .col-lg-2.col-md-3
+            %strong Bypass team scoping:
+          .col-sm-9
+            Yes
+            .form-text This group's members see every customer and project regardless of team membership. The flag is set in a migration and cannot be edited from the UI.
+
+      - unless @group.builtin?
+        .row.mb-3{"data-controller" => "permission-pair"}
+          = label_tag nil, 'Permissions', class: 'col-lg-2 col-md-3 col-form-label'
+          .col-sm-9
+            - selected = @group.permissions
+            - Permission.grouped.each do |category, entries|
+              .card.mb-2
+                .card-header.py-1
+                  %strong= category
+                .card-body.py-2
+                  - entries.reject(&:admin_only).each do |entry|
+                    .form-check
+                      = check_box_tag 'group[permission_keys][]', entry.key, selected.include?(entry.key), id: "perm_#{entry.key.gsub('.', '_')}", class: 'form-check-input'
+                      %label.form-check-label.ms-1{for: "perm_#{entry.key.gsub('.', '_')}"}
+                        %code.me-1= entry.key
+                        = entry.label
+      - else
+        .row.mb-3
+          .col-lg-2.col-md-3
+            %strong Permissions:
+          .col-sm-9
+            .text-muted
+              Built-in group permissions cannot be edited.
+              The Admin group always holds every permission.
+
+      .row.mb-3
+        = label_tag nil, 'Members', class: 'col-lg-2 col-md-3 col-form-label'
+        .col-sm-9
+          - current_member_ids = @group.user_ids
+          - User.order(:username).each do |user|
+            .form-check
+              = check_box_tag 'group[user_ids][]', user.id, current_member_ids.include?(user.id), id: "group_user_#{user.id}", class: 'form-check-input'
+              = label_tag "group_user_#{user.id}", user.username, class: 'form-check-label'
+
+    %br
+
+    = action_buttons_wrapper do
+      = f.button :submit, :class => 'btn btn-primary'
+      = cancel_button(@group)

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,0 +1,5 @@
+%h1.page-header
+  Editing group
+  = @group.name
+
+= render 'form'

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -1,0 +1,31 @@
+= page_header_with_new_button('Groups', new_group_path)
+
+%p.text-muted
+  Groups bundle system-level permissions. A user inherits all permissions of every group they belong to.
+
+%table.table.table-striped.table-sm
+  %tr
+    %th Name
+    %th Description
+    %th Members
+    %th Permissions
+    %th Bypass team scoping
+    %th{width: "3%"}
+    %th{width: "3%"}
+
+  - @groups.each do |group|
+    %tr
+      %td
+        = link_to(group.name, group)
+        - if group.builtin?
+          %span.badge.bg-secondary.ms-1 built-in
+      %td= group.description
+      %td= group.member_count
+      %td= group.permission_count
+      %td= group.bypass_team_scoping? ? 'Yes' : 'No'
+      %td= list_action_link('Edit', edit_group_path(group), :edit)
+      %td
+        - if group.builtin?
+          %span.text-muted —
+        - else
+          = destroy_link(group, "Delete group \"#{group.name}\"?")

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,0 +1,3 @@
+%h1.page-header New group
+
+= render 'form'

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -1,0 +1,53 @@
+= page_header_with_edit_button("Group \"#{@group.name}\"", edit_group_path(@group))
+
+.row
+  .col-md-8
+    .card.mb-3
+      .card-header Information
+      .card-body
+        .row.mb-2
+          .col-sm-3
+            %strong Name:
+          .col-sm-9
+            = @group.name
+            - if @group.builtin?
+              %span.badge.bg-secondary.ms-1 built-in
+        .row.mb-2
+          .col-sm-3
+            %strong Description:
+          .col-sm-9
+            = @group.description
+        .row.mb-2
+          .col-sm-3
+            %strong Bypass team scoping:
+          .col-sm-9
+            = @group.bypass_team_scoping? ? 'Yes' : 'No'
+
+    .card.mb-3
+      .card-header
+        Permissions
+        %span.badge.bg-secondary.ms-1= @permissions.size
+      .card-body
+        - if @permissions.empty?
+          .text-muted No permissions
+        - else
+          %ul.list-unstyled.mb-0
+            - @permissions.each do |key|
+              %li
+                %code= key
+                %span.text-muted.ms-2= Permission.label_for(key)
+
+    .card
+      .card-header
+        Members
+        %span.badge.bg-secondary.ms-1= @members.size
+      .card-body
+        - if @members.empty?
+          .text-muted No members
+        - else
+          %ul.list-unstyled.mb-0
+            - @members.each do |user|
+              %li= link_to(user.username, user_path(user))
+
+= action_buttons_wrapper do
+  = action_button 'Back', groups_path, :secondary

--- a/app/views/invoices/index.html.haml
+++ b/app/views/invoices/index.html.haml
@@ -1,4 +1,4 @@
-= page_header_with_new_button('Listing invoices', new_invoice_path)
+= page_header_with_new_button('Listing invoices', new_invoice_path, permission: 'invoices.edit')
 
 
 .bulk-select-container{data: { controller: 'bulk-select' }}
@@ -86,5 +86,5 @@
           %td
             - if invoice.published? and not invoice.attachment.nil?
               = link_to 'PDF', attachment_path(invoice.attachment), target: '_blank', data: { turbo: false }, class: 'btn btn-sm btn-outline-success py-0'
-            - else
+            - elsif can?('invoices.edit')
               = list_action_link('Edit', edit_invoice_path(invoice), :edit)

--- a/app/views/invoices/preview_email.html.haml
+++ b/app/views/invoices/preview_email.html.haml
@@ -1,0 +1,63 @@
+.row
+  .col-md-12
+    .card
+      .card-header.d-flex.justify-content-between.align-items-center
+        %h6.mb-0 Email Details
+        .btn-group{"role" => "group", "aria-label" => "Email format"}
+          %button.btn.btn-sm.btn-outline-primary.active{"data-format" => "html"}
+            HTML
+          - if @email_body_text
+            %button.btn.btn-sm.btn-outline-primary{"data-format" => "text"}
+              Text
+      .card-body
+        .row.mb-2
+          .col-sm-2
+            %strong To:
+          .col-sm-10
+            = @email_to || %i{No recipient configured}
+
+        .row.mb-2
+          .col-sm-2
+            %strong From:
+          .col-sm-10
+            = @email_from || %i{No sender configured}
+
+        - if @email_bcc.present?
+          .row.mb-2
+            .col-sm-2
+              %strong BCC:
+            .col-sm-10
+              = @email_bcc
+
+        .row.mb-2
+          .col-sm-2
+            %strong Subject:
+          .col-sm-10
+            = @email_subject || %i{No subject}
+
+        - if @attachments.any?
+          .row.mb-2
+            .col-sm-2
+              %strong Files:
+            .col-sm-10
+              - @attachments.each do |attachment|
+                .d-flex.align-items-center.mb-1
+                  %span.me-1 📎
+                  %span= attachment[:filename]
+                  %small.text-muted.ms-2
+                    (#{number_to_human_size(attachment[:size])})
+
+    .card.mt-4
+      .card-header
+        Email Content
+      .card-body.email-preview-content{"data-format-content" => "html"}
+        - if @email_body_html.present?
+          %iframe.email-preview-iframe{"src" => preview_email_raw_invoice_path(@invoice)}
+        - else
+          %p.text-muted
+            %i No HTML content available
+
+      - if @email_body_text
+        .card-body.email-preview-content.d-none{"data-format-content" => "text"}
+          %pre.mb-0.font-monospace.text-pre-wrap
+            = @email_body_text

--- a/app/views/invoices/show.html.haml
+++ b/app/views/invoices/show.html.haml
@@ -166,22 +166,23 @@
               %td.text-end
                 %strong= format_currency(@invoice.sum_total)
 
-.email-preview-wrapper{"data-controller" => "generic-email-preview", "data-generic-email-preview-preview-url-value" => preview_email_invoice_path(@invoice), "data-generic-email-preview-raw-preview-url-value" => preview_email_raw_invoice_path(@invoice), "data-generic-email-preview-send-url-value" => send_email_invoice_path(@invoice)}
+.email-preview-wrapper{"data-controller" => "generic-email-preview", "data-generic-email-preview-preview-url-value" => preview_email_invoice_path(@invoice), "data-generic-email-preview-send-url-value" => send_email_invoice_path(@invoice)}
+  - can_edit_invoice = can?('invoices.edit')
   = action_buttons_wrapper do
     = action_button 'Back', invoices_path, :secondary
-    - unless @invoice.published
+    - if !@invoice.published && can_edit_invoice
       = action_button 'Edit', edit_invoice_path(@invoice), :primary
     - if @invoice.attachment
       = action_button 'PDF', @invoice.attachment, :success, { target: '_blank', data: { turbo: false } }
-      - if @invoice.customer&.email.present? || (@invoice.customer&.invoice_email_auto_enabled && @invoice.customer&.invoice_email_auto_to.present?)
+      - if can_edit_invoice && (@invoice.customer&.email.present? || (@invoice.customer&.invoice_email_auto_enabled && @invoice.customer&.invoice_email_auto_to.present?))
         %button.btn.btn-warning{"data-action" => "click->generic-email-preview#open"}
           Send E-Mail
     - else
       = action_button 'Preview', preview_invoice_path(@invoice), :info, { target: '_blank', data: { turbo: false } }
-    - unless @invoice.published
+    - if !@invoice.published && can_edit_invoice
       = button_to 'Test Booking', book_invoice_path(@invoice, :save => false), method: :post, class: 'btn btn-warning'
       = destroy_link(@invoice, "Are you sure you want to delete invoice \"#{@invoice.document_number || "##{@invoice.id}"}\"?")
-    - if @invoice.published?
+    - if @invoice.published? && can_edit_invoice
       - if @invoice.paid?
         = button_to 'Mark Unpaid', mark_unpaid_invoice_path(@invoice), method: :post, class: 'btn btn-outline-secondary', data: { 'turbo-confirm': 'Mark this invoice as unpaid?' }
       - else

--- a/app/views/issuer_companies/show.html.haml
+++ b/app/views/issuer_companies/show.html.haml
@@ -1,4 +1,4 @@
-= page_header_with_edit_button('Issuer Company', edit_issuer_company_path)
+= page_header_with_edit_button('Issuer Company', edit_issuer_company_path, permission: 'issuer_company.edit')
 
 .row
   .col-md-6

--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -4,14 +4,18 @@
     %span.navbar-toggler-icon
   .collapse.navbar-collapse{"data-navbar-target" => "menu"}
     %ul.navbar-nav.me-auto
-      %li.nav-item
-        = link_to('Customers', customers_path, :class => 'nav-link')
-      %li.nav-item
-        = link_to('Projects', projects_path, :class => 'nav-link')
-      %li.nav-item
-        = link_to('Deliveries', delivery_notes_path, :class => 'nav-link')
-      %li.nav-item
-        = link_to('Invoices', invoices_path, :class => 'nav-link')
+      - if can?('customers.view')
+        %li.nav-item
+          = link_to('Customers', customers_path, :class => 'nav-link')
+      - if can?('projects.view')
+        %li.nav-item
+          = link_to('Projects', projects_path, :class => 'nav-link')
+      - if can?('delivery_notes.view')
+        %li.nav-item
+          = link_to('Deliveries', delivery_notes_path, :class => 'nav-link')
+      - if can?('invoices.view')
+        %li.nav-item
+          = link_to('Invoices', invoices_path, :class => 'nav-link')
     %ul.navbar-nav
       %li.nav-item.dropdown.initially-hidden{"data-controller" => "error-notification", "data-error-notification-max-errors-value" => "5", "data-error-notification-target" => "icon"}
         %a.nav-link{:href => "#", :role => "button", :"data-action" => "click->error-notification#toggle"}
@@ -24,26 +28,42 @@
           %li
             %hr.dropdown-divider
           %ul.list-unstyled.mb-0{"data-error-notification-target" => "list"}
-      %li.nav-item.dropdown{"data-controller" => "navbar"}
-        %a.nav-link.dropdown-toggle{:href => "#", :role => "button", :"data-navbar-target" => "toggle", :"data-action" => "click->navbar#toggle"}
-          Configuration
-        %ul.dropdown-menu.dropdown-menu-end{"data-navbar-target" => "menu"}
-          %li
-            = link_to('Issuer Company', issuer_company_path, :class => 'dropdown-item')
-          %li
-            %hr.dropdown-divider
-          %li
-            = link_to('Product Catalog', products_path, :class => 'dropdown-item')
-          %li
-            = link_to('Sales Tax', sales_tax_rates_path, :class => 'dropdown-item')
-          %li
-            %hr.dropdown-divider
-          %li
-            = link_to('Users', users_path, :class => 'dropdown-item')
-          %li
-            %hr.dropdown-divider
-          %li
-            = link_to('Background Jobs', jobs_status_path, :class => 'dropdown-item')
+      - config_perms = %w[issuer_company.view products.view sales_tax.view users.view jobs_status.view groups.manage teams.manage]
+      - show_config = config_perms.any? { |p| can?(p) }
+      - if show_config
+        %li.nav-item.dropdown{"data-controller" => "navbar"}
+          %a.nav-link.dropdown-toggle{:href => "#", :role => "button", :"data-navbar-target" => "toggle", :"data-action" => "click->navbar#toggle"}
+            Configuration
+          %ul.dropdown-menu.dropdown-menu-end{"data-navbar-target" => "menu"}
+            - if can?('issuer_company.view')
+              %li
+                = link_to('Issuer Company', issuer_company_path, :class => 'dropdown-item')
+              %li
+                %hr.dropdown-divider
+            - if can?('products.view')
+              %li
+                = link_to('Product Catalog', products_path, :class => 'dropdown-item')
+            - if can?('sales_tax.view')
+              %li
+                = link_to('Sales Tax', sales_tax_rates_path, :class => 'dropdown-item')
+            - if can?('products.view') || can?('sales_tax.view')
+              %li
+                %hr.dropdown-divider
+            - if can?('users.view')
+              %li
+                = link_to('Users', users_path, :class => 'dropdown-item')
+            - if can?('groups.manage')
+              %li
+                = link_to('Groups', groups_path, :class => 'dropdown-item')
+            - if can?('teams.manage')
+              %li
+                = link_to('Teams', teams_path, :class => 'dropdown-item')
+            - if can?('users.view') || can?('groups.manage') || can?('teams.manage')
+              %li
+                %hr.dropdown-divider
+            - if can?('jobs_status.view')
+              %li
+                = link_to('Background Jobs', jobs_status_path, :class => 'dropdown-item')
       %li.nav-item.dropdown{"data-controller" => "navbar"}
         %a.nav-link.dropdown-toggle{:href => "#", :role => "button", :"data-navbar-target" => "toggle", :"data-action" => "click->navbar#toggle"}
           = Current.user.username

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -1,4 +1,4 @@
-= page_header_with_new_button('Listing products', new_product_path)
+= page_header_with_new_button('Listing products', new_product_path, permission: 'products.edit')
 
 %table.table.table-striped.table-sm
   %tr
@@ -13,5 +13,9 @@
       %td= link_to (product.title || "\##{product.id}"), product
       %td= format_currency(product.rate)
       %td= product.sales_tax_product_class && product.sales_tax_product_class.name
-      %td= list_action_link('Edit', edit_product_path(product), :edit)
-      %td= destroy_link(product, "Are you sure you want to delete product \"#{product.title}\"?")
+      %td
+        - if can?('products.edit')
+          = list_action_link('Edit', edit_product_path(product), :edit)
+      %td
+        - if can?('products.edit')
+          = destroy_link(product, "Are you sure you want to delete product \"#{product.title}\"?")

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -1,4 +1,4 @@
-= page_header_with_edit_button("Product \"#{@product.title}\"", edit_product_path(@product))
+= page_header_with_edit_button("Product \"#{@product.title}\"", edit_product_path(@product), permission: 'products.edit')
 
 .row
   .col-md-8

--- a/app/views/projects/_form.html.haml
+++ b/app/views/projects/_form.html.haml
@@ -23,10 +23,19 @@
       = f.label :description, class: 'col-lg-2 col-md-3 col-form-label'
       .col-lg-9
         = f.text_area :description, :class => 'form-control', :rows => 3
-    .row.mb-3
-      = f.label :bill_to_customer_id, 'Bill to customer', class: 'col-lg-2 col-md-3 col-form-label'
-      .col-lg-5.col-md-4
-        = f.collection_select :bill_to_customer_id, Customer.order(:name), :id, :name, { prompt: 'Select customer...', include_blank: 'No customer (reusable project)' }, {:class => 'form-select'}
+    %div{"data-controller" => "project-team"}
+      .row.mb-3
+        = f.label :bill_to_customer_id, 'Bill to customer', class: 'col-lg-2 col-md-3 col-form-label'
+        .col-lg-5.col-md-4
+          - selected_customer_team = @customer_options.find { |c| c.id == @project.bill_to_customer_id }&.team
+          = f.collection_select :bill_to_customer_id, @customer_options, :id, :name, { prompt: 'Select customer...', include_blank: 'No customer (reusable project)' }, {:class => 'form-select', "data-project-team-target" => "customer", "data-customer-team-map" => @customer_options.to_h { |c| [c.id, { team_id: c.team_id, team_name: c.team&.name }] }.to_json}
+
+      .row.mb-3{"data-project-team-target" => "teamRow"}
+        = f.label :team_id, 'Team', class: 'col-lg-2 col-md-3 col-form-label'
+        .col-sm-5
+          = f.collection_select :team_id, available_teams, :id, :name, { prompt: 'Select team...' }, {:class => 'form-select', :required => true, "data-project-team-target" => "teamSelect"}
+          - if @project.bill_to_customer_id.present? && selected_customer_team
+            .form-text Locked to <strong>#{selected_customer_team.name}</strong> because the bill-to customer belongs to that team.
 
   = action_buttons_wrapper do
     = f.button :submit, :class => 'btn btn-primary'

--- a/app/views/projects/index.html.haml
+++ b/app/views/projects/index.html.haml
@@ -1,4 +1,4 @@
-= page_header_with_new_button('Listing projects', new_project_path)
+= page_header_with_new_button('Listing projects', new_project_path, permission: 'projects.edit')
 
 .mb-3
   .btn-toolbar.mb-3{:role=>"toolbar", "aria-label"=>"List toolbar"}
@@ -13,6 +13,7 @@
     %th{:width => "7%"} Status
     %th Name
     %th Bill to customer
+    %th{:width => "10%"} Team
     %th{:width => "3%"}
     %th{:width => "3%"}
 
@@ -26,7 +27,10 @@
           %span.badge.bg-secondary Inactive
       %td= project.description
       %td= project.bill_to_customer.try(:matchcode)
-      %td= list_action_link('Edit', edit_project_path(project), :edit)
+      %td= project.team&.name
       %td
-        - if project.can_be_deleted?
+        - if can?('projects.edit')
+          = list_action_link('Edit', edit_project_path(project), :edit)
+      %td
+        - if can?('projects.edit') && project.can_be_deleted?
           = destroy_link(project, "Are you sure you want to delete project \"#{project.matchcode}\"?")

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -1,4 +1,4 @@
-= page_header_with_edit_button("Project #{@project.matchcode}", edit_project_path(@project))
+= page_header_with_edit_button("Project #{@project.matchcode}", edit_project_path(@project), permission: 'projects.edit')
 
 .row
   .col-md-8
@@ -37,6 +37,12 @@
               %span.badge.bg-success Active
             - else
               %span.badge.bg-secondary Inactive
+
+        .row.mb-2
+          .col-sm-3
+            %strong Team:
+          .col-sm-9
+            = @project.team&.name
 
 = action_buttons_wrapper do
   = action_button 'Back', projects_path, :secondary

--- a/app/views/sales_tax_customer_classes/index.html.haml
+++ b/app/views/sales_tax_customer_classes/index.html.haml
@@ -1,4 +1,4 @@
-= page_header_with_new_button('Listing Sales Tax - Customer Classes', new_sales_tax_customer_class_path)
+= page_header_with_new_button('Listing Sales Tax - Customer Classes', new_sales_tax_customer_class_path, permission: 'sales_tax.edit')
 
 %table.table.table-striped.table-sm
   %tr
@@ -11,5 +11,9 @@
     %tr
       %td= sales_tax_customer_class.name
       %td= sales_tax_customer_class.invoice_note
-      %td= list_action_link('Edit', edit_sales_tax_customer_class_path(sales_tax_customer_class), :edit)
-      %td= destroy_link(sales_tax_customer_class, "Are you sure you want to delete customer class \"#{sales_tax_customer_class.name}\"?")
+      %td
+        - if can?('sales_tax.edit')
+          = list_action_link('Edit', edit_sales_tax_customer_class_path(sales_tax_customer_class), :edit)
+      %td
+        - if can?('sales_tax.edit')
+          = destroy_link(sales_tax_customer_class, "Are you sure you want to delete customer class \"#{sales_tax_customer_class.name}\"?")

--- a/app/views/sales_tax_customer_classes/show.html.haml
+++ b/app/views/sales_tax_customer_classes/show.html.haml
@@ -6,5 +6,6 @@
   = @sales_tax_customer_class.invoice_note
 
 = action_buttons_wrapper do
-  = action_button 'Edit', edit_sales_tax_customer_class_path(@sales_tax_customer_class), :primary
+  - if can?('sales_tax.edit')
+    = action_button 'Edit', edit_sales_tax_customer_class_path(@sales_tax_customer_class), :primary
   = action_button 'Back', sales_tax_customer_classes_path, :secondary

--- a/app/views/sales_tax_product_classes/index.html.haml
+++ b/app/views/sales_tax_product_classes/index.html.haml
@@ -1,4 +1,4 @@
-= page_header_with_new_button('Listing Sales Tax - Product Classes', new_sales_tax_product_class_path)
+= page_header_with_new_button('Listing Sales Tax - Product Classes', new_sales_tax_product_class_path, permission: 'sales_tax.edit')
 
 %table.table.table-striped.table-sm
   %tr
@@ -15,5 +15,9 @@
       %td
         - if sales_tax_product_class.is_default?
           %span.badge.bg-success Default
-      %td= list_action_link('Edit', edit_sales_tax_product_class_path(sales_tax_product_class), :edit)
-      %td= destroy_link(sales_tax_product_class, "Are you sure you want to delete product class \"#{sales_tax_product_class.name}\"?")
+      %td
+        - if can?('sales_tax.edit')
+          = list_action_link('Edit', edit_sales_tax_product_class_path(sales_tax_product_class), :edit)
+      %td
+        - if can?('sales_tax.edit')
+          = destroy_link(sales_tax_product_class, "Are you sure you want to delete product class \"#{sales_tax_product_class.name}\"?")

--- a/app/views/sales_tax_product_classes/show.html.haml
+++ b/app/views/sales_tax_product_classes/show.html.haml
@@ -12,5 +12,6 @@
     No
 
 = action_buttons_wrapper do
-  = action_button 'Edit', edit_sales_tax_product_class_path(@sales_tax_product_class), :primary
+  - if can?('sales_tax.edit')
+    = action_button 'Edit', edit_sales_tax_product_class_path(@sales_tax_product_class), :primary
   = action_button 'Back', sales_tax_product_classes_path, :secondary

--- a/app/views/sales_tax_rates/index.html.haml
+++ b/app/views/sales_tax_rates/index.html.haml
@@ -1,4 +1,4 @@
-= page_header_with_new_button('Listing Sales Tax Rates', new_sales_tax_rate_path)
+= page_header_with_new_button('Listing Sales Tax Rates', new_sales_tax_rate_path, permission: 'sales_tax.edit')
 
 %table.table.table-striped.table-sm
   %tr
@@ -15,8 +15,12 @@
       %td
         = sales_tax_rate.rate
         \%
-      %td= list_action_link('Edit', edit_sales_tax_rate_path(sales_tax_rate), :edit)
-      %td= destroy_link(sales_tax_rate, "Are you sure you want to delete tax rate for \"#{sales_tax_rate.sales_tax_customer_class&.name}\" / \"#{sales_tax_rate.sales_tax_product_class&.name}\"?")
+      %td
+        - if can?('sales_tax.edit')
+          = list_action_link('Edit', edit_sales_tax_rate_path(sales_tax_rate), :edit)
+      %td
+        - if can?('sales_tax.edit')
+          = destroy_link(sales_tax_rate, "Are you sure you want to delete tax rate for \"#{sales_tax_rate.sales_tax_customer_class&.name}\" / \"#{sales_tax_rate.sales_tax_product_class&.name}\"?")
 
 - if @sales_tax_rates.empty?
   %p
@@ -63,6 +67,7 @@
                 Create
 %br
 
-%div
-  = link_to 'Edit Customer Classes', sales_tax_customer_classes_path, class: 'btn btn-outline-secondary me-2'
-  = link_to 'Edit Product Classes', sales_tax_product_classes_path, class: 'btn btn-outline-secondary'
+- if can?('sales_tax.edit')
+  %div
+    = link_to 'Edit Customer Classes', sales_tax_customer_classes_path, class: 'btn btn-outline-secondary me-2'
+    = link_to 'Edit Product Classes', sales_tax_product_classes_path, class: 'btn btn-outline-secondary'

--- a/app/views/sales_tax_rates/show.html.haml
+++ b/app/views/sales_tax_rates/show.html.haml
@@ -9,5 +9,6 @@
   = @sales_tax_rate.rate
 
 = action_buttons_wrapper do
-  = action_button 'Edit', edit_sales_tax_rate_path(@sales_tax_rate), :primary
+  - if can?('sales_tax.edit')
+    = action_button 'Edit', edit_sales_tax_rate_path(@sales_tax_rate), :primary
   = action_button 'Back', sales_tax_rate_path, :secondary

--- a/app/views/teams/_form.html.haml
+++ b/app/views/teams/_form.html.haml
@@ -1,0 +1,36 @@
+.fieldset
+  = simple_form_for(@team, :validation => true, :html => {:class => 'form-horizontal'}) do |f|
+    - if @team.errors.any?
+      .alert.alert-danger
+        %h4
+          = pluralize(@team.errors.count, 'error')
+          prohibited saving:
+        %ul
+          - @team.errors.full_messages.each do |msg|
+            %li= msg
+
+    .form-inputs
+      .row.mb-3
+        = f.label :name, class: 'col-lg-2 col-md-3 col-form-label'
+        .col-sm-6
+          = f.text_field :name, {:class => 'form-control', :required => true}
+
+      .row.mb-3
+        = f.label :description, class: 'col-lg-2 col-md-3 col-form-label'
+        .col-sm-9
+          = f.text_field :description, {:class => 'form-control'}
+
+      .row.mb-3
+        = label_tag nil, 'Members', class: 'col-lg-2 col-md-3 col-form-label'
+        .col-sm-9
+          - current_member_ids = @team.user_ids
+          - User.order(:username).each do |user|
+            .form-check
+              = check_box_tag 'team[user_ids][]', user.id, current_member_ids.include?(user.id), id: "team_user_#{user.id}", class: 'form-check-input'
+              = label_tag "team_user_#{user.id}", user.username, class: 'form-check-label'
+
+    %br
+
+    = action_buttons_wrapper do
+      = f.button :submit, :class => 'btn btn-primary'
+      = cancel_button(@team)

--- a/app/views/teams/edit.html.haml
+++ b/app/views/teams/edit.html.haml
@@ -1,0 +1,5 @@
+%h1.page-header
+  Editing team
+  = @team.name
+
+= render 'form'

--- a/app/views/teams/index.html.haml
+++ b/app/views/teams/index.html.haml
@@ -1,0 +1,31 @@
+= page_header_with_new_button('Teams', new_team_path)
+
+%p.text-muted
+  Teams control which customers and projects a user can see. Every customer and project belongs to exactly one team.
+
+%table.table.table-striped.table-sm
+  %tr
+    %th Name
+    %th Description
+    %th Members
+    %th Customers
+    %th Projects
+    %th{width: "3%"}
+    %th{width: "3%"}
+
+  - @teams.each do |team|
+    %tr
+      %td
+        = link_to(team.name, team)
+        - if team.builtin?
+          %span.badge.bg-secondary.ms-1 built-in
+      %td= team.description
+      %td= team.member_count
+      %td= team.customer_count
+      %td= team.project_count
+      %td= list_action_link('Edit', edit_team_path(team), :edit)
+      %td
+        - if team.builtin?
+          %span.text-muted —
+        - else
+          = destroy_link(team, "Delete team \"#{team.name}\"?")

--- a/app/views/teams/new.html.haml
+++ b/app/views/teams/new.html.haml
@@ -1,0 +1,3 @@
+%h1.page-header New team
+
+= render 'form'

--- a/app/views/teams/show.html.haml
+++ b/app/views/teams/show.html.haml
@@ -1,0 +1,44 @@
+= page_header_with_edit_button("Team \"#{@team.name}\"", edit_team_path(@team))
+
+.row
+  .col-md-8
+    .card.mb-3
+      .card-header Information
+      .card-body
+        .row.mb-2
+          .col-sm-3
+            %strong Name:
+          .col-sm-9
+            = @team.name
+            - if @team.builtin?
+              %span.badge.bg-secondary.ms-1 built-in
+        .row.mb-2
+          .col-sm-3
+            %strong Description:
+          .col-sm-9
+            = @team.description
+        .row.mb-2
+          .col-sm-3
+            %strong Customers:
+          .col-sm-9
+            = @customer_count
+        .row.mb-2
+          .col-sm-3
+            %strong Projects:
+          .col-sm-9
+            = @project_count
+
+    .card
+      .card-header
+        Members
+        %span.badge.bg-secondary.ms-1= @members.size
+      .card-body
+        - if @members.empty?
+          .text-muted No members
+        - else
+          %ul.list-unstyled.mb-0
+            - @members.each do |user|
+              %li= link_to(user.username, user_path(user))
+
+= action_buttons_wrapper do
+  = action_button 'Back', teams_path, :secondary

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -86,6 +86,66 @@
         - if @sessions.empty?
           %li.list-group-item.text-muted No active sessions
 
+    .card.mb-3
+      .card-header
+        Groups
+        %span.badge.bg-secondary.ms-1= @user_groups.size
+      - if can?('groups.manage')
+        = form_with url: update_groups_user_path(@user), method: :patch, local: true do |f|
+          %ul.list-group.list-group-flush
+            - Group.ordered.each do |group|
+              %li.list-group-item
+                .form-check
+                  = check_box_tag 'group_ids[]', group.id, @user.group_ids.include?(group.id), id: "ug_#{group.id}", class: 'form-check-input'
+                  = label_tag "ug_#{group.id}", class: 'form-check-label' do
+                    = group.name
+                    - if group.builtin?
+                      %span.badge.bg-secondary.ms-1 built-in
+                    - if group.description.present?
+                      %span.text-muted.ms-2= group.description
+          .card-body
+            = f.submit 'Save groups', class: 'btn btn-primary btn-sm'
+      - else
+        %ul.list-group.list-group-flush
+          - if @user_groups.empty?
+            %li.list-group-item.text-muted No groups
+          - else
+            - @user_groups.each do |group|
+              %li.list-group-item
+                = group.name
+                - if group.builtin?
+                  %span.badge.bg-secondary.ms-1 built-in
+
+    .card.mb-3
+      .card-header
+        Teams
+        %span.badge.bg-secondary.ms-1= @user_teams.size
+      - if can?('teams.manage')
+        = form_with url: update_teams_user_path(@user), method: :patch, local: true do |f|
+          %ul.list-group.list-group-flush
+            - Team.ordered.each do |team|
+              %li.list-group-item
+                .form-check
+                  = check_box_tag 'team_ids[]', team.id, @user.team_ids.include?(team.id), id: "ut_#{team.id}", class: 'form-check-input'
+                  = label_tag "ut_#{team.id}", class: 'form-check-label' do
+                    = team.name
+                    - if team.builtin?
+                      %span.badge.bg-secondary.ms-1 built-in
+                    - if team.description.present?
+                      %span.text-muted.ms-2= team.description
+          .card-body
+            = f.submit 'Save teams', class: 'btn btn-primary btn-sm'
+      - else
+        %ul.list-group.list-group-flush
+          - if @user_teams.empty?
+            %li.list-group-item.text-muted No teams
+          - else
+            - @user_teams.each do |team|
+              %li.list-group-item
+                = team.name
+                - if team.builtin?
+                  %span.badge.bg-secondary.ms-1 built-in
+
 = action_buttons_wrapper do
   - if @user.blocked?
     = button_to 'Unblock', unblock_user_path(@user), method: :post,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,11 +34,16 @@ Rails.application.routes.draw do
       post :unblock
       post :reset_passkeys
       get :audit
+      patch :update_groups
+      patch :update_teams
     end
     resources :emails, only: [ :create, :update, :destroy ], controller: "users/emails"
   end
 
   resources :user_invites, only: [ :new, :create, :index ]
+
+  resources :groups
+  resources :teams
 
   resource :issuer_company, only: [ :show, :edit, :update ] do
     get :png_logo, on: :member
@@ -51,7 +56,6 @@ Rails.application.routes.draw do
     member do
       get "preview"
       get "preview_email"
-      get "preview_email_raw"
       get "book"
       post "book"
       post "send_email"
@@ -66,7 +70,6 @@ Rails.application.routes.draw do
     member do
       get "preview"
       get "preview_email"
-      get "preview_email_raw"
       get "publish"
       post "publish"
       post "send_email"

--- a/db/migrate/20260522150001_create_groups_and_teams.rb
+++ b/db/migrate/20260522150001_create_groups_and_teams.rb
@@ -1,0 +1,142 @@
+class CreateGroupsAndTeams < ActiveRecord::Migration[8.1]
+  ADMIN_PERMISSIONS = %w[
+    customers.view customers.edit
+    projects.view projects.edit
+    invoices.view invoices.edit
+    delivery_notes.view delivery_notes.edit
+    products.view products.edit
+    sales_tax.view sales_tax.edit
+    issuer_company.view issuer_company.edit
+    users.view users.block users.reset_passkeys users.auto_confirm_email
+    user_invites.manage
+    groups.manage
+    teams.manage
+    jobs_status.view
+  ].freeze
+
+  def up
+    create_table :groups do |t|
+      t.string :name, null: false
+      t.string :description
+      t.boolean :builtin, default: false, null: false
+      t.boolean :bypass_team_scoping, default: false, null: false
+      t.timestamps
+    end
+    add_index :groups, :name, unique: true
+
+    create_table :group_permissions do |t|
+      t.references :group, null: false, foreign_key: true
+      t.string :permission, null: false
+      t.timestamps
+    end
+    add_index :group_permissions, [ :group_id, :permission ], unique: true
+
+    create_table :group_memberships do |t|
+      t.references :group, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.timestamps
+    end
+    add_index :group_memberships, [ :group_id, :user_id ], unique: true
+
+    create_table :teams do |t|
+      t.string :name, null: false
+      t.string :description
+      t.boolean :builtin, default: false, null: false
+      # Exactly one team carries `default: true`. New users auto-join it via
+      # User#join_default_team. Independent of `builtin` so the default team
+      # can be renamed without breaking the lookup. The partial unique index
+      # enforces "at most one default" at the DB level.
+      t.boolean :default, default: false, null: false
+      t.timestamps
+    end
+    add_index :teams, :name, unique: true
+    add_index :teams, :default, unique: true, where: '"default"', name: "index_teams_unique_default"
+
+    create_table :team_memberships do |t|
+      t.references :team, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.timestamps
+    end
+    add_index :team_memberships, [ :team_id, :user_id ], unique: true
+
+    # team_id columns on existing tables (nullable for backfill, NOT NULL added at end)
+    add_reference :customers, :team, foreign_key: true, null: true
+    add_reference :projects, :team, foreign_key: true, null: true
+
+    # Seed built-in Admin group with all permissions and bypass scoping.
+    # The literal name 'Admin' is intentional (migrations should be
+    # self-contained and not depend on app constants that may rename).
+    # Group::ADMIN_NAME mirrors it in the application layer.
+    now = Time.current
+    admin_group_id = execute_insert(
+      'groups',
+      name: 'Admin',
+      description: 'Built-in administrator group with all permissions',
+      builtin: true,
+      bypass_team_scoping: true,
+      created_at: now,
+      updated_at: now
+    )
+
+    ADMIN_PERMISSIONS.each do |perm|
+      execute_insert(
+        'group_permissions',
+        group_id: admin_group_id,
+        permission: perm,
+        created_at: now,
+        updated_at: now
+      )
+    end
+
+    # Seed built-in Default team and backfill memberships. Literal mirrored
+    # by Team::DEFAULT_NAME in the application layer. `default: true` marks
+    # this row as the new-user join target (see Team.default).
+    everyone_team_id = execute_insert(
+      'teams',
+      name: 'Default',
+      description: 'Built-in default team. All pre-existing users, customers and projects belong here.',
+      builtin: true,
+      default: true,
+      created_at: now,
+      updated_at: now
+    )
+
+    User.find_each do |user|
+      execute_insert(
+        'team_memberships',
+        team_id: everyone_team_id,
+        user_id: user.id,
+        created_at: now,
+        updated_at: now
+      )
+    end
+
+    execute "UPDATE customers SET team_id = #{everyone_team_id} WHERE team_id IS NULL"
+    execute "UPDATE projects  SET team_id = #{everyone_team_id} WHERE team_id IS NULL"
+
+    change_column_null :customers, :team_id, false
+    change_column_null :projects,  :team_id, false
+  end
+
+  def down
+    remove_reference :projects,  :team, foreign_key: true
+    remove_reference :customers, :team, foreign_key: true
+    drop_table :team_memberships
+    drop_table :teams
+    drop_table :group_memberships
+    drop_table :group_permissions
+    drop_table :groups
+  end
+
+  private
+
+  def execute_insert(table, attrs)
+    conn = ActiveRecord::Base.connection
+    cols = attrs.keys.map { |k| conn.quote_column_name(k) }.join(', ')
+    vals = attrs.values.map { |v| conn.quote(v) }.join(', ')
+    conn.insert(
+      "INSERT INTO #{conn.quote_table_name(table)} (#{cols}) VALUES (#{vals})",
+      "CreateGroupsAndTeams seed: #{table}"
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -35,10 +35,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_24_221140) do
     t.integer "payment_terms_days", default: 30, null: false
     t.integer "sales_tax_customer_class_id"
     t.text "supplier_number"
+    t.integer "team_id", null: false
     t.datetime "updated_at", null: false
     t.text "vat_id"
     t.index ["language_id"], name: "index_customers_on_language_id"
     t.index ["name"], name: "index_customers_on_name"
+    t.index ["team_id"], name: "index_customers_on_team_id"
   end
 
   create_table "delivery_note_lines", force: :cascade do |t|
@@ -87,6 +89,35 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_24_221140) do
     t.string "last_number"
     t.integer "sequence"
     t.datetime "updated_at", null: false
+  end
+
+  create_table "group_memberships", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "group_id", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["group_id", "user_id"], name: "index_group_memberships_on_group_id_and_user_id", unique: true
+    t.index ["group_id"], name: "index_group_memberships_on_group_id"
+    t.index ["user_id"], name: "index_group_memberships_on_user_id"
+  end
+
+  create_table "group_permissions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "group_id", null: false
+    t.string "permission", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id", "permission"], name: "index_group_permissions_on_group_id_and_permission", unique: true
+    t.index ["group_id"], name: "index_group_permissions_on_group_id"
+  end
+
+  create_table "groups", force: :cascade do |t|
+    t.boolean "builtin", default: false, null: false
+    t.boolean "bypass_team_scoping", default: false, null: false
+    t.datetime "created_at", null: false
+    t.string "description"
+    t.string "name", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_groups_on_name", unique: true
   end
 
   create_table "invoice_lines", force: :cascade do |t|
@@ -200,8 +231,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_24_221140) do
     t.datetime "created_at", null: false
     t.text "description"
     t.string "matchcode"
+    t.integer "team_id", null: false
     t.datetime "updated_at", null: false
     t.index ["matchcode"], name: "index_projects_on_matchcode"
+    t.index ["team_id"], name: "index_projects_on_team_id"
   end
 
   create_table "sales_tax_customer_classes", force: :cascade do |t|
@@ -226,6 +259,27 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_24_221140) do
     t.integer "sales_tax_customer_class_id"
     t.integer "sales_tax_product_class_id"
     t.datetime "updated_at", null: false
+  end
+
+  create_table "team_memberships", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "team_id", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["team_id", "user_id"], name: "index_team_memberships_on_team_id_and_user_id", unique: true
+    t.index ["team_id"], name: "index_team_memberships_on_team_id"
+    t.index ["user_id"], name: "index_team_memberships_on_user_id"
+  end
+
+  create_table "teams", force: :cascade do |t|
+    t.boolean "builtin", default: false, null: false
+    t.datetime "created_at", null: false
+    t.boolean "default", default: false, null: false
+    t.string "description"
+    t.string "name", null: false
+    t.datetime "updated_at", null: false
+    t.index ["default"], name: "index_teams_unique_default", unique: true, where: "\"default\""
+    t.index ["name"], name: "index_teams_on_name", unique: true
   end
 
   create_table "user_audit_events", force: :cascade do |t|
@@ -318,11 +372,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_24_221140) do
   end
 
   add_foreign_key "customers", "languages"
+  add_foreign_key "customers", "teams"
   add_foreign_key "delivery_note_lines", "delivery_notes"
   add_foreign_key "delivery_notes", "attachments", column: "acceptance_attachment_id"
   add_foreign_key "delivery_notes", "customers"
   add_foreign_key "delivery_notes", "invoices"
   add_foreign_key "delivery_notes", "projects"
+  add_foreign_key "group_memberships", "groups"
+  add_foreign_key "group_memberships", "users"
+  add_foreign_key "group_permissions", "groups"
+  add_foreign_key "projects", "teams"
+  add_foreign_key "team_memberships", "teams"
+  add_foreign_key "team_memberships", "users"
   add_foreign_key "user_audit_events", "users", column: "actor_user_id", on_delete: :nullify
   add_foreign_key "user_audit_events", "users", on_delete: :nullify
   add_foreign_key "user_credentials", "users"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,6 +4,23 @@
 # Essential data needed for all environments
 puts "🌱 Creating essential data..."
 
+# Built-in Admin group (all permissions, bypasses team scoping). Idempotent for
+# fresh installs that loaded schema.rb without running the migration's seed.
+admin_group = Group.find_or_create_by!(builtin: true, name: Group::ADMIN_NAME) do |g|
+  g.description = "Built-in administrator group with all permissions"
+  g.bypass_team_scoping = true
+end
+Permission::ALL_KEYS.each do |perm|
+  admin_group.group_permissions.find_or_create_by!(permission: perm)
+end
+
+# Built-in Default team. Every newly-created User auto-joins this team
+# (lookup goes through Team.default, which uses the `default: true` flag).
+Team.find_or_create_by!(builtin: true, name: Team::DEFAULT_NAME) do |t|
+  t.description = "Built-in default team. Every new user starts here."
+  t.default = true
+end
+
 # Languages (required for customer language selection)
 english = Language.find_or_create_by(iso_code: 'en') do |lang|
   lang.title = 'English'
@@ -108,6 +125,8 @@ if Rails.env.development?
     puts "📊 Loaded example logos for issuer company"
   end
 
+  default_team = Team.default || raise("Built-in Default team missing; run db:migrate first")
+
   # Sample customers
   good_company = Customer.find_or_create_by(matchcode: 'GOODEU') do |customer|
     customer.name = 'Good Company Poland B.V.'
@@ -121,6 +140,7 @@ if Rails.env.development?
     customer.notes = 'Long-term client, monthly invoicing'
     customer.sales_tax_customer_class = eu_class
     customer.language = english
+    customer.team = default_team
   end
 
   local_company = Customer.find_or_create_by(matchcode: 'LOCALNAT') do |customer|
@@ -135,6 +155,7 @@ if Rails.env.development?
     customer.notes = 'Project-based work'
     customer.sales_tax_customer_class = national_class
     customer.language = german
+    customer.team = default_team
   end
 
   export_company = Customer.find_or_create_by(matchcode: 'USACORP') do |customer|
@@ -148,38 +169,45 @@ if Rails.env.development?
     customer.notes = 'US-based client, quarterly invoicing'
     customer.sales_tax_customer_class = export_class
     customer.language = english
+    customer.team = default_team
   end
 
   # Sample projects
   webapp_project = Project.find_or_create_by(matchcode: 'WEBAPP') do |project|
     project.description = 'Web Application Development'
     project.bill_to_customer = good_company
+    project.team = default_team
   end
 
   consulting_project = Project.find_or_create_by(matchcode: 'CONSULT') do |project|
     project.description = 'IT Consulting Services'
     project.bill_to_customer = local_company
+    project.team = default_team
   end
 
   api_project = Project.find_or_create_by(matchcode: 'APIDEV') do |project|
     project.description = 'API Development and Integration'
     project.bill_to_customer = export_company
+    project.team = default_team
   end
 
   # Reusable projects (no customer assigned)
   training_project = Project.find_or_create_by(matchcode: 'TRAINING') do |project|
     project.description = 'Technical Training & Workshops'
     project.bill_to_customer = nil  # Reusable project
+    project.team = default_team
   end
 
   Project.find_or_create_by(matchcode: 'MAINT') do |project|
     project.description = 'System Maintenance & Support'
     project.bill_to_customer = nil  # Reusable project
+    project.team = default_team
   end
 
   Project.find_or_create_by(matchcode: 'RESEARCH') do |project|
     project.description = 'R&D and Technology Research'
     project.bill_to_customer = nil  # Reusable project
+    project.team = default_team
   end
 
   # Sample products

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -1,5 +1,5 @@
 namespace :users do
-  desc "Create a signup invite URL for bootstrapping the first user"
+  desc "Create a signup invite URL. If no users exist yet, the new signup will be auto-promoted to the Admin group."
   task invite: :environment do
     invite, plaintext = UserInvite.create_signup!(actor: nil)
     UserAuditEvent.record!(
@@ -14,6 +14,10 @@ namespace :users do
     puts ""
     puts "Invite URL (valid until " + invite.expires_at.utc.iso8601 + "):"
     puts url
+    if User.count.zero?
+      puts ""
+      puts "NOTE: No users exist yet. The first user to sign up will be auto-promoted to the Admin group."
+    end
     puts ""
   end
 end

--- a/test/controllers/attachments_controller_test.rb
+++ b/test/controllers/attachments_controller_test.rb
@@ -21,4 +21,40 @@ class AttachmentsControllerTest < ActionDispatch::IntegrationTest
     assert_match(/attachment/, response.headers["Content-Disposition"].to_s)
     assert_equal "nosniff", response.headers["X-Content-Type-Options"]
   end
+
+  test "show denies an attachment with no parent invoice or delivery note" do
+    orphan = Attachment.create!(
+      title: "orphan",
+      filename: "orphan.pdf",
+      content_type: "application/pdf",
+      data: "orphan"
+    )
+    get attachment_url(orphan)
+    assert_redirected_to root_path
+  end
+
+  test "show denies an attachment whose parent invoice belongs to another team" do
+    other_team = Team.create!(name: "OutsideTeam")
+    outside_customer = Customer.create!(
+      matchcode: "OUT",
+      name: "Outside Co.",
+      sales_tax_customer_class: sales_tax_customer_classes(:eu),
+      language: languages(:english),
+      team: other_team
+    )
+    outside_attachment = Attachment.create!(
+      title: "secret",
+      filename: "secret.pdf",
+      content_type: "application/pdf",
+      data: "secret"
+    )
+    Invoice.create!(customer: outside_customer, project: projects(:reusable_project), attachment: outside_attachment)
+
+    bob = users(:bob)
+    bob.groups << groups(:sales)  # invoices.view but not bypass
+    sign_in_as(bob)
+
+    get attachment_url(outside_attachment)
+    assert_redirected_to root_path
+  end
 end

--- a/test/controllers/customers_controller_test.rb
+++ b/test/controllers/customers_controller_test.rb
@@ -29,7 +29,8 @@ class CustomersControllerTest < ActionDispatch::IntegrationTest
         customer: {
           matchcode: "TEST123",
           name: "Test Company",
-          sales_tax_customer_class_id: @customer.sales_tax_customer_class_id
+          sales_tax_customer_class_id: @customer.sales_tax_customer_class_id,
+          team_id: teams(:default).id
         }
       }
     end
@@ -41,7 +42,8 @@ class CustomersControllerTest < ActionDispatch::IntegrationTest
     unused_customer = Customer.create!(
       matchcode: "UNUSED",
       name: "Unused Customer",
-      sales_tax_customer_class: @customer.sales_tax_customer_class
+      sales_tax_customer_class: @customer.sales_tax_customer_class,
+      team: teams(:default)
     )
 
     assert_difference("Customer.count", -1) do
@@ -72,7 +74,8 @@ class CustomersControllerTest < ActionDispatch::IntegrationTest
     unused_customer = Customer.create!(
       matchcode: "UNUSED2",
       name: "Another Unused Customer",
-      sales_tax_customer_class: @customer.sales_tax_customer_class
+      sales_tax_customer_class: @customer.sales_tax_customer_class,
+      team: teams(:default)
     )
     assert_not unused_customer.used_in_invoices?
 
@@ -87,7 +90,8 @@ class CustomersControllerTest < ActionDispatch::IntegrationTest
       matchcode: "INACTIVE",
       name: "Inactive Customer",
       active: false,
-      sales_tax_customer_class: @customer.sales_tax_customer_class
+      sales_tax_customer_class: @customer.sales_tax_customer_class,
+      team: teams(:default)
     )
 
     # Test all filter options in a single request cycle

--- a/test/controllers/groups_controller_test.rb
+++ b/test/controllers/groups_controller_test.rb
@@ -1,0 +1,171 @@
+require "test_helper"
+
+class GroupsControllerTest < ActionDispatch::IntegrationTest
+  test "admin can list groups" do
+    get groups_path
+    assert_response :success
+    assert_select "h1", text: "Groups"
+  end
+
+  test "non-admin is denied" do
+    sign_in_as(users(:bob))
+    get groups_path
+    assert_redirected_to root_path
+  end
+
+  test "admin can create a group with permissions and members" do
+    assert_difference "Group.count", 1 do
+      post groups_path, params: {
+        group: {
+          name: "Bookkeeping",
+          description: "Books and invoices",
+          bypass_team_scoping: false,
+          permission_keys: %w[invoices.view invoices.edit],
+          user_ids: [ users(:bob).id ]
+        }
+      }
+    end
+    assert_redirected_to groups_path
+    group = Group.find_by(name: "Bookkeeping")
+    assert_equal %w[invoices.edit invoices.view].sort, group.permissions.to_a.sort
+    assert_includes group.users, users(:bob)
+  end
+
+  test "admin can update a group" do
+    group = groups(:sales)
+    patch group_path(group), params: {
+      group: { name: "Sales Renamed", description: "X", permission_keys: %w[customers.view], user_ids: [] }
+    }
+    assert_redirected_to groups_path
+    assert_equal "Sales Renamed", group.reload.name
+    assert_equal %w[customers.view], group.permissions.to_a
+  end
+
+  test "built-in admin group cannot be deleted" do
+    admin = groups(:admin)
+    assert_no_difference "Group.count" do
+      delete group_path(admin)
+    end
+  end
+
+  test "non-built-in group can be deleted" do
+    sales = groups(:sales)
+    assert_difference "Group.count", -1 do
+      delete group_path(sales)
+    end
+  end
+
+  test "bypass_team_scoping cannot be set from the form (privilege escalation guard)" do
+    post groups_path, params: {
+      group: {
+        name: "Sneaky",
+        description: "tries to bypass",
+        bypass_team_scoping: true,
+        permission_keys: [],
+        user_ids: []
+      }
+    }
+    sneaky = Group.find_by(name: "Sneaky")
+    refute sneaky.bypass_team_scoping?
+  end
+
+  test "bypass_team_scoping cannot be enabled on update either" do
+    sales = groups(:sales)
+    refute sales.bypass_team_scoping?
+    patch group_path(sales), params: {
+      group: { name: sales.name, description: sales.description, bypass_team_scoping: true }
+    }
+    refute sales.reload.bypass_team_scoping?
+  end
+
+  test "admin-only permissions cannot be granted to a non-Admin group via the form" do
+    sales = groups(:sales)
+    patch group_path(sales), params: {
+      group: {
+        name: sales.name,
+        description: sales.description,
+        permission_keys: %w[customers.view users.reset_passkeys users.auto_confirm_email]
+      }
+    }
+    sales.reload
+    refute_includes sales.permissions, "users.reset_passkeys"
+    refute_includes sales.permissions, "users.auto_confirm_email"
+    assert_includes sales.permissions, "customers.view"
+  end
+
+  test "creating a group with admin-only permissions strips them" do
+    post groups_path, params: {
+      group: {
+        name: "Helpdesk",
+        description: "tries to grab credential primitives",
+        permission_keys: %w[users.view users.reset_passkeys users.auto_confirm_email]
+      }
+    }
+    helpdesk = Group.find_by(name: "Helpdesk")
+    refute_nil helpdesk
+    assert_includes helpdesk.permissions, "users.view"
+    refute_includes helpdesk.permissions, "users.reset_passkeys"
+    refute_includes helpdesk.permissions, "users.auto_confirm_email"
+  end
+
+  # Defense against renaming the built-in Admin group via PATCH /groups/:id.
+  # If the rename succeeded, Group#admin? (builtin? && name == "Admin")
+  # would silently return false on the next request, disabling the
+  # last-admin protection, admin-only permission validation, and the
+  # permission filter in Group#permissions=.
+  test "PATCH cannot rename the built-in Admin group" do
+    admin = groups(:admin)
+    patch group_path(admin), params: { group: { name: "Renamed", description: admin.description } }
+    admin.reload
+    assert_equal "Admin", admin.name
+    # admin? still resolves correctly so the security checks still fire.
+    assert admin.admin?
+  end
+
+  test "PATCH can rename a non-built-in group" do
+    # Sanity check that the controller filter only suppresses name changes
+    # for built-in groups, not all groups.
+    sales = groups(:sales)
+    patch group_path(sales), params: { group: { name: "Renamed Sales", description: sales.description } }
+    assert_equal "Renamed Sales", sales.reload.name
+  end
+
+  # Privilege escalation guard for the other path: a `groups.manage` holder
+  # that isn't an admin must not be able to add themselves (or anyone) to
+  # the Admin group by editing the Admin group's member list.
+  test "non-admin with groups.manage cannot add members to the Admin group" do
+    helpdesk = Group.create!(name: "Helpdesk", description: "groups.manage only")
+    helpdesk.permissions = %w[groups.manage]
+    helpdesk.users << users(:bob)
+
+    sign_in_as(users(:bob))
+    patch group_path(groups(:admin)), params: {
+      group: { description: groups(:admin).description,
+               user_ids: [ users(:alice).id, users(:bob).id ] }
+    }
+    refute_includes groups(:admin).reload.users, users(:bob)
+  end
+
+  # Symmetric guard: a non-admin must not be able to REMOVE admins by
+  # editing the Admin group's member list either. Without this guard, a
+  # single PATCH with one admin id in user_ids would silently delete every
+  # other admin's GroupMembership (has_many through swallows the
+  # prevent_removing_last_admin abort for non-final rows).
+  test "non-admin with groups.manage cannot remove members from the Admin group" do
+    helpdesk = Group.create!(name: "Helpdesk", description: "groups.manage only")
+    helpdesk.permissions = %w[groups.manage]
+    helpdesk.users << users(:bob)
+
+    # Add a second admin so a partial removal wouldn't trip the last-admin floor.
+    second_admin = User.create!(username: "second_admin", full_name: "Second Admin",
+                                webauthn_id: "second-admin-webauthn-id")
+    groups(:admin).users << second_admin
+
+    sign_in_as(users(:bob))
+    patch group_path(groups(:admin)), params: {
+      group: { description: groups(:admin).description,
+               user_ids: [ users(:alice).id ] }
+    }
+    assert_includes groups(:admin).reload.users, second_admin
+  end
+end

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -18,7 +18,8 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
       matchcode: "INACTIVE",
       description: "Inactive project",
       active: false,
-      bill_to_customer: @customer
+      bill_to_customer: @customer,
+      team: teams(:default)
     )
 
     # Test all filter options in a single request cycle
@@ -67,7 +68,8 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
           matchcode: "NEW_PROJECT",
           description: "New project",
           bill_to_customer_id: @customer.id,
-          active: true
+          active: true,
+          team_id: @customer.team_id
         }
       }
     end
@@ -83,7 +85,8 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
           matchcode: "NO_CUSTOMER_PROJECT",
           description: "Project without customer for reuse",
           bill_to_customer_id: "", # Empty customer ID
-          active: true
+          active: true,
+          team_id: teams(:default).id
         }
       }
     end
@@ -119,7 +122,8 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     unused_project = Project.create!(
       matchcode: "UNUSED",
       description: "Unused project",
-      bill_to_customer: @customer
+      bill_to_customer: @customer,
+      team: teams(:default)
     )
 
     assert_difference("Project.count", -1) do
@@ -135,7 +139,8 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     used_project = Project.create!(
       matchcode: "USED",
       description: "Used project",
-      bill_to_customer: @customer
+      bill_to_customer: @customer,
+      team: teams(:default)
     )
 
     Invoice.create!(
@@ -156,7 +161,8 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     unused_project = Project.create!(
       matchcode: "UNUSED",
       description: "Unused project",
-      bill_to_customer: @customer
+      bill_to_customer: @customer,
+      team: teams(:default)
     )
 
     # Verify it's not used
@@ -175,7 +181,8 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     used_project = Project.create!(
       matchcode: "USED",
       description: "Used project",
-      bill_to_customer: @customer
+      bill_to_customer: @customer,
+      team: teams(:default)
     )
 
     Invoice.create!(
@@ -202,7 +209,8 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
       matchcode: "NO_CUSTOMER",
       description: "Project without customer",
       bill_to_customer: nil,
-      active: true
+      active: true,
+      team: teams(:default)
     )
 
     get project_url(project_without_customer)
@@ -216,7 +224,8 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
       matchcode: "NO_CUSTOMER",
       description: "Project without customer",
       bill_to_customer: nil,
-      active: true
+      active: true,
+      team: teams(:default)
     )
 
     get edit_project_url(project_without_customer)
@@ -253,14 +262,16 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
       matchcode: "CUST_A",
       description: "Project for Customer A",
       bill_to_customer: customer_a,
-      active: true
+      active: true,
+      team: teams(:default)
     )
 
     project_b = Project.create!(
       matchcode: "CUST_B",
       description: "Project for Customer B",
       bill_to_customer: customer_b,
-      active: true
+      active: true,
+      team: teams(:default)
     )
 
     get projects_url(format: :json, customer_id: customer_a.id)
@@ -279,7 +290,8 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
       matchcode: "REUSABLE",
       description: "Reusable project",
       bill_to_customer: nil,
-      active: true
+      active: true,
+      team: teams(:default)
     )
 
     get projects_url(format: :json, include_reusable: "true")
@@ -301,7 +313,8 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
       matchcode: "ASSIGNED",
       description: "Project assigned to customer",
       bill_to_customer: customer,
-      active: true
+      active: true,
+      team: teams(:default)
     )
 
     # Create reusable project
@@ -309,7 +322,8 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
       matchcode: "REUSABLE",
       description: "Reusable project",
       bill_to_customer: nil,
-      active: true
+      active: true,
+      team: teams(:default)
     )
 
     # Create project for different customer
@@ -318,7 +332,8 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
       matchcode: "OTHER",
       description: "Project for other customer",
       bill_to_customer: other_customer,
-      active: true
+      active: true,
+      team: teams(:default)
     )
 
     get projects_url(format: :json, customer_id: customer.id, include_reusable: "true")
@@ -356,14 +371,16 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
       matchcode: "WITH_CUST",
       description: "With customer",
       bill_to_customer: customers(:good_eu),
-      active: true
+      active: true,
+      team: teams(:default)
     )
 
     without_customer = Project.create!(
       matchcode: "NO_CUST",
       description: "Without customer",
       bill_to_customer: nil,
-      active: true
+      active: true,
+      team: teams(:default)
     )
 
     get projects_url(format: :json, filter: "active")

--- a/test/controllers/teams_controller_test.rb
+++ b/test/controllers/teams_controller_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+class TeamsControllerTest < ActionDispatch::IntegrationTest
+  test "admin can list teams" do
+    get teams_path
+    assert_response :success
+    assert_select "h1", text: "Teams"
+  end
+
+  test "non-admin is denied" do
+    sign_in_as(users(:bob))
+    get teams_path
+    assert_redirected_to root_path
+  end
+
+  test "admin can create a team" do
+    assert_difference "Team.count", 1 do
+      post teams_path, params: {
+        team: { name: "EU", description: "EU customers", user_ids: [ users(:bob).id ] }
+      }
+    end
+    new_team = Team.find_by(name: "EU")
+    assert_includes new_team.users, users(:bob)
+  end
+
+  test "built-in default team cannot be deleted" do
+    default = teams(:default)
+    assert_no_difference "Team.count" do
+      delete team_path(default)
+    end
+  end
+
+  test "team in use cannot be deleted" do
+    # Acme has no customers/projects in fixtures, so add one.
+    Customer.create!(
+      matchcode: "IN_USE_TEAM",
+      name: "In Use",
+      sales_tax_customer_class: sales_tax_customer_classes(:eu),
+      language: languages(:english),
+      team: teams(:acme)
+    )
+    assert_no_difference "Team.count" do
+      delete team_path(teams(:acme))
+    end
+  end
+end

--- a/test/controllers/users/emails_controller_test.rb
+++ b/test/controllers/users/emails_controller_test.rb
@@ -32,7 +32,7 @@ class Users::EmailsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "admin can remove a non-last email" do
-    sign_in_as(users(:bob))
+    sign_in_as(users(:alice))
     alice = users(:alice)
     secondary = alice.emails.find_by(address: "alice.alt@example.com")
     delete user_email_path(user_id: alice, id: secondary)

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -86,4 +86,30 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "code", text: "login_success"
   end
+
+  # The takeover chain is: add attacker email -> block target -> reset passkeys.
+  # Each of those three primitives must require a different, increasingly
+  # restricted permission. A bearer of only users.block must not be able to
+  # issue passkey-reset invites or add emails.
+  test "users.block alone cannot reset passkeys or manage emails" do
+    helpdesk = Group.create!(name: "Helpdesk")
+    helpdesk.permissions = %w[users.view users.block]
+    bob = users(:bob)
+    bob.groups << helpdesk
+    sign_in_as(bob)
+
+    carol = users(:blocked_carol)
+    # Has users.block, can unblock.
+    post unblock_user_path(carol)
+    assert_redirected_to user_path(carol)
+
+    # Lacks users.reset_passkeys.
+    carol.update!(blocked_at: Time.current, blocked_reason: "test")
+    post reset_passkeys_user_path(carol)
+    assert_redirected_to root_path
+
+    # Lacks users.auto_confirm_email.
+    post user_emails_path(carol), params: { user_email: { address: "evil@example.com" } }
+    assert_redirected_to root_path
+  end
 end

--- a/test/controllers/users_membership_test.rb
+++ b/test/controllers/users_membership_test.rb
@@ -1,0 +1,84 @@
+require "test_helper"
+
+class UsersMembershipTest < ActionDispatch::IntegrationTest
+  test "admin can update group memberships" do
+    bob = users(:bob)
+    patch update_groups_user_path(bob), params: { group_ids: [ groups(:sales).id ] }
+    assert_redirected_to user_path(bob)
+    assert_includes bob.reload.groups, groups(:sales)
+  end
+
+  test "admin can update team memberships" do
+    bob = users(:bob)
+    patch update_teams_user_path(bob), params: { team_ids: [ teams(:acme).id ] }
+    assert_redirected_to user_path(bob)
+    assert_equal [ teams(:acme).id ], bob.reload.team_ids
+  end
+
+  test "cannot remove the last admin" do
+    alice = users(:alice)
+    # Try to remove alice from admin while she is the only admin member.
+    patch update_groups_user_path(alice), params: { group_ids: [] }
+    assert_redirected_to user_path(alice)
+    assert_includes alice.reload.groups, groups(:admin)
+  end
+
+  test "non-admin cannot update group memberships" do
+    sign_in_as(users(:bob))
+    patch update_groups_user_path(users(:bob)), params: { group_ids: [] }
+    assert_redirected_to root_path
+  end
+
+  # Privilege escalation guard: a `groups.manage` holder is NOT an admin
+  # and must not be able to self-promote (or promote anyone else) into the
+  # Admin group via PATCH /users/:id/update_groups. Admin membership confers
+  # bypass_team_scoping plus the admin-only credential primitives.
+  test "non-admin with groups.manage cannot promote themselves to Admin" do
+    helpdesk = Group.create!(name: "Helpdesk", description: "groups.manage only")
+    helpdesk.permissions = %w[groups.manage]
+    helpdesk.users << users(:bob)
+
+    sign_in_as(users(:bob))
+    patch update_groups_user_path(users(:bob)), params: {
+      group_ids: [ helpdesk.id, groups(:admin).id ]
+    }
+    assert_redirected_to user_path(users(:bob))
+    refute_includes users(:bob).reload.groups, groups(:admin)
+  end
+
+  test "non-admin with groups.manage cannot promote another user to Admin" do
+    helpdesk = Group.create!(name: "Helpdesk", description: "groups.manage only")
+    helpdesk.permissions = %w[groups.manage]
+    helpdesk.users << users(:bob)
+
+    sign_in_as(users(:bob))
+    target = User.create!(username: "target", full_name: "Target User",
+                          webauthn_id: "target-webauthn-id")
+    patch update_groups_user_path(target), params: {
+      group_ids: [ groups(:admin).id ]
+    }
+    assert_redirected_to user_path(target)
+    refute_includes target.reload.groups, groups(:admin)
+  end
+
+  # Symmetric to the add-direction guard: a non-admin holder of groups.manage
+  # must not be able to demote an existing admin via update_groups either.
+  # The last-admin floor protects only the final row; without this guard a
+  # non-admin could pick off admins one at a time down to the floor.
+  test "non-admin with groups.manage cannot remove another user from Admin" do
+    helpdesk = Group.create!(name: "Helpdesk", description: "groups.manage only")
+    helpdesk.permissions = %w[groups.manage]
+    helpdesk.users << users(:bob)
+
+    # Promote a second admin so removing the original wouldn't trip the
+    # last-admin guard.
+    second_admin = User.create!(username: "second_admin", full_name: "Second Admin",
+                                webauthn_id: "second-admin-webauthn-id")
+    groups(:admin).users << second_admin
+
+    sign_in_as(users(:bob))
+    patch update_groups_user_path(users(:alice)), params: { group_ids: [] }
+    assert_redirected_to user_path(users(:alice))
+    assert_includes users(:alice).reload.groups, groups(:admin)
+  end
+end

--- a/test/fixtures/customers.yml
+++ b/test/fixtures/customers.yml
@@ -11,6 +11,7 @@ good_eu:
   sales_tax_customer_class: eu
   language: english
   active: true
+  team: default
 
 good_national:
   matchcode: GOODNAT
@@ -25,6 +26,7 @@ good_national:
   sales_tax_customer_class: national
   language: german
   active: true
+  team: default
 
 auto_email_customer:
   matchcode: AUTOEMAIL
@@ -41,6 +43,7 @@ auto_email_customer:
   sales_tax_customer_class: national
   language: english
   active: true
+  team: default
 
 no_email_customer:
   matchcode: NOEMAIL
@@ -53,3 +56,4 @@ no_email_customer:
   sales_tax_customer_class: eu
   language: english
   active: true
+  team: default

--- a/test/fixtures/group_memberships.yml
+++ b/test/fixtures/group_memberships.yml
@@ -1,0 +1,3 @@
+alice_in_admin:
+  group: admin
+  user: alice

--- a/test/fixtures/group_permissions.yml
+++ b/test/fixtures/group_permissions.yml
@@ -1,0 +1,82 @@
+admin_customers_view:
+  group: admin
+  permission: customers.view
+admin_customers_edit:
+  group: admin
+  permission: customers.edit
+admin_projects_view:
+  group: admin
+  permission: projects.view
+admin_projects_edit:
+  group: admin
+  permission: projects.edit
+admin_invoices_view:
+  group: admin
+  permission: invoices.view
+admin_invoices_edit:
+  group: admin
+  permission: invoices.edit
+admin_delivery_notes_view:
+  group: admin
+  permission: delivery_notes.view
+admin_delivery_notes_edit:
+  group: admin
+  permission: delivery_notes.edit
+admin_products_view:
+  group: admin
+  permission: products.view
+admin_products_edit:
+  group: admin
+  permission: products.edit
+admin_sales_tax_view:
+  group: admin
+  permission: sales_tax.view
+admin_sales_tax_edit:
+  group: admin
+  permission: sales_tax.edit
+admin_issuer_company_view:
+  group: admin
+  permission: issuer_company.view
+admin_issuer_company_edit:
+  group: admin
+  permission: issuer_company.edit
+admin_users_view:
+  group: admin
+  permission: users.view
+admin_users_block:
+  group: admin
+  permission: users.block
+admin_users_reset_passkeys:
+  group: admin
+  permission: users.reset_passkeys
+admin_users_auto_confirm_email:
+  group: admin
+  permission: users.auto_confirm_email
+admin_user_invites_manage:
+  group: admin
+  permission: user_invites.manage
+admin_groups_manage:
+  group: admin
+  permission: groups.manage
+admin_teams_manage:
+  group: admin
+  permission: teams.manage
+admin_jobs_status_view:
+  group: admin
+  permission: jobs_status.view
+
+sales_customers_view:
+  group: sales
+  permission: customers.view
+
+sales_customers_edit:
+  group: sales
+  permission: customers.edit
+
+sales_invoices_view:
+  group: sales
+  permission: invoices.view
+
+sales_invoices_edit:
+  group: sales
+  permission: invoices.edit

--- a/test/fixtures/groups.yml
+++ b/test/fixtures/groups.yml
@@ -1,0 +1,11 @@
+admin:
+  name: Admin
+  description: Built-in administrator group with all permissions
+  builtin: true
+  bypass_team_scoping: true
+
+sales:
+  name: Sales
+  description: Test group with restricted permissions
+  builtin: false
+  bypass_team_scoping: false

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -3,27 +3,32 @@ one:
   description: Main test project
   bill_to_customer: good_eu
   active: true
+  team: default
 
 two:
   matchcode: PROJ002
   description: Secondary test project
   bill_to_customer: good_national
   active: true
+  team: default
 
 test_project:
   matchcode: TEST
   description: Test project for PDF generation tests
   bill_to_customer: good_eu
   active: true
+  team: default
 
 reusable_project:
   matchcode: REUSABLE
   description: Reusable project without customer
   bill_to_customer:
   active: true
+  team: default
 
 inactive_project:
   matchcode: INACTIVE
   description: Inactive project for filtering tests
   bill_to_customer: good_eu
   active: false
+  team: default

--- a/test/fixtures/team_memberships.yml
+++ b/test/fixtures/team_memberships.yml
@@ -1,0 +1,11 @@
+alice_in_default:
+  team: default
+  user: alice
+
+bob_in_default:
+  team: default
+  user: bob
+
+bob_in_acme:
+  team: acme
+  user: bob

--- a/test/fixtures/teams.yml
+++ b/test/fixtures/teams.yml
@@ -1,0 +1,11 @@
+default:
+  name: Default
+  description: Built-in default team
+  builtin: true
+  default: true
+
+acme:
+  name: Acme
+  description: Test team for scoping tests
+  builtin: false
+  default: false

--- a/test/integration/authorization_audit_test.rb
+++ b/test/integration/authorization_audit_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+class AuthorizationAuditTest < ActionDispatch::IntegrationTest
+  test "updating a user's groups writes a groups_updated audit event" do
+    bob = users(:bob)
+    assert_difference -> { UserAuditEvent.where(action: "groups_updated").count }, 1 do
+      patch update_groups_user_path(bob), params: { group_ids: [ groups(:sales).id ] }
+    end
+    event = UserAuditEvent.where(action: "groups_updated").last
+    assert_equal users(:alice), event.actor
+    assert_equal bob, event.user
+    assert_includes event.metadata["added"], "Sales"
+  end
+
+  test "updating a user's teams writes a teams_updated audit event" do
+    bob = users(:bob)
+    bob.team_memberships.where(team_id: teams(:acme).id).destroy_all
+    assert_difference -> { UserAuditEvent.where(action: "teams_updated").count }, 1 do
+      patch update_teams_user_path(bob), params: { team_ids: [ teams(:acme).id ] }
+    end
+    event = UserAuditEvent.where(action: "teams_updated").last
+    assert_includes event.metadata["added"], "Acme"
+  end
+
+  test "group_created and group_deleted are audited" do
+    assert_difference -> { UserAuditEvent.where(action: "group_created").count }, 1 do
+      post groups_path, params: { group: { name: "Auditors", description: "audit me",
+                                            permission_keys: %w[customers.view],
+                                            user_ids: [] } }
+    end
+    new_group = Group.find_by(name: "Auditors")
+    assert_difference -> { UserAuditEvent.where(action: "group_deleted").count }, 1 do
+      delete group_path(new_group)
+    end
+  end
+
+  test "team_created and team_deleted are audited" do
+    assert_difference -> { UserAuditEvent.where(action: "team_created").count }, 1 do
+      post teams_path, params: { team: { name: "EMEA", description: "eu", user_ids: [] } }
+    end
+    new_team = Team.find_by(name: "EMEA")
+    assert_difference -> { UserAuditEvent.where(action: "team_deleted").count }, 1 do
+      delete team_path(new_team)
+    end
+  end
+end

--- a/test/integration/home_dashboard_scoping_test.rb
+++ b/test/integration/home_dashboard_scoping_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+# Regression test: home dashboard aggregates must be scoped to the
+# current_user's visible invoices, not the whole database.
+class HomeDashboardScopingTest < ActionDispatch::IntegrationTest
+  skip_default_signin!
+
+  test "admin sees aggregates over all invoices" do
+    sign_in_as(users(:alice))
+    get root_path
+    assert_response :success
+    # Alice bypasses team scoping; smoke check the page renders.
+  end
+
+  test "user in no teams sees zero aggregates" do
+    # blocked_carol has no team_memberships and no group memberships, so
+    # un-block her so she can sign in but still has no permissions/teams.
+    carol = users(:blocked_carol)
+    carol.unblock!(actor: users(:alice), reason: "test setup")
+
+    sign_in_as(carol)
+    get root_path
+    assert_response :success
+    # Each invoice stat is rendered in its own coloured h2 cell. Assert
+    # against the cells specifically — matching a bare "0" anywhere on the
+    # page would silently pass even if the regression returned (dates,
+    # footers, version strings, etc. all contain zeroes).
+    assert_select "h2.text-primary", text: "0"
+    assert_select "h2.text-info", text: "0"
+    # Currency totals start with the EUR symbol; check for the zero amount.
+    assert_select "h2.text-success", text: /€\s*0\.00\z/
+    assert_select "h2.text-warning", text: /€\s*0\.00\z/
+  end
+end

--- a/test/integration/invoice_language_test.rb
+++ b/test/integration/invoice_language_test.rb
@@ -15,7 +15,8 @@ class InvoiceLanguageTest < ActionDispatch::IntegrationTest
       address: "123 English Street\nLondon, UK",
       vat_id: "EN123456789",
       sales_tax_customer_class: sales_tax_customer_classes(:national),
-      language: languages(:english)
+      language: languages(:english),
+      team: teams(:default)
     )
 
     english_invoice = Invoice.create!(
@@ -47,7 +48,8 @@ class InvoiceLanguageTest < ActionDispatch::IntegrationTest
       address: "Musterstraße 123\n12345 Berlin, Deutschland",
       vat_id: "DE987654321",
       sales_tax_customer_class: sales_tax_customer_classes(:national),
-      language: languages(:german)
+      language: languages(:german),
+      team: teams(:default)
     )
 
     german_invoice = Invoice.create!(
@@ -77,14 +79,16 @@ class InvoiceLanguageTest < ActionDispatch::IntegrationTest
       name: "English Customer", matchcode: "ENG1", address: "English Address",
       vat_id: "EN111111111",
       sales_tax_customer_class: sales_tax_customer_classes(:national),
-      language: languages(:english)
+      language: languages(:english),
+      team: teams(:default)
     )
 
     german_customer = Customer.create!(
       name: "German Customer", matchcode: "GER1", address: "German Address",
       vat_id: "DE222222222",
       sales_tax_customer_class: sales_tax_customer_classes(:national),
-      language: languages(:german)
+      language: languages(:german),
+      team: teams(:default)
     )
 
     english_invoice = Invoice.create!(customer: english_customer, project: @project)
@@ -115,7 +119,8 @@ class InvoiceLanguageTest < ActionDispatch::IntegrationTest
       name: "Test Customer",
       matchcode: "TEST",
       address: "Test Address",
-      sales_tax_customer_class: sales_tax_customer_classes(:national)
+      sales_tax_customer_class: sales_tax_customer_classes(:national),
+      team: teams(:default)
     )
 
     assert_equal languages(:english), customer.language

--- a/test/integration/permission_check_verification_test.rb
+++ b/test/integration/permission_check_verification_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+# Proves the verify_permission_check_performed after_action catches controllers
+# that forget to declare a permission gate or an explicit opt-out.
+class PermissionCheckVerificationTest < ActionDispatch::IntegrationTest
+  class ForgotPermissionCheckController < ApplicationController
+    def index
+      render plain: "should never reach here"
+    end
+  end
+
+  setup do
+    Rails.application.routes.draw do
+      get "forgot_permission_check_test/index",
+          to: "permission_check_verification_test/forgot_permission_check#index"
+      get "/" => "home#index", as: :root
+    end
+  end
+
+  teardown do
+    Rails.application.reload_routes!
+  end
+
+  test "after_action raises MissingPermissionCheck if action did not gate" do
+    assert_raises(ApplicationController::MissingPermissionCheck) do
+      get "/forgot_permission_check_test/index"
+    end
+  end
+end

--- a/test/integration/permissions_enforcement_test.rb
+++ b/test/integration/permissions_enforcement_test.rb
@@ -1,0 +1,67 @@
+require "test_helper"
+
+class PermissionsEnforcementTest < ActionDispatch::IntegrationTest
+  skip_default_signin!
+
+  test "admin can reach all main sections" do
+    sign_in_as(users(:alice))
+    [ customers_path, projects_path, invoices_path, delivery_notes_path,
+     products_path, sales_tax_rates_path, issuer_company_path, users_path,
+     user_invites_path, groups_path, teams_path, jobs_status_path ].each do |path|
+      get path
+      assert_response :success, "expected admin to load #{path}, got #{response.status}"
+    end
+  end
+
+  test "user without permissions is denied with redirect" do
+    sign_in_as(users(:bob))
+    [ customers_path, invoices_path, products_path, sales_tax_rates_path,
+     issuer_company_path, users_path, user_invites_path, groups_path,
+     teams_path, jobs_status_path ].each do |path|
+      get path
+      assert_response :redirect, "expected redirect for #{path}, got #{response.status}"
+      assert_redirected_to root_path
+    end
+  end
+
+  test "user with partial permissions reaches granted sections only" do
+    bob = users(:bob)
+    bob.groups << groups(:sales)
+
+    sign_in_as(bob)
+    get customers_path
+    assert_response :success
+    get invoices_path
+    assert_response :success
+
+    get products_path
+    assert_redirected_to root_path
+    get groups_path
+    assert_redirected_to root_path
+  end
+
+  test "navigation hides items the user cannot access" do
+    sign_in_as(users(:bob))
+    get root_path
+    assert_response :success
+    assert_no_match(/href="#{customers_path}"/, response.body)
+    assert_no_match(/href="#{groups_path}"/, response.body)
+
+    bob = users(:bob)
+    bob.groups << groups(:sales)
+    sign_in_as(bob)
+    get root_path
+    assert_response :success
+    assert_match(/href="#{customers_path}"/, response.body)
+    # No groups.manage perm yet.
+    assert_no_match(/href="#{groups_path}"/, response.body)
+  end
+
+  test "admin sees groups and teams links in navigation" do
+    sign_in_as(users(:alice))
+    get root_path
+    assert_response :success
+    assert_match(/href="#{groups_path}"/, response.body)
+    assert_match(/href="#{teams_path}"/, response.body)
+  end
+end

--- a/test/models/customer_team_scoping_test.rb
+++ b/test/models/customer_team_scoping_test.rb
@@ -1,0 +1,85 @@
+require "test_helper"
+
+class CustomerTeamScopingTest < ActiveSupport::TestCase
+  test "visible_to returns all customers for bypass users" do
+    visible = Customer.visible_to(users(:alice)).pluck(:id).sort
+    assert_equal Customer.pluck(:id).sort, visible
+  end
+
+  test "visible_to filters by team for non-bypass users" do
+    acme_customer = Customer.create!(
+      matchcode: "ACME_ONLY",
+      name: "Acme Only",
+      sales_tax_customer_class: sales_tax_customer_classes(:eu),
+      language: languages(:english),
+      team: teams(:acme)
+    )
+    # Bob is in Default + Acme
+    bob_visible = Customer.visible_to(users(:bob)).pluck(:id)
+    assert_includes bob_visible, acme_customer.id
+    assert_includes bob_visible, customers(:good_eu).id
+
+    # blocked_carol is in no teams
+    refute_includes Customer.visible_to(users(:blocked_carol)).pluck(:id), acme_customer.id
+  end
+
+  test "current user must be a member of the target team" do
+    bob = users(:bob)
+    # bob is in Default + Acme; bob can assign to Acme.
+    Current.set(user: bob) do
+      customer = Customer.new(
+        matchcode: "AS_BOB",
+        name: "Bob Customer",
+        sales_tax_customer_class: sales_tax_customer_classes(:eu),
+        language: languages(:english),
+        team: teams(:acme)
+      )
+      assert customer.valid?
+    end
+
+    # Create a team bob is NOT in.
+    other_team = Team.create!(name: "Stranger")
+    Current.set(user: bob) do
+      customer2 = Customer.new(
+        matchcode: "BAD_BOB",
+        name: "Bob Bad",
+        sales_tax_customer_class: sales_tax_customer_classes(:eu),
+        language: languages(:english),
+        team: other_team
+      )
+      refute customer2.valid?
+      assert_includes customer2.errors[:team_id], "must be a team you are a member of"
+    end
+  end
+
+  test "bypass user can assign to any team" do
+    alice = users(:alice)
+    other_team = Team.create!(name: "StrangerToAlice")
+    refute alice.teams.include?(other_team)
+    Current.set(user: alice) do
+      customer = Customer.new(
+        matchcode: "AS_ALICE",
+        name: "Alice Customer",
+        sales_tax_customer_class: sales_tax_customer_classes(:eu),
+        language: languages(:english),
+        team: other_team
+      )
+      assert customer.valid?
+    end
+  end
+
+  # System contexts (seeds, console, background jobs) have no Current.user
+  # set. The validation skips so they can legitimately seed records.
+  test "system contexts without a current user are allowed to assign" do
+    other_team = Team.create!(name: "SystemOnly")
+    customer = Customer.new(
+      matchcode: "SYS",
+      name: "System Customer",
+      sales_tax_customer_class: sales_tax_customer_classes(:eu),
+      language: languages(:english),
+      team: other_team
+    )
+    # Current.user is nil in this test body.
+    assert customer.valid?
+  end
+end

--- a/test/models/customer_test.rb
+++ b/test/models/customer_test.rb
@@ -7,6 +7,7 @@ class CustomerTest < ActiveSupport::TestCase
       name: "Test Customer",
       sales_tax_customer_class: sales_tax_customer_classes(:eu),
       language: languages(:english),
+      team: teams(:default),
       active: true
     }.merge(overrides))
   end
@@ -68,6 +69,29 @@ class CustomerTest < ActiveSupport::TestCase
     inactive = create_customer(active: false)
     assert_includes Customer.active, customers(:good_eu)
     assert_not_includes Customer.active, inactive
+  end
+
+  # Without this cascade, projects billing to the customer would be left
+  # with team_id pointing at the old team — instantly violating
+  # Project#team_must_match_customer (no save possible) and invisible to
+  # members of the new team because TeamOwned#visible_to filters by team_id.
+  test "changing a customer's team cascades to projects billing that customer" do
+    customer = create_customer(team: teams(:default))
+    project = Project.create!(matchcode: "P1", bill_to_customer: customer, team: teams(:default))
+
+    customer.update!(team: teams(:acme))
+
+    assert_equal teams(:acme).id, project.reload.team_id
+  end
+
+  test "changing a customer's team leaves unrelated projects alone" do
+    customer = create_customer(team: teams(:default))
+    other_customer = create_customer(matchcode: "OTHER", team: teams(:default))
+    project = Project.create!(matchcode: "P2", bill_to_customer: other_customer, team: teams(:default))
+
+    customer.update!(team: teams(:acme))
+
+    assert_equal teams(:default).id, project.reload.team_id
   end
 
   test "inactive scope returns only inactive customers" do

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -1,0 +1,100 @@
+require "test_helper"
+
+class GroupTest < ActiveSupport::TestCase
+  test "requires name" do
+    group = Group.new
+    refute group.valid?
+    assert_includes group.errors[:name], "can't be blank"
+  end
+
+  test "permissions= syncs the join table" do
+    group = Group.create!(name: "Test Group")
+    group.permissions = %w[customers.view invoices.view]
+    group.reload
+    assert_equal %w[customers.view invoices.view].sort, group.permissions.to_a.sort
+    group.permissions = %w[customers.view products.view]
+    group.reload
+    assert_equal %w[customers.view products.view].sort, group.permissions.to_a.sort
+  end
+
+  test "permissions= ignores unknown keys" do
+    group = Group.create!(name: "Test Group")
+    group.permissions = %w[customers.view not.a.real.perm]
+    group.reload
+    assert_equal %w[customers.view], group.permissions.to_a
+  end
+
+  test "permission? checks membership" do
+    group = Group.create!(name: "Test Group")
+    group.permissions = %w[customers.view]
+    assert group.permission?("customers.view")
+    refute group.permission?("customers.edit")
+  end
+
+  test "built-in group cannot be destroyed" do
+    admin = groups(:admin)
+    refute admin.destroy
+    assert_includes admin.errors[:base], "Cannot delete a built-in group"
+    assert Group.exists?(admin.id)
+  end
+
+  test "non-built-in group can be destroyed" do
+    sales = groups(:sales)
+    assert sales.destroy
+    refute Group.exists?(sales.id)
+  end
+
+  test "admin? recognizes the built-in Admin" do
+    assert groups(:admin).admin?
+    refute groups(:sales).admin?
+  end
+
+  test "admin-only permissions cannot be assigned to non-Admin groups" do
+    sales = groups(:sales)
+    gp = sales.group_permissions.build(permission: "users.reset_passkeys")
+    refute gp.valid?
+    assert_match(/can only be granted to the built-in Admin group/, gp.errors[:permission].first)
+
+    gp2 = sales.group_permissions.build(permission: "users.auto_confirm_email")
+    refute gp2.valid?
+  end
+
+  test "permissions= silently drops admin-only keys for non-Admin groups" do
+    sales = groups(:sales)
+    sales.permissions = %w[customers.view users.reset_passkeys users.auto_confirm_email]
+    sales.reload
+    refute_includes sales.permissions, "users.reset_passkeys"
+    refute_includes sales.permissions, "users.auto_confirm_email"
+    assert_includes sales.permissions, "customers.view"
+  end
+
+  test "admin-only permissions can attach to the Admin group" do
+    admin = groups(:admin)
+    # Both are already attached via fixtures.
+    assert_includes admin.permissions, "users.reset_passkeys"
+    assert_includes admin.permissions, "users.auto_confirm_email"
+  end
+
+  # Renaming the Admin group would silently disable Group#admin? — the
+  # last-admin protection, the admin-only permission validation, and the
+  # permission filter in Group#permissions= all key off `name == "Admin"`.
+  test "built-in group name cannot be changed at the model layer" do
+    admin = groups(:admin)
+    admin.name = "Renamed"
+    refute admin.valid?
+    assert_includes admin.errors[:name], "of a built-in group cannot be changed"
+    assert_equal "Admin", admin.reload.name
+  end
+
+  test "non-built-in groups can be renamed" do
+    sales = groups(:sales)
+    assert sales.update(name: "Renamed Sales")
+    assert_equal "Renamed Sales", sales.reload.name
+  end
+
+  test "description on a built-in group can still be edited" do
+    admin = groups(:admin)
+    assert admin.update(description: "Updated description")
+    assert_equal "Updated description", admin.reload.description
+  end
+end

--- a/test/models/permission_test.rb
+++ b/test/models/permission_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+
+class PermissionTest < ActiveSupport::TestCase
+  test "ALL contains expected categories" do
+    assert_includes Permission::CATEGORIES, "Operations"
+    assert_includes Permission::CATEGORIES, "Administration"
+  end
+
+  test "ALL_KEYS contains the canonical permissions" do
+    %w[customers.view customers.edit invoices.edit groups.manage teams.manage].each do |key|
+      assert_includes Permission::ALL_KEYS, key
+    end
+  end
+
+  test "valid? returns true for known keys" do
+    assert Permission.valid?("customers.view")
+    refute Permission.valid?("not.a.permission")
+    refute Permission.valid?("")
+  end
+
+  test "label_for returns a human label for a known key" do
+    assert_equal "View customers", Permission.label_for("customers.view")
+    assert_equal "unknown.key", Permission.label_for("unknown.key")
+  end
+
+  test "grouped returns entries by category" do
+    grouped = Permission.grouped
+    assert grouped["Operations"].any? { |e| e.key == "customers.view" }
+    assert grouped["Administration"].any? { |e| e.key == "groups.manage" }
+  end
+
+  test "admin-only keys are flagged" do
+    assert Permission.admin_only?("users.reset_passkeys")
+    assert Permission.admin_only?("users.auto_confirm_email")
+    refute Permission.admin_only?("users.view")
+    refute Permission.admin_only?("users.block")
+  end
+
+  test "ADMIN_ONLY_KEYS contains the credential-issuance permissions" do
+    assert_equal %w[users.reset_passkeys users.auto_confirm_email].sort,
+                 Permission::ADMIN_ONLY_KEYS.to_a.sort
+  end
+end

--- a/test/models/project_team_scoping_test.rb
+++ b/test/models/project_team_scoping_test.rb
@@ -1,0 +1,59 @@
+require "test_helper"
+
+class ProjectTeamScopingTest < ActiveSupport::TestCase
+  test "project team must match customer team when bill_to_customer is set" do
+    acme_customer = Customer.create!(
+      matchcode: "ACME_CUST",
+      name: "Acme Co.",
+      sales_tax_customer_class: sales_tax_customer_classes(:eu),
+      language: languages(:english),
+      team: teams(:acme)
+    )
+
+    # Mismatched team should be invalid.
+    project = Project.new(
+      matchcode: "MISMATCH",
+      description: "mismatched",
+      bill_to_customer: acme_customer,
+      team: teams(:default)
+    )
+    refute project.valid?
+    assert_match(/must match the team of the bill-to customer/, project.errors[:team_id].first)
+
+    # Matching team is valid.
+    project.team = teams(:acme)
+    assert project.valid?
+  end
+
+  test "reusable project (no customer) is free to pick any team" do
+    project = Project.new(
+      matchcode: "REUSE",
+      description: "no customer",
+      bill_to_customer: nil,
+      team: teams(:acme)
+    )
+    assert project.valid?
+  end
+
+  test "visible_to filters by team" do
+    acme_customer = Customer.create!(
+      matchcode: "ACME_CUST2",
+      name: "Acme 2",
+      sales_tax_customer_class: sales_tax_customer_classes(:eu),
+      language: languages(:english),
+      team: teams(:acme)
+    )
+    acme_project = Project.create!(
+      matchcode: "ACMEPRJ",
+      description: "Acme only project",
+      bill_to_customer: acme_customer,
+      team: teams(:acme)
+    )
+
+    bob_visible = Project.visible_to(users(:bob)).pluck(:id)
+    assert_includes bob_visible, acme_project.id
+
+    carol_visible = Project.visible_to(users(:blocked_carol)).pluck(:id)
+    refute_includes carol_visible, acme_project.id
+  end
+end

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -6,7 +6,8 @@ class ProjectTest < ActiveSupport::TestCase
     @project = Project.create!(
       matchcode: "TEST_PROJECT",
       description: "Test project",
-      bill_to_customer: @customer
+      bill_to_customer: @customer,
+      team: @customer.team
     )
   end
 
@@ -23,7 +24,8 @@ class ProjectTest < ActiveSupport::TestCase
   test "should be active by default" do
     new_project = Project.new(
       matchcode: "NEW_PROJECT",
-      bill_to_customer: @customer
+      bill_to_customer: @customer,
+      team: @customer.team
     )
     assert new_project.active?
   end
@@ -33,13 +35,15 @@ class ProjectTest < ActiveSupport::TestCase
     active_project = Project.create!(
       matchcode: "ACTIVE",
       bill_to_customer: @customer,
-      active: true
+      active: true,
+      team: @customer.team
     )
 
     inactive_project = Project.create!(
       matchcode: "INACTIVE",
       bill_to_customer: @customer,
-      active: false
+      active: false,
+      team: @customer.team
     )
 
     assert_includes Project.active, active_project
@@ -106,7 +110,8 @@ class ProjectTest < ActiveSupport::TestCase
   test "should allow projects without bill_to_customer" do
     project_without_customer = Project.new(
       matchcode: "NO_CUSTOMER_PROJECT",
-      description: "Project without customer"
+      description: "Project without customer",
+      team: teams(:default)
     )
 
     assert project_without_customer.valid?

--- a/test/models/sales_tax_customer_class_test.rb
+++ b/test/models/sales_tax_customer_class_test.rb
@@ -23,7 +23,8 @@ class SalesTaxCustomerClassTest < ActiveSupport::TestCase
       matchcode: "STC_TEST",
       name: "Test Customer",
       sales_tax_customer_class: klass,
-      language: languages(:english)
+      language: languages(:english),
+      team: teams(:default)
     )
     assert_raises(ActiveRecord::DeleteRestrictionError) { klass.destroy }
   end

--- a/test/models/scoped_through_customer_test.rb
+++ b/test/models/scoped_through_customer_test.rb
@@ -1,0 +1,89 @@
+require "test_helper"
+
+# Regression coverage for the ScopedThroughCustomer concern. Invoices and
+# delivery notes have no team_id of their own — visibility is derived from
+# their customer. Without this concern a user with invoices.edit/
+# delivery_notes.edit in team A could mass-assign `customer_id` pointing
+# at another team's customer and plant a record in that team's books.
+class ScopedThroughCustomerTest < ActiveSupport::TestCase
+  setup do
+    # bob is in Default + Acme (per fixtures); create a team he's NOT in
+    # and a customer/project hanging off it.
+    @other_team = Team.create!(name: "Other")
+    @other_customer = Customer.create!(
+      matchcode: "OTHER",
+      name: "Other Co",
+      sales_tax_customer_class: sales_tax_customer_classes(:eu),
+      language: languages(:english),
+      team: @other_team
+    )
+    @other_project = Project.create!(
+      matchcode: "OTHER_PROJ",
+      bill_to_customer: @other_customer,
+      team: @other_team
+    )
+  end
+
+  test "Invoice.new rejects customer_id from a team Current.user can't see" do
+    Current.set(user: users(:bob)) do
+      invoice = Invoice.new(customer_id: @other_customer.id)
+      refute invoice.valid?
+      assert_includes invoice.errors[:customer_id], "must be a customer you can access"
+    end
+  end
+
+  test "Invoice.new rejects project_id from a team Current.user can't see" do
+    Current.set(user: users(:bob)) do
+      invoice = Invoice.new(customer: customers(:good_eu), project_id: @other_project.id)
+      refute invoice.valid?
+      assert_includes invoice.errors[:project_id], "must be a project you can access"
+    end
+  end
+
+  test "Invoice.new accepts customer_id from a team Current.user can see" do
+    Current.set(user: users(:bob)) do
+      invoice = Invoice.new(customer: customers(:good_eu), project: projects(:one))
+      assert invoice.valid?, invoice.errors.full_messages.inspect
+    end
+  end
+
+  test "Invoice.new bypasses scope for bypass_team_scoping users" do
+    Current.set(user: users(:alice)) do
+      invoice = Invoice.new(customer: @other_customer, project: @other_project)
+      assert invoice.valid?, invoice.errors.full_messages.inspect
+    end
+  end
+
+  test "Invoice.new in a system context (no Current.user) is allowed" do
+    invoice = Invoice.new(customer: @other_customer, project: @other_project)
+    assert invoice.valid?, invoice.errors.full_messages.inspect
+  end
+
+  test "DeliveryNote.new rejects customer_id from a team Current.user can't see" do
+    Current.set(user: users(:bob)) do
+      dn = DeliveryNote.new(customer_id: @other_customer.id,
+                            delivery_start_date: Date.current)
+      refute dn.valid?
+      assert_includes dn.errors[:customer_id], "must be a customer you can access"
+    end
+  end
+
+  test "DeliveryNote.new rejects project_id from a team Current.user can't see" do
+    Current.set(user: users(:bob)) do
+      dn = DeliveryNote.new(customer: customers(:good_eu),
+                            project_id: @other_project.id,
+                            delivery_start_date: Date.current)
+      refute dn.valid?
+      assert_includes dn.errors[:project_id], "must be a project you can access"
+    end
+  end
+
+  test "DeliveryNote.new accepts customer_id from a team Current.user can see" do
+    Current.set(user: users(:bob)) do
+      dn = DeliveryNote.new(customer: customers(:good_eu),
+                            project: projects(:one),
+                            delivery_start_date: Date.current)
+      assert dn.valid?, dn.errors.full_messages.inspect
+    end
+  end
+end

--- a/test/models/team_test.rb
+++ b/test/models/team_test.rb
@@ -1,0 +1,60 @@
+require "test_helper"
+
+class TeamTest < ActiveSupport::TestCase
+  test "requires name" do
+    team = Team.new
+    refute team.valid?
+    assert_includes team.errors[:name], "can't be blank"
+  end
+
+  test "name must be unique (case-insensitive)" do
+    Team.create!(name: "UniqueOne")
+    dup = Team.new(name: "uniqueone")
+    refute dup.valid?
+  end
+
+  test "built-in team cannot be destroyed" do
+    default = teams(:default)
+    refute default.destroy
+    assert_includes default.errors[:base], "Cannot delete a built-in team"
+    assert Team.exists?(default.id)
+  end
+
+  test "team in use by a customer cannot be destroyed" do
+    team = Team.create!(name: "Disposable")
+    Customer.create!(
+      matchcode: "INUSE",
+      name: "In Use Co.",
+      sales_tax_customer_class: sales_tax_customer_classes(:eu),
+      language: languages(:english),
+      team: team
+    )
+    refute team.destroy
+    assert_includes team.errors[:base], "Cannot delete a team that owns customers or projects"
+  end
+
+  test "team with no customers/projects can be destroyed" do
+    team = Team.create!(name: "Empty")
+    assert team.destroy
+  end
+
+  test "Team.default resolves by the default flag and survives a rename" do
+    default = teams(:default)
+    assert_equal default, Team.default
+
+    default.update!(name: "Headquarters")
+    assert_equal default, Team.default, "Team.default must not depend on the literal name"
+  end
+
+  test "renaming the Default team does not break new-user join" do
+    teams(:default).update!(name: "Headquarters")
+    new_user = User.create!(username: "joiner-rn", full_name: "Joiner", webauthn_id: "joiner-rn-id")
+    assert_includes new_user.teams, teams(:default).reload
+  end
+
+  test "only one team can carry default: true" do
+    other = Team.create!(name: "Other")
+    err = assert_raises(ActiveRecord::RecordNotUnique) { other.update!(default: true) }
+    assert_match(/default/i, err.message)
+  end
+end

--- a/test/models/user_permission_test.rb
+++ b/test/models/user_permission_test.rb
@@ -1,0 +1,93 @@
+require "test_helper"
+
+class UserPermissionTest < ActiveSupport::TestCase
+  test "admin user has all permissions and bypasses team scoping" do
+    alice = users(:alice)
+    assert alice.bypass_team_scoping?
+    Permission::ALL_KEYS.each do |key|
+      assert alice.permission?(key), "alice should have #{key}"
+    end
+  end
+
+  test "non-admin user starts with no permissions" do
+    bob = users(:bob)
+    refute bob.bypass_team_scoping?
+    refute bob.permission?("customers.view")
+    refute bob.permission?("groups.manage")
+  end
+
+  test "group membership grants the permissions of that group" do
+    bob = users(:bob)
+    bob.groups << groups(:sales)
+    bob.reload
+    # sales has customers.view + customers.edit + invoices.view + invoices.edit
+    assert bob.permission?("customers.view")
+    assert bob.permission?("customers.edit")
+    assert bob.permission?("invoices.view")
+    refute bob.permission?("groups.manage")
+  end
+
+  test "visible_team_ids returns all teams for bypass users" do
+    assert_equal Team.pluck(:id).sort, users(:alice).visible_team_ids.sort
+  end
+
+  test "visible_team_ids only returns member teams for non-bypass users" do
+    assert_equal users(:bob).team_ids.sort, users(:bob).visible_team_ids.sort
+  end
+
+  test "auto_promote_first_user adds to admin when this is the only user" do
+    new_user = User.create!(
+      username: "pioneer",
+      full_name: "Pioneer",
+      webauthn_id: "pioneer-id"
+    )
+    # The fixture users still exist, so the callback didn't fire on create.
+    refute_includes new_user.groups, groups(:admin)
+    # Exercise the callback by simulating User.count == 1.
+    User.singleton_class.define_method(:count) { 1 }
+    begin
+      new_user.send(:auto_promote_first_user)
+    ensure
+      User.singleton_class.send(:remove_method, :count)
+    end
+    assert_includes new_user.reload.groups, groups(:admin)
+  end
+
+  test "subsequent users are not auto-promoted" do
+    new_user = User.create!(
+      username: "plebs",
+      full_name: "Plebs",
+      webauthn_id: "plebs-id"
+    )
+    assert_empty new_user.groups
+  end
+
+  test "every new user is auto-added to the Default team" do
+    new_user = User.create!(
+      username: "joiner",
+      full_name: "Joiner",
+      webauthn_id: "joiner-id"
+    )
+    assert_includes new_user.teams, teams(:default)
+  end
+
+  test "first user lands in both Admin group and Default team" do
+    new_user = User.create!(
+      username: "pioneer2",
+      full_name: "Pioneer 2",
+      webauthn_id: "pioneer-2-id"
+    )
+    # join_default_team fires unconditionally
+    assert_includes new_user.teams, teams(:default)
+    # auto_promote_first_user only fires when this is actually the first user
+    User.singleton_class.define_method(:count) { 1 }
+    begin
+      new_user.send(:auto_promote_first_user)
+    ensure
+      User.singleton_class.send(:remove_method, :count)
+    end
+    new_user.reload
+    assert_includes new_user.groups, groups(:admin)
+    assert_includes new_user.teams, teams(:default)
+  end
+end

--- a/test/system/email_preview_test.rb
+++ b/test/system/email_preview_test.rb
@@ -24,38 +24,6 @@ class EmailPreviewTest < ApplicationSystemTestCase
     assert_includes send_url, "send_email", "Send URL should contain send_email action"
   end
 
-  test "invoice email preview iframe renders styled email body under strict CSP" do
-    visit invoice_path(@invoice)
-
-    click_on "Send E-Mail"
-
-    iframe_element = find("iframe.email-preview-iframe", wait: 5)
-
-    within_frame(iframe_element) do
-      assert_text "Dear #{@invoice.customer.name}", wait: 5
-      # The mailer layout sets body { background-color: #f8f9fa } via an inline
-      # <style> block. If CSP blocks it the body stays transparent — this
-      # assertion guards against the auto-nonced style-src directive overriding
-      # 'unsafe-inline'.
-      bg = page.evaluate_script("getComputedStyle(document.body).backgroundColor")
-      assert_equal "rgb(248, 249, 250)", bg, "Inline <style> from mailer layout should be applied in iframe"
-    end
-  end
-
-  test "delivery note email preview iframe renders styled email body under strict CSP" do
-    visit delivery_note_path(@delivery_note)
-
-    click_on "Send E-Mail"
-
-    iframe_element = find("iframe.email-preview-iframe", wait: 5)
-
-    within_frame(iframe_element) do
-      assert_text "Dear #{@delivery_note.customer.name}", wait: 5
-      bg = page.evaluate_script("getComputedStyle(document.body).backgroundColor")
-      assert_equal "rgb(248, 249, 250)", bg, "Inline <style> from mailer layout should be applied in iframe"
-    end
-  end
-
   test "delivery note email preview URLs use correct paths for subdirectory deployment" do
     visit delivery_note_path(@delivery_note)
 

--- a/test/system/project_team_lock_test.rb
+++ b/test/system/project_team_lock_test.rb
@@ -1,0 +1,49 @@
+require "application_system_test_case"
+
+# Regression coverage for the customer→team locking on the project form.
+# The Stimulus controller MUST find both the customer and teamSelect
+# targets — if they live in sibling rows that the controller's element
+# doesn't enclose, `hasTeamSelectTarget` returns false and the lock
+# silently no-ops while the dropdown keeps offering every team. The form
+# server-side validation still rejects the bad submission, but the UI
+# becomes a trap.
+class ProjectTeamLockTest < ApplicationSystemTestCase
+  setup do
+    @acme_team = teams(:acme)
+    # Alice is in fixtures with bypass_team_scoping (Admin group), so the
+    # raw team dropdown contains every team — the most aggressive case for
+    # the lock to filter down.
+    @customer = customers(:good_eu) # team: default per fixture
+  end
+
+  test "selecting a customer narrows the team dropdown to that customer's team" do
+    visit new_project_path
+
+    team_options = -> { find("select[name='project[team_id]']").all("option").map(&:value).reject(&:empty?) }
+
+    # No customer yet → the bypass-admin sees every team option.
+    assert_includes team_options.call, @acme_team.id.to_s,
+                    "with no customer selected, Acme should be an option for an admin user"
+
+    select @customer.name, from: "project[bill_to_customer_id]"
+
+    # Wait for the filter to take effect: the only option should be Default.
+    assert_selector "select[name='project[team_id]'] option", count: 1
+    refute_includes team_options.call, @acme_team.id.to_s,
+                    "Acme should no longer appear once a Default-team customer is selected"
+    assert_equal [ @customer.team_id.to_s ], team_options.call
+  end
+
+  test "clearing the customer restores the full team list" do
+    visit new_project_path
+    select @customer.name, from: "project[bill_to_customer_id]"
+    assert_selector "select[name='project[team_id]'] option", count: 1
+
+    select "No customer (reusable project)", from: "project[bill_to_customer_id]"
+
+    # Multiple options back in play once we're reusable (and Acme is one of them).
+    team_values = find("select[name='project[team_id]']").all("option").map(&:value).reject(&:empty?)
+    assert_includes team_values, @acme_team.id.to_s
+    assert_includes team_values, teams(:default).id.to_s
+  end
+end


### PR DESCRIPTION
## Summary

Adds authorization on top of the user system. Two concepts, cleanly split:

- **Groups** bundle system-level permissions and decide *which features a user can use*.
- **Teams** own customers and projects and decide *which records a user can see*. `customers.team_id` and `projects.team_id` are `NOT NULL`. A project's team must match its bill-to customer's team. Users can only assign records to teams they belong to (unless their group has `bypass_team_scoping`). `Invoice` and `DeliveryNote` inherit team scope from their customer via `ScopedThroughCustomer`, which rejects mass-assigned `customer_id` / `project_id` pointing at teams the current user can't see.

Each top-level entrypoint has its own permission; most split into `.view` / `.edit`. Navigation hides menu items the user can't access; per-row Edit/Delete controls hide when the user lacks `.edit` (page headers still render so `.view`-only users see the page).

### Permission inventory (23 keys)

| Category | Keys |
| --- | --- |
| Operations | `customers.{view,edit}`, `projects.{view,edit}`, `invoices.{view,edit}`, `delivery_notes.{view,edit}` |
| Catalog & tax | `products.{view,edit}`, `sales_tax.{view,edit}` |
| Company settings | `issuer_company.{view,edit}` |
| Administration | `users.view`, `users.block`, `users.reset_passkeys` *(Admin-only)*, `users.auto_confirm_email` *(Admin-only)*, `user_invites.manage`, `groups.manage`, `teams.manage`, `jobs_status.view` |

`users.*` is split fine-grained so a help-desk role (`users.view` + `users.block`) cannot mount the email-add → passkey-reset takeover chain. The two credential-issuance primitives (`users.reset_passkeys`, `users.auto_confirm_email`) are tagged `admin_only: true` in `Permission::ALL` and cannot be granted to any non-Admin group from the UI or via `Group#permissions=`; `GroupPermission` validates this at the model layer.

`.edit` and `.view` are independent keys server-side. The group form auto-ticks `.view` when `.edit` is selected (and unticks `.edit` when `.view` is removed) via `permission_pair_controller`, so admins can't accidentally grant `.edit` without the underlying `.view` it depends on.

### Built-ins and bootstrap

- Built-in **Admin** group: all permissions including the admin-only ones, `bypass_team_scoping: true`. Undeletable. Name immutable (`prevent_name_change_if_builtin` on the model, plus controller-level `params.delete(:name) if @group.builtin?`) — keying `Group#admin?` off the name would otherwise be a silent rename-to-escape exploit. Permissions and bypass flag are also immutable.
- Built-in **Default** team. Undeletable. Renamable — `Team.default` looks the team up via a dedicated `default: boolean` column with a partial unique index (`where: '"default"'`), so renaming the team to e.g. "Headquarters" doesn't break the new-user join callback or any other consumer.
- Migration backfills every existing user → Default, customer → Default, project → Default. Same migration also seeds the Admin group and Default team for fresh installs; `db/seeds.rb` is idempotent so DBs created from `schema.rb` (CI, etc.) end up with the same seed state.
- Every newly-created user auto-joins the Default team via `after_create_commit :join_default_team`.
- The very first user is additionally auto-promoted to Admin via `after_create_commit :auto_promote_first_user`.
- `Group::ADMIN_NAME` and `Team::DEFAULT_NAME` constants + `Group.admin` / `Team.default` class methods centralize the lookup so the literal strings live in one place.

### UI

- New `/groups` and `/teams` admin sections (gated by `groups.manage` / `teams.manage`), linked from the Configuration dropdown.
- User detail page gains Groups and Teams sections with inline checkbox forms (gated by the respective manage permissions).
- `/account/profile` gains read-only Groups and Teams sections so users can see their own memberships.
- Customer and Project forms gain a required Team dropdown populated with the user's teams (or all teams for bypass users).
- Project form: a Stimulus controller (`project_team_controller`) replaces the team dropdown's options with just the selected customer's team — the only legal choice — and restores the full list when the project is reusable (no customer). `pointer-events: none` is unreliable on `<select>` in Safari, and the controller needs both targets under the same root element to bind correctly. Covered by a Cuprite system test (`test/system/project_team_lock_test.rb`). Server-side validation `team_must_match_customer` enforces the same rule independently.
- `Customer#sync_project_teams` cascades a customer's team change to every project that bills to it. Otherwise those projects instantly violate `team_must_match_customer` (no save possible) and disappear from members of the new team because `TeamOwned#visible_to` filters by `team_id`.
- Admin-only permissions are hidden from the permission checkboxes for non-Admin groups.
- Edit/Delete buttons across resource index/show pages (customers, projects, invoices, delivery notes, products, sales-tax rates/classes, issuer company) are hidden for users without the corresponding `.edit` permission. Server-side gates remain authoritative; the view-level hiding is for UX so users don't see clickable controls that 403.

### Defense-in-depth and audit trail

- `HomeController#index` scopes invoice aggregates via `Invoice.visible_to(current_user)` — no cross-team aggregate leak on the dashboard.
- `AttachmentsController#show` gated by the parent invoice or delivery note's team visibility.
- New `ApplicationController` guardrail: every action must either call `require_permission!` or declare `allow_without_permission_check`. An `after_action :verify_permission_check_performed` raises `MissingPermissionCheck` otherwise so a forgotten gate fails in tests rather than ship as a silent open endpoint. Account, Home, and `SessionsController#destroy` explicitly opt out.
- `bypass_team_scoping` is **never** permitted from request params.
- `Users::EmailsController` (auto-confirm semantics) requires `users.auto_confirm_email` — Admin-only — closing the email-add → passkey-reset takeover chain.
- `UsersController#reset_passkeys` requires `users.reset_passkeys` — Admin-only.
- `UsersController#update_groups` and `GroupsController#assign_members` only allow Admin-group membership changes (in **either direction**) by actors that are already in Admin. Without the symmetric guard, a `groups.manage` holder could either self-promote into Admin or demote other admins down to the last-admin floor — both unauthorized privilege modifications. The last-admin guard remains as a secondary defense.
- `Invoice` and `DeliveryNote` mass-assignment of `customer_id` / `project_id` is validated by the `ScopedThroughCustomer` concern against `Current.user`'s team visibility, mirroring `TeamOwned`'s pattern. Without this a `.edit` user in team A could file invoices into team B's books.
- Every privilege change (group/team CRUD, membership additions/removals) writes a `UserAuditEvent` via `ApplicationController#audit_privilege_change!`. Audited actions: `group_created`, `group_updated`, `group_deleted`, `team_created`, `team_updated`, `team_deleted`, `groups_updated`, `teams_updated`.
- `TeamOwned#validate_team_assignment` and `ScopedThroughCustomer`'s visibility validations read `Current.user` directly (set by `ApplicationController#authenticate` on every authenticated request). A future controller that touches a TeamOwned record can't "forget" to authorize — the check fires automatically. System contexts (seeds, console, jobs) have no `Current.user` set and the check skips, so they can legitimately seed records.

### Refactor / shared concerns

- `app/models/concerns/team_owned.rb` — `belongs_to :team`, `visible_to(user)`, and the membership validation. Customer and Project include it.
- `app/models/concerns/scoped_through_customer.rb` — `customer_id` / `project_id` visibility validations for records whose team is derived from their customer (Invoice, DeliveryNote).
- `ApplicationController#audit_privilege_change!` and `#available_teams` deduplicated across the groups/teams/users and customers/projects controllers.
- `ProjectsController` loads `@customer_options` in a `before_action` rather than running `Customer.visible_to(Current.user)` inside the HAML view, matching the project's convention of surfacing form options via the controller.

### Out of scope

WebAuthn-ceremony hygiene (TTL, replay protection, atomic consume) is handled by master #313 (`Tighten session and WebAuthn cookie hygiene`, `WebauthnPendingStore`). An earlier draft of this PR shipped a cookie-store-backed `WebauthnCeremony` concern; it was removed during rebase because master's server-side cache store now provides the same guarantees with smaller cookies and less code.

## Test plan

- [x] `bundle exec rails test` — 527 runs, 1935 assertions, 0 failures, 0 errors
- [x] `pre-commit run --all-files` — clean (incl. rubocop)
- [x] `npm run lint` — Stimulus controllers clean
- [x] Regression tests for: built-in Admin group name cannot be changed (model + controller layers), `bypass_team_scoping` cannot be enabled via the form (create + update), admin-only permissions cannot be granted to a non-Admin group, `users.block` alone cannot reset passkeys or manage emails, last-Admin protection refuses to empty Admin, Default team can be renamed without breaking new-user join, only one team can carry `default: true`, system contexts without `Current.user` can still seed records, non-Admin `groups.manage` holder cannot add OR remove Admin-group members via either `/users/:id/update_groups` or `/groups/:admin_id`, Invoice/DeliveryNote reject cross-team `customer_id` / `project_id` mass-assignment, project team dropdown filters to the customer's team (Cuprite system test), Customer team change cascades to billed projects (and leaves unrelated projects alone)
- [x] Migration runs cleanly; backfill confirmed; schema includes `groups`, `group_memberships`, `group_permissions`, `teams` (with `default` column + partial unique index), `team_memberships`, plus `team_id NOT NULL` on customers and projects
- [x] Manual: wipe DB, run `bin/rails users:invite`, complete first signup, verify auto-promotion to Admin and Default team
- [ ] Manual: invite a second user, verify they see only Home + My account by default plus Default-team customers/projects
- [ ] Manual: as admin, create a Sales group (`customers.{view,edit}` + `invoices.{view,edit}`) and an Acme team; assign second user; verify scoped access end-to-end
- [ ] Manual: project↔customer team alignment refused when mismatched
- [ ] Manual: on `/projects/new`, picking a customer shrinks the team dropdown to just that customer's team; picking "No customer (reusable project)" restores the full team list
- [ ] Manual: editing a customer to a different team auto-migrates every project billing that customer to the same team
- [ ] **Operator note for existing installs:** any project rows already inconsistent with their customer's team need a one-off backfill (the cascade only fires on new updates). Console: `Project.includes(:bill_to_customer).find_each { |p| next if p.bill_to_customer.nil? || p.team_id == p.bill_to_customer.team_id; p.update_column(:team_id, p.bill_to_customer.team_id) }`
- [ ] Manual: as a `.view`-only user, confirm Edit/Delete controls are hidden on each resource's index and show pages

