### PR TITLE
Mark a default SalesTaxProductClass and use it on conversion

### DIFF
--- a/app/controllers/delivery_notes_controller.rb
+++ b/app/controllers/delivery_notes_controller.rb
@@ -202,7 +202,7 @@ class DeliveryNotesController < ApplicationController
         prelude: enhanced_prelude
       )
 
-      default_sales_tax_product_class_id = SalesTaxProductClass.first&.id
+      default_sales_tax_product_class_id = SalesTaxProductClass.default&.id
 
       ActiveRecord::Base.transaction do
         invoice.save!

--- a/app/controllers/sales_tax_product_classes_controller.rb
+++ b/app/controllers/sales_tax_product_classes_controller.rb
@@ -50,6 +50,6 @@ class SalesTaxProductClassesController < ApplicationController
 
 private
   def sales_tax_product_classes_params
-    params.require(:sales_tax_product_class).permit(:name, :indicator_code)
+    params.require(:sales_tax_product_class).permit(:name, :indicator_code, :is_default)
   end
 end

--- a/app/models/sales_tax_product_class.rb
+++ b/app/models/sales_tax_product_class.rb
@@ -3,4 +3,16 @@ class SalesTaxProductClass < ApplicationRecord
 
   validates :name, :indicator_code, :presence => true
   validates :indicator_code, :uniqueness => true
+
+  before_save :unset_other_defaults, if: -> { is_default? && is_default_changed? }
+
+  def self.default
+    find_by(is_default: true)
+  end
+
+  private
+
+  def unset_other_defaults
+    self.class.where(is_default: true).where.not(id: id).update_all(is_default: false)
+  end
 end

--- a/app/views/sales_tax_product_classes/_form.html.haml
+++ b/app/views/sales_tax_product_classes/_form.html.haml
@@ -17,6 +17,13 @@
       = f.label :indicator_code, class: 'col-sm-3 col-form-label'
       .col-sm-9
         = f.text_field :indicator_code, :class => 'form-control', :placeholder => "A"
+    .row.mb-3
+      .col-sm-9.offset-sm-3
+        .form-check
+          = f.check_box :is_default, class: 'form-check-input'
+          = f.label :is_default, 'Default for new invoice lines', class: 'form-check-label'
+          %small.form-text.text-muted.d-block
+            Used when converting a delivery note to an invoice. Only one class can be the default; setting this will unset any other default.
 
   %br
 

--- a/app/views/sales_tax_product_classes/index.html.haml
+++ b/app/views/sales_tax_product_classes/index.html.haml
@@ -4,6 +4,7 @@
   %tr
     %th Name
     %th Indicator code
+    %th Default
     %th{:width => "3%"}
     %th{:width => "3%"}
 
@@ -11,5 +12,8 @@
     %tr
       %td= sales_tax_product_class.name
       %td= sales_tax_product_class.indicator_code
+      %td
+        - if sales_tax_product_class.is_default?
+          %span.badge.bg-success Default
       %td= list_action_link('Edit', edit_sales_tax_product_class_path(sales_tax_product_class), :edit)
       %td= destroy_link(sales_tax_product_class, "Are you sure you want to delete product class \"#{sales_tax_product_class.name}\"?")

--- a/app/views/sales_tax_product_classes/show.html.haml
+++ b/app/views/sales_tax_product_classes/show.html.haml
@@ -4,6 +4,12 @@
 %p
   %b Indicator code:
   = @sales_tax_product_class.indicator_code
+%p
+  %b Default:
+  - if @sales_tax_product_class.is_default?
+    %span.badge.bg-success Yes
+  - else
+    No
 
 = action_buttons_wrapper do
   = action_button 'Edit', edit_sales_tax_product_class_path(@sales_tax_product_class), :primary

--- a/db/migrate/20260524221140_add_is_default_to_sales_tax_product_classes.rb
+++ b/db/migrate/20260524221140_add_is_default_to_sales_tax_product_classes.rb
@@ -1,0 +1,6 @@
+class AddIsDefaultToSalesTaxProductClasses < ActiveRecord::Migration[8.0]
+  def change
+    add_column :sales_tax_product_classes, :is_default, :boolean, default: false, null: false
+    add_index :sales_tax_product_classes, :is_default, unique: true, where: "is_default = true"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_22_140006) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_24_221140) do
   create_table "attachments", force: :cascade do |t|
     t.string "content_type"
     t.datetime "created_at", null: false
@@ -214,8 +214,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_22_140006) do
   create_table "sales_tax_product_classes", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "indicator_code"
