### PR TITLE
Migrate test/functional/ to ActionDispatch::IntegrationTest

### DIFF
--- a/test/controllers/delivery_notes_controller_test.rb
+++ b/test/controllers/delivery_notes_controller_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
 
-class DeliveryNotesControllerTest < ActionController::TestCase
+class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
   test "should get index" do
-    get :index
+    get delivery_notes_url
     assert_response :success
   end
 
@@ -25,11 +25,11 @@ class DeliveryNotesControllerTest < ActionController::TestCase
     )
 
     # Test current year (default)
-    get :index
+    get delivery_notes_url
     assert_response :success
 
     # Test specific year filter
-    get :index, params: { year: 2023 }
+    get delivery_notes_url(year: 2023)
     assert_response :success
     # Verify the page contains the 2023 note reference but not 2024
     assert_select 'td', text: '2023-TEST'
@@ -46,24 +46,24 @@ class DeliveryNotesControllerTest < ActionController::TestCase
       # date is nil for draft notes
     )
 
-    get :index
+    get delivery_notes_url
     assert_response :success
     assert_select 'td', text: 'DRAFT-NO-DATE'
   end
 
   test "should show delivery note" do
-    get :show, params: { id: delivery_notes(:published_delivery_note) }
+    get delivery_note_url(delivery_notes(:published_delivery_note))
     assert_response :success
   end
 
   test "should get new" do
-    get :new
+    get new_delivery_note_url
     assert_response :success
   end
 
   test "should create delivery note" do
     assert_difference('DeliveryNote.count') do
-      post :create, params: {
+      post delivery_notes_url, params: {
         delivery_note: {
           customer_id: customers(:good_eu).id,
           project_id: projects(:one).id,
@@ -75,7 +75,7 @@ class DeliveryNotesControllerTest < ActionController::TestCase
       }
     end
 
-    assert_redirected_to delivery_note_path(DeliveryNote.last)
+    assert_redirected_to delivery_note_url(DeliveryNote.last)
 
     delivery_note = DeliveryNote.last
     assert_equal Date.new(2025, 5, 1), delivery_note.delivery_start_date
@@ -84,50 +84,49 @@ class DeliveryNotesControllerTest < ActionController::TestCase
   end
 
   test "should get edit" do
-    get :edit, params: { id: delivery_notes(:draft_delivery_note) }
+    get edit_delivery_note_url(delivery_notes(:draft_delivery_note))
     assert_response :success
   end
 
   test "should update delivery note" do
-    patch :update, params: {
-      id: delivery_notes(:draft_delivery_note),
+    patch delivery_note_url(delivery_notes(:draft_delivery_note)), params: {
       delivery_note: { cust_reference: "UPDATED-REF" }
     }
-    assert_redirected_to delivery_note_path(DeliveryNote.last)
+    assert_redirected_to delivery_note_url(DeliveryNote.last)
   end
 
   test "should destroy delivery note" do
     assert_difference('DeliveryNote.count', -1) do
-      delete :destroy, params: { id: delivery_notes(:draft_delivery_note) }
+      delete delivery_note_url(delivery_notes(:draft_delivery_note))
     end
 
-    assert_redirected_to delivery_notes_path
+    assert_redirected_to delivery_notes_url
   end
 
   test "should not destroy published delivery note" do
     assert_no_difference('DeliveryNote.count') do
-      delete :destroy, params: { id: delivery_notes(:published_delivery_note) }
+      delete delivery_note_url(delivery_notes(:published_delivery_note))
     end
 
-    assert_redirected_to delivery_notes_path
+    assert_redirected_to delivery_notes_url
     assert_match 'cannot be deleted', flash[:alert]
   end
 
   test "should get preview pdf" do
-    get :preview, params: { id: delivery_notes(:draft_delivery_note) }
+    get preview_delivery_note_url(delivery_notes(:draft_delivery_note))
     assert_response :success
     assert_equal 'application/pdf', response.content_type
   end
 
   test "should get pdf for published delivery note" do
-    get :pdf, params: { id: delivery_notes(:published_delivery_note) }
+    get pdf_delivery_note_url(delivery_notes(:published_delivery_note))
     assert_response :success
     assert_equal 'application/pdf', response.content_type
   end
 
   test "should not get pdf for draft delivery note" do
-    get :pdf, params: { id: delivery_notes(:draft_delivery_note) }
-    assert_redirected_to delivery_note_path(delivery_notes(:draft_delivery_note))
+    get pdf_delivery_note_url(delivery_notes(:draft_delivery_note))
+    assert_redirected_to delivery_note_url(delivery_notes(:draft_delivery_note))
     assert_match 'Draft delivery notes can not be used for this action', flash[:error]
   end
 
@@ -135,8 +134,8 @@ class DeliveryNotesControllerTest < ActionController::TestCase
     published_note = delivery_notes(:published_delivery_note)
     original_document_number = published_note.document_number
 
-    post :unpublish, params: { id: published_note }
-    assert_redirected_to delivery_note_path(published_note)
+    post unpublish_delivery_note_url(published_note)
+    assert_redirected_to delivery_note_url(published_note)
 
     published_note.reload
     assert_not published_note.published?
@@ -146,8 +145,8 @@ class DeliveryNotesControllerTest < ActionController::TestCase
   end
 
   test "should not unpublish draft delivery note" do
-    post :unpublish, params: { id: delivery_notes(:draft_delivery_note) }
-    assert_redirected_to delivery_note_path(delivery_notes(:draft_delivery_note))
+    post unpublish_delivery_note_url(delivery_notes(:draft_delivery_note))
+    assert_redirected_to delivery_note_url(delivery_notes(:draft_delivery_note))
     assert_match 'Draft delivery notes can not be used for this action', flash[:error]
   end
 
@@ -161,8 +160,8 @@ class DeliveryNotesControllerTest < ActionController::TestCase
     published_note = delivery_notes(:published_delivery_note)
     assert_nil published_note.acceptance_attachment
 
-    post :upload_acceptance, params: { id: published_note, acceptance_pdf: pdf_file }
-    assert_redirected_to delivery_note_path(published_note)
+    post upload_acceptance_delivery_note_url(published_note), params: { acceptance_pdf: pdf_file }
+    assert_redirected_to delivery_note_url(published_note)
 
     published_note.reload
     assert published_note.acceptance_attachment.present?
@@ -177,8 +176,8 @@ class DeliveryNotesControllerTest < ActionController::TestCase
       original_filename: 'test.txt'
     )
 
-    post :upload_acceptance, params: { id: delivery_notes(:published_delivery_note), acceptance_pdf: text_file }
-    assert_redirected_to delivery_note_path(delivery_notes(:published_delivery_note))
+    post upload_acceptance_delivery_note_url(delivery_notes(:published_delivery_note)), params: { acceptance_pdf: text_file }
+    assert_redirected_to delivery_note_url(delivery_notes(:published_delivery_note))
     assert_match 'Only PDF files are allowed', flash[:error]
   end
 
@@ -191,7 +190,7 @@ class DeliveryNotesControllerTest < ActionController::TestCase
       tax_class.indicator_code = 'STD'
     end
 
-    post :convert_to_invoice, params: { id: published_note }
+    post convert_to_invoice_delivery_note_url(published_note)
 
     published_note.reload
 
@@ -219,19 +218,19 @@ class DeliveryNotesControllerTest < ActionController::TestCase
     published_note.update!(invoice: invoice)
 
     assert_no_difference('Invoice.count') do
-      post :convert_to_invoice, params: { id: published_note }
+      post convert_to_invoice_delivery_note_url(published_note)
     end
 
-    assert_redirected_to delivery_note_path(published_note)
+    assert_redirected_to delivery_note_url(published_note)
     assert_match 'already been converted', flash[:error]
   end
 
   test "should not convert draft delivery note to invoice" do
     assert_no_difference('Invoice.count') do
-      post :convert_to_invoice, params: { id: delivery_notes(:draft_delivery_note) }
+      post convert_to_invoice_delivery_note_url(delivery_notes(:draft_delivery_note))
     end
 
-    assert_redirected_to delivery_note_path(delivery_notes(:draft_delivery_note))
+    assert_redirected_to delivery_note_url(delivery_notes(:draft_delivery_note))
     assert_match 'Draft delivery notes can not be used for this action', flash[:error]
   end
 
@@ -243,7 +242,7 @@ class DeliveryNotesControllerTest < ActionController::TestCase
       Rails.root.join('test', 'fixtures', 'files', 'example_logo.pdf'),
       'application/pdf'
     )
-    post :upload_acceptance, params: { id: published_note, acceptance_pdf: first_pdf }
+    post upload_acceptance_delivery_note_url(published_note), params: { acceptance_pdf: first_pdf }
 
     published_note.reload
     original_attachment_id = published_note.acceptance_attachment.id
@@ -255,7 +254,7 @@ class DeliveryNotesControllerTest < ActionController::TestCase
       original_filename: 'replacement.pdf'
     )
 
