### PR TITLE
Filter :token from request logs

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += [:password, :token]


### PR DESCRIPTION
## Summary
- Add `:token` to `Rails.application.config.filter_parameters` so plaintext invite/confirmation tokens that travel as query params are redacted from request logs (previously only `:password` was filtered).

## Test plan
- [ ] Tail `log/development.log` while hitting a URL containing a `?token=...` query param and confirm the value is logged as `[FILTERED]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)