+    t.boolean "is_default", default: false, null: false
     t.string "name"
     t.datetime "updated_at", null: false
+    t.index ["is_default"], name: "index_sales_tax_product_classes_on_is_default", unique: true, where: "is_default = true"
   end
 
   create_table "sales_tax_rates", force: :cascade do |t|

--- a/test/controllers/delivery_notes_controller_test.rb
+++ b/test/controllers/delivery_notes_controller_test.rb
@@ -184,20 +184,9 @@ class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
     published_note = delivery_notes(:published_delivery_note)
     assert_nil published_note.invoice
 
-    # Ensure there's a sales tax product class for the conversion
-    SalesTaxProductClass.find_or_create_by(name: 'Standard') do |tax_class|
-      tax_class.indicator_code = 'STD'
-    end
-
     post convert_to_invoice_delivery_note_url(published_note)
 
     published_note.reload
-
-    # Debug what happened
-    if published_note.invoice.nil?
-      puts "Flash error: #{flash[:error]}"
-      puts "Flash success: #{flash[:success]}"
-    end
 
     assert published_note.invoice.present?, "Invoice should have been created and linked"
     assert_not published_note.invoice.published?
@@ -208,6 +197,24 @@ class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
     # Check that the enhanced prelude includes delivery note information
     assert_match "Based on Delivery Note #{published_note.document_number}", published_note.invoice.prelude
     assert_match "Delivery Note Date:", published_note.invoice.prelude
+  end
+
+  test "convert_to_invoice uses the default sales tax product class for item lines" do
+    published_note = delivery_notes(:published_delivery_note)
+    default_class = sales_tax_product_classes(:standard)
+    assert default_class.is_default?
+
+    # Add a non-default class to make sure the default is selected, not just any row.
+    SalesTaxProductClass.create!(name: "Reduced", indicator_code: "RED", is_default: false)
+
+    post convert_to_invoice_delivery_note_url(published_note)
+
+    published_note.reload
+    item_lines = published_note.invoice.invoice_lines.where(type: 'item')
+    assert item_lines.any?, "expected at least one item line on the converted invoice"
+    item_lines.each do |line|
+      assert_equal default_class.id, line.sales_tax_product_class_id
+    end
   end
 
   test "should not convert delivery note to invoice twice" do

--- a/test/fixtures/sales_tax_product_classes.yml
+++ b/test/fixtures/sales_tax_product_classes.yml
@@ -1,2 +1,4 @@
 standard:
   name: Standard Goods
+  indicator_code: STD
+  is_default: true

--- a/test/models/sales_tax_product_class_test.rb
+++ b/test/models/sales_tax_product_class_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+class SalesTaxProductClassTest < ActiveSupport::TestCase
+  test "default returns the row flagged as default" do
+    assert_equal sales_tax_product_classes(:standard), SalesTaxProductClass.default
+  end
+
+  test "default returns nil when no row is flagged" do
+    SalesTaxProductClass.update_all(is_default: false)
+    assert_nil SalesTaxProductClass.default
+  end
+
+  test "setting a new default unsets the previous default" do
+    previous_default = sales_tax_product_classes(:standard)
+    assert previous_default.is_default?
+
+    new_default = SalesTaxProductClass.create!(name: "Reduced", indicator_code: "RED", is_default: true)
+
+    assert SalesTaxProductClass.find(new_default.id).is_default?
+    assert_not previous_default.reload.is_default?
+  end
+
+  test "leaving is_default unchanged on save does not touch siblings" do
+    other = SalesTaxProductClass.create!(name: "Other", indicator_code: "OTH", is_default: false)
+    default = sales_tax_product_classes(:standard)
+
+    other.update!(name: "Other Renamed")
+
+    assert default.reload.is_default?
+  end
+end


### PR DESCRIPTION
## Summary
- Adds a `is_default` boolean to `sales_tax_product_classes` with a partial unique index (`WHERE is_default = true`) so at most one row is the default.
- Admin UI: checkbox + help text on the form, "Default" column on the index, Default line on show, `:is_default` in strong params.
- `SalesTaxProductClass.default` class method + `before_save` callback that unsets any prior default when a new one is set, so flipping the flag is a single user action.
- `DeliveryNotesController#convert_to_invoice` now uses `SalesTaxProductClass.default&.id` instead of `.first&.id`, replacing the ID-order coincidence with an explicit choice.

## Test plan
- [x] `bundle exec rails test` — 346 runs, 0 failures.
- New model test covers `.default` lookup, sibling-unset on toggle, no-op on unrelated saves.
- New controller test pins that conversion picks the default-flagged class when multiple are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)