### PR TITLE
Dedup line models and mailer locale switching

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -29,6 +29,10 @@ class ApplicationMailer < ActionMailer::Base
     )
   end
 
+  def with_customer_locale(customer, &block)
+    I18n.with_locale(customer.language.iso_code, &block)
+  end
+
   # Strip CR/LF from values interpolated into mail headers (e.g. Subject) to
   # prevent header injection. The mail gem strips CRLF too, but doing it
   # explicitly keeps us safe if that ever changes.

--- a/app/mailers/delivery_note_mailer.rb
+++ b/app/mailers/delivery_note_mailer.rb
@@ -6,7 +6,7 @@ class DeliveryNoteMailer < ApplicationMailer
     customer = @delivery_note.customer
     to = subject = nil
 
-    I18n.with_locale(customer.language.iso_code) do
+    with_customer_locale(customer) do
       if customer.email.present?
         subject = I18n.t("mailers.delivery_note.subject", issuer_name: @issuer.short_name, document_number: @delivery_note.document_number)
         to = customer.email
@@ -25,7 +25,7 @@ class DeliveryNoteMailer < ApplicationMailer
     customer = @customer
     to = subject = nil
 
-    I18n.with_locale(customer.language.iso_code) do
+    with_customer_locale(customer) do
       if customer.email.present?
         document_numbers = @delivery_notes.map(&:document_number).join(", ")
         subject = I18n.t("mailers.delivery_note.bulk_subject", issuer_name: @issuer.short_name, document_numbers: document_numbers)

--- a/app/mailers/invoice_mailer.rb
+++ b/app/mailers/invoice_mailer.rb
@@ -9,7 +9,7 @@ class InvoiceMailer < ApplicationMailer
     customer = @invoice.customer
     to = cc = subject = nil
 
-    I18n.with_locale(customer.language.iso_code) do
+    with_customer_locale(customer) do
       if customer.invoice_email_auto_enabled
         subject = customer.invoice_email_auto_subject_template
                           .gsub("$CUST_ORDER$", sanitize_header_value(@invoice.cust_order))

--- a/app/models/concerns/line_item.rb
+++ b/app/models/concerns/line_item.rb
@@ -1,0 +1,23 @@
+module LineItem
+  extend ActiveSupport::Concern
+
+  TYPE_OPTIONS = {
+    "Text" => "text",
+    "Item" => "item",
+    "Subheading" => "subheading",
+    "Plaintext" => "plain"
+  }.freeze
+
+  included do
+    validates :title, presence: true
+    validates :type, presence: true, inclusion: TYPE_OPTIONS.values
+
+    def self.inheritance_column
+      "type_"
+    end
+  end
+
+  def is_item?
+    self[:type] == "item"
+  end
+end

--- a/app/models/delivery_note_line.rb
+++ b/app/models/delivery_note_line.rb
@@ -1,22 +1,7 @@
 class DeliveryNoteLine < ApplicationRecord
-  TYPE_OPTIONS = {
-    "Text" => "text",
-    "Item" => "item",
-    "Subheading" => "subheading",
-    "Plaintext" => "plain"
-  }.freeze
+  include LineItem
 
-  validates :title, presence: true
-  validates :type, presence: true, inclusion: TYPE_OPTIONS.values
   validates :quantity, presence: true, if: :is_item?
 
   belongs_to :delivery_note
-
-  def self.inheritance_column
-    "type_"
-  end
-
-  def is_item?
-    self[:type] == "item"
-  end
 end

--- a/app/models/invoice_line.rb
+++ b/app/models/invoice_line.rb
@@ -1,22 +1,11 @@
 class InvoiceLine < ApplicationRecord
-  TYPE_OPTIONS = {
-    "Text" => "text",
-    "Item" => "item",
-    "Subheading" => "subheading",
-    "Plaintext" => "plain"
-  }.freeze
+  include LineItem
 
-  validates :title, presence: true
-  validates :type, presence: true, inclusion: TYPE_OPTIONS.values
   validates :rate, presence: true, if: :is_item?
   validates :quantity, presence: true, if: :is_item?
 
   belongs_to :invoice
   belongs_to :sales_tax_product_class, optional: true
-
-  def self.inheritance_column
-    "type_"
-  end
 
   before_save :clear_non_item_fields
   before_save :calculate_amount
@@ -27,10 +16,6 @@ class InvoiceLine < ApplicationRecord
     else
       self[:amount] = 0
     end
-  end
-
-  def is_item?
-    self[:type] == "item"
   end
 
 private


### PR DESCRIPTION
## Summary
- Extract `LineItem` concern (`app/models/concerns/line_item.rb`) for `TYPE_OPTIONS`, `inheritance_column`, `is_item?`, and shared title/type validations. `InvoiceLine` and `DeliveryNoteLine` `include LineItem`.
- Lift `I18n.with_locale(customer.language.iso_code)` into `ApplicationMailer#with_customer_locale`; used by `InvoiceMailer` and `DeliveryNoteMailer` (3 sites).

Net: -35/+32 lines. No behavior change — `Class::TYPE_OPTIONS` still resolves via included-module constant lookup.

## Test plan
- [x] `bundle exec rails test` — 348 runs, 0 failures
- [x] `pre-commit run --all-files` — passes (rubocop included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)