-    post :upload_acceptance, params: { id: published_note, acceptance_pdf: second_pdf }
+    post upload_acceptance_delivery_note_url(published_note), params: { acceptance_pdf: second_pdf }
 
     published_note.reload
     assert published_note.acceptance_attachment.present?
@@ -271,13 +270,13 @@ class DeliveryNotesControllerTest < ActionController::TestCase
       Rails.root.join('test', 'fixtures', 'files', 'example_logo.pdf'),
       'application/pdf'
     )
-    post :upload_acceptance, params: { id: published_note, acceptance_pdf: pdf_file }
+    post upload_acceptance_delivery_note_url(published_note), params: { acceptance_pdf: pdf_file }
 
     published_note.reload
     assert published_note.acceptance_attachment.present?
 
     # Delete the acceptance document
-    post :delete_acceptance, params: { id: published_note }
+    post delete_acceptance_delivery_note_url(published_note)
 
     published_note.reload
     assert_nil published_note.acceptance_attachment
@@ -288,9 +287,9 @@ class DeliveryNotesControllerTest < ActionController::TestCase
     published_note = delivery_notes(:published_delivery_note)
     assert_nil published_note.acceptance_attachment
 
-    post :delete_acceptance, params: { id: published_note }
+    post delete_acceptance_delivery_note_url(published_note)
 
-    assert_redirected_to delivery_note_path(published_note)
+    assert_redirected_to delivery_note_url(published_note)
     assert_match 'No acceptance document to delete', flash[:error]
   end
 
@@ -303,7 +302,7 @@ class DeliveryNotesControllerTest < ActionController::TestCase
       'application/pdf',
       original_filename: 'signed_acceptance.pdf'
     )
-    post :upload_acceptance, params: { id: published_note, acceptance_pdf: pdf_file }
+    post upload_acceptance_delivery_note_url(published_note), params: { acceptance_pdf: pdf_file }
 
     published_note.reload
     assert published_note.acceptance_attachment.present?
@@ -314,7 +313,7 @@ class DeliveryNotesControllerTest < ActionController::TestCase
     end
 
     # Convert to invoice
-    post :convert_to_invoice, params: { id: published_note }
+    post convert_to_invoice_delivery_note_url(published_note)
 
     published_note.reload
     assert published_note.invoice.present?
@@ -325,12 +324,12 @@ class DeliveryNotesControllerTest < ActionController::TestCase
   end
 
   test "should get email preview" do
-    get :preview_email, params: { id: delivery_notes(:published_delivery_note) }
+    get preview_email_delivery_note_url(delivery_notes(:published_delivery_note))
     assert_response :success
   end
 
   test "should get email preview json" do
-    get :preview_email, params: { id: delivery_notes(:published_delivery_note) }, format: :json
+    get preview_email_delivery_note_url(delivery_notes(:published_delivery_note), format: :json)
     assert_response :success
     json_response = JSON.parse(response.body)
     assert json_response.key?('subject')
@@ -340,14 +339,14 @@ class DeliveryNotesControllerTest < ActionController::TestCase
   test "should bulk send emails to selected delivery notes" do
     published_note = delivery_notes(:published_delivery_note)
 
-    post :bulk_send_emails, params: { delivery_note_ids: [published_note.id] }
-    assert_redirected_to delivery_notes_path
+    post bulk_send_emails_delivery_notes_url, params: { delivery_note_ids: [published_note.id] }
+    assert_redirected_to delivery_notes_url
     assert_match '1 emails queued for sending', flash[:notice]
   end
 
   test "should not bulk send emails if no delivery notes selected" do
