### PR TITLE
Add model tests for previously untested models

### DIFF
--- a/test/models/customer_test.rb
+++ b/test/models/customer_test.rb
@@ -1,46 +1,46 @@
 require "test_helper"
 
 class CustomerTest < ActiveSupport::TestCase
-  def fresh_customer(**overrides)
+  def build_customer(**overrides)
     Customer.new({
-      matchcode: "FRESH",
-      name: "Fresh Customer",
+      matchcode: "TEST",
+      name: "Test Customer",
       sales_tax_customer_class: sales_tax_customer_classes(:eu),
       language: languages(:english),
       active: true
     }.merge(overrides))
   end
 
+  def create_customer(**overrides)
+    build_customer(**overrides).tap(&:save!)
+  end
+
   test "requires matchcode" do
-    customer = fresh_customer(matchcode: nil)
+    customer = build_customer(matchcode: nil)
     assert_not customer.valid?
     assert_includes customer.errors[:matchcode], "can't be blank"
   end
 
   test "requires name" do
-    customer = fresh_customer(name: nil)
+    customer = build_customer(name: nil)
     assert_not customer.valid?
     assert_includes customer.errors[:name], "can't be blank"
   end
 
   test "set_default_language assigns English on create when language is not set" do
-    customer = fresh_customer(language: nil)
+    customer = build_customer(language: nil)
     customer.valid?
     assert_equal languages(:english), customer.language
   end
 
   test "set_default_language does not override an explicitly set language" do
-    customer = fresh_customer(language: languages(:german))
+    customer = build_customer(language: languages(:german))
     customer.valid?
     assert_equal languages(:german), customer.language
   end
 
   test "set_default_language only runs on create" do
-    customer = Customer.create!(
-      matchcode: "DEFAULT_LANG",
-      name: "Default Language Customer",
-      sales_tax_customer_class: sales_tax_customer_classes(:eu)
-    )
+    customer = create_customer(language: nil)
     customer.language = nil
     customer.valid?
     assert_nil customer.language
@@ -51,13 +51,7 @@ class CustomerTest < ActiveSupport::TestCase
   end
 
   test "used_in_invoices? is false for a customer without invoices" do
-    customer = Customer.create!(
-      matchcode: "UNUSED",
-      name: "Unused Customer",
-      sales_tax_customer_class: sales_tax_customer_classes(:eu),
-      language: languages(:english)
-    )
-    assert_not customer.used_in_invoices?
+    assert_not create_customer.used_in_invoices?
   end
 
   test "before_destroy rejects destroy when invoices reference the customer" do
@@ -67,35 +61,17 @@ class CustomerTest < ActiveSupport::TestCase
   end
 
   test "destroy succeeds when no invoices reference the customer" do
-    customer = Customer.create!(
-      matchcode: "UNUSED",
-      name: "Unused Customer",
-      sales_tax_customer_class: sales_tax_customer_classes(:eu),
-      language: languages(:english)
-    )
-    assert customer.destroy
+    assert create_customer.destroy
   end
 
   test "active scope returns only active customers" do
-    inactive = Customer.create!(
-      matchcode: "INACTIVE",
-      name: "Inactive Customer",
-      sales_tax_customer_class: sales_tax_customer_classes(:eu),
-      language: languages(:english),
-      active: false
-    )
+    inactive = create_customer(active: false)
     assert_includes Customer.active, customers(:good_eu)
     assert_not_includes Customer.active, inactive
   end
 
   test "inactive scope returns only inactive customers" do
-    inactive = Customer.create!(
-      matchcode: "INACTIVE",
-      name: "Inactive Customer",
-      sales_tax_customer_class: sales_tax_customer_classes(:eu),
-      language: languages(:english),
-      active: false
-    )
+    inactive = create_customer(active: false)
     assert_includes Customer.inactive, inactive
     assert_not_includes Customer.inactive, customers(:good_eu)
   end

