### PR TITLE
Tighten session and WebAuthn cookie hygiene

### DIFF
--- a/app/controllers/account/blocks_controller.rb
+++ b/app/controllers/account/blocks_controller.rb
@@ -5,7 +5,7 @@ class Account::BlocksController < ApplicationController
       actor: current_user,
       request: request
     )
-    reset_session_cookie
+    reset_auth_cookie
     Current.user = nil
     Current.session = nil
     redirect_to new_session_path, notice: "Your account has been blocked at your request."

--- a/app/controllers/account/credentials_controller.rb
+++ b/app/controllers/account/credentials_controller.rb
@@ -18,16 +18,13 @@ class Account::CredentialsController < ApplicationController
       authenticator_selection: { resident_key: "required", user_verification: "preferred" }
     )
 
-    session[:webauthn_credential_add] = {
-      challenge: options.challenge,
-      nickname: nickname
-    }
+    webauthn_write(:credential_add, challenge: options.challenge, nickname: nickname)
 
     render json: options.as_json
   end
 
   def verify
-    pending = session[:webauthn_credential_add]
+    pending = webauthn_consume(:credential_add)
     if pending.blank?
       return render json: { error: "No registration in progress" }, status: :unprocessable_content
     end
@@ -46,7 +43,6 @@ class Account::CredentialsController < ApplicationController
       nickname: pending["nickname"],
       sign_count: webauthn_credential.sign_count
     )
