### PR TITLE
Include sub-path mount in invite and email-confirmation URLs

### DIFF
--- a/app/controllers/account/emails_controller.rb
+++ b/app/controllers/account/emails_controller.rb
@@ -17,7 +17,8 @@ class Account::EmailsController < ApplicationController
       confirmation_url = account_email_confirmation_url(
         token: plaintext,
         host: Settings.app.host,
-        protocol: Settings.app.protocol
+        protocol: Settings.app.protocol,
+        script_name: Settings.app.script_name
       )
       UserMailer.email_confirmation(email, confirmation_url).deliver_later
 

--- a/app/controllers/user_invites_controller.rb
+++ b/app/controllers/user_invites_controller.rb
@@ -13,7 +13,8 @@ class UserInvitesController < ApplicationController
                             request: request,
                             metadata: { purpose: 'signup', source: 'web' })
 
-    @invite_url = invite_url(token: plaintext, host: Settings.app.host, protocol: Settings.app.protocol)
+    @invite_url = invite_url(token: plaintext, host: Settings.app.host, protocol: Settings.app.protocol,
+                              script_name: Settings.app.script_name)
     @invite = invite
     render :show_invite
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -43,7 +43,8 @@ class UsersController < ApplicationController
     end
 
     _invite, plaintext = @user.reset_passkeys!(actor: current_user, request: request)
-    invite_url = invite_url(token: plaintext, host: Settings.app.host, protocol: Settings.app.protocol)
+    invite_url = invite_url(token: plaintext, host: Settings.app.host, protocol: Settings.app.protocol,
+                             script_name: Settings.app.script_name)
 
     UserAuditEvent.record!(action: 'invite_created', user: @user, actor: current_user,
                             request: request,

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,8 @@
 app:
   host: 'localhost:3000'
   protocol: 'http'
+  # Sub-path the app is mounted at, e.g. '/abt'. Leave blank for root.
+  script_name: ''
 
 payments:
 #  public_url: 'https://pay.deduktiva.com/p/%token%'


### PR DESCRIPTION
## Summary

Invite URLs (signup, passkey-reset) and email-confirmation URLs were missing the sub-path when the app is mounted under a sub-directory. Passing `host:` to a Rails URL helper makes Rails build the URL from scratch and drop `config.relative_url_root` / `SCRIPT_NAME`, so the mount prefix never appeared in the generated link.

- Add `app.script_name` to `config/settings.yml` (defaults to `''` for root-mount)
- Forward `script_name: Settings.app.script_name` alongside the existing `host:` / `protocol:` in:
  - `user_invites#create` (signup invite URL shown on screen)
  - `users#reset_passkeys` (passkey-reset invite URL emailed to the user)
  - `account/emails#create` (email-confirmation URL emailed to the user)

To enable in a sub-path deployment, set `app.script_name: '/abt'` (or whatever the mount point is) in the environment's settings file.

## Test plan

- [x] `bundle exec rails test` — 343 runs, 0 failures
- [ ] Manually verify a generated invite URL contains the configured `script_name` prefix when one is set

https://claude.ai/code/session_01APPAR5g9TdcaPEeoPGRoj2

---
_Generated by [Claude Code](https://claude.ai/code/session_01APPAR5g9TdcaPEeoPGRoj2)_