--- a/test/models/customer_test.rb
+++ b/test/models/customer_test.rb
@@ -1,0 +1,102 @@
+require "test_helper"
+
+class CustomerTest < ActiveSupport::TestCase
+  def fresh_customer(**overrides)
+    Customer.new({
+      matchcode: "FRESH",
+      name: "Fresh Customer",
+      sales_tax_customer_class: sales_tax_customer_classes(:eu),
+      language: languages(:english),
+      active: true
+    }.merge(overrides))
+  end
+
+  test "requires matchcode" do
+    customer = fresh_customer(matchcode: nil)
+    assert_not customer.valid?
+    assert_includes customer.errors[:matchcode], "can't be blank"
+  end
+
+  test "requires name" do
+    customer = fresh_customer(name: nil)
+    assert_not customer.valid?
+    assert_includes customer.errors[:name], "can't be blank"
+  end
+
+  test "set_default_language assigns English on create when language is not set" do
+    customer = fresh_customer(language: nil)
+    customer.valid?
+    assert_equal languages(:english), customer.language
+  end
+
+  test "set_default_language does not override an explicitly set language" do
+    customer = fresh_customer(language: languages(:german))
+    customer.valid?
+    assert_equal languages(:german), customer.language
+  end
+
+  test "set_default_language only runs on create" do
+    customer = Customer.create!(
+      matchcode: "DEFAULT_LANG",
+      name: "Default Language Customer",
+      sales_tax_customer_class: sales_tax_customer_classes(:eu)
+    )
+    customer.language = nil
+    customer.valid?
+    assert_nil customer.language
+  end
+
+  test "used_in_invoices? is true for a customer with invoices" do
+    assert customers(:good_eu).used_in_invoices?
+  end
+
+  test "used_in_invoices? is false for a customer without invoices" do
+    customer = Customer.create!(
+      matchcode: "UNUSED",
+      name: "Unused Customer",
+      sales_tax_customer_class: sales_tax_customer_classes(:eu),
+      language: languages(:english)
+    )
+    assert_not customer.used_in_invoices?
+  end
+
+  test "before_destroy rejects destroy when invoices reference the customer" do
+    customer = customers(:good_eu)
+    assert_not customer.destroy
+    assert_includes customer.errors[:base], "Cannot delete customer that has been used in invoices"
+  end
+
+  test "destroy succeeds when no invoices reference the customer" do
+    customer = Customer.create!(
+      matchcode: "UNUSED",
+      name: "Unused Customer",
+      sales_tax_customer_class: sales_tax_customer_classes(:eu),
+      language: languages(:english)
+    )
+    assert customer.destroy
+  end
+
+  test "active scope returns only active customers" do
+    inactive = Customer.create!(
+      matchcode: "INACTIVE",
+      name: "Inactive Customer",
+      sales_tax_customer_class: sales_tax_customer_classes(:eu),
+      language: languages(:english),
+      active: false
+    )
+    assert_includes Customer.active, customers(:good_eu)
+    assert_not_includes Customer.active, inactive
+  end
+
+  test "inactive scope returns only inactive customers" do
+    inactive = Customer.create!(
+      matchcode: "INACTIVE",
+      name: "Inactive Customer",
+      sales_tax_customer_class: sales_tax_customer_classes(:eu),
+      language: languages(:english),
+      active: false
+    )
+    assert_includes Customer.inactive, inactive
+    assert_not_includes Customer.inactive, customers(:good_eu)
+  end
+end

--- a/test/models/document_number_test.rb
+++ b/test/models/document_number_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+
+class DocumentNumberTest < ActiveSupport::TestCase
+  test "get_next increments sequence and formats the number" do
+    dn = document_numbers(:fresh)
+    number = dn.get_next(Date.new(2026, 3, 1))
+    assert_equal 1, dn.sequence
+    assert_equal "20260001", number.to_s
+    assert_equal Date.new(2026, 3, 1), dn.last_date
+  end
+
+  test "get_next resets sequence on year change when format includes year" do
+    dn = document_numbers(:used1) # sequence=1, last_date=2014-01-10, format includes year
+    number = dn.get_next(Date.new(2015, 1, 5))
+    assert_equal 1, dn.sequence
+    assert_equal "20150001", number.to_s
+  end
+
+  test "get_next does not reset sequence when staying within the same year" do
+    dn = document_numbers(:used1) # sequence=1
+    dn.get_next(Date.new(2014, 6, 1))
+    assert_equal 2, dn.sequence
+  end
+
+  test "get_next does not reset sequence when format omits year" do
+    dn = DocumentNumber.create!(code: "yearless", format: "%<number>06d", sequence: 5, last_date: Date.new(2014, 12, 31))
+    dn.get_next(Date.new(2015, 1, 1))
+    assert_equal 6, dn.sequence
+  end
+
+  test "get_next raises DateNotMonotonicError when date moves backward" do
+    dn = document_numbers(:used1)
+    assert_raises(DateNotMonotonicError) do
+      dn.get_next(Date.new(2014, 1, 9))
+    end
+  end
+
+  test "get_next_for raises NoDocumentNumberRangeError for unknown code" do
+    assert_raises(NoDocumentNumberRangeError) do
+      DocumentNumber.get_next_for("does-not-exist", Date.current)
+    end
+  end
+
+  test "get_next_for saves the row and returns the formatted number" do
+    number = DocumentNumber.get_next_for("invoice", Date.new(2026, 1, 1))
+    assert_equal "20260001", number.to_s
+    dn = DocumentNumber.find_by(code: "invoice")
+    assert_equal 1, dn.sequence
+    assert_equal Date.new(2026, 1, 1), dn.last_date
+  end
+end