-    session.delete(:webauthn_credential_add)
 
     UserAuditEvent.record!(action: "passkey_added", user: current_user, actor: current_user,
                             request: request,

--- a/app/controllers/account/credentials_controller.rb
+++ b/app/controllers/account/credentials_controller.rb
@@ -29,13 +29,7 @@ class Account::CredentialsController < ApplicationController
       return render json: { error: "No registration in progress" }, status: :unprocessable_content
     end
 
-    webauthn_credential = WebAuthn::Credential.from_create(params[:credential].to_unsafe_h)
-
-    begin
-      webauthn_credential.verify(pending["challenge"])
-    rescue WebAuthn::Error => e
-      return render json: { error: "Verification failed: #{e.message}" }, status: :unprocessable_content
-    end
+    webauthn_credential = verify_webauthn_create(pending["challenge"]) or return
 
     credential = current_user.credentials.create!(
       external_id: webauthn_credential.id,

--- a/app/controllers/account/sessions_controller.rb
+++ b/app/controllers/account/sessions_controller.rb
@@ -9,7 +9,7 @@ class Account::SessionsController < ApplicationController
     session_record.terminate!(reason: "user_terminated", actor: current_user, request: request)
 
     if is_current
-      reset_session_cookie
+      reset_auth_cookie
       Current.user = nil
       Current.session = nil
       redirect_to new_session_path, notice: "Session terminated. You have been signed out."

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -68,6 +68,14 @@ class ApplicationController < ActionController::Base
     nil
   end
 
+  def webauthn_write(flow, **payload)
+    WebauthnPendingStore.write(session: session, flow: flow, **payload)
+  end
+
+  def webauthn_consume(flow)
+    WebauthnPendingStore.consume(session: session, flow: flow)
+  end
+
   def sign_in_user!(user)
     session_record, plaintext = UserSession.create_for!(user: user, request: request)
     cookies.signed.permanent[AUTH_COOKIE] = {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
-  SESSION_COOKIE = :abt_session
+  AUTH_COOKIE = :abt_auth
 
   before_action :authenticate
 
@@ -24,18 +24,18 @@ class ApplicationController < ActionController::Base
   private
 
   def authenticate
-    plaintext = read_session_token
+    plaintext = read_auth_token
     session_record = plaintext.present? ? UserSession.authenticate(plaintext) : nil
 
     if session_record.nil?
-      reset_session_cookie
+      reset_auth_cookie
       redirect_to_login and return
     end
 
     user = session_record.user
     if user.blocked?
       session_record.terminate!(reason: "blocked_user", actor: nil) unless session_record.terminated_at
-      reset_session_cookie
+      reset_auth_cookie
       redirect_to_login(alert: "Your account has been blocked.") and return
     end
 
@@ -55,22 +55,22 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def reset_session_cookie
-    cookies.delete(SESSION_COOKIE)
+  def reset_auth_cookie
+    cookies.delete(AUTH_COOKIE)
   end
 
-  def read_session_token
-    value = cookies.signed[SESSION_COOKIE]
+  def read_auth_token
+    value = cookies.signed[AUTH_COOKIE]
     return value if value.present?
     # In test env, integration tests cannot easily set signed cookies through
     # rack-test's CookieJar; allow the raw cookie as a fallback there.
-    return cookies[SESSION_COOKIE] if Rails.env.test?
+    return cookies[AUTH_COOKIE] if Rails.env.test?
     nil
   end
 
   def sign_in_user!(user)
     session_record, plaintext = UserSession.create_for!(user: user, request: request)
-    cookies.signed.permanent[SESSION_COOKIE] = {
+    cookies.signed.permanent[AUTH_COOKIE] = {
       value: plaintext,
       httponly: true,
       secure: Rails.env.production?,

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -76,6 +76,18 @@ class ApplicationController < ActionController::Base
     WebauthnPendingStore.consume(session: session, flow: flow)
   end
 
+  # Verifies a WebAuthn create-style assertion against the given challenge.
+  # Returns the credential on success; on WebAuthn::Error, renders a 422 JSON
+  # error and returns nil — callers should `return` on nil.
+  def verify_webauthn_create(challenge)
+    credential = WebAuthn::Credential.from_create(params[:credential].to_unsafe_h)
+    credential.verify(challenge)
+    credential
+  rescue WebAuthn::Error => e
+    render json: { error: "Verification failed: #{e.message}" }, status: :unprocessable_content
+    nil
+  end
+
   def sign_in_user!(user)
     session_record, plaintext = UserSession.create_for!(user: user, request: request)
     cookies.signed.permanent[AUTH_COOKIE] = {

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -57,7 +57,7 @@ class InvitesController < ApplicationController
       authenticator_selection: { resident_key: "required", user_verification: "preferred" }
     )
 
-    session[:webauthn_signup] = {
+    webauthn_write(:signup,
       invite_token: params[:token],
       challenge: options.challenge,
       webauthn_user_id: webauthn_user_id,
@@ -65,7 +65,7 @@ class InvitesController < ApplicationController
       full_name: full_name,
       email: email,
       nickname: params[:nickname].to_s.presence || "Initial passkey"
-    }
+    )
 
     render json: options.as_json
   end
@@ -80,18 +80,18 @@ class InvitesController < ApplicationController
       authenticator_selection: { resident_key: "required", user_verification: "preferred" }
     )
 
-    session[:webauthn_passkey_reset] = {
+    webauthn_write(:passkey_reset,
       invite_token: params[:token],
       challenge: options.challenge,
       target_user_id: target.id,
       nickname: params[:nickname].to_s.presence || "Passkey"
-    }
+    )
 
     render json: options.as_json
   end
 
   def complete_signup
-    pending = session[:webauthn_signup]
+    pending = webauthn_consume(:signup)
     unless invite_token_matches?(pending)
       return render json: { error: "No signup in progress" }, status: :unprocessable_content
     end
@@ -124,7 +124,6 @@ class InvitesController < ApplicationController
       @invite.consume!(user: user)
     end
 
-    session.delete(:webauthn_signup)
     sign_in_user!(user)
 
     UserAuditEvent.record!(action: "invite_used", user: user, actor: user, request: request,
@@ -144,7 +143,7 @@ class InvitesController < ApplicationController
   end
 
   def complete_passkey_reset
-    pending = session[:webauthn_passkey_reset]
+    pending = webauthn_consume(:passkey_reset)
     unless invite_token_matches?(pending)
       return render json: { error: "No passkey reset in progress" }, status: :unprocessable_content
     end
@@ -175,7 +174,6 @@ class InvitesController < ApplicationController
       end
     end
 
-    session.delete(:webauthn_passkey_reset)
     sign_in_user!(target)
 
     UserAuditEvent.record!(action: "invite_used", user: target, actor: target, request: request,

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -96,13 +96,7 @@ class InvitesController < ApplicationController
       return render json: { error: "No signup in progress" }, status: :unprocessable_content
     end
 
-    webauthn_credential = WebAuthn::Credential.from_create(params[:credential].to_unsafe_h)
-
-    begin
-      webauthn_credential.verify(pending["challenge"])
-    rescue WebAuthn::Error => e
-      return render json: { error: "Verification failed: #{e.message}" }, status: :unprocessable_content
-    end
+    webauthn_credential = verify_webauthn_create(pending["challenge"]) or return
 
     user = nil
     User.transaction do
@@ -151,13 +145,7 @@ class InvitesController < ApplicationController
     target = User.find_by(id: pending["target_user_id"])
     return render_invalid unless target
 
-    webauthn_credential = WebAuthn::Credential.from_create(params[:credential].to_unsafe_h)
-
-    begin
-      webauthn_credential.verify(pending["challenge"])
-    rescue WebAuthn::Error => e
-      return render json: { error: "Verification failed: #{e.message}" }, status: :unprocessable_content
-    end
+    webauthn_credential = verify_webauthn_create(pending["challenge"]) or return
 
     User.transaction do
       target.credentials.create!(

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -77,7 +77,7 @@ class SessionsController < ApplicationController
         request: request, metadata: { username: current_user.username }
       )
     end
-    reset_session_cookie
+    reset_auth_cookie
     Current.user = nil
     Current.session = nil
     redirect_to new_session_path, notice: "Signed out."

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,14 +9,14 @@ class SessionsController < ApplicationController
       user_verification: "preferred"
     )
 
-    session[:webauthn_login] = { challenge: options.challenge }
+    webauthn_write(:login, challenge: options.challenge)
 
     render json: options.as_json
   end
 
   def verify
-    login_session = session[:webauthn_login]
-    if login_session.blank? || login_session["challenge"].blank?
+    pending = webauthn_consume(:login)
+    if pending.blank? || pending["challenge"].blank?
       return render json: { error: "No login in progress" }, status: :unprocessable_content
     end
 
@@ -41,7 +41,7 @@ class SessionsController < ApplicationController
 
     begin
       webauthn_credential.verify(
-        login_session["challenge"],
+        pending["challenge"],
         public_key: stored.public_key,
         sign_count: stored.sign_count,
         user_verification: false
@@ -55,7 +55,6 @@ class SessionsController < ApplicationController
     end
 
     stored.touch_used!(webauthn_credential.sign_count)
-    session.delete(:webauthn_login)
     new_session = sign_in_user!(user)
     UserAuditEvent.record!(
       action: "login_success", user: user, actor: user, request: request,
@@ -86,7 +85,6 @@ class SessionsController < ApplicationController
   private
 
   def render_login_error(message)
-    session.delete(:webauthn_login)
     render json: { error: message }, status: :unauthorized
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,8 @@ class User < ApplicationRecord
 
   belongs_to :blocked_by_user, class_name: "User", optional: true
 
+  attribute :webauthn_id, default: -> { WebAuthn.generate_user_id }
+
   validates :username, presence: true, uniqueness: { case_sensitive: false },
             format: { with: USERNAME_FORMAT },
             length: { in: 2..40 }
@@ -18,8 +20,6 @@ class User < ApplicationRecord
   validates :webauthn_id, presence: true
 
   normalizes :username, with: ->(v) { v.strip.downcase }
-
-  before_validation :assign_webauthn_id, on: :create
 
   scope :active, -> { where(blocked_at: nil) }
   scope :blocked, -> { where.not(blocked_at: nil) }
@@ -85,11 +85,5 @@ class User < ApplicationRecord
       )
       [ invite, plaintext ]
     end
-  end
-
-  private
-
-  def assign_webauthn_id
-    self.webauthn_id ||= WebAuthn.generate_user_id
   end
 end

--- a/app/services/webauthn_pending_store.rb
+++ b/app/services/webauthn_pending_store.rb
@@ -1,0 +1,27 @@
+module WebauthnPendingStore
+  TTL = 5.minutes
+
+  def self.write(session:, flow:, **payload)
+    nonce = SecureRandom.urlsafe_base64(32)
+    Rails.cache.write(cache_key(flow, nonce), payload.stringify_keys, expires_in: TTL)
+    session[session_key(flow)] = nonce
+  end
+
+  def self.consume(session:, flow:)
+    nonce = session.delete(session_key(flow))
+    return nil if nonce.blank?
+    payload = Rails.cache.read(cache_key(flow, nonce))
+    Rails.cache.delete(cache_key(flow, nonce))
+    payload
+  end
+
+  def self.session_key(flow)
+    "webauthn_#{flow}_nonce".to_sym
+  end
+  private_class_method :session_key
+
+  def self.cache_key(flow, nonce)
+    "webauthn:#{flow}:#{nonce}"
+  end
+  private_class_method :cache_key
+end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -31,13 +31,13 @@ class Rack::Attack
     client_ip(req)
   end
 
-  # Whether the request carries a validly-signed session cookie. Does not
+  # Whether the request carries a validly-signed auth cookie. Does not
   # verify the session is still active server-side; that is the controller's
   # job. The cookie was minted by us after a successful WebAuthn login, so an
   # attacker cannot forge one without our signing key.
   def self.authenticated_request?(req)
     ActionDispatch::Request.new(req.env)
-      .cookie_jar.signed[ApplicationController::SESSION_COOKIE].present?
+      .cookie_jar.signed[ApplicationController::AUTH_COOKIE].present?
   rescue StandardError
     false
   end
@@ -78,7 +78,7 @@ class Rack::Attack
     end
   end
 
-  # Backstop. Skips static assets and authenticated requests (signed session
+  # Backstop. Skips static assets and authenticated requests (signed auth
   # cookie present) so a chatty SPA does not hit this limit. /up is NOT
   # exempted: see the file-level note above.
   throttle("req/ip", limit: 300, period: 1.minute) do |req|

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -30,6 +30,6 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(users(:alice))
     delete session_path
     assert_redirected_to new_session_path
-    assert cookies[ApplicationController::SESSION_COOKIE].blank?
+    assert cookies[ApplicationController::AUTH_COOKIE].blank?
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class UserTest < ActiveSupport::TestCase
-  test "requires username, full name, webauthn id" do
+  test "requires username, full name" do
     user = User.new
     assert_not user.valid?
     assert_includes user.errors[:username], "can't be blank"

--- a/test/services/webauthn_pending_store_test.rb
+++ b/test/services/webauthn_pending_store_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class WebauthnPendingStoreTest < ActiveSupport::TestCase
+  setup do
+    @session = {}
+  end
+
+  test "write then consume returns the payload with string keys" do
+    WebauthnPendingStore.write(session: @session, flow: :login, challenge: "abc")
+    pending = WebauthnPendingStore.consume(session: @session, flow: :login)
+    assert_equal({ "challenge" => "abc" }, pending)
+  end
+
+  test "consume deletes the session nonce" do
+    WebauthnPendingStore.write(session: @session, flow: :login, challenge: "abc")
+    assert @session[:webauthn_login_nonce].present?
+    WebauthnPendingStore.consume(session: @session, flow: :login)
+    assert_nil @session[:webauthn_login_nonce]
+  end
+
+  test "second consume returns nil (single-use)" do
+    WebauthnPendingStore.write(session: @session, flow: :login, challenge: "abc")
+    WebauthnPendingStore.consume(session: @session, flow: :login)
+    assert_nil WebauthnPendingStore.consume(session: @session, flow: :login)
+  end
+
+  test "consume on empty session returns nil" do
+    assert_nil WebauthnPendingStore.consume(session: @session, flow: :login)
+  end
+
+  test "payload expires after TTL" do
+    WebauthnPendingStore.write(session: @session, flow: :login, challenge: "abc")
+    travel WebauthnPendingStore::TTL + 1.second do
+      assert_nil WebauthnPendingStore.consume(session: @session, flow: :login)
+    end
+  end
+
+  test "different flows are isolated" do
+    WebauthnPendingStore.write(session: @session, flow: :login, challenge: "login-c")
+    WebauthnPendingStore.write(session: @session, flow: :signup, challenge: "signup-c")
+
+    login = WebauthnPendingStore.consume(session: @session, flow: :login)
+    signup = WebauthnPendingStore.consume(session: @session, flow: :signup)
+
+    assert_equal "login-c", login["challenge"]
+    assert_equal "signup-c", signup["challenge"]
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -46,9 +46,9 @@ module TestAuthHelpers
     session_record, plaintext = UserSession.create_for!(user: user, request: request_obj)
     if is_a?(ActionDispatch::SystemTestCase)
       visit "/" if page.current_url.blank? || page.current_url == "about:blank"
-      page.driver.set_cookie(ApplicationController::SESSION_COOKIE.to_s, plaintext)
+      page.driver.set_cookie(ApplicationController::AUTH_COOKIE.to_s, plaintext)
     else
-      cookies[ApplicationController::SESSION_COOKIE] = plaintext
+      cookies[ApplicationController::AUTH_COOKIE] = plaintext
     end
     session_record
   end


### PR DESCRIPTION
## Summary

Four related cleanups in the auth/WebAuthn area:

- **Rename the auth cookie** `:abt_session` → `:abt_auth` (and `SESSION_COOKIE` → `AUTH_COOKIE`, `reset_session_cookie` → `reset_auth_cookie`, `read_session_token` → `read_auth_token`). The old name differed from Rails' framework session cookie `_abt_session` by a single underscore.
- **Move WebAuthn pending state out of the cookie session.** Challenges + signup PII (invite token, email, names) previously round-tripped through the browser inside the encrypted `_abt_session`. They now live in `Rails.cache` (solid_cache) keyed by a per-flow random nonce, with a 5-minute TTL; only the nonce is kept in the framework session. Single-use semantics enforced by `consume` (read+delete).
- **Extract `verify_webauthn_create` helper** to dedupe the identical `WebAuthn::Credential.from_create + verify + rescue` block across signup, passkey reset, and credential add.
- **`User`: use `attribute :webauthn_id, default: -> { WebAuthn.generate_user_id }`** instead of a `before_validation` callback + private method. Drops 6 LOC and reads top-to-bottom.

## Deploy impact

- The cookie rename signs everyone out at deploy (the old cookie name is no longer read).
- In-flight WebAuthn flows at deploy restart (the old `session[:webauthn_*]` entries are not migrated).
- No DB migration; solid_cache schema already exists.

## Test plan

- [ ] `bundle exec rails test` — 352 runs / 1338 assertions / 0 failures locally
- [ ] `bundle exec rails test test/system/` — Cuprite headless system tests covering login, signup-via-invite, passkey reset, and adding a credential
- [ ] Smoke-check in dev: log in with a passkey, inspect `_abt_session` in DevTools — should contain only a short nonce, not the challenge bytes

🤖 Generated with [Claude Code](https://claude.com/claude-code)