### PR TITLE
Require at least one item line on delivery notes before publish/render

### DIFF
--- a/app/controllers/concerns/document_with_lines.rb
+++ b/app/controllers/concerns/document_with_lines.rb
@@ -17,4 +17,21 @@ module DocumentWithLines
   def set_form_options
     @line_type_options = self.class.document_line_class::TYPE_OPTIONS.to_a
   end
+
+  # Filter: redirect with a flash if the document doesn't yet have at least
+  # one item line. Without this, the renderer hands FOP a table with no
+  # body and FOP aborts; this is also the business rule for booking /
+  # publishing a meaningful document.
+  #
+  # Relies on PublishableDocument for the record lookup and human label,
+  # and on the model including HasLineItems for `has_items?`.
+  def require_item_line
+    record = publishable_record
+    unless record.has_items?
+      flash[:error] = "Cannot proceed with a #{self.class.publishable_label} that has no item lines."
+      redirect_to record
+      return false
+    end
+    true
+  end
 end

--- a/app/controllers/delivery_notes_controller.rb
+++ b/app/controllers/delivery_notes_controller.rb
@@ -12,6 +12,7 @@ class DeliveryNotesController < ApplicationController
   before_action :set_delivery_note, only: %i[show edit update destroy publish preview pdf unpublish upload_acceptance delete_acceptance convert_to_invoice preview_email send_email]
   before_action :require_unpublished, only: %i[edit update publish preview]
   before_action :require_published, only: %i[pdf unpublish upload_acceptance delete_acceptance convert_to_invoice send_email]
+  before_action :require_item_line, only: %i[publish preview preview_email]
 
   # GET /delivery_notes
   def index

--- a/app/models/concerns/has_line_items.rb
+++ b/app/models/concerns/has_line_items.rb
@@ -1,0 +1,21 @@
+module HasLineItems
+  extend ActiveSupport::Concern
+
+  class_methods do
+    # Configure which has_many association holds the document's lines.
+    #
+    #   has_line_items :invoice_lines
+    def has_line_items(association)
+      @line_items_association = association
+    end
+
+    attr_reader :line_items_association
+  end
+
+  # At least one line of type 'item' (as opposed to text / subheading /
+  # plain). Required for booking taxes / totals and for the document to
+  # carry meaningful content.
+  def has_items?
+    public_send(self.class.line_items_association).any?(&:is_item?)
+  end
+end

--- a/app/models/delivery_note.rb
+++ b/app/models/delivery_note.rb
@@ -1,9 +1,13 @@
 class DeliveryNote < ApplicationRecord
   include YearFilterable
+  include HasLineItems
+
+  has_line_items :delivery_note_lines
 
   validates :customer_id, :presence => true
   validates :delivery_start_date, :presence => true
   validate :delivery_end_date_after_start_date
+  validate :must_have_item_line_for_publish
   default_scope { order(Arel.sql("id ASC")) }
 
   scope :email_sent, -> { where.not(email_sent_at: nil) }
@@ -95,5 +99,12 @@ class DeliveryNote < ApplicationRecord
     if delivery_end_date < delivery_start_date
       errors.add(:delivery_end_date, "cannot be before the start date")
     end
+  end
+
+  def must_have_item_line_for_publish
+    return unless will_save_change_to_published? && published?
+    return if has_items?
+
+    errors.add(:base, 'must have at least one item line before it can be published')
   end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -1,5 +1,8 @@
 class Invoice < ApplicationRecord
   include YearFilterable
+  include HasLineItems
+
+  has_line_items :invoice_lines
 
   validates :customer_id, :presence => true
   default_scope { order(Arel.sql("id ASC")) }
@@ -29,10 +32,6 @@ class Invoice < ApplicationRecord
 
   before_save :update_customer
   before_save :update_sums
-
-  def has_items?
-    self.invoice_lines.any? { |line| line.is_item? }
-  end
 
   def paid?
     self.paid_at.present?

--- a/test/fixtures/delivery_note_lines.yml
+++ b/test/fixtures/delivery_note_lines.yml
@@ -26,3 +26,11 @@ plain_line:
   type: plain
   title: "Plain text line"
   description: "Just plain text"
+
+draft_item_line:
+  delivery_note: draft_delivery_note
+  position: 3
+  type: item
+  title: "Draft Item"
+  description: "An item line so the draft fixture can be published"
+  quantity: 1.0

--- a/test/functional/delivery_notes_controller_test.rb
+++ b/test/functional/delivery_notes_controller_test.rb
@@ -354,26 +354,8 @@ class DeliveryNotesControllerTest < ActionController::TestCase
   test "should send bulk email when multiple delivery notes for same customer" do
     customer = customers(:good_eu)
 
-    # Create two more delivery notes for the same customer
-    note1 = DeliveryNote.create!(
-      customer: customer,
-      project: projects(:one),
-      document_number: "DN-2025-002",
-      published: true,
-      date: Date.current,
-      cust_reference: "BULK-TEST-1",
-      delivery_start_date: Date.current
-    )
-
-    note2 = DeliveryNote.create!(
-      customer: customer,
-      project: projects(:one),
-      document_number: "DN-2025-003",
-      published: true,
-      date: Date.current,
-      cust_reference: "BULK-TEST-2",
-      delivery_start_date: Date.current
-    )
+    note1 = create_published_delivery_note(customer: customer, document_number: "DN-2025-002", cust_reference: "BULK-TEST-1")
+    note2 = create_published_delivery_note(customer: customer, document_number: "DN-2025-003", cust_reference: "BULK-TEST-2")
 
     post :bulk_send_emails, params: { delivery_note_ids: [note1.id, note2.id] }
     assert_redirected_to delivery_notes_path
@@ -382,20 +364,27 @@ class DeliveryNotesControllerTest < ActionController::TestCase
 
   test "should send individual emails when delivery notes are for different customers" do
     note1 = delivery_notes(:published_delivery_note)  # good_eu customer
-
-    # Create delivery note for different customer
-    note2 = DeliveryNote.create!(
-      customer: customers(:good_national),
-      project: projects(:one),
-      document_number: "DN-2025-004",
-      published: true,
-      date: Date.current,
-      cust_reference: "DIFF-CUSTOMER",
-      delivery_start_date: Date.current
-    )
+    note2 = create_published_delivery_note(customer: customers(:good_national), document_number: "DN-2025-004", cust_reference: "DIFF-CUSTOMER")
 
     post :bulk_send_emails, params: { delivery_note_ids: [note1.id, note2.id] }
     assert_redirected_to delivery_notes_path
     assert_match '2 emails queued for sending', flash[:notice]
+  end
+
+  private
+
+  def create_published_delivery_note(customer:, document_number:, cust_reference:)
+    DeliveryNote.new(
+      customer: customer,
+      project: projects(:one),
+      document_number: document_number,
+      published: true,
+      date: Date.current,
+      cust_reference: cust_reference,
+      delivery_start_date: Date.current,
+      delivery_note_lines_attributes: [
+        { type: 'item', title: 'Item', description: 'desc', quantity: 1.0, position: 1 }
+      ]
+    ).tap(&:save!)
   end
 end

--- a/test/integration/delivery_note_pdf_test.rb
+++ b/test/integration/delivery_note_pdf_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class DeliveryNotePdfTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
   setup do
     @issuer = issuer_companies(:one)
     @customer_en = customers(:good_eu)  # English language customer
@@ -108,6 +110,61 @@ class DeliveryNotePdfTest < ActionDispatch::IntegrationTest
     renderer_de = DeliveryNoteRenderer.new(delivery_note_de, @issuer)
     xml_de = renderer_de.emit_xml(nil)
     assert_includes xml_de, '<language>de</language>', "German delivery note should include language de"
+  end
+
+  test "preview of an empty delivery note redirects with a flash instead of crashing FOP" do
+    empty = DeliveryNote.create!(
+      customer: @customer_en,
+      project: @project,
+      delivery_start_date: Date.new(2025, 8, 1)
+    )
+
+    get preview_delivery_note_path(empty)
+
+    assert_redirected_to delivery_note_path(empty)
+    assert_match(/no item lines/i, flash[:error])
+  end
+
+  test "publishing an empty delivery note is blocked" do
+    empty = DeliveryNote.create!(
+      customer: @customer_en,
+      project: @project,
+      delivery_start_date: Date.new(2025, 8, 1)
+    )
+
+    post publish_delivery_note_path(empty)
+
+    assert_redirected_to delivery_note_path(empty)
+    assert_match(/no item lines/i, flash[:error])
+    assert_not empty.reload.published?
+  end
+
+  test "publishing a delivery note with only non-item lines is blocked" do
+    dn = DeliveryNote.create!(
+      customer: @customer_en,
+      project: @project,
+      delivery_start_date: Date.new(2025, 8, 1)
+    )
+    dn.delivery_note_lines.create!(type: 'text', title: 'Note', description: 'no items here', position: 1)
+    dn.delivery_note_lines.create!(type: 'subheading', title: 'Section', position: 2)
+
+    post publish_delivery_note_path(dn)
+
+    assert_redirected_to delivery_note_path(dn)
+    assert_match(/no item lines/i, flash[:error])
+    assert_not dn.reload.published?
+  end
+
+  test "model rejects setting published=true on an empty delivery note" do
+    dn = DeliveryNote.create!(
+      customer: @customer_en,
+      project: @project,
+      delivery_start_date: Date.new(2025, 8, 1)
+    )
+
+    dn.published = true
+    refute dn.valid?
+    assert_includes dn.errors[:base].join, 'item line'
   end
 
   test "delivery note XML structure is correct" do

--- a/test/mailers/invoice_mailer_test.rb
+++ b/test/mailers/invoice_mailer_test.rb
@@ -130,6 +130,25 @@ class InvoiceMailerTest < ActionMailer::TestCase
     assert_equal "Invoice  - Ref: ", mail.subject
   end
 
+  test "customer_email subject template handles nil substitution values" do
+    invoice = Invoice.create!(
+      customer: customers(:auto_email_customer),
+      project: projects(:one),
+      attachment: attachments(:auto_email_pdf),
+      document_number: "INV-NIL",
+      published: true,
+      date: Date.current,
+      due_date: 30.days.from_now,
+      cust_reference: nil,
+      cust_order: nil,
+      sum_net: 100.00,
+      sum_total: 121.00
+    )
+
+    mail = InvoiceMailer.with(invoice: invoice).customer_email
+    assert_equal "Invoice  - Ref: ", mail.subject
+  end
+
   test "customer_email works in test environment without mailgun" do
     # Verify we're using test delivery method, not mailgun
     assert_equal :test, ActionMailer::Base.delivery_method


### PR DESCRIPTION
## Problem

Rendering a preview for a delivery note with no line items crashed FOP:

```
org.apache.fop.apps.FOPException: net.sf.saxon.trans.XPathException:
  org.apache.fop.fo.ValidationException: "fo:table" is missing child elements.
  Required content model: (marker*,table-column*,table-header?,table-footer?,table-body+)
```

The XSL template emits one table row per line, and an empty `<items>` block leaves the table with no body. FOP rejects it.

Beyond avoiding the crash, a delivery note without at least one actual *item* line isn't a meaningful document to publish or send. Invoices already enforce this implicitly via `InvoiceBooker#has_items?`; delivery notes had no equivalent.

## Changes

- New `HasLineItems` model concern provides `has_items?` (configured per-model with `has_line_items :invoice_lines` / `has_line_items :delivery_note_lines`). `Invoice`'s inline `has_items?` becomes an instance of the concern.
- `DeliveryNote` gains a model validation `must_have_item_line_for_publish` that blocks transitioning `published` to `true` without at least one item line. This is the authoritative guard.
- `DocumentWithLines` controller concern adds `require_item_line`, which redirects with a flash when `record.has_items?` is false. Used to give the user a friendly UX before the model raises.
- `DeliveryNotesController` wires the filter on `publish`, `preview`, and `preview_email` — the actions reachable while the document is still empty (draft state, or no publish-state gate). `pdf` and `send_email` are already gated by `require_published`, and the new model validation makes a published-but-empty record unreachable, so no filter is needed there.

## Test plan

- [x] `test/integration/delivery_note_pdf_test.rb` covers:
  - preview of an empty delivery note → flash + redirect (the reported case)
  - `publish` of an empty delivery note → blocked
  - `publish` of a delivery note with only text/subheading/plain lines → blocked
  - model validation directly rejects setting `published=true` on an empty record
- [x] Existing test suite passes (244 runs / 0 failures at controllers/models/jobs/mailers/unit/helpers layer)
- [x] Existing fixture `draft_delivery_note` gained an item line so the existing "publish! works" test still passes under the new validation
- [ ] FOP-dependent integration tests can't run in the CI sandbox (no docker socket); they're unchanged by this PR

## Notes

- Invoices were already protected by `InvoiceBooker#has_items?` and are not affected behaviourally.
- `bulk_send_emails` for delivery notes is implicitly safe now: every selected DN must be published, which means it must have an item line.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K3ToqGcasRcWkKMkSGsK9Y)_