### PR TITLE
Drop assume_ssl, rely on Apache's HTTPS env via mod_passenger

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -35,10 +35,11 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
-  # Assume all access to the app is happening through a SSL-terminating reverse proxy.
-  config.assume_ssl = true
-
-  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  # Scheme detection is provided by Apache + mod_passenger: Apache's mod_ssl
+  # sets HTTPS=on in the CGI env on SSL requests, which Passenger forwards into
+  # the Rack env. Rack::Request#scheme reads it directly (no trusted_proxies
+  # gating), so request.ssl? reflects reality and force_ssl only redirects
+  # requests that actually arrived over plain HTTP.
   config.force_ssl = true
 
   # Skip http-to-https redirect for the default health check endpoint.


### PR DESCRIPTION
## Summary

Removes `config.assume_ssl = true` from production. The deployment is Apache + mod_passenger (`apache2.conf.tpl`); Apache's mod_ssl already sets `HTTPS=on` in the CGI env on SSL requests, mod_passenger forwards it into Rack, and `Rack::Request#scheme` reads it directly (no trusted-proxies gating). So `request.ssl?` already reflects reality, and `assume_ssl` was just lying — telling Rails every request is HTTPS even if it weren't.

Keeps `config.force_ssl = true` as-is. It now does its real job: redirect any genuinely-HTTP request to HTTPS, emit HSTS, secure cookies.

## URL-generation audit

No URL becomes wrong:

- **Mailer URLs** go through `app/services/absolute_url.rb`, which reads `Settings.app.protocol` / `Settings.app.host` explicitly — independent of `assume_ssl`/`force_ssl`.
- **Controller `redirect_to *_url`** builds from `request.scheme`. Apache+mod_passenger sets `HTTPS=on`, so scheme is `"https"` — same result as today.
- **View helpers** use relative `*_path` and `form_with url:` — no scheme involved.

## Test plan

- [x] `RAILS_ENV=production SECRET_KEY_BASE=dummy ./bin/rails runner 'p Rails.application.middleware.map(&:name).grep(/SSL/)'` → `["ActionDispatch::SSL"]` (AssumeSSL gone, SSL middleware retained).
- [ ] After deploy: `https://abt/up` returns 200 (no redirect loop).
- [ ] After deploy: load an invoice page over HTTPS, confirm session cookie still has `Secure; HttpOnly` and response carries `Strict-Transport-Security`.
- [ ] After deploy: send an invite/email-confirmation, confirm the link in the email starts with `https://` (exercises `AbsoluteUrl`).

Closes #289

https://claude.ai/code/session_01PRwJnVApVETFcrKRCGrLiv

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRwJnVApVETFcrKRCGrLiv)_