### PR TITLE
Set paid_at dates for seed invoices

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -472,6 +472,7 @@ if Rails.env.development?
     current_year_invoice.attachment.title = 'My Example Invoice 20250001'
     current_year_invoice.attachment.save!
 
+    current_year_invoice.paid_at = Date.new(2025, 2, 10)
     current_year_invoice.save!
   end
 
@@ -552,6 +553,7 @@ if Rails.env.development?
       last_year_invoice.attachment.save!
     end
 
+    last_year_invoice.paid_at = Date.new(2025, 1, 20)
     last_year_invoice.save!
   end
 


### PR DESCRIPTION
## Summary
Updates the database seed file to set `paid_at` dates for the example invoices created during seeding, making the seed data more realistic for development and testing.

## Changes
- Set `paid_at` to February 10, 2025 for the current year invoice example
- Set `paid_at` to January 20, 2025 for the last year invoice example

## Details
These dates are set before calling `save!` on each invoice, ensuring the seed data includes payment information that reflects realistic invoice workflows. This allows developers and testers to work with invoices that have complete lifecycle data (created, booked, and paid states).

https://claude.ai/code/session_01Pd28xW6oXifUHo5QSMumAf