--- a/test/models/invoice_line_test.rb
+++ b/test/models/invoice_line_test.rb
@@ -1,0 +1,84 @@
+require "test_helper"
+
+class InvoiceLineTest < ActiveSupport::TestCase
+  test "requires title" do
+    line = InvoiceLine.new(type: "item", rate: 10, quantity: 1, invoice: invoices(:draft_invoice))
+    assert_not line.valid?
+    assert_includes line.errors[:title], "can't be blank"
+  end
+
+  test "requires type" do
+    line = InvoiceLine.new(title: "x", invoice: invoices(:draft_invoice))
+    assert_not line.valid?
+    assert_includes line.errors[:type], "can't be blank"
+  end
+
+  test "type must be one of the allowed values" do
+    line = InvoiceLine.new(title: "x", type: "bogus", invoice: invoices(:draft_invoice))
+    assert_not line.valid?
+    assert_includes line.errors[:type], "is not included in the list"
+  end
+
+  test "item lines require rate and quantity" do
+    line = InvoiceLine.new(title: "x", type: "item", invoice: invoices(:draft_invoice))
+    assert_not line.valid?
+    assert_includes line.errors[:rate], "can't be blank"
+    assert_includes line.errors[:quantity], "can't be blank"
+  end
+
+  test "non-item lines do not require rate or quantity" do
+    [ "text", "subheading", "plain" ].each do |t|
+      line = InvoiceLine.new(title: "x", type: t, invoice: invoices(:draft_invoice))
+      assert line.valid?, "expected type=#{t} to be valid without rate/quantity"
+    end
+  end
+
+  test "before_save clears rate, quantity, product_class on non-item lines and zeroes amount" do
+    line = InvoiceLine.create!(
+      invoice: invoices(:draft_invoice),
+      title: "Notes",
+      type: "text",
+      rate: 99,
+      quantity: 5,
+      sales_tax_product_class: sales_tax_product_classes(:standard)
+    )
+    assert_nil line.rate
+    assert_nil line.quantity
+    assert_nil line.sales_tax_product_class_id
+    # clear_non_item_fields nils amount, then calculate_amount runs and sets it to 0
+    assert_equal 0, line.amount
+  end
+
+  test "calculate_amount sets amount = rate * quantity for item lines" do
+    line = InvoiceLine.new(
+      invoice: invoices(:draft_invoice),
+      title: "Widget",
+      type: "item",
+      rate: 12.5,
+      quantity: 4
+    )
+    line.calculate_amount
+    assert_equal 50.0, line.amount
+  end
+
+  test "calculate_amount sets amount = 0 for non-item lines" do
+    line = InvoiceLine.new(
+      invoice: invoices(:draft_invoice),
+      title: "Section",
+      type: "subheading"
+    )
+    line.calculate_amount
+    assert_equal 0, line.amount
+  end
+
+  test "is_item? is only true for type=item" do
+    assert InvoiceLine.new(type: "item").is_item?
+    assert_not InvoiceLine.new(type: "text").is_item?
+    assert_not InvoiceLine.new(type: "subheading").is_item?
+    assert_not InvoiceLine.new(type: "plain").is_item?
+  end
+
+  test "inheritance_column is type_ to avoid STI collision with type column" do
+    assert_equal "type_", InvoiceLine.inheritance_column
+  end
+end

