### PR TITLE
Show and enforce required-field markers in admin forms

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,4 +1,6 @@
 class Product < ApplicationRecord
   belongs_to :sales_tax_product_class
   has_many :sales_tax_rates, through: :sales_tax_product_class
+
+  validates :title, :rate, presence: true
 end

--- a/app/views/customers/_form.html.haml
+++ b/app/views/customers/_form.html.haml
@@ -13,14 +13,14 @@
     .row.mb-3
       = f.label :matchcode, class: 'col-lg-2 col-md-3 col-form-label'
       .col-md-5.col-sm-7
-        = f.text_field :matchcode, :class => 'form-control'
+        = f.text_field :matchcode, :class => 'form-control', :required => true
       .col-md-3
         .form-check
           = f.input_field :active, as: :boolean, class: 'form-check-input'
           = f.label :active, class: 'form-check-label'
 
     .row.mb-3
-      = f.label :team_id, 'Team', class: 'col-lg-2 col-md-3 col-form-label'
+      = f.label :team_id, label: 'Team', required: true, class: 'col-lg-2 col-md-3 col-form-label'
       .col-sm-5
         = f.collection_select :team_id, available_teams, :id, :name, { prompt: 'Select team...' }, {:class => 'form-select', :required => true}
         - if available_teams.empty?
@@ -29,7 +29,7 @@
     .row.mb-3
       = f.label :name, class: 'col-lg-2 col-md-3 col-form-label'
       .col-lg-5
-        = f.text_area :name, :class => 'form-control', :rows => 2
+        = f.text_area :name, :class => 'form-control', :rows => 2, :required => true
     .row.mb-3
       = f.label :address, class: 'col-lg-2 col-md-3 col-form-label'
       .col-lg-5
@@ -39,11 +39,11 @@
       .col-sm-5
         = f.text_field :vat_id, :class => 'form-control'
     .row.mb-3
-      = f.label :sales_tax_customer_class_id, class: 'col-lg-2 col-md-3 col-form-label', label: "Sales Tax Class"
+      = f.label :sales_tax_customer_class_id, required: true, class: 'col-lg-2 col-md-3 col-form-label', label: "Sales Tax Class"
       .col-sm-5
         = f.collection_select :sales_tax_customer_class_id, SalesTaxCustomerClass.all, :id, :name, { prompt: 'Select tax class...' }, {:class => 'form-select', :required => true}
     .row.mb-3
-      = f.label :language_id, class: 'col-lg-2 col-md-3 col-form-label', label: "Language"
+      = f.label :language_id, required: true, class: 'col-lg-2 col-md-3 col-form-label', label: "Language"
       .col-sm-5
         = f.collection_select :language_id, Language.all, :id, :title, { prompt: 'Select language...' }, {:class => 'form-select', :required => true}
     %hr

--- a/app/views/products/_form.html.haml
+++ b/app/views/products/_form.html.haml
@@ -11,7 +11,7 @@
 
   .form-inputs
     .row.mb-3
-      = f.label :title, class: 'col-lg-2 col-md-3 col-form-label'
+      = f.label :title, required: true, class: 'col-lg-2 col-md-3 col-form-label'
       .col-sm-3
         = f.text_field :title, {:class => 'form-control', :required => true}
     .row.mb-3
@@ -19,11 +19,11 @@
       .col-sm-9
         = f.text_area :description, {:class => 'form-control', :rows => 4}
     .row.mb-3
-      = f.label :rate, class: 'col-lg-2 col-md-3 col-form-label'
+      = f.label :rate, required: true, class: 'col-lg-2 col-md-3 col-form-label'
       .col-sm-3
         = f.number_field :rate, {:class => 'form-control', :required => true}
     .row.mb-3
-      = f.label :sales_tax_product_class_id, class: 'col-lg-2 col-md-3 col-form-label', label: "Sales Tax Class"
+      = f.label :sales_tax_product_class_id, required: true, class: 'col-lg-2 col-md-3 col-form-label', label: "Sales Tax Class"
       .col-sm-3
         = f.collection_select :sales_tax_product_class_id, SalesTaxProductClass.all, :id, :name, { prompt: 'Select tax class...' }, {:class => 'form-select', :required => true}
 

