### PR TITLE
Cache app_version at boot instead of per request

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -137,21 +137,6 @@ module ApplicationHelper
   end
 
   def app_version
-    # Cache the version to avoid repeated git calls
-    @app_version ||= begin
-      if Rails.env.test?
-        # Don't call git in tests to avoid slowing them down
-        "test-version"
-      else
-        # Try to get git revision
-        revision = `git rev-parse --short HEAD 2>/dev/null`.strip
-        if $?.success? && !revision.empty?
-          "v#{revision}"
-        else
-          # Fallback if git is not available or not in a git repo
-          "unknown"
-        end
-      end
-    end
+    Rails.application.config.x.app_version
   end
 end

--- a/config/initializers/app_version.rb
+++ b/config/initializers/app_version.rb
@@ -1,0 +1,14 @@
+# Compute the running app version once per process. Passenger spawns fresh
+# workers on restart (tmp/restart.txt), so the SHA is refreshed every deploy
+# without shelling out to git on each request.
+Rails.application.config.x.app_version =
+  if Rails.env.test?
+    "test-version"
+  else
+    revision = IO.popen(["git", "rev-parse", "--short", "HEAD"], err: File::NULL, chdir: Rails.root.to_s, &:read).to_s.strip
+    if $?.success? && !revision.empty?
+      "v#{revision}"
+    else
+      "unknown"
+    end
+  end


### PR DESCRIPTION
## Summary

Closes #286.

`ApplicationHelper#app_version` used to shell out to `git rev-parse --short HEAD` on first call per request. The issue's suggested fix (bake a `REVISION` file at deploy time via Kamal/Capistrano/Docker/Actions) doesn't fit how ABT deploys — `script/production-update` does `git pull --rebase` in place and `.git/` is always present at runtime.

Instead, compute the SHA once at boot in an initializer and store it on `Rails.application.config.x.app_version`. The helper becomes a one-liner that reads it. Passenger spawns fresh workers on `tmp/restart.txt`, so every deploy re-runs the initializer and picks up the new SHA — no changes to `script/production-update` needed.

## Test plan

- [x] `bin/rails test test/helpers/application_helper_test.rb` — existing tests pass unchanged (`"test-version"` short-circuit still applies in the test env).
- [x] `bin/rails runner 'puts Rails.application.config.x.app_version'` prints `v<sha>` matching `git rev-parse --short HEAD`.
- [ ] Smoke-load a page on the deployed app after the next `script/production-update` run and confirm the footer shows the new SHA after Passenger restarts.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NzvNnsbdKJyP1XoAhjnDwW)_