### PR TITLE
Use Rails I18n for date/time formatting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,12 +157,13 @@ For testing against PostgreSQL (matches production environment):
 - This app supports multiple regions - NEVER hardcode currency symbols like $ or USD
 - Use IssuerCompany.currency field for currency configuration (defaults to EUR)
 - Currency formatting handled by ApplicationHelper#format_currency
-- Date formatting via ApplicationHelper#format_date and #format_datetime
+- Date/datetime formatting: use Rails' `l(date)` / `l(time)` in views (or `I18n.l(...)` in controllers/models). Defaults are configured in `config/locales/en.yml` under `date.formats.default` (`%d.%m.%Y`) and `time.formats.default` (`%d.%m.%Y %H:%M`).
 
 ### Formatting Standards
 - ALWAYS use European date formats: DD.MM.YYYY for dates, DD.MM.YYYY HH:MM for datetimes
 - Use DD.MM for short dates when year is implied
 - NEVER use American MM/DD/YYYY or MM-DD formats
+- To render a `datetime` column as date-only (e.g. `email_sent_at` in compact list rows), call `l(value.to_date)` — `l` on a `Time`/`DateTime` produces the time format.
 
 ### UI Helper Methods
 - `action_buttons_wrapper` - Container for action button groups

--- a/app/controllers/delivery_notes_controller.rb
+++ b/app/controllers/delivery_notes_controller.rb
@@ -185,9 +185,9 @@ class DeliveryNotesController < ApplicationController
       # Build enhanced prelude with delivery note information
       delivery_note_info = []
       delivery_note_info << "Based on Delivery Note #{@delivery_note.document_number}"
-      delivery_note_info << "Delivery Note Date: #{format_date(@delivery_note.date)}" if @delivery_note.date
+      delivery_note_info << "Delivery Note Date: #{I18n.l(@delivery_note.date)}" if @delivery_note.date
       if @delivery_note.acceptance_attachment
-        delivery_note_info << "Acceptance Document: #{@delivery_note.acceptance_attachment.filename} (#{format_date(@delivery_note.acceptance_attachment.created_at.to_date)})"
+        delivery_note_info << "Acceptance Document: #{@delivery_note.acceptance_attachment.filename} (#{I18n.l(@delivery_note.acceptance_attachment.created_at.to_date)})"
       end
 
       enhanced_prelude = delivery_note_info.join("\n")

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -158,7 +158,7 @@ class InvoicesController < ApplicationController
     paid_date = params[:paid_at].presence
     @invoice.paid_at = paid_date ? Date.parse(paid_date) : Date.current
     @invoice.save!
-    redirect_to @invoice, notice: "Invoice marked as paid on #{helpers.format_date(@invoice.paid_at)}."
+    redirect_to @invoice, notice: "Invoice marked as paid on #{I18n.l(@invoice.paid_at)}."
   rescue ArgumentError
     redirect_to @invoice, alert: "Invalid date."
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -124,16 +124,6 @@ module ApplicationHelper
     action_button("Cancel", cancel_path, :secondary)
   end
 
-  def format_date(date)
-    return "" if date.nil?
-    date.strftime("%Y-%m-%d")
-  end
-
-  def format_datetime(datetime)
-    return "" if datetime.nil?
-    datetime.strftime("%Y-%m-%d %H:%M")
-  end
-
   def app_version
     Rails.application.config.x.app_version
   end

--- a/app/views/account/audit_events/index.html.haml
+++ b/app/views/account/audit_events/index.html.haml
@@ -13,7 +13,7 @@
   %tbody
     - @audit_events.each do |event|
       %tr
-        %td= format_datetime(event.created_at)
+        %td= l(event.created_at)
         %td
           %code= event.action
         %td= event.actor&.username || '—'

--- a/app/views/account/credentials/index.html.haml
+++ b/app/views/account/credentials/index.html.haml
@@ -13,8 +13,8 @@
     - @credentials.each do |cred|
       %tr
         %td= cred.nickname
-        %td= format_datetime(cred.created_at)
-        %td= cred.last_used_at ? format_datetime(cred.last_used_at) : '—'
+        %td= l(cred.created_at)
+        %td= cred.last_used_at ? l(cred.last_used_at) : '—'
         %td
           - if @credentials.size > 1
             = button_to 'Remove', account_credential_path(cred), method: :delete,

