### PR TITLE
Hoist SalesTaxProductClass lookup out of convert-to-invoice loop

### DIFF
--- a/app/controllers/delivery_notes_controller.rb
+++ b/app/controllers/delivery_notes_controller.rb
@@ -202,6 +202,8 @@ class DeliveryNotesController < ApplicationController
         prelude: enhanced_prelude
       )
 
+      default_sales_tax_product_class_id = SalesTaxProductClass.first&.id
+
       ActiveRecord::Base.transaction do
         invoice.save!
         # Copy delivery note lines to invoice lines without triggering callbacks that cause issues
@@ -219,7 +221,7 @@ class DeliveryNotesController < ApplicationController
           if dn_line.type == 'item'
             attrs[:quantity] = (dn_line.quantity&.to_f || 1.0).to_f
             attrs[:rate] = 0.01 # Small non-zero rate
-            attrs[:sales_tax_product_class_id] = SalesTaxProductClass.first&.id
+            attrs[:sales_tax_product_class_id] = default_sales_tax_product_class_id
             attrs[:amount] = attrs[:rate] * attrs[:quantity] # Pre-calculate amount
           else
             attrs[:amount] = 0


### PR DESCRIPTION
## Summary
- `DeliveryNotesController#convert_to_invoice` called `SalesTaxProductClass.first&.id` inside the per-line loop, issuing one redundant `SELECT … LIMIT 1` per item line.
- Hoist it into a local before the loop; same row is still picked, just looked up once.
- Flagged by GitHub code scanning ("Database query in a loop") at `app/controllers/delivery_notes_controller.rb:222`.

Out of scope: `SalesTaxProductClass` has no default flag or ordering scope, so picking `.first` is fragile — but that's a separate design call, not what scanning is asking for here.

## Test plan
- [x] `bundle exec rails test test/controllers/delivery_notes_controller_test.rb` — 30 runs, 0 failures (existing `should convert published delivery note to invoice` test pins the behaviour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)