### PR TITLE
Fix db:reset failure and verify dev seeds in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,15 @@ jobs:
         bundle exec rails db:migrate
         bundle exec rails db:seed
 
+    - name: Verify development seeds
+      env:
+        RAILS_ENV: development
+        DATABASE_URL: postgres://postgres:postgres@localhost:5432/abt_development
+      run: |
+        bundle exec rails db:create
+        bundle exec rails db:migrate
+        bundle exec rails db:seed
+
     - name: Run tests
       env:
         RAILS_ENV: test

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -672,8 +672,7 @@ if Rails.env.development?
       date: 5.days.ago.to_date,
       delivery_start_date: 2.weeks.ago.to_date,
       delivery_end_date: 5.days.ago.to_date,
-      published: true,
-      document_number: 'LN20250001'
+      published: false
     )
 
     delivery_note_de.delivery_note_lines.create!(
@@ -705,6 +704,8 @@ if Rails.env.development?
       title: 'Alle Lieferungen wurden termingerecht und entsprechend den Spezifikationen erbracht.',
       position: 4
     )
+
+    delivery_note_de.update!(published: true, document_number: 'LN20250001')
   end
 
   # Update document number sequence for delivery notes


### PR DESCRIPTION
## Summary
- `rails db:reset` aborted because a seeded DeliveryNote set `published: true` before any item lines existed, tripping `must_have_item_line_for_publish`. Fixed by creating it unpublished, adding lines, then updating to `published: true` with the seeded `document_number`.
- Added a CI step that runs `db:create/migrate/seed` under `RAILS_ENV=development`, so failures in the development-only seed block (currently skipped by the test-env CI step) are caught.

## Test plan
- [x] `bundle exec rails db:reset` succeeds locally.
- [ ] CI: new "Verify development seeds" step passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)