### PR TITLE
Prevent email header injection in invoice subject lines

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -28,4 +28,11 @@ class ApplicationMailer < ActionMailer::Base
       subject: subject
     )
   end
+
+  # Strip CR/LF from values interpolated into mail headers (e.g. Subject) to
+  # prevent header injection. The mail gem strips CRLF too, but doing it
+  # explicitly keeps us safe if that ever changes.
+  def sanitize_header_value(value)
+    value.to_s.gsub(/[\r\n]+/, ' ')
+  end
 end

--- a/app/mailers/invoice_mailer.rb
+++ b/app/mailers/invoice_mailer.rb
@@ -12,8 +12,8 @@ class InvoiceMailer < ApplicationMailer
     I18n.with_locale(customer.language.iso_code) do
       if customer.invoice_email_auto_enabled
         subject = customer.invoice_email_auto_subject_template
-                          .gsub('$CUST_ORDER$', @invoice.cust_order)
-                          .gsub('$CUST_REF$', @invoice.cust_reference)
+                          .gsub('$CUST_ORDER$', sanitize_header_value(@invoice.cust_order))
+                          .gsub('$CUST_REF$', sanitize_header_value(@invoice.cust_reference))
         to = customer.invoice_email_auto_to
         cc = customer.email if customer.email.present? && customer.email != to
       elsif customer.email.present?

--- a/test/mailers/invoice_mailer_test.rb
+++ b/test/mailers/invoice_mailer_test.rb
@@ -97,6 +97,19 @@ class InvoiceMailerTest < ActionMailer::TestCase
     assert_match "Example Company B.V.", text_body  # issuer legal_name from fixture
   end
 
+  test "customer_email subject strips CRLF from user-controlled substitution values" do
+    invoice = invoices(:auto_email_invoice)
+    invoice.update!(
+      cust_order: "ORDER\r\nBcc: attacker@example.com",
+      cust_reference: "REF\nX-Injected: yes"
+    )
+
+    mail = InvoiceMailer.with(invoice: invoice).customer_email
+
+    assert_equal "Invoice ORDER Bcc: attacker@example.com - Ref: REF X-Injected: yes", mail.subject
+    assert_no_match(/[\r\n]/, mail.subject)
+  end
+
   test "customer_email subject template handles empty substitution values" do
     # Create invoice with empty reference fields
     invoice = Invoice.create!(


### PR DESCRIPTION
## Summary
Fixes a security vulnerability where user-controlled invoice fields (`cust_order` and `cust_reference`) could be exploited to inject email headers (e.g., Bcc, X-Injected) via carriage return and line feed characters in the invoice subject line.

## Changes
- **ApplicationMailer**: Added `sanitize_header_value()` helper method that strips CR/LF characters from values before they're interpolated into mail headers
- **InvoiceMailer**: Updated `customer_email()` to sanitize `cust_order` and `cust_reference` values before substituting them into the subject template
- **Tests**: Added test case verifying that CRLF characters in user-controlled fields are stripped from the subject line

## Implementation Details
The sanitization converts any sequence of carriage returns and line feeds to a single space character using `gsub(/[\r\n]+/, ' ')`. This prevents header injection while preserving readability of the subject line. The approach is defensive—while the mail gem also strips CRLF, explicit sanitization ensures protection if that behavior ever changes.

https://claude.ai/code/session_01JDbTdsLV8QAmRP3hE5svbB