### PR TITLE
Add database.yml seeding and chromium verification to session setup

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -35,6 +35,20 @@ fi
 echo "== Installing Ruby gems =="
 bundle install --quiet
 
+echo "== Seeding config/database.yml from sample (if missing) =="
+if [ ! -f config/database.yml ]; then
+  cp config/database.yml.sample config/database.yml
+fi
+
+echo "== Verifying chromium for system tests =="
+# BROWSER_PATH is set in .claude/settings.json to the version-stable
+# Playwright chromium symlink; we just sanity-check it here.
+if [ -x "${BROWSER_PATH:-/opt/pw-browsers/chromium}" ]; then
+  "${BROWSER_PATH:-/opt/pw-browsers/chromium}" --version
+else
+  echo "WARNING: chromium not found at ${BROWSER_PATH:-/opt/pw-browsers/chromium} — system tests will fail until BROWSER_PATH is fixed."
+fi
+
 echo "== Creating FOP wrapper at ./bin/abt-fop-container =="
 mkdir -p bin
 cat > bin/abt-fop-container << 'WRAPPER'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "BROWSER_PATH": "/opt/pw-browsers/chromium"
+  },
   "hooks": {
     "SessionStart": [
       {

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -9,7 +9,13 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   # Allow pointing at a non-standard Chromium binary (e.g. the Playwright build
   # in /opt/pw-browsers in our sandbox) and add --no-sandbox when running as
   # root, which Chrome refuses by default.
-  cuprite_options[:browser_path] = ENV['BROWSER_PATH'] if ENV['BROWSER_PATH'].present?
+  if ENV['BROWSER_PATH'].present?
+    if File.executable?(ENV['BROWSER_PATH'])
+      cuprite_options[:browser_path] = ENV['BROWSER_PATH']
+    else
+      warn "WARNING: BROWSER_PATH=#{ENV['BROWSER_PATH']} is not executable; falling back to cuprite's default chrome lookup."
+    end
+  end
   if Process.uid.zero? || ENV['CHROME_NO_SANDBOX'] == '1'
     cuprite_options[:browser_options] = { 'no-sandbox' => nil }
   end


### PR DESCRIPTION
## Summary
Enhances the session start hook to automatically seed the database configuration file and verify the chromium browser is available for system tests.

## Key Changes
- **Database configuration seeding**: Automatically copies `config/database.yml.sample` to `config/database.yml` if the file is missing, streamlining initial setup
- **Chromium verification**: Added sanity check during session start to verify chromium is available at the configured `BROWSER_PATH`, with a clear warning if not found
- **Environment configuration**: Added `BROWSER_PATH` environment variable to `.claude/settings.json` pointing to the Playwright chromium installation at `/opt/pw-browsers/chromium`

## Implementation Details
- The database.yml seeding is conditional and only runs if the file doesn't already exist, preventing accidental overwrites
- Chromium verification uses the `BROWSER_PATH` environment variable with a sensible fallback path
- The verification runs `chromium --version` to confirm the binary is executable and functional
- Clear warning message guides developers to fix `BROWSER_PATH` if chromium is not found, preventing silent test failures

https://claude.ai/code/session_014nox8Z7i4XfFEZT52HpKys