--- a/test/models/invoice_tax_class_test.rb
+++ b/test/models/invoice_tax_class_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+
+class InvoiceTaxClassTest < ActiveSupport::TestCase
+  def build_tax_class(rate: 20)
+    InvoiceTaxClass.new(
+      invoice: invoices(:draft_invoice),
+      sales_tax_product_class: sales_tax_product_classes(:standard),
+      name: "Standard",
+      indicator_code: "STD",
+      rate: rate,
+      net: 0,
+      total: 0
+    )
+  end
+
+  test "requires net" do
+    itc = build_tax_class
+    itc[:net] = nil
+    assert_not itc.valid?
+    assert_includes itc.errors[:net], "can't be blank"
+  end
+
+  test "requires rate" do
+    itc = build_tax_class
+    itc[:rate] = nil
+    assert_not itc.valid?
+    assert_includes itc.errors[:rate], "can't be blank"
+  end
+
+  test "net= computes value and total from rate" do
+    itc = build_tax_class(rate: 20)
+    itc.net = 100
+    assert_equal 100, itc.net
+    assert_in_delta 20.0, itc.value, 0.0001
+    assert_in_delta 120.0, itc.total, 0.0001
+  end
+
+  test "net= recomputes value and total on reassignment" do
+    itc = build_tax_class(rate: 20)
+    itc.net = 100
+    itc.net = 50
+    assert_equal 50, itc.net
+    assert_in_delta 10.0, itc.value, 0.0001
+    assert_in_delta 60.0, itc.total, 0.0001
+  end
+
+  test "net= with rate=0 leaves total equal to net" do
+    itc = build_tax_class(rate: 0)
+    itc.net = 75
+    assert_equal 75, itc.net
+    assert_in_delta 0.0, itc.value, 0.0001
+    assert_in_delta 75.0, itc.total, 0.0001
+  end
+end

--- a/test/models/invoice_tax_class_test.rb
+++ b/test/models/invoice_tax_class_test.rb
@@ -28,7 +28,7 @@ class InvoiceTaxClassTest < ActiveSupport::TestCase
   end
 
   test "net= computes value and total from rate" do
-    itc = build_tax_class(rate: 20)
+    itc = build_tax_class
     itc.net = 100
     assert_equal 100, itc.net
     assert_in_delta 20.0, itc.value, 0.0001
@@ -36,7 +36,7 @@ class InvoiceTaxClassTest < ActiveSupport::TestCase
   end
 
   test "net= recomputes value and total on reassignment" do
-    itc = build_tax_class(rate: 20)
+    itc = build_tax_class
     itc.net = 100
     itc.net = 50
     assert_equal 50, itc.net

