### PR TITLE
Fix Lint/UselessAssignment offenses surfaced by Code Quality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 
 # Ignore bundler config
 /.bundle
+# Ignore bundler-generated binstubs
+/bin/rubocop
 
 # Ignore the default SQLite database.
 /db/*.sqlite3*

--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,8 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
+
+  gem "rubocop", require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     android_key_attestation (0.3.0)
+    ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
     bindata (2.5.1)
@@ -178,6 +179,8 @@ GEM
     json (2.19.5)
     jwt (3.2.0)
       base64
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.25.1)
       crass (~> 1.0.2)
@@ -235,6 +238,10 @@ GEM
     openssl-signature_algorithm (1.3.0)
       openssl (> 2.0)
     ostruct (0.6.3)
+    parallel (2.1.0)
+    parser (3.3.11.1)
+      ast (~> 2.4.1)
+      racc
     pg (1.6.3)
     pg (1.6.3-aarch64-linux)
     pg (1.6.3-aarch64-linux-musl)
@@ -295,6 +302,7 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       tsort (>= 0.2)
       zeitwerk (~> 2.6)
+    rainbow (3.1.1)
     rake (13.3.1)
     rdoc (7.2.0)
       erb
@@ -303,6 +311,21 @@ GEM
     regexp_parser (2.11.0)
     reline (0.6.3)
       io-console (~> 0.5)
+    rubocop (1.86.2)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (>= 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.49.1)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
     ruby-vips (2.3.0)
       ffi (~> 1.12)
       logger
@@ -366,6 +389,9 @@ GEM
       railties (>= 7.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
     uri (1.1.1)
     useragent (0.16.11)
     web-console (4.3.0)
@@ -419,6 +445,7 @@ DEPENDENCIES
   puma (>= 6.0)
   rack-attack (~> 6.7)
   rails (~> 8.1.3)
+  rubocop
   sass-rails
   simple_form
   solid_cache

--- a/app/extras/rfc4648_base32.rb
+++ b/app/extras/rfc4648_base32.rb
@@ -1,6 +1,6 @@
 class Rfc4648Base32
   def self.i_to_s(val)
-    val.to_s(base=32).tr('0123456789abcdefghijklmnopqrstuv', 'abcdefghijklmnopqrstuvwxyz234567')
+    val.to_s(32).tr('0123456789abcdefghijklmnopqrstuv', 'abcdefghijklmnopqrstuvwxyz234567')
   end
 
   def self.s_to_i(val)

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -83,7 +83,6 @@ private
 
     self.setup_tax_classes
     self.invoice_tax_classes.records  # ensure invoice_tax_classes is loaded
-    modified_itcs = []
     valid = true
 
     # Reset all tax class sums before recalculating

--- a/app/services/fop_renderer.rb
+++ b/app/services/fop_renderer.rb
@@ -72,7 +72,7 @@ class FopRenderer
 
       fop_result = nil
       exit_status = nil
-      IO.popen(fop_command, mode="r", :err=>[:child, :out]) do |fop_io|
+      IO.popen(fop_command, "r", :err=>[:child, :out]) do |fop_io|
         fop_result = fop_io.read
         fop_io.close
         exit_status = $?.exitstatus

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -172,12 +172,12 @@ if Rails.env.development?
     project.bill_to_customer = nil  # Reusable project
   end
 
-  maintenance_project = Project.find_or_create_by(matchcode: 'MAINT') do |project|
+  Project.find_or_create_by(matchcode: 'MAINT') do |project|
     project.description = 'System Maintenance & Support'
     project.bill_to_customer = nil  # Reusable project
   end
 
-  research_project = Project.find_or_create_by(matchcode: 'RESEARCH') do |project|
+  Project.find_or_create_by(matchcode: 'RESEARCH') do |project|
     project.description = 'R&D and Technology Research'
     project.bill_to_customer = nil  # Reusable project
   end

--- a/test/controllers/customers_controller_test.rb
+++ b/test/controllers/customers_controller_test.rb
@@ -83,7 +83,7 @@ class CustomersControllerTest < ActionDispatch::IntegrationTest
 
   test "should filter customers by active status and handle index properly" do
     # Create inactive customer
-    inactive = Customer.create!(
+    Customer.create!(
       matchcode: 'INACTIVE',
       name: 'Inactive Customer',
       active: false,

--- a/test/controllers/delivery_notes_controller_test.rb
+++ b/test/controllers/delivery_notes_controller_test.rb
@@ -8,7 +8,7 @@ class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
 
   test "should get index with year filter" do
     # Create delivery notes in different years
-    note_2023 = DeliveryNote.create!(
+    DeliveryNote.create!(
       customer: customers(:good_eu),
       project: projects(:one),
       cust_reference: "2023-TEST",
@@ -16,7 +16,7 @@ class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
       delivery_start_date: Date.new(2023, 6, 15)
     )
 
-    note_2024 = DeliveryNote.create!(
+    DeliveryNote.create!(
       customer: customers(:good_eu),
       project: projects(:one),
       cust_reference: "2024-TEST",
@@ -38,7 +38,7 @@ class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
 
   test "should include draft delivery notes with nil date in current year" do
     # Create a draft delivery note (no date)
-    draft_note = DeliveryNote.create!(
+    DeliveryNote.create!(
       customer: customers(:good_eu),
       project: projects(:one),
       cust_reference: "DRAFT-NO-DATE",
@@ -132,7 +132,6 @@ class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
 
   test "should unpublish delivery note" do
     published_note = delivery_notes(:published_delivery_note)
-    original_document_number = published_note.document_number
 
     post unpublish_delivery_note_url(published_note)
     assert_redirected_to delivery_note_url(published_note)

--- a/test/controllers/invoices_controller_test.rb
+++ b/test/controllers/invoices_controller_test.rb
@@ -8,14 +8,14 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
 
   test "should get index with year filter" do
     # Create invoices in different years
-    invoice_2023 = Invoice.create!(
+    Invoice.create!(
       customer: customers(:good_eu),
       project: projects(:test_project),
       cust_reference: "2023-TEST",
       date: Date.new(2023, 6, 15)
     )
 
-    invoice_2024 = Invoice.create!(
+    Invoice.create!(
       customer: customers(:good_eu),
       project: projects(:test_project),
       cust_reference: "2024-TEST",
@@ -39,7 +39,7 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
     current_year = Date.current.year
 
     # Create a draft invoice (no date)
-    draft_invoice = Invoice.create!(
+    Invoice.create!(
       customer: customers(:good_eu),
       project: projects(:test_project),
       cust_reference: "DRAFT-NO-DATE"
@@ -47,7 +47,7 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
     )
 
     # Create a booked invoice from previous year
-    old_invoice = Invoice.create!(
+    Invoice.create!(
       customer: customers(:good_eu),
       project: projects(:test_project),
       cust_reference: "OLD-BOOKED",

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -14,7 +14,7 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
 
   test "should filter projects by active status and handle index properly" do
     # Create inactive project
-    inactive = Project.create!(
+    Project.create!(
       matchcode: 'INACTIVE',
       description: 'Inactive project',
       active: false,

--- a/test/models/user_session_test.rb
+++ b/test/models/user_session_test.rb
@@ -20,7 +20,7 @@ class UserSessionTest < ActiveSupport::TestCase
   end
 
   test 'active scope excludes terminated and expired' do
-    session, plaintext = UserSession.create_for!(user: users(:alice), request: fake_request)
+    session, _plaintext = UserSession.create_for!(user: users(:alice), request: fake_request)
     assert_includes UserSession.active.to_a, session
     session.update_column(:last_seen_at, 31.days.ago)
     assert_not_includes UserSession.active.to_a, session

--- a/test/system/delivery_note_acceptance_upload_test.rb
+++ b/test/system/delivery_note_acceptance_upload_test.rb
@@ -13,7 +13,7 @@ class DeliveryNoteAcceptanceUploadTest < ApplicationSystemTestCase
     assert_button "Upload PDF"
 
     # Find the file input field - should have no files
-    file_input = find('input[type="file"][name="acceptance_pdf"]', visible: :all)
+    find('input[type="file"][name="acceptance_pdf"]', visible: :all)
 
     # Verify no file is selected initially
     files_count = page.execute_script(<<~JS) || 0
@@ -98,7 +98,7 @@ class DeliveryNoteAcceptanceUploadTest < ApplicationSystemTestCase
     assert_button "Replace"
 
     # Find the file input field - should have no files
-    file_input = find('input[type="file"][name="acceptance_pdf"]', visible: :all)
+    find('input[type="file"][name="acceptance_pdf"]', visible: :all)
 
     # Verify no file is selected initially
     files_count = page.execute_script(<<~JS) || 0

--- a/test/system/line_management_test.rb
+++ b/test/system/line_management_test.rb
@@ -285,7 +285,6 @@ class LineManagementTest < ApplicationSystemTestCase
     visit edit_invoice_path(@invoice)
 
     # Remove existing lines to get down to single line scenario
-    initial_count = all('[data-line-index]').count
     all('[data-line-index]')[1..-1].each do |line|
       within line do
         click_button "🗑"


### PR DESCRIPTION
## Summary

GitHub's Code Quality tab flagged a handful of `rb/useless-assignment-to-local` findings. The REST/GraphQL APIs don't expose those, so this branch wires rubocop into the dev bundle to catch the same class of issue locally, then fixes every `Lint/UselessAssignment` offense (19 in total — 8 from the original list plus 11 more found by sweeping the tree).

Commits are split per region so review can focus on each fix:

- `4702c62` Add rubocop (+ binstub) to the development bundle
- `8fe6a9e` Tests: drop bindings around `create!` / `find` / counts that no assertion read
- `3537922` `Rfc4648Base32`: `val.to_s(base=32)` → `val.to_s(32)` (Python-style keyword arg masquerade)
- `d62d026` `Invoice#update_sums`: drop dead `modified_itcs = []`
- `fcc7cd0` `FopRenderer`: same `mode="r"` Python-style arg in `IO.popen`
- `9c73082` `db/seeds.rb`: drop unused `maintenance_project` / `research_project` locals (kept the `find_or_create_by` calls)

After: `bin/rubocop --only Lint/UselessAssignment` reports 0 offenses across 223 files.

## Test plan

- [x] `bin/rubocop --only Lint/UselessAssignment` → clean
- [x] `bundle exec rails test test/controllers/{projects,customers,invoices,delivery_notes}_controller_test.rb test/models/user_session_test.rb` → 85 runs, 0 failures
- [ ] System tests (`test/system/delivery_note_acceptance_upload_test.rb`, `test/system/line_management_test.rb`) — changes are mechanical drops of unused locals; CI will cover

🤖 Generated with [Claude Code](https://claude.com/claude-code)