--- a/app/views/account/emails/index.html.haml
+++ b/app/views/account/emails/index.html.haml
@@ -18,7 +18,7 @@
             %span.badge.bg-success Confirmed
           - else
             %span.badge.bg-warning Pending
-        %td= format_datetime(email.created_at)
+        %td= l(email.created_at)
         %td
           - if email.confirmed? && current_user.confirmed_emails.count <= 1
             %span.text-muted.small Only confirmed — add another to remove

--- a/app/views/account/profiles/show.html.haml
+++ b/app/views/account/profiles/show.html.haml
@@ -13,7 +13,7 @@
           %dt.col-sm-4 Full name
           %dd.col-sm-8= @user.full_name
           %dt.col-sm-4 Member since
-          %dd.col-sm-8= format_datetime(@user.created_at)
+          %dd.col-sm-8= l(@user.created_at)
     .card.mb-3
       .card-header
         .d-flex.justify-content-between.align-items-center
@@ -38,7 +38,7 @@
             = cred.nickname
             %span.text-muted.ms-2.small
               - if cred.last_used_at
-                Last used #{format_datetime(cred.last_used_at)}
+                Last used #{l(cred.last_used_at)}
               - else
                 Never used
   .col-md-6
@@ -55,7 +55,7 @@
               - if current_user_session && current_user_session.id == s.id
                 %span.badge.bg-info.ms-2 This session
             .small.text-muted= s.user_agent.to_s.truncate(80)
-            .small.text-muted Last seen: #{format_datetime(s.last_seen_at)}
+            .small.text-muted Last seen: #{l(s.last_seen_at)}
     .card.mb-3
       .card-header
         .d-flex.justify-content-between.align-items-center
@@ -65,7 +65,7 @@
         - @audit_events.each do |event|
           %li.list-group-item
             %code= event.action
-            %span.text-muted.ms-2.small= format_datetime(event.created_at)
+            %span.text-muted.ms-2.small= l(event.created_at)
     .card.border-danger
       .card-header.bg-danger.text-white Danger zone
       .card-body

--- a/app/views/account/sessions/index.html.haml
+++ b/app/views/account/sessions/index.html.haml
@@ -18,8 +18,8 @@
           - if current_user_session && current_user_session.id == s.id
             %span.badge.bg-info.ms-1 This session
         %td.small= s.user_agent.to_s.truncate(80)
-        %td= format_datetime(s.last_seen_at)
-        %td= format_datetime(s.created_at)
+        %td= l(s.last_seen_at)
+        %td= l(s.created_at)
         %td
           = button_to 'Terminate', account_session_path(s), method: :delete,
               data: { turbo_confirm: 'Terminate this session?' },

--- a/app/views/delivery_notes/index.html.haml
+++ b/app/views/delivery_notes/index.html.haml
@@ -41,12 +41,12 @@
           %td= link_to(delivery_note.document_number, delivery_note)
           %td= delivery_note.customer.name
           %td= delivery_note.project && delivery_note.project.display_name
-          %td= format_date(delivery_note.date)
+          %td= l(delivery_note.date) if delivery_note.date
           %td= delivery_note.cust_reference
           %td= delivery_note.cust_order
           %td
             - if delivery_note.email_sent_at
-              %span.badge.bg-success Sent #{format_date(delivery_note.email_sent_at)}
+              %span.badge.bg-success Sent #{l(delivery_note.email_sent_at.to_date)}
             - else
               %span.badge.bg-warning Unsent
           %td
@@ -68,7 +68,7 @@
             = link_to(delivery_note.document_number || "Draft \##{delivery_note.id}", delivery_note)
           %td= delivery_note.customer.name
           %td= delivery_note.project && delivery_note.project.display_name
-          %td= format_date(delivery_note.date)
+          %td= l(delivery_note.date) if delivery_note.date
           %td= delivery_note.cust_reference
           %td= delivery_note.cust_order
           %td

--- a/app/views/delivery_notes/show.html.haml
+++ b/app/views/delivery_notes/show.html.haml
@@ -15,7 +15,7 @@
             .col-sm-4
               %strong Date:
             .col-sm-8
-              = format_date(@delivery_note.date)
+              = l(@delivery_note.date)
         .row.mb-2
           .col-sm-4
             %strong Customer:
@@ -27,7 +27,7 @@
               %strong Email Status:
             .col-sm-8
               - if @delivery_note.email_sent_at