--- a/test/models/invoice_test.rb
+++ b/test/models/invoice_test.rb
@@ -1,0 +1,165 @@
+require "test_helper"
+
+class InvoiceTest < ActiveSupport::TestCase
+  test "requires customer_id" do
+    invoice = Invoice.new
+    assert_not invoice.valid?
+    assert_includes invoice.errors[:customer_id], "can't be blank"
+  end
+
+  test "after_initialize sets sum_net and sum_total to 0.0" do
+    invoice = Invoice.new
+    assert_equal 0.0, invoice.sum_net
+    assert_equal 0.0, invoice.sum_total
+  end
+
+  test "published scope returns only published invoices" do
+    assert_includes Invoice.published, invoices(:published_invoice)
+    assert_not_includes Invoice.published, invoices(:draft_invoice)
+  end
+
+  test "unpaid scope returns invoices without paid_at" do
+    paid = invoices(:published_invoice)
+    paid.update_column(:paid_at, Time.current)
+    assert_not_includes Invoice.unpaid, paid
+    assert_includes Invoice.unpaid, invoices(:draft_invoice)
+  end
+
+  test "paid? reflects paid_at" do
+    invoice = invoices(:published_invoice)
+    assert_not invoice.paid?
+    invoice.paid_at = Time.current
+    assert invoice.paid?
+  end
+
+  test "overdue? is true for a published, unpaid invoice past its due_date" do
+    invoice = invoices(:published_invoice)
+    invoice.update_columns(paid_at: nil, due_date: 1.day.ago.to_date)
+    assert invoice.overdue?
+  end
+
+  test "overdue? is false for a draft invoice past its due date" do
+    invoice = invoices(:draft_invoice)
+    invoice.update_columns(due_date: 1.day.ago.to_date)
+    assert_not invoice.overdue?
+  end
+
+  test "overdue? is false for a paid invoice past its due date" do
+    invoice = invoices(:published_invoice)
+    invoice.update_columns(paid_at: Time.current, due_date: 1.day.ago.to_date)
+    assert_not invoice.overdue?
+  end
+
+  test "overdue? is false when due_date is in the future" do
+    invoice = invoices(:published_invoice)
+    invoice.update_columns(paid_at: nil, due_date: 1.day.from_now.to_date)
+    assert_not invoice.overdue?
+  end
+
+  test "update_customer copies customer fields to the draft invoice on save" do
+    invoice = invoices(:draft_invoice)
+    invoice.save!
+    assert_equal invoice.customer.name, invoice.customer_name
+    assert_equal invoice.customer.address, invoice.customer_address
+    assert_equal invoice.customer.id, invoice.customer_account_number.to_i
+    assert_equal invoice.customer.vat_id, invoice.customer_vat_id
+    assert_equal invoice.customer.payment_terms_days, invoice.payment_terms_days
+    assert_equal invoice.customer.sales_tax_customer_class.invoice_note, invoice.tax_note
+  end
+
+  test "update_customer does not mutate a published invoice on save" do
+    invoice = invoices(:published_invoice)
+    invoice.update_columns(customer_name: "Frozen Name")
+    invoice.customer.update!(name: "Changed Name")
+    invoice.save!
+    assert_equal "Frozen Name", invoice.reload.customer_name
+  end
+
+  test "update_sums computes net and total from item lines on a draft" do
+    invoice = invoices(:license_invoice) # good_national (rate 20%), 2 item lines: 15000 + 3000
+    invoice.invoice_lines.where(type: "item").update_all(
+      sales_tax_product_class_id: sales_tax_product_classes(:standard).id
+    )
+    invoice.reload.save!
+    assert_equal 18000, invoice.sum_net
+    assert_in_delta 21600.0, invoice.sum_total, 0.0001
+  end
+
+  test "update_sums skips a published invoice" do
+    invoice = invoices(:published_invoice)
+    invoice.update_columns(sum_net: 999.99, sum_total: 1234.56)
+    invoice.touch
+    assert_equal 999.99, invoice.reload.sum_net
+    assert_equal 1234.56, invoice.reload.sum_total
+  end
+
+  def license_invoice_with_tax_config
+    invoice = invoices(:license_invoice)
+    invoice.invoice_lines.where(type: "item").update_all(
+      sales_tax_product_class_id: sales_tax_product_classes(:standard).id
+    )
+    invoice.reload.save!
+    invoice.reload
+  end
+
+  test "validate_lines_for_booking returns success for a valid line set" do
+    invoice = license_invoice_with_tax_config
+    result = invoice.validate_lines_for_booking
+    assert result[:success], result[:errors].inspect
+    assert_empty result[:errors]
+  end
+
+  test "validate_lines_for_booking reports a missing rate" do
+    invoice = license_invoice_with_tax_config
+    invoice.invoice_lines.find_by(type: "item").update_columns(rate: nil)
+
+    result = invoice.reload.validate_lines_for_booking
+    assert_not result[:success]
+    assert(result[:errors].any? { |e| e.include?("no rate") })
+  end
+
+  test "validate_lines_for_booking reports a missing quantity" do
+    invoice = license_invoice_with_tax_config
+    invoice.invoice_lines.find_by(type: "item").update_columns(quantity: nil)
+
+    result = invoice.reload.validate_lines_for_booking
+    assert_not result[:success]
+    assert(result[:errors].any? { |e| e.include?("no quantity") })
+  end
+
+  test "validate_lines_for_booking reports a missing tax config" do
+    invoice = license_invoice_with_tax_config
+    invoice.invoice_lines.find_by(type: "item").update_columns(sales_tax_product_class_id: 999_999)
+
+    result = invoice.reload.validate_lines_for_booking
+    assert_not result[:success]
+    assert(result[:errors].any? { |e| e.include?("no tax config") })
+  end
+
+  test "in_year returns invoices whose date falls in the given year" do
+    year = Date.current.year
+    assert_includes Invoice.in_year(year), invoices(:published_invoice)
+
+    other_year = year - 5
+    assert_not_includes Invoice.in_year(other_year), invoices(:published_invoice)
+  end
+
+  test "in_year with include_drafts: true includes invoices with a null date" do
+    invoices(:draft_invoice).update_columns(date: nil)
+    year = Date.current.year
+    assert_not_includes Invoice.in_year(year), invoices(:draft_invoice)
+    assert_includes Invoice.in_year(year, include_drafts: true), invoices(:draft_invoice)
+  end
+
+  test "available_years returns distinct years with a non-null date, newest first" do
+    invoices(:draft_invoice).update_columns(date: Date.new(2020, 6, 1))
+    invoices(:license_invoice).update_columns(date: Date.new(2022, 4, 1))
+    invoices(:no_email_invoice).update_columns(date: nil)
+
+    years = Invoice.available_years
+    assert_equal years, years.uniq.sort.reverse
+    assert_includes years, 2020
+    assert_includes years, 2022
+    assert_not_includes years, nil
+  end
+end

--- a/test/models/invoice_test.rb
+++ b/test/models/invoice_test.rb
@@ -1,6 +1,17 @@
 require "test_helper"
 
 class InvoiceTest < ActiveSupport::TestCase