-    post :bulk_send_emails, params: { delivery_note_ids: [] }
-    assert_redirected_to delivery_notes_path
+    post bulk_send_emails_delivery_notes_url, params: { delivery_note_ids: [] }
+    assert_redirected_to delivery_notes_url
     assert_match 'No delivery notes selected', flash[:alert]
   end
 
@@ -357,8 +356,8 @@ class DeliveryNotesControllerTest < ActionController::TestCase
     note1 = create_published_delivery_note(customer: customer, document_number: "DN-2025-002", cust_reference: "BULK-TEST-1")
     note2 = create_published_delivery_note(customer: customer, document_number: "DN-2025-003", cust_reference: "BULK-TEST-2")
 
-    post :bulk_send_emails, params: { delivery_note_ids: [note1.id, note2.id] }
-    assert_redirected_to delivery_notes_path
+    post bulk_send_emails_delivery_notes_url, params: { delivery_note_ids: [note1.id, note2.id] }
+    assert_redirected_to delivery_notes_url
     assert_match '2 emails queued for sending', flash[:notice]
   end
 
@@ -366,8 +365,8 @@ class DeliveryNotesControllerTest < ActionController::TestCase
     note1 = delivery_notes(:published_delivery_note)  # good_eu customer
     note2 = create_published_delivery_note(customer: customers(:good_national), document_number: "DN-2025-004", cust_reference: "DIFF-CUSTOMER")
 
-    post :bulk_send_emails, params: { delivery_note_ids: [note1.id, note2.id] }
-    assert_redirected_to delivery_notes_path
+    post bulk_send_emails_delivery_notes_url, params: { delivery_note_ids: [note1.id, note2.id] }
+    assert_redirected_to delivery_notes_url
     assert_match '2 emails queued for sending', flash[:notice]
   end
 

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
 
-class HomeControllerTest < ActionController::TestCase
+class HomeControllerTest < ActionDispatch::IntegrationTest
   test "should display home page with business statistics and dashboard" do
-    get :index
+    get root_url
     assert_response :success
     assert_select 'h1', text: 'Business Dashboard'
 
@@ -31,7 +31,7 @@ class HomeControllerTest < ActionController::TestCase
     SalesTaxCustomerClass.delete_all
     SalesTaxProductClass.delete_all
 
-    get :index
+    get root_url
     assert_response :success
     assert_select '.alert-warning h5', text: 'Quick Setup Required'
   end

--- a/test/controllers/invoices_controller_test.rb
+++ b/test/controllers/invoices_controller_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
 
-class InvoicesControllerTest < ActionController::TestCase
+class InvoicesControllerTest < ActionDispatch::IntegrationTest
   test "should get index" do
-    get :index
+    get invoices_url
     assert_response :success
   end
 
@@ -23,12 +23,12 @@ class InvoicesControllerTest < ActionController::TestCase
     )
 
     # Test current year (default)
-    get :index
+    get invoices_url
     assert_response :success
     assert_select '.year-pagination'
 
     # Test specific year filter
-    get :index, params: { year: 2023 }
+    get invoices_url(year: 2023)
     assert_response :success
     # Verify the page contains the 2023 invoice reference but not 2024
     assert_select 'td', text: '2023-TEST'
@@ -55,26 +55,26 @@ class InvoicesControllerTest < ActionController::TestCase
     )
 
     # Test current year (should include draft invoice)
-    get :index, params: { year: current_year }
+    get invoices_url(year: current_year)
     assert_response :success
     assert_select 'td', text: 'DRAFT-NO-DATE'  # Draft should appear
     assert_select 'td', text: 'OLD-BOOKED', count: 0  # Old invoice should not appear
 
     # Test previous year (should include old invoice, not draft)
-    get :index, params: { year: current_year - 1 }
+    get invoices_url(year: current_year - 1)
     assert_response :success
     assert_select 'td', text: 'OLD-BOOKED'  # Old invoice should appear
     assert_select 'td', text: 'DRAFT-NO-DATE', count: 0  # Draft should not appear in old year
   end
 
   test "should get new" do
-    get :new
+    get new_invoice_url
     assert_response :success
   end
 
   test "should create invoice" do
     assert_difference('Invoice.count') do
