### PR TITLE
Increase Cuprite process timeout for CI reliability

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -3,7 +3,8 @@ require "test_helper"
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   cuprite_options = {
     js_errors: true,
-    headless: ENV['HEADLESS'] != '0'  # Default to headless unless explicitly disabled
+    headless: ENV['HEADLESS'] != '0',  # Default to headless unless explicitly disabled
+    process_timeout: 30  # Chromium can take longer than the 10s default to start on busy CI runners
   }
 
   # Allow pointing at a non-standard Chromium binary (e.g. the Playwright build


### PR DESCRIPTION
## Summary
Increases the Cuprite/Chromium process timeout from the default 10 seconds to 30 seconds to improve system test reliability on busy CI runners where Chromium startup can take longer.

## Changes
- Added `process_timeout: 30` configuration to cuprite_options in ApplicationSystemTestCase
- Fixed trailing comma on `headless` option for proper Ruby syntax

## Details
Chromium can take longer than 10 seconds to start on resource-constrained CI environments, causing system tests to fail with timeout errors. This change provides additional startup time while maintaining reasonable test execution bounds. The 30-second timeout is a conservative value that accommodates slower CI runners without significantly impacting test feedback loops.

https://claude.ai/code/session_01SXX9CQgJiydT7HAbfz67kJ