+  # license_invoice fixture has 2 item lines (15000 + 3000) but no product class
+  # assigned. Tax classes get set up via the customer's sales_tax_rates on save.
+  def license_invoice_with_tax_config
+    invoice = invoices(:license_invoice)
+    invoice.invoice_lines.where(type: "item").update_all(
+      sales_tax_product_class_id: sales_tax_product_classes(:standard).id
+    )
+    invoice.reload.save!
+    invoice.reload
+  end
+
   test "requires customer_id" do
     invoice = Invoice.new
     assert_not invoice.valid?
@@ -76,11 +87,7 @@ class InvoiceTest < ActiveSupport::TestCase
   end
 
   test "update_sums computes net and total from item lines on a draft" do
-    invoice = invoices(:license_invoice) # good_national (rate 20%), 2 item lines: 15000 + 3000
-    invoice.invoice_lines.where(type: "item").update_all(
-      sales_tax_product_class_id: sales_tax_product_classes(:standard).id
-    )
-    invoice.reload.save!
+    invoice = license_invoice_with_tax_config # good_national (20%), items 15000 + 3000
     assert_equal 18000, invoice.sum_net
     assert_in_delta 21600.0, invoice.sum_total, 0.0001
   end
@@ -89,17 +96,9 @@ class InvoiceTest < ActiveSupport::TestCase
     invoice = invoices(:published_invoice)
     invoice.update_columns(sum_net: 999.99, sum_total: 1234.56)
     invoice.touch
-    assert_equal 999.99, invoice.reload.sum_net
-    assert_equal 1234.56, invoice.reload.sum_total
-  end
-
-  def license_invoice_with_tax_config
-    invoice = invoices(:license_invoice)
-    invoice.invoice_lines.where(type: "item").update_all(
-      sales_tax_product_class_id: sales_tax_product_classes(:standard).id
-    )
-    invoice.reload.save!
     invoice.reload
+    assert_equal 999.99, invoice.sum_net
+    assert_equal 1234.56, invoice.sum_total
   end
 
   test "validate_lines_for_booking returns success for a valid line set" do

--- a/test/models/issuer_company_test.rb
+++ b/test/models/issuer_company_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+class IssuerCompanyTest < ActiveSupport::TestCase
+  test "requires short_name" do
+    company = IssuerCompany.new(legal_name: "Test Ltd")
+    assert_not company.valid?
+    assert_includes company.errors[:short_name], "can't be blank"
+  end
+
+  test "requires legal_name" do
+    company = IssuerCompany.new(short_name: "Test")
+    assert_not company.valid?
+    assert_includes company.errors[:legal_name], "can't be blank"
+  end
+
+  test "document_accent_color accepts hex colors of 3, 4, 6, and 8 hex digits" do
+    [ "#abc", "#ABCD", "#aabbcc", "#AABBCCDD" ].each do |color|
+      company = IssuerCompany.new(short_name: "X", legal_name: "Y", document_accent_color: color)
+      assert company.valid?, "expected color=#{color} to be valid"
+    end
+  end
+
+  test "document_accent_color rejects non-hex values" do
+    [ "red", "#xyz", "3366cc", "#12" ].each do |color|
+      company = IssuerCompany.new(short_name: "X", legal_name: "Y", document_accent_color: color)
+      assert_not company.valid?, "expected color=#{color} to be invalid"
+      assert_includes company.errors[:document_accent_color], "must be a hex color like #rrggbb"
+    end
+  end
+
+  test "document_accent_color is optional" do
+    company = IssuerCompany.new(short_name: "X", legal_name: "Y", document_accent_color: nil)
+    assert company.valid?
+    company.document_accent_color = ""
+    assert company.valid?
+  end
+
+  test "get_the_issuer! returns the active issuer" do
+    assert_equal issuer_companies(:one), IssuerCompany.get_the_issuer!
+  end
+
+  test "get_the_issuer! returns nil when no active issuer exists" do
+    issuer_companies(:one).update!(active: false)
+    assert_nil IssuerCompany.get_the_issuer!
+  end
+end

