### PR TITLE
Centralize external URL building in AbsoluteUrl

### DIFF
--- a/app/controllers/account/emails_controller.rb
+++ b/app/controllers/account/emails_controller.rb
@@ -14,12 +14,7 @@ class Account::EmailsController < ApplicationController
                               request: request,
                               metadata: { username: current_user.username, address: address })
 
-      confirmation_url = account_email_confirmation_url(
-        token: plaintext,
-        host: Settings.app.host,
-        protocol: Settings.app.protocol,
-        script_name: Settings.app.script_name
-      )
+      confirmation_url = AbsoluteUrl.account_email_confirmation(plaintext)
       UserMailer.email_confirmation(email, confirmation_url).deliver_later
 
       current_user.confirmed_emails.where.not(id: email.id).find_each do |existing|

--- a/app/controllers/user_invites_controller.rb
+++ b/app/controllers/user_invites_controller.rb
@@ -13,8 +13,7 @@ class UserInvitesController < ApplicationController
                             request: request,
                             metadata: { purpose: 'signup', source: 'web' })
 
-    @invite_url = invite_url(token: plaintext, host: Settings.app.host, protocol: Settings.app.protocol,
-                              script_name: Settings.app.script_name)
+    @invite_url = AbsoluteUrl.invite(plaintext)
     @invite = invite
     render :show_invite
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -43,8 +43,7 @@ class UsersController < ApplicationController
     end
 
     _invite, plaintext = @user.reset_passkeys!(actor: current_user, request: request)
-    invite_url = invite_url(token: plaintext, host: Settings.app.host, protocol: Settings.app.protocol,
-                             script_name: Settings.app.script_name)
+    invite_url = AbsoluteUrl.invite(plaintext)
 
     UserAuditEvent.record!(action: 'invite_created', user: @user, actor: current_user,
                             request: request,

--- a/app/services/absolute_url.rb
+++ b/app/services/absolute_url.rb
@@ -1,0 +1,19 @@
+module AbsoluteUrl
+  module_function
+
+  def options
+    {
+      host: Settings.app.host,
+      protocol: Settings.app.protocol,
+      script_name: Settings.app.script_name
+    }
+  end
+
+  def invite(token)
+    Rails.application.routes.url_helpers.invite_url(token: token, **options)
+  end
+
+  def account_email_confirmation(token)
+    Rails.application.routes.url_helpers.account_email_confirmation_url(token: token, **options)
+  end
+end

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -9,11 +9,7 @@ namespace :users do
       metadata: { purpose: 'signup', source: 'rake' }
     )
 
-    url = Rails.application.routes.url_helpers.invite_url(
-      token: plaintext,
-      host: Settings.app.host,
-      protocol: Settings.app.protocol
-    )
+    url = AbsoluteUrl.invite(plaintext)
 
     puts ''
     puts 'Invite URL (valid until ' + invite.expires_at.utc.iso8601 + '):'

--- a/test/services/absolute_url_test.rb
+++ b/test/services/absolute_url_test.rb
@@ -1,0 +1,47 @@
+require 'test_helper'
+
+class AbsoluteUrlTest < ActiveSupport::TestCase
+  setup do
+    @original = {
+      host: Settings.app.host,
+      protocol: Settings.app.protocol,
+      script_name: Settings.app.script_name
+    }
+  end
+
+  teardown do
+    Settings.app.host = @original[:host]
+    Settings.app.protocol = @original[:protocol]
+    Settings.app.script_name = @original[:script_name]
+  end
+
+  test 'invite URL includes host, protocol, and script_name from Settings' do
+    Settings.app.host = 'example.test'
+    Settings.app.protocol = 'https'
+    Settings.app.script_name = '/abt'
+
+    url = AbsoluteUrl.invite('tok-123')
+
+    assert_equal 'https://example.test/abt/invites/tok-123', url
+  end
+
+  test 'invite URL omits sub-path when script_name is blank' do
+    Settings.app.host = 'example.test'
+    Settings.app.protocol = 'https'
+    Settings.app.script_name = ''
+
+    url = AbsoluteUrl.invite('tok-123')
+
+    assert_equal 'https://example.test/invites/tok-123', url
+  end
+
+  test 'account_email_confirmation URL includes script_name from Settings' do
+    Settings.app.host = 'example.test'
+    Settings.app.protocol = 'https'
+    Settings.app.script_name = '/abt'
+
+    url = AbsoluteUrl.account_email_confirmation('tok-xyz')
+
+    assert_equal 'https://example.test/abt/account/email_confirmations/tok-xyz', url
+  end
+end


### PR DESCRIPTION
## Summary

`rake users:invite` was printing an invite URL without the configured sub-path because the rake task wasn't included in the previous fix (#282). It built the URL inline with the same `host:` / `protocol:` kwargs and never picked up `Settings.app.script_name`.

Rather than fix the rake site in isolation and leave four near-identical copies of the same call, this PR pulls all external-URL building into one place:

- New `app/services/absolute_url.rb` with `AbsoluteUrl.invite(token)` and `AbsoluteUrl.account_email_confirmation(token)`, both reading `host`, `protocol`, and `script_name` from `Settings.app`.
- Route all four call sites through the helper: `user_invites#create`, `users#reset_passkeys`, `account/emails#create`, and `lib/tasks/users.rake`.
- Add `test/services/absolute_url_test.rb` covering script_name set, unset, and the email-confirmation path.

## Test plan

- [x] `bundle exec rails test` — 346 runs (3 new), 0 failures
- [ ] In production with `app.script_name: '/abt'` set, confirm `rake users:invite` prints a URL containing `/abt/invites/...`

https://claude.ai/code/session_01APPAR5g9TdcaPEeoPGRoj2

---
_Generated by [Claude Code](https://claude.ai/code/session_01APPAR5g9TdcaPEeoPGRoj2)_