### PR TITLE
Replace Rfc4648Base32 with SecureRandom.base58

### DIFF
--- a/app/extras/rfc4648_base32.rb
+++ b/app/extras/rfc4648_base32.rb
@@ -1,9 +1,0 @@
-class Rfc4648Base32
-  def self.i_to_s(val)
-    val.to_s(32).tr('0123456789abcdefghijklmnopqrstuv', 'abcdefghijklmnopqrstuvwxyz234567')
-  end
-
-  def self.s_to_i(val)
-    val.tr('abcdefghijklmnopqrstuvwxyz234567', '0123456789abcdefghijklmnopqrstuv').to_i
-  end
-end

--- a/app/services/invoice_booker.rb
+++ b/app/services/invoice_booker.rb
@@ -61,7 +61,7 @@ class InvoiceBooker
         @invoice.document_number = DocumentNumber.get_next_for 'invoice', @invoice.date
       end
       @log << "Assigned Document Number #{@invoice.document_number}"
-      @invoice.token = Rfc4648Base32.i_to_s((SecureRandom.random_number(100).to_s + (@invoice.customer.id + 100000).to_s + @invoice.document_number.to_s).to_i)
+      @invoice.token = SecureRandom.base58(13)
       @invoice.published = true
       @invoice.save!
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -540,7 +540,7 @@ if Rails.env.development?
     # Set invoice totals and generate token, then publish
     last_year_invoice.sum_net = net_amount
     last_year_invoice.sum_total = net_amount + tax_amount # National customer with 20% VAT
-    last_year_invoice.token = Rfc4648Base32.i_to_s((SecureRandom.random_number(100).to_s + (last_year_invoice.customer.id + 100000).to_s + last_year_invoice.document_number.to_s).to_i)
+    last_year_invoice.token = SecureRandom.base58(13)
     last_year_invoice.published = true # Now publish the invoice
 
     # Create a sample PDF attachment


### PR DESCRIPTION
## Summary

`app/extras/rfc4648_base32.rb` was a 9-line custom class whose only purpose was generating `invoice.token` for payment URLs. Replace both call sites with `SecureRandom.base58(13)` — the same generator `ActiveRecord::SecureToken` uses internally — and drop the class.

This is **not** purely cosmetic. The old construction was

```ruby
@invoice.token = Rfc4648Base32.i_to_s(
  (SecureRandom.random_number(100).to_s +
   (@invoice.customer.id + 100000).to_s +
   @invoice.document_number.to_s).to_i
)
```

That's `random(0..99)` concatenated with customer ID and document number, base32-encoded. Only ~6.6 bits are unpredictable — an attacker who can guess customer/document numbering can enumerate payment URLs. `SecureRandom.base58(13)` gives ~76 bits of entropy in a URL-safe, copy-paste-friendly alphabet.

The other half of the class (`.s_to_i`) was already dead code, and had a real bug: `.to_i` was missing the `(32)` base argument.

The `invoices.token` column has no length cap, uniqueness index, or format validation, so existing tokens stored in the DB stay valid (they're opaque strings to the external payment system).

## Test plan

- [x] `rg Rfc4648Base32` → no hits
- [x] `bundle exec rails test test/services/invoice_booker_test.rb` → 4 runs, 0 failures
- [x] `bin/rubocop --only Lint/UselessAssignment` → 0 offenses across 222 files
- [ ] Smoke: book a draft invoice in console, confirm `invoice.token` is a 13-char base58 string

🤖 Generated with [Claude Code](https://claude.com/claude-code)