-                %span.badge.bg-success Sent #{format_datetime(@delivery_note.email_sent_at)}
+                %span.badge.bg-success Sent #{l(@delivery_note.email_sent_at)}
               - elsif @delivery_note.customer.email.present?
                 %span.badge.bg-warning Unsent
               - else
@@ -86,7 +86,7 @@
                 %i.fas.fa-file-pdf.text-danger.me-2
                 = link_to @delivery_note.acceptance_attachment.filename, @delivery_note.acceptance_attachment, class: 'me-auto', target: '_blank'
                 %small.text-muted.ms-2
-                  = "Uploaded #{format_datetime(@delivery_note.acceptance_attachment.created_at)}"
+                  = "Uploaded #{l(@delivery_note.acceptance_attachment.created_at)}"
             .d-flex.gap-2
               = form_with url: upload_acceptance_delivery_note_path(@delivery_note), method: :post, multipart: true, local: true, class: 'd-flex align-items-center', data: { controller: 'file-upload-validation' } do |form|
                 .me-2

--- a/app/views/invoices/index.html.haml
+++ b/app/views/invoices/index.html.haml
@@ -42,12 +42,12 @@
           %td= link_to(invoice.document_number, invoice)
           %td= invoice.customer.name
           %td= invoice.project && invoice.project.display_name
-          %td= format_date(invoice.date)
+          %td= l(invoice.date) if invoice.date
           %td= invoice.cust_reference
           %td= invoice.cust_order
           %td
             - if invoice.email_sent_at
-              %span.badge.bg-success Sent #{format_date(invoice.email_sent_at)}
+              %span.badge.bg-success Sent #{l(invoice.email_sent_at.to_date)}
             - else
               %span.badge.bg-warning Unsent
           %td
@@ -72,13 +72,13 @@
             = link_to(invoice.document_number || "Draft \##{invoice.id}", invoice)
           %td= invoice.customer.name
           %td= invoice.project && invoice.project.display_name
-          %td= format_date(invoice.date)
+          %td= l(invoice.date) if invoice.date
           %td= invoice.cust_reference
           %td= invoice.cust_order
           %td
             - if invoice.published?
               - if invoice.paid?
-                %span.badge.bg-success Paid #{format_date(invoice.paid_at)}
+                %span.badge.bg-success Paid #{l(invoice.paid_at)}
               - elsif invoice.overdue?
                 %span.badge.bg-danger Overdue
               - else

--- a/app/views/invoices/show.html.haml
+++ b/app/views/invoices/show.html.haml
@@ -15,7 +15,7 @@
             .col-sm-4
               %strong Date:
             .col-sm-8
-              = format_date(@invoice.date)
+              = l(@invoice.date)
         .row.mb-2
           .col-sm-4
             %strong Customer:
@@ -32,7 +32,7 @@
             .col-sm-4
               %strong Due Date:
             .col-sm-8
-              = format_date(@invoice.due_date)
+              = l(@invoice.due_date)
 
         - if @invoice.published?
           .row.mb-2
@@ -40,7 +40,7 @@
               %strong Email Status:
             .col-sm-8
               - if @invoice.email_sent_at
-                %span.badge.bg-success Sent #{format_datetime(@invoice.email_sent_at)}
+                %span.badge.bg-success Sent #{l(@invoice.email_sent_at)}
               - elsif @invoice.customer.email.present? || @invoice.customer.invoice_email_auto_enabled
                 %span.badge.bg-warning Unsent
               - else
@@ -51,7 +51,7 @@
               %strong Payment Status:
             .col-sm-8
               - if @invoice.paid?
-                %span.badge.bg-success Paid #{format_date(@invoice.paid_at)}
+                %span.badge.bg-success Paid #{l(@invoice.paid_at)}
               - elsif @invoice.overdue?
                 %span.badge.bg-danger Overdue
               - else

--- a/app/views/jobs_status/show.html.haml
+++ b/app/views/jobs_status/show.html.haml
@@ -68,7 +68,7 @@
                 %td= process.hostname
                 %td= process.pid
                 %td