--- a/test/models/language_test.rb
+++ b/test/models/language_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+
+class LanguageTest < ActiveSupport::TestCase
+  test "requires iso_code" do
+    language = Language.new(title: "Spanish")
+    assert_not language.valid?
+    assert_includes language.errors[:iso_code], "can't be blank"
+  end
+
+  test "requires title" do
+    language = Language.new(iso_code: "es")
+    assert_not language.valid?
+    assert_includes language.errors[:title], "can't be blank"
+  end
+
+  test "iso_code must be exactly 2 characters" do
+    too_short = Language.new(iso_code: "e", title: "Bad")
+    assert_not too_short.valid?
+    assert_includes too_short.errors[:iso_code], "is the wrong length (should be 2 characters)"
+
+    too_long = Language.new(iso_code: "eng", title: "Bad")
+    assert_not too_long.valid?
+    assert_includes too_long.errors[:iso_code], "is the wrong length (should be 2 characters)"
+  end
+
+  test "iso_code must be unique" do
+    duplicate = Language.new(iso_code: "en", title: "English Again")
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:iso_code], "has already been taken"
+  end
+
+  test "destroy is blocked when customers reference the language" do
+    language = languages(:english)
+    assert_not language.destroy
+    assert_includes language.errors[:base].join, "Cannot delete record because dependent customers exist"
+  end
+
+  test "destroy succeeds when no customers reference the language" do
+    language = Language.create!(iso_code: "es", title: "Spanish")
+    assert language.destroy
+  end
+end

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -1,0 +1,14 @@
+require "test_helper"
+
+class ProductTest < ActiveSupport::TestCase
+  test "belongs to a sales_tax_product_class" do
+    product = Product.new(sales_tax_product_class: sales_tax_product_classes(:standard))
+    assert_equal sales_tax_product_classes(:standard), product.sales_tax_product_class
+  end
+
+  test "sales_tax_rates returns rates of the product class" do
+    product = Product.new(sales_tax_product_class: sales_tax_product_classes(:standard))
+    assert_includes product.sales_tax_rates, sales_tax_rates(:national_standard)
+    assert_includes product.sales_tax_rates, sales_tax_rates(:eu_standard)
+  end
+end

--- a/test/models/sales_tax_customer_class_test.rb
+++ b/test/models/sales_tax_customer_class_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+class SalesTaxCustomerClassTest < ActiveSupport::TestCase
+  test "requires name" do
+    klass = SalesTaxCustomerClass.new
+    assert_not klass.valid?
+    assert_includes klass.errors[:name], "can't be blank"
+  end
+
+  test "destroy is blocked when sales_tax_rates reference the class" do
+    klass = SalesTaxCustomerClass.create!(name: "Test Region With Rate")
+    SalesTaxRate.create!(
+      sales_tax_customer_class: klass,
+      sales_tax_product_class: sales_tax_product_classes(:standard),
+      rate: 5
+    )
+    assert_raises(ActiveRecord::DeleteRestrictionError) { klass.destroy }
+  end
+
+  test "destroy is blocked when customers reference the class" do
+    klass = SalesTaxCustomerClass.create!(name: "Test Region")
+    Customer.create!(
+      matchcode: "STC_TEST",
+      name: "Test Customer",
+      sales_tax_customer_class: klass,
+      language: languages(:english)
+    )
+    assert_raises(ActiveRecord::DeleteRestrictionError) { klass.destroy }
+  end
+
+  test "destroy succeeds when no rates or customers reference the class" do
+    klass = SalesTaxCustomerClass.create!(name: "Test Region")
+    assert klass.destroy
+  end
+end

--- a/test/models/sales_tax_rate_test.rb
+++ b/test/models/sales_tax_rate_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+
+class SalesTaxRateTest < ActiveSupport::TestCase
+  def setup
+    @customer_class = SalesTaxCustomerClass.create!(name: "Test Region")
+    @product_class = SalesTaxProductClass.create!(name: "Test Product Class", indicator_code: "TPC")
+  end
+
+  test "requires rate" do
+    rate = SalesTaxRate.new(
+      sales_tax_customer_class: @customer_class,
+      sales_tax_product_class: @product_class
+    )
+    assert_not rate.valid?
+    assert_includes rate.errors[:rate], "can't be blank"
+  end
+
+  test "requires sales_tax_customer_class" do
+    rate = SalesTaxRate.new(sales_tax_product_class: @product_class, rate: 10)
+    assert_not rate.valid?
+    assert_includes rate.errors[:sales_tax_customer_class], "can't be blank"
+  end
+
+  test "requires sales_tax_product_class" do
+    rate = SalesTaxRate.new(sales_tax_customer_class: @customer_class, rate: 10)
+    assert_not rate.valid?
+    assert_includes rate.errors[:sales_tax_product_class], "can't be blank"
+  end
+
+  test "rate accepts 0, intermediate values, and 100" do
+    [ 0, 10, 20, 100 ].each do |valid_rate|
+      rate = SalesTaxRate.new(
+        sales_tax_customer_class: @customer_class,
+        sales_tax_product_class: @product_class,
+        rate: valid_rate
+      )
+      assert rate.valid?, "expected rate=#{valid_rate} to be valid"
+    end
+  end
+
+  test "rate rejects values outside 0..100" do
+    [ -1, 101, 200 ].each do |invalid_rate|
+      rate = SalesTaxRate.new(
+        sales_tax_customer_class: @customer_class,
+        sales_tax_product_class: @product_class,
+        rate: invalid_rate
+      )
+      assert_not rate.valid?, "expected rate=#{invalid_rate} to be invalid"
+      assert_includes rate.errors[:rate], "is not included in the list"
+    end
+  end
+end