-      post :create, params: {
+      post invoices_url, params: {
         invoice: {
           customer_id: customers(:good_eu).id,
           project_id: projects(:test_project).id,
@@ -93,7 +93,7 @@ class InvoicesControllerTest < ActionController::TestCase
       project: projects(:test_project),
       cust_reference: "TEST"
     )
-    get :show, params: { id: invoice.id }
+    get invoice_url(invoice)
     assert_response :success
   end
 
@@ -130,7 +130,7 @@ class InvoicesControllerTest < ActionController::TestCase
     tax_class.net = 200.0
     tax_class.save!
 
-    get :show, params: { id: invoice.id }
+    get invoice_url(invoice)
     assert_response :success
     assert_select 'table.table-bordered'
     assert_select '.badge.bg-success', text: 'Booked'
@@ -156,7 +156,7 @@ class InvoicesControllerTest < ActionController::TestCase
       position: 1
     )
 
-    get :show, params: { id: invoice.id }
+    get invoice_url(invoice)
     assert_response :success
     assert_select '.badge.bg-warning', text: 'Draft'
   end
@@ -167,7 +167,7 @@ class InvoicesControllerTest < ActionController::TestCase
       project: projects(:test_project),
       cust_reference: "TEST"
     )
-    get :edit, params: { id: invoice.id }
+    get edit_invoice_url(invoice)
     assert_response :success
   end
 
@@ -196,7 +196,7 @@ class InvoicesControllerTest < ActionController::TestCase
       position: 2
     )
 
-    get :edit, params: { id: invoice.id }
+    get edit_invoice_url(invoice)
     assert_response :success
   end
 
@@ -207,8 +207,7 @@ class InvoicesControllerTest < ActionController::TestCase
       cust_reference: "TEST"
     )
 