-                  = format_datetime(process.last_heartbeat_at)
+                  = l(process.last_heartbeat_at)
                   %small.text-muted
                     \(#{time_ago_in_words(process.last_heartbeat_at)} ago)
                 %td
@@ -108,7 +108,7 @@
                 %td
                   - next_run = @next_recurring_runs[task.key]
                   - if next_run
-                    = format_datetime(next_run)
+                    = l(next_run)
                   - else
                     %span.text-muted —
 
@@ -137,7 +137,7 @@
                     %strong= failed.exception_class
                   %div.small.text-muted.job-row-description
                     = failed.message
-                %td= format_datetime(failed.created_at)
+                %td= l(failed.created_at)
 
 .card
   .card-header
@@ -158,4 +158,4 @@
               %tr
                 %td= job.class_name
                 %td= job.queue_name
-                %td= format_datetime(job.finished_at)
+                %td= l(job.finished_at)

--- a/app/views/overdue_invoices_mailer/overdue_report.html.haml
+++ b/app/views/overdue_invoices_mailer/overdue_report.html.haml
@@ -22,7 +22,7 @@
   }
 
 .greeting
-  = t('mailers.overdue_invoices.heading', date: @today.strftime('%d.%m.%Y'))
+  = t('mailers.overdue_invoices.heading', date: l(@today))
 
 .main-message
   = t('mailers.overdue_invoices.main_message', count: @invoices.size)
@@ -41,7 +41,7 @@
       %tr
         %td= invoice.document_number
         %td= invoice.customer.matchcode
-        %td= invoice.date&.strftime('%d.%m.%Y')
-        %td= invoice.due_date&.strftime('%d.%m.%Y')
+        %td= l(invoice.date) if invoice.date
+        %td= l(invoice.due_date) if invoice.due_date
         %td.numeric= sprintf('%.2f', invoice.sum_total)
         %td.numeric= (@today - invoice.due_date).to_i

--- a/app/views/overdue_invoices_mailer/overdue_report.text.haml
+++ b/app/views/overdue_invoices_mailer/overdue_report.text.haml
@@ -1,7 +1,7 @@
-= t('mailers.overdue_invoices.heading', date: @today.strftime('%d.%m.%Y'))
+= t('mailers.overdue_invoices.heading', date: l(@today))
 \
 = t('mailers.overdue_invoices.main_message', count: @invoices.size)
 \
 - @invoices.each do |invoice|
   - days_overdue = (@today - invoice.due_date).to_i
-  = "#{invoice.document_number}  #{invoice.customer.matchcode}  #{t('mailers.overdue_invoices.short.invoice_date')} #{invoice.date&.strftime('%d.%m.%Y')}  #{t('mailers.overdue_invoices.short.due_date')} #{invoice.due_date&.strftime('%d.%m.%Y')}  #{sprintf('%.2f', invoice.sum_total)}  #{t('mailers.overdue_invoices.short.days_overdue', days: days_overdue)}"
+  = "#{invoice.document_number}  #{invoice.customer.matchcode}  #{t('mailers.overdue_invoices.short.invoice_date')} #{l(invoice.date) if invoice.date}  #{t('mailers.overdue_invoices.short.due_date')} #{l(invoice.due_date) if invoice.due_date}  #{sprintf('%.2f', invoice.sum_total)}  #{t('mailers.overdue_invoices.short.days_overdue', days: days_overdue)}"

--- a/app/views/user_invites/index.html.haml
+++ b/app/views/user_invites/index.html.haml
@@ -13,13 +13,13 @@
   %tbody
     - @invites.each do |invite|
       %tr
-        %td= format_datetime(invite.created_at)
+        %td= l(invite.created_at)
         %td= invite.created_by_user&.username || 'system'
-        %td= format_datetime(invite.expires_at)
+        %td= l(invite.expires_at)
         %td
           - if invite.used_at
             %span.badge.bg-success Used
-            = format_datetime(invite.used_at)
+            = l(invite.used_at)
           - elsif invite.expires_at <= Time.current
             %span.badge.bg-secondary Expired
           - else

--- a/app/views/user_invites/show_invite.html.haml
+++ b/app/views/user_invites/show_invite.html.haml
@@ -7,7 +7,7 @@
 
 .card.mb-3
   .card-body
