### PR TITLE
Pin FOP font cache to tmp/ so it stops leaking into lib/foptemplate

### DIFF
--- a/app/services/fop_renderer.rb
+++ b/app/services/fop_renderer.rb
@@ -18,6 +18,11 @@ class FopRenderer
     @rails_tmp = Rails.root.join('tmp')
     @template_path = Rails.root.join('lib', 'foptemplate')
     @fop_conf = @template_path.join('fop-conf.xml')
+    # Pin the font cache to tmp/. Otherwise FOP writes it relative to
+    # <base>.</base> in fop-conf.xml, which resolves to the cwd we set in
+    # build_fop_command (lib/foptemplate/), leaving an untracked .fop/
+    # directory in the source tree after every render.
+    @fop_cache = @rails_tmp.join('fop-fonts.cache')
   end
 
   def render_pdf_with_logo(xsl_template, logo_data = nil)
@@ -115,7 +120,8 @@ class FopRenderer
   def build_fop_command(fop_binary, xml_path, xsl_path, pdf_path)
     "cd \"#{@template_path}\" && " +
     "\"#{fop_binary}\" " +
-    "-xml \"#{xml_path}\" -xsl \"#{xsl_path}\" -pdf \"#{pdf_path}\" -c \"#{@fop_conf}\""
+    "-xml \"#{xml_path}\" -xsl \"#{xsl_path}\" -pdf \"#{pdf_path}\" -c \"#{@fop_conf}\" " +
+    "-cache \"#{@fop_cache}\""
   end
 
   # Write file with explicit permissions to work around restrictive umask


### PR DESCRIPTION
## Summary

- `FopRenderer` cd's into `lib/foptemplate/` before invoking FOP (necessary so the relative `embed-url` font paths in `fop-conf.xml` resolve). Combined with `<base>.</base>` in that config, FOP wrote its font cache to `lib/foptemplate/.fop/fop-fonts.cache` after every render, leaving an untracked directory in the source tree.
- Pass `-cache <Rails.root>/tmp/fop-fonts.cache` on the FOP CLI so the cache lives in the already-gitignored `tmp/` instead. Works identically for the container launcher (`bin/abt-fop-container`, used by dev/test/CI) and the native one (`script/abt-fop`, used by prod and the Claude Code sandbox).
- Cache is now persistent across runs in every environment — small perf win for repeated FOP invocations.

## Test plan

- [x] `bundle exec rails test test/services/fop_renderer_test.rb` — 3 runs, 14 assertions, 0 failures
- [x] `bundle exec rails test test/integration/pdf_generation_test.rb test/integration/delivery_note_pdf_test.rb test/integration/fop_installation_test.rb` — 16 runs, 74 assertions, 0 failures
- [x] `ls lib/foptemplate/.fop` after a full FOP render — no such file (was previously created on every run)
- [x] `ls tmp/fop-fonts.cache` after a render — exists, ~9.7 KB

🤖 Generated with [Claude Code](https://claude.com/claude-code)