### PR TITLE
Two security hardening fixes from crypto audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,22 @@ jobs:
       run: |
         HEADLESS=1 bundle exec rails test:system --verbose
 
+  brakeman:
+    name: Brakeman
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.3'
+        bundler-cache: true
+
+    - name: Run Brakeman
+      run: bundle exec brakeman --no-pager --exit-on-warn --exit-on-error
+
   stimulus-memory-leak-check:
     name: Stimulus Memory Leak Check
     runs-on: ubuntu-latest

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -92,7 +92,7 @@ class InvitesController < ApplicationController
 
   def complete_signup
     pending = session[:webauthn_signup]
-    if pending.blank? || pending['invite_token'] != params[:token]
+    unless invite_token_matches?(pending)
       return render json: { error: 'No signup in progress' }, status: :unprocessable_content
     end
 
@@ -145,7 +145,7 @@ class InvitesController < ApplicationController
 
   def complete_passkey_reset
     pending = session[:webauthn_passkey_reset]
-    if pending.blank? || pending['invite_token'] != params[:token]
+    unless invite_token_matches?(pending)
       return render json: { error: 'No passkey reset in progress' }, status: :unprocessable_content
     end
 
@@ -190,6 +190,14 @@ class InvitesController < ApplicationController
     render json: { redirect_url: account_profile_path }
   rescue ActiveRecord::RecordInvalid => e
     render json: { error: e.record.errors.full_messages.join(', ') }, status: :unprocessable_content
+  end
+
+  def invite_token_matches?(pending)
+    return false if pending.blank?
+    session_token = pending['invite_token']
+    supplied = params[:token]
+    return false if session_token.blank? || supplied.blank?
+    ActiveSupport::SecurityUtils.secure_compare(session_token, supplied)
   end
 
   def signup_form_errors(username, full_name, email)


### PR DESCRIPTION
## Summary
- Use `ActiveSupport::SecurityUtils.secure_compare` instead of `==` when matching the pending invite token in the WebAuthn signup/passkey-reset flows. The compared value is server-side session state, so this is defense-in-depth, not a fix for an exploitable timing attack.
- Run Brakeman in CI. The gem was already in `:development, :test` but never invoked; this adds a dedicated `brakeman` job that runs `bundle exec brakeman --no-pager --exit-on-warn --exit-on-error` on every push and PR. Currently reports 0 warnings against the branch.

Both commits arose from an audit for outdated crypto / weak randomness; the audit's third finding (predictable payment-URL token) was already fixed independently in #306.

## Test plan
- [ ] `bundle exec rails test test/services/invoice_booker_test.rb test/controllers/invites_controller_test.rb` passes locally
- [ ] `bundle exec brakeman --no-pager --exit-on-warn --exit-on-error` exits 0 locally
- [ ] CI Brakeman job runs and passes
- [ ] Manual invite signup / passkey reset flow still succeeds end-to-end (no regression from the helper extraction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)