### PR TITLE
Configure Host header protection with dynamic settings

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,11 +81,8 @@ Rails.application.configure do
   config.active_record.attributes_for_inspect = [ :id ]
 
   # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
-  #
+  config.hosts << Settings.app.host if Settings.app.host.present?
+
   # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end


### PR DESCRIPTION
## Summary
Enable Rails Host header attack protection in production by configuring allowed hosts dynamically from application settings, and enable the health check endpoint exclusion for host authorization.

## Changes
- Replace commented-out `config.hosts` configuration with dynamic setup that appends the configured app host from `Settings.app.host` when present
- Uncomment and enable `config.host_authorization` to exclude the `/up` health check endpoint from host header validation

## Implementation Details
- The host configuration now reads from the settings system rather than being hardcoded, allowing environment-specific host configuration without code changes
- The health check endpoint exclusion ensures monitoring and uptime checks can reach the application without triggering host authorization failures
- This follows Rails security best practices for preventing DNS rebinding attacks while maintaining operational flexibility

https://claude.ai/code/session_01PRwJnVApVETFcrKRCGrLiv