-    put :update, params: {
-      id: invoice.id,
+    patch invoice_url(invoice), params: {
       invoice: {
         cust_reference: "UPDATED_REF",
         invoice_lines_attributes: {
@@ -231,7 +230,7 @@ class InvoicesControllerTest < ActionController::TestCase
       }
     }
 
-    assert_redirected_to invoice_path(invoice)
+    assert_redirected_to invoice_url(invoice)
     invoice.reload
     assert_equal "UPDATED_REF", invoice.cust_reference
     assert_equal 2, invoice.invoice_lines.count
@@ -251,8 +250,7 @@ class InvoicesControllerTest < ActionController::TestCase
       cust_reference: "TEST"
     )
 
-    put :update, params: {
-      id: invoice.id,
+    patch invoice_url(invoice), params: {
       invoice: {
         customer_id: nil, # This should cause validation error
         cust_reference: "INVALID"
@@ -280,9 +278,9 @@ class InvoicesControllerTest < ActionController::TestCase
       position: 1
     )
 
-    post :book, params: { id: invoice.id, save: false }
+    post book_invoice_url(invoice), params: { save: false }
 
-    assert_redirected_to book_invoice_path(invoice)
+    assert_redirected_to book_invoice_url(invoice)
     invoice.reload
 
     # Verify that test booking calculated and persisted totals
@@ -310,7 +308,7 @@ class InvoicesControllerTest < ActionController::TestCase
     )
 
     # Run test booking first time to create tax classes
-    put :update, params: { id: invoice.id, invoice: { cust_reference: "NEW_REF" } }
+    patch invoice_url(invoice), params: { invoice: { cust_reference: "NEW_REF" } }
     invoice.reload
 
     # Remember the tax class ID
@@ -321,7 +319,7 @@ class InvoicesControllerTest < ActionController::TestCase
     invoice.invoice_lines.first.update!(quantity: 3.0)
 
     # Run test booking again - should reuse existing tax class
-    put :update, params: { id: invoice.id, invoice: { cust_reference: "NEW_REF2" } }
+    patch invoice_url(invoice), params: { invoice: { cust_reference: "NEW_REF2" } }
     invoice.reload
 
     # Verify the tax class was updated, not recreated
@@ -350,7 +348,7 @@ class InvoicesControllerTest < ActionController::TestCase
     )
 
     # Update with national customer to calculate initial taxes
-    put :update, params: { id: invoice.id, invoice: { cust_reference: "TAX_TEST_NATIONAL" } }
+    patch invoice_url(invoice), params: { invoice: { cust_reference: "TAX_TEST_NATIONAL" } }
     invoice.reload
 
     # Verify national customer has 20% tax
@@ -361,8 +359,7 @@ class InvoicesControllerTest < ActionController::TestCase
     assert_equal 40.0, tax_class.value, "Tax value should be 40.0"
 
     # Now change to EU customer (0% tax)
-    put :update, params: {
-      id: invoice.id,
+    patch invoice_url(invoice), params: {
       invoice: {
         customer_id: customers(:good_eu).id,
         cust_reference: "TAX_TEST_EU"
@@ -400,9 +397,9 @@ class InvoicesControllerTest < ActionController::TestCase
     end
 
     # Test booking should work without cookie overflow
-    post :book, params: { id: invoice.id, save: false }
+    post book_invoice_url(invoice), params: { save: false }
 
-    assert_redirected_to book_invoice_path(invoice)
+    assert_redirected_to book_invoice_url(invoice)
 
     # Verify flash data was set instead of session data to avoid cookie overflow
     assert flash[:booking_success].present?, "Flash should contain booking success status"
@@ -410,7 +407,7 @@ class InvoicesControllerTest < ActionController::TestCase
     assert flash[:notice].include?('succeeded'), "Flash notice should indicate success"
 
     # Test the GET request to the booking results page
-    get :book, params: { id: invoice.id }
+    get book_invoice_url(invoice)
     assert_response :success
 
     # Verify booking log is accessible and contains expected information
@@ -450,16 +447,16 @@ class InvoicesControllerTest < ActionController::TestCase
 
     # Book each invoice in sequence, simulating rapid successive bookings
     invoices.each_with_index do |invoice, index|
-      post :book, params: { id: invoice.id, save: false }
+      post book_invoice_url(invoice), params: { save: false }
 
-      assert_redirected_to book_invoice_path(invoice), "Invoice #{index + 1} booking should redirect"
+      assert_redirected_to book_invoice_url(invoice), "Invoice #{index + 1} booking should redirect"
 
       # Verify booking succeeded
       assert flash[:booking_success].present?, "Invoice #{index + 1} booking should succeed"
       assert flash[:notice].present?, "Invoice #{index + 1} should have booking notice"
 
       # Make a GET request to the booking result page
-      get :book, params: { id: invoice.id }
+      get book_invoice_url(invoice)
       assert_response :success, "Should be able to view booking results for invoice #{index + 1}"
 
       # Check that booking log is available in cache storage
@@ -487,10 +484,10 @@ class InvoicesControllerTest < ActionController::TestCase
     )
 
     # Direct GET request without prior POST booking
-    get :book, params: { id: invoice.id }
+    get book_invoice_url(invoice)
 
     # Should redirect to the invoice show page since there's no flash data
-    assert_redirected_to invoice_path(invoice)
+    assert_redirected_to invoice_url(invoice)
   end
 
 end

--- a/test/controllers/products_controller_test.rb
+++ b/test/controllers/products_controller_test.rb
@@ -1,13 +1,13 @@
 require 'test_helper'
 
-class ProductsControllerTest < ActionController::TestCase
+class ProductsControllerTest < ActionDispatch::IntegrationTest
   test "should get index" do
-    get :index
+    get products_url
     assert_response :success
   end
 
   test "should get new" do
-    get :new
+    get new_product_url
     assert_response :success
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -58,10 +58,6 @@ class ActionDispatch::IntegrationTest
   include TestAuthHelpers
 end
 
-class ActionController::TestCase
-  include TestAuthHelpers
-end
-
 class ActionDispatch::SystemTestCase
   include TestAuthHelpers
 end


### PR DESCRIPTION
## Summary
- Finishes the half-done migration: the four remaining controller tests under `test/functional/` were still using the deprecated `ActionController::TestCase` base class with symbol-action syntax (`get :index`, `post :create, params: { id: ... }`, etc.).
- They now use `ActionDispatch::IntegrationTest` with path helpers and live under `test/controllers/` like the rest of the controller tests.
- `test_helper.rb` no longer includes `TestAuthHelpers` into `ActionController::TestCase`, and the empty `test/functional/` directory is removed.

## Test plan
- [x] `bundle exec rails test` — 345 runs, 1425 assertions, 0 failures, 0 errors, 0 skips
- [x] `pre-commit run --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)