### PR TITLE
Use normalizes instead of before_validation shims

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,8 +17,9 @@ class User < ApplicationRecord
   validates :full_name, presence: true, length: { maximum: 120 }
   validates :webauthn_id, presence: true
 
+  normalizes :username, with: ->(v) { v.strip.downcase }
+
   before_validation :assign_webauthn_id, on: :create
-  before_validation :normalize_username
 
   scope :active, -> { where(blocked_at: nil) }
   scope :blocked, -> { where.not(blocked_at: nil) }
@@ -87,10 +88,6 @@ class User < ApplicationRecord
   end
 
   private
-
-  def normalize_username
-    self.username = username.to_s.strip.downcase if username.present?
-  end
 
   def assign_webauthn_id
     self.webauthn_id ||= WebAuthn.generate_user_id

--- a/app/models/user_email.rb
+++ b/app/models/user_email.rb
@@ -9,7 +9,7 @@ class UserEmail < ApplicationRecord
             format: { with: URI::MailTo::EMAIL_REGEXP },
             uniqueness: { case_sensitive: false }
 
-  before_validation :normalize_address
+  normalizes :address, with: ->(v) { v.strip.downcase }
 
   scope :confirmed, -> { where.not(confirmed_at: nil) }
   scope :pending, -> { where(confirmed_at: nil) }
@@ -41,11 +41,5 @@ class UserEmail < ApplicationRecord
       .where("confirmation_expires_at > ?", Time.current)
       .where(confirmed_at: nil)
       .first
-  end
-
-  private
-
-  def normalize_address
-    self.address = address.to_s.strip.downcase if address.present?
   end
 end


### PR DESCRIPTION
## Summary

- Replace `User#normalize_username` and `UserEmail#normalize_address` private methods with Rails 7.1+ `normalizes :attr, with: ->(v) { v.strip.downcase }` declarations.
- Removes two `before_validation` callbacks, two private methods, and the now-orphaned `private` block in `UserEmail`.
- Net: **-9 LOC** (3 insertions, 12 deletions). Same behaviour at save time; values additionally normalize on assignment (e.g. `User.new(username: "FOO").username == "foo"`).
- `assign_webauthn_id` callback is intentionally left alone — it's an assignment, not a normalization.

## Test plan

- [x] `bundle exec rails test` — 346 runs, 0 failures
- [x] `UserEmailTest#normalizes_address_before_save` still passes (no test changes)
- [x] `UserTest#username_is_unique_case-insensitively` still passes
- [x] `pre-commit run` — clean
- [x] `grep -rn "before_validation :normalize" app/` — zero hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)