### PR TITLE
Stop caching publicKey in passkey_controller

### DIFF
--- a/app/javascript/controllers/passkey_controller.js
+++ b/app/javascript/controllers/passkey_controller.js
@@ -14,7 +14,6 @@ export default class extends Controller {
   }
 
   connect() {
-    this.cachedPublicKey = null
     this.conditionalAbortController = null
     if (this.autoAuthenticateValue) {
       this.startConditionalMediation()
@@ -32,11 +31,14 @@ export default class extends Controller {
     this.conditionalAbortController = null
   }
 
+  // Each call mints a fresh nonce server-side (WebauthnPendingStore.write).
+  // Don't cache the result: the nonce is single-use and consumed on every
+  // /session/verify, so reusing a stale publicKey produces "No login in
+  // progress" on the next attempt (e.g. button click after a conditional-
+  // mediation /verify already burned the nonce).
   async fetchOptions() {
-    if (this.cachedPublicKey) return this.cachedPublicKey
     const optionsJSON = await this.postJSON(this.optionsUrlValue, {})
-    this.cachedPublicKey = this.parseRequestOptions(optionsJSON)
-    return this.cachedPublicKey
+    return this.parseRequestOptions(optionsJSON)
   }
 
   async startConditionalMediation() {


### PR DESCRIPTION
## Summary
- Client-side caching of the parsed `publicKey` in `passkey_controller.js` broke the server's single-use nonce semantics: `WebauthnPendingStore` mints a fresh nonce on every `/session/options` and consumes it on every `/session/verify`. Reusing a cached `publicKey` after any prior `/verify` (success redirect, error state, or a conditional-mediation ceremony that already burned the nonce) produced "No login in progress" on the next attempt.
- Always re-POST `/session/options` for each ceremony attempt — the cost is sub-100ms and matches the server's single-use semantics.

Cherry-picked from a feature branch where it sat alongside unrelated permissions/groups work; sending it on its own so it can land independently.

## Test plan
- [ ] Sign in with passkey via button click — succeeds
- [ ] Trigger conditional mediation, then click sign-in button — second ceremony succeeds (previously failed with "No login in progress")
- [ ] Verify error path: enter wrong credential, retry — second attempt gets a fresh nonce

🤖 Generated with [Claude Code](https://claude.com/claude-code)