--- a/test/models/user_credential_test.rb
+++ b/test/models/user_credential_test.rb
@@ -1,0 +1,61 @@
+require "test_helper"
+
+class UserCredentialTest < ActiveSupport::TestCase
+  def build_credential(**overrides)
+    users(:alice).credentials.build({
+      external_id: "new-ext-id",
+      public_key: "new-pubkey",
+      nickname: "New Key",
+      sign_count: 0
+    }.merge(overrides))
+  end
+
+  test "requires external_id" do
+    cred = build_credential(external_id: nil)
+    assert_not cred.valid?
+    assert_includes cred.errors[:external_id], "can't be blank"
+  end
+
+  test "external_id must be unique" do
+    cred = build_credential(external_id: user_credentials(:alice_key).external_id)
+    assert_not cred.valid?
+    assert_includes cred.errors[:external_id], "has already been taken"
+  end
+
+  test "requires public_key" do
+    cred = build_credential(public_key: nil)
+    assert_not cred.valid?
+    assert_includes cred.errors[:public_key], "can't be blank"
+  end
+
+  test "requires nickname" do
+    cred = build_credential(nickname: nil)
+    assert_not cred.valid?
+    assert_includes cred.errors[:nickname], "can't be blank"
+  end
+
+  test "nickname is limited to 80 characters" do
+    cred = build_credential(nickname: "x" * 81)
+    assert_not cred.valid?
+    assert_includes cred.errors[:nickname], "is too long (maximum is 80 characters)"
+  end
+
+  test "sign_count must be a non-negative integer" do
+    cred = build_credential(sign_count: -1)
+    assert_not cred.valid?
+    assert_includes cred.errors[:sign_count], "must be greater than or equal to 0"
+
+    cred = build_credential(sign_count: 1.5)
+    assert_not cred.valid?
+    assert_includes cred.errors[:sign_count], "must be an integer"
+  end
+
+  test "touch_used! updates sign_count and last_used_at" do
+    cred = user_credentials(:alice_key)
+    cred.update_column(:last_used_at, 1.day.ago)
+    cred.touch_used!(42)
+    cred.reload
+    assert_equal 42, cred.sign_count
+    assert_in_delta Time.current.to_f, cred.last_used_at.to_f, 5
+  end
+end


### PR DESCRIPTION
## Summary
- Adds focused unit tests for the 11 models in `app/models/` that had no test file: Customer, Invoice, InvoiceLine, InvoiceTaxClass, DocumentNumber, Product, IssuerCompany, Language, SalesTaxCustomerClass, SalesTaxRate, UserCredential.
- Style mirrors existing model tests (`project_test.rb`, `delivery_note_test.rb`, `sales_tax_product_class_test.rb`): fixtures over factories, plain Minitest asserts.
- Concerns (`HasLineItems`, `YearFilterable`, `DigestedToken`) are exercised transitively through `invoice_test.rb` and the existing `delivery_note_test.rb` / `user_*_test.rb` files — no separate concern test files.

Highlights of what's covered:
- `Invoice`: published-invoice freeze on `update_customer` / `update_sums`, sums computed from item lines, `validate_lines_for_booking` happy + error paths, `YearFilterable.in_year` / `available_years`.
- `InvoiceLine`: conditional rate/quantity validation, `clear_non_item_fields` + `calculate_amount` ordering, `inheritance_column == "type_"`.
- `InvoiceTaxClass`: `net=` setter invariant `total = net + net * rate/100`.
- `DocumentNumber`: sequence increment, year-wraparound, monotonicity error, `get_next_for` unknown-code error.
- `Customer`: `set_default_language` only-on-create, `before_destroy` guard, active/inactive scopes.
- `Language` / `SalesTaxCustomerClass`: `restrict_with_error` / `restrict_with_exception` on destroy.
- `UserCredential`: validations + `touch_used!`.

## Test plan
- [x] `bundle exec rails test test/models/` — 163 runs, 0 failures
- [x] `bundle exec rails test` (full suite) — 432 runs, 0 failures
- [x] `pre-commit run --all-files` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)