--- a/app/views/projects/_form.html.haml
+++ b/app/views/projects/_form.html.haml
@@ -13,7 +13,7 @@
     .row.mb-3
       = f.label :matchcode, class: 'col-lg-2 col-md-3 col-form-label'
       .col-lg-3
-        = f.text_field :matchcode, :class => 'form-control'
+        = f.text_field :matchcode, :class => 'form-control', :required => true
       .col-lg-6
         .form-check
           = f.input_field :active, as: :boolean, class: 'form-check-input'
@@ -31,7 +31,7 @@
           = f.collection_select :bill_to_customer_id, @customer_options, :id, :name, { prompt: 'Select customer...', include_blank: 'No customer (reusable project)' }, {:class => 'form-select', "data-project-team-target" => "customer", "data-customer-team-map" => @customer_options.to_h { |c| [c.id, { team_id: c.team_id, team_name: c.team&.name }] }.to_json}
 
       .row.mb-3{"data-project-team-target" => "teamRow"}
-        = f.label :team_id, 'Team', class: 'col-lg-2 col-md-3 col-form-label'
+        = f.label :team_id, label: 'Team', required: true, class: 'col-lg-2 col-md-3 col-form-label'
         .col-sm-5
           = f.collection_select :team_id, available_teams, :id, :name, { prompt: 'Select team...' }, {:class => 'form-select', :required => true, "data-project-team-target" => "teamSelect"}
           - if @project.bill_to_customer_id.present? && selected_customer_team

--- a/app/views/sales_tax_customer_classes/_form.html.haml
+++ b/app/views/sales_tax_customer_classes/_form.html.haml
@@ -12,7 +12,7 @@
     .row.mb-3
       = f.label :name, class: 'col-sm-3 col-form-label'
       .col-sm-9
-        = f.text_field :name, :class => 'form-control', :placeholder => "National"
+        = f.text_field :name, :class => 'form-control', :placeholder => "National", :required => true
     .row.mb-3
       = f.label :invoice_note, class: 'col-sm-3 col-form-label'
       .col-sm-9

--- a/app/views/sales_tax_product_classes/_form.html.haml
+++ b/app/views/sales_tax_product_classes/_form.html.haml
@@ -12,11 +12,11 @@
     .row.mb-3
       = f.label :name, class: 'col-sm-3 col-form-label'
       .col-sm-9
-        = f.text_field :name, :class => 'form-control', :placeholder => "Standard goods"
+        = f.text_field :name, :class => 'form-control', :placeholder => "Standard goods", :required => true
     .row.mb-3
       = f.label :indicator_code, class: 'col-sm-3 col-form-label'
       .col-sm-9
-        = f.text_field :indicator_code, :class => 'form-control', :placeholder => "A"
+        = f.text_field :indicator_code, :class => 'form-control', :placeholder => "A", :required => true
     .row.mb-3
       .col-sm-9.offset-sm-3
         .form-check

--- a/app/views/sales_tax_rates/_form.html.haml
+++ b/app/views/sales_tax_rates/_form.html.haml
@@ -10,18 +10,18 @@
 
   .form-inputs
     .row.mb-3
-      = f.label :sales_tax_customer_class_id, "Customer Class", class: 'col-sm-3 col-form-label'
+      = f.label :sales_tax_customer_class_id, label: "Customer Class", required: true, class: 'col-sm-3 col-form-label'
       .col-sm-9
         = f.collection_select :sales_tax_customer_class_id, SalesTaxCustomerClass.all, :id, :name, { prompt: 'Select customer class...' }, {:class => 'form-select', :required => true}
     .row.mb-3
-      = f.label :sales_tax_product_class_id, "Product Class", class: 'col-sm-3 col-form-label'
+      = f.label :sales_tax_product_class_id, label: "Product Class", required: true, class: 'col-sm-3 col-form-label'
       .col-sm-9
         = f.collection_select :sales_tax_product_class_id, SalesTaxProductClass.all, :id, :name, { prompt: 'Select product class...' }, {:class => 'form-select', :required => true}
     .row.mb-3
       = f.label :rate, class: 'col-sm-3 col-form-label'
       .col-sm-9
         .input-group