-    %p.mb-1.text-muted Invite URL (valid until #{format_datetime(@invite.expires_at)}):
+    %p.mb-1.text-muted Invite URL (valid until #{l(@invite.expires_at)}):
     %pre.mb-0
       %code= @invite_url
 

--- a/app/views/user_mailer/email_confirmation.html.haml
+++ b/app/views/user_mailer/email_confirmation.html.haml
@@ -4,6 +4,6 @@
 .main-message
   = link_to 'Confirm email address', @confirmation_url
 .main-message
-  This link expires on #{l(@expires_at, format: '%Y-%m-%d %H:%M %Z')}.
+  This link expires on #{l(@expires_at, format: '%d.%m.%Y %H:%M %Z')}.
 .main-message
   If you did not request this, you can ignore this email.

--- a/app/views/user_mailer/email_confirmation.text.haml
+++ b/app/views/user_mailer/email_confirmation.text.haml
@@ -5,6 +5,6 @@
 
   #{@confirmation_url}
 
-  This link expires on #{l(@expires_at, format: '%Y-%m-%d %H:%M %Z')}.
+  This link expires on #{l(@expires_at, format: '%d.%m.%Y %H:%M %Z')}.
 
   If you did not request this, you can ignore this email.

--- a/app/views/users/audit.html.haml
+++ b/app/views/users/audit.html.haml
@@ -13,7 +13,7 @@
   %tbody
     - @audit_events.each do |event|
       %tr
-        %td= format_datetime(event.created_at)
+        %td= l(event.created_at)
         %td
           %code= event.action
         %td= event.actor&.username || '—'

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -22,7 +22,7 @@
             %span.badge.bg-danger Blocked
           - else
             %span.badge.bg-success Active
-        %td= format_datetime(user.created_at)
+        %td= l(user.created_at)
         %td= list_action_link('View', user_path(user), :show)
 
 .mt-4

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -21,10 +21,10 @@
           %dt.col-sm-4 Full name
           %dd.col-sm-8= @user.full_name
           %dt.col-sm-4 Created
-          %dd.col-sm-8= format_datetime(@user.created_at)
+          %dd.col-sm-8= l(@user.created_at)
           - if @user.blocked?
             %dt.col-sm-4 Blocked at
-            %dd.col-sm-8= format_datetime(@user.blocked_at)
+            %dd.col-sm-8= l(@user.blocked_at)
             %dt.col-sm-4 Reason
             %dd.col-sm-8= @user.blocked_reason
             %dt.col-sm-4 Blocked by
@@ -69,7 +69,7 @@
             = cred.nickname
             %span.text-muted.ms-2.small
               - if cred.last_used_at
-                Last used #{format_datetime(cred.last_used_at)}
+                Last used #{l(cred.last_used_at)}
               - else
                 Never used
         - if @credentials.empty?
@@ -82,7 +82,7 @@
           %li.list-group-item
             %code.small= s.ip_address
             .small.text-muted= s.user_agent.to_s.truncate(80)
-            .small.text-muted Last seen: #{format_datetime(s.last_seen_at)}
+            .small.text-muted Last seen: #{l(s.last_seen_at)}
         - if @sessions.empty?
           %li.list-group-item.text-muted No active sessions
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,13 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
+  date:
+    formats:
+      default: "%d.%m.%Y"
+  time:
+    formats:
+      default: "%d.%m.%Y %H:%M"
+
   mailers:
     overdue_invoices:
       subject: "[%{issuer_name}] %{count} overdue invoice(s)"


### PR DESCRIPTION
## Summary

- Configure `date.formats.default` / `time.formats.default` in `config/locales/en.yml` to the European formats (`%d.%m.%Y` / `%d.%m.%Y %H:%M`) that `CLAUDE.md` already mandates.
- Delete `ApplicationHelper#format_date` / `#format_datetime` — they output ISO `%Y-%m-%d`, the opposite of the documented standard — and replace all 39 callsites with `l(...)`.
- Fold the overdue-invoices mailer's inline `strftime('%d.%m.%Y')` into the same mechanism (the existing mailer test asserts on that exact string and still passes unchanged).
- `user_mailer/email_confirmation.{html,text}.haml`: update the explicit format from ISO to European (timezone display preserved).
- Index views that previously truncated `email_sent_at` (datetime column) to date-only via `format_date` now call `l(value.to_date)` to preserve that compact display.
- `CLAUDE.md` updated to document the new mechanism and the `.to_date` idiom.

## Test plan

- [x] `bundle exec rails test` — 346 runs, 0 failures
- [x] `pre-commit run --all-files` — clean
- [x] `grep -rn 'format_date\|format_datetime' app lib test config` — zero hits
- [x] `grep -rn '%Y-%m-%d' app config` — zero hits
- [ ] Manual spot-check: `/invoices`, `/invoices/:id`, `/delivery_notes`, `/delivery_notes/:id`, `/users`, `/account/profile`, `/jobs/status` — dates render as `25.05.2026` / `25.05.2026 14:30`
- [ ] Trigger "Mark Paid" on an invoice — flash reads `Invoice marked as paid on 25.05.2026.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)