-          = f.number_field :rate, :class => 'form-control', :step => 0.01
+          = f.number_field :rate, :class => 'form-control', :step => 0.01, :required => true
           %span.input-group-text %
 
   %br

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -108,7 +108,7 @@ SimpleForm.setup do |config|
 
   # Tell browsers whether to use default HTML5 validations (novalidate option).
   # Default is enabled.
-  config.browser_validations = false
+  # config.browser_validations = true
 
   # Collection of methods to detect if a file type was given.
   # config.file_methods = [ :mounted_as, :file?, :public_filename ]

--- a/test/controllers/customers_controller_test.rb
+++ b/test/controllers/customers_controller_test.rb
@@ -23,6 +23,20 @@ class CustomersControllerTest < ActionDispatch::IntegrationTest
     assert_select "form"
   end
 
+  test "new customer form marks required fields and lets the browser validate them" do
+    get new_customer_url
+    assert_response :success
+
+    assert_select "form#new_customer:not([novalidate])"
+
+    assert_select "input#customer_matchcode[required]"
+    assert_select "textarea#customer_name[required]"
+
+    assert_select "label.required[for='customer_team_id']"
+    assert_select "label.required[for='customer_sales_tax_customer_class_id']"
+    assert_select "label.required[for='customer_language_id']"
+  end
+
   test "should create customer" do
     assert_difference("Customer.count") do
       post customers_url, params: {

--- a/test/controllers/products_controller_test.rb
+++ b/test/controllers/products_controller_test.rb
@@ -10,4 +10,19 @@ class ProductsControllerTest < ActionDispatch::IntegrationTest
     get new_product_url
     assert_response :success
   end
+
+  test "new product form marks required fields and lets the browser validate them" do
+    get new_product_url
+    assert_response :success
+
+    assert_select "form#new_product:not([novalidate])"
+
+    assert_select "input#product_title[required]"
+    assert_select "input#product_rate[required]"
+    assert_select "select#product_sales_tax_product_class_id[required]"
+
+    assert_select "label.required[for='product_title']"
+    assert_select "label.required[for='product_rate']"
+    assert_select "label.required[for='product_sales_tax_product_class_id']"
+  end
 end

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -61,6 +61,19 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "new project form marks required fields and lets the browser validate them" do
+    get new_project_url
+    assert_response :success
+
+    assert_select "form#new_project:not([novalidate])"
+
+    assert_select "input#project_matchcode[required]"
+    assert_select "select#project_team_id[required]"
+
+    assert_select "label.required[for='project_matchcode']"
+    assert_select "label.required[for='project_team_id']"
+  end
+
   test "should create project" do
     assert_difference("Project.count") do
       post projects_url, params: {


### PR DESCRIPTION
## Summary
- Re-enable simple_form's browser HTML5 validation. The initializer was forcing `browser_validations = false`, which added `novalidate` to every form and silently disabled every `required` attribute, so missing required fields surfaced only as server-side errors.
- Add the missing visual required marker on belongs_to `_id` labels (simple_form looks up validators by attribute name, not by association, so `f.label :foo_id` got no marker) and on labels using the positional-string form (which short-circuits to ActionView's plain label, skipping simple_form's required handling entirely). Customer, product, project, and sales-tax-rate forms all had at least one of these.
- Fill in the `required` HTML attribute on text inputs whose models already declare presence validators but whose forms hadn't propagated that to the input element (`matchcode`, `name`, etc.).
- Add server-side presence validators for `Product#title` and `Product#rate`. The form has always treated them as required in the browser, but the model had no validations — so an API caller or anything bypassing JS could save a Product with both fields blank.

## Test plan
- [x] `bundle exec rails test` (530 runs, 1974 assertions, 0 failures)
- [ ] Manual: open `/customers/new` and submit empty — browser blocks submit on Matchcode, Team, Name, Sales Tax Class, Language.
- [ ] Manual: open `/products/new` and submit empty — browser blocks submit on Title, Rate, Sales Tax Class.
- [ ] Manual: open `/projects/new` and submit empty — browser blocks submit on Matchcode, Team.
- [ ] Manual: open `/sales_tax_rates/new`, `/sales_tax_customer_classes/new`, `/sales_tax_product_classes/new` and verify required fields trigger browser warnings and show the visual marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)