### PR TITLE
Add per-customer email contacts (#67)

### DIFF
--- a/app/controllers/customer_contacts_controller.rb
+++ b/app/controllers/customer_contacts_controller.rb
@@ -1,0 +1,94 @@
+class CustomerContactsController < ApplicationController
+  before_action -> { require_permission!("customers.view") }, only: %i[show]
+  before_action -> { require_permission!("customers.edit") }, only: %i[new create edit update destroy]
+
+  before_action :set_customer, only: %i[new create]
+  before_action :set_contact,  only: %i[show edit update destroy]
+
+  # GET /customer_contacts/:id — used by Turbo Frame "Cancel" to revert
+  # an edit back to the read-only row partial.
+  def show
+    render partial: "customer_contacts/row", locals: { contact: @contact }
+  end
+
+  # GET /customers/:customer_id/customer_contacts/new
+  # ?cancel=1 reverts the new_customer_contact frame to its add-link state.
+  def new
+    @contact = @customer.customer_contacts.build
+    if params[:cancel]
+      render partial: "customer_contacts/add_link", locals: { customer: @customer }
+    end
+  end
+
+  # POST /customers/:customer_id/customer_contacts
+  def create
+    @contact = @customer.customer_contacts.build(contact_params)
+    assign_projects(@contact, params.dig(:customer_contact, :project_ids))
+
+    if @contact.save
+      respond_to do |format|
+        format.turbo_stream do
+          render turbo_stream: [
+            turbo_stream.append("customer_contacts_tbody", partial: "customer_contacts/row", locals: { contact: @contact }),
+            turbo_stream.replace("new_customer_contact", partial: "customer_contacts/add_link", locals: { customer: @customer })
+          ]
+        end
+        format.html { redirect_to @customer }
+      end
+    else
+      render :new, status: :unprocessable_content
+    end
+  end
+
+  # GET /customer_contacts/:id/edit
+  def edit
+  end
+
+  # PATCH /customer_contacts/:id
+  def update
+    @contact.assign_attributes(contact_params)
+    assign_projects(@contact, params.dig(:customer_contact, :project_ids))
+
+    if @contact.save
+      render partial: "customer_contacts/row", locals: { contact: @contact }
+    else
+      render :edit, status: :unprocessable_content
+    end
+  end
+
+  # DELETE /customer_contacts/:id
+  def destroy
+    @contact.destroy
+    respond_to do |format|
+      format.turbo_stream { render turbo_stream: turbo_stream.remove(helpers.dom_id(@contact)) }
+      format.html { redirect_to @contact.customer }
+    end
+  end
+
+  private
+
+  def set_customer
+    @customer = Customer.visible_to(current_user).find(params[:customer_id])
+  end
+
+  def set_contact
+    @contact  = CustomerContact.joins(:customer).merge(Customer.visible_to(current_user)).find(params[:id])
+    @customer = @contact.customer
+  end
+
+  def contact_params
+    params.require(:customer_contact).permit(:name, :email, :receives_invoice_emails, :receives_delivery_note_emails)
+  end
+
+  # Server-side scope on project_ids: pick only IDs the user can see AND that
+  # are eligible for this customer (their own projects or unassigned).
+  def assign_projects(contact, ids)
+    ids = Array(ids).reject(&:blank?).map(&:to_i)
+    return contact.projects = [] if ids.empty?
+
+    eligible = Project.visible_to(current_user)
+                      .where(id: ids)
+                      .where("bill_to_customer_id = ? OR bill_to_customer_id IS NULL", @customer.id)
+    contact.projects = eligible.to_a
+  end
+end

--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -88,8 +88,8 @@ class CustomersController < ApplicationController
 private
   def customers_params
     params.require(:customer).permit(
-        :matchcode, :name, :address, :email, :vat_id, :notes, :sales_tax_customer_class_id, :language_id, :payment_terms_days,
-        :invoice_email_auto_to, :invoice_email_auto_subject_template, :invoice_email_auto_enabled, :active,
+        :matchcode, :name, :address, :vat_id, :notes, :sales_tax_customer_class_id, :language_id, :payment_terms_days,
+        :invoice_email_auto_to, :invoice_email_auto_subject_template, :invoice_email_auto_enabled, :invoice_email_auto_contact_mode, :active,
         :team_id
     )
   end

--- a/app/controllers/delivery_notes_controller.rb
+++ b/app/controllers/delivery_notes_controller.rb
@@ -281,6 +281,9 @@ class DeliveryNotesController < ApplicationController
   end
 
   def send_email
+    unless @delivery_note.emailable?
+      redirect_to @delivery_note, alert: "No recipient configured for this delivery note." and return
+    end
     DeliveryNoteMailer.with(delivery_note: @delivery_note).customer_email.deliver_later
     @delivery_note.update_column(:email_sent_at, Time.current)
     respond_to do |format|
@@ -298,26 +301,32 @@ class DeliveryNotesController < ApplicationController
       return
     end
 
-    delivery_notes = DeliveryNote.where(id: delivery_note_ids, published: true)
-
-    # Group delivery notes by customer
-    grouped_by_customer = delivery_notes.group_by(&:customer)
+    delivery_notes = DeliveryNote.visible_to(current_user).where(id: delivery_note_ids, published: true)
     queued_count = 0
+    skipped_count = 0
     now = Time.current
 
-    grouped_by_customer.each do |customer, customer_delivery_notes|
-      next unless customer.email.present?
-
-      if customer_delivery_notes.length == 1
-        DeliveryNoteMailer.with(delivery_note: customer_delivery_notes.first).customer_email.deliver_later
-      else
-        DeliveryNoteMailer.with(delivery_notes: customer_delivery_notes).bulk_customer_email.deliver_later
+    # Partition by [customer_id, resolved-recipient-set]. Two DNs to the same
+    # customer with different project-scoped contacts must NOT be combined,
+    # otherwise we leak DN A's recipients onto DN B.
+    delivery_notes.group_by { |dn| [ dn.customer_id, dn.email_recipients.sort ] }.each do |(_cid, recipients), dns|
+      if recipients.empty?
+        skipped_count += dns.length
+        next
       end
-      DeliveryNote.where(id: customer_delivery_notes.map(&:id)).update_all(email_sent_at: now)
-      queued_count += customer_delivery_notes.length
+
+      if dns.length == 1
+        DeliveryNoteMailer.with(delivery_note: dns.first).customer_email.deliver_later
+      else
+        DeliveryNoteMailer.with(delivery_notes: dns, recipients: recipients).bulk_customer_email.deliver_later
+      end
+      DeliveryNote.where(id: dns.map(&:id)).update_all(email_sent_at: now)
+      queued_count += dns.length
     end
 
-    redirect_to delivery_notes_path, notice: "#{queued_count} emails queued for sending."
+    notice = "#{queued_count} emails queued for sending."
+    notice += " #{skipped_count} skipped (no recipients)." if skipped_count > 0
+    redirect_to delivery_notes_path, notice: notice
   end
 
 protected

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -173,6 +173,9 @@ class InvoicesController < ApplicationController
   end
 
   def send_email
+    unless @invoice.emailable?
+      redirect_to @invoice, alert: "No recipient configured for this invoice." and return
+    end
     InvoiceMailer.with(invoice: @invoice).customer_email.deliver_later
     @invoice.update_column(:email_sent_at, Time.current)
     respond_to do |format|
@@ -204,19 +207,24 @@ class InvoicesController < ApplicationController
       return
     end
 
-    invoices = Invoice.where(id: invoice_ids, published: true)
+    invoices = Invoice.visible_to(current_user).where(id: invoice_ids, published: true)
     queued_count = 0
+    skipped_count = 0
     now = Time.current
 
     invoices.each do |invoice|
-      if invoice.customer.email.present? || invoice.customer.invoice_email_auto_enabled
+      if invoice.emailable?
         InvoiceMailer.with(invoice: invoice).customer_email.deliver_later
         invoice.update_column(:email_sent_at, now)
         queued_count += 1
+      else
+        skipped_count += 1
       end
     end
 
-    redirect_to invoices_path, notice: "#{queued_count} emails queued for sending."
+    notice = "#{queued_count} emails queued for sending."
+    notice += " #{skipped_count} skipped (no recipients)." if skipped_count > 0
+    redirect_to invoices_path, notice: notice
   end
 
 protected

--- a/app/mailers/delivery_note_mailer.rb
+++ b/app/mailers/delivery_note_mailer.rb
@@ -4,34 +4,28 @@ class DeliveryNoteMailer < ApplicationMailer
     attach_pdf(@delivery_note) unless params[:skip_attachments]
 
     customer = @delivery_note.customer
-    to = subject = nil
+    to = @delivery_note.email_recipients
 
     with_customer_locale(customer) do
-      if customer.email.present?
-        subject = I18n.t("mailers.delivery_note.subject", issuer_name: @issuer.short_name, document_number: @delivery_note.document_number)
-        to = customer.email
-      end
-
+      subject = I18n.t("mailers.delivery_note.subject", issuer_name: @issuer.short_name, document_number: @delivery_note.document_number)
       document_mail(to: to, subject: subject)
     end
   end
 
+  # Caller must ensure every delivery note in @delivery_notes resolves to the
+  # same `recipients` set, otherwise we'd leak one DN's recipients onto
+  # another. DeliveryNotesController#bulk_send_emails partitions accordingly
+  # by [customer_id, sorted recipient list].
   def bulk_customer_email
     @delivery_notes = params[:delivery_notes]
     @customer = @delivery_notes.first.customer
+    to = params[:recipients] || @customer.contacts_for_delivery_note(@delivery_notes.first).map(&:email)
 
     @delivery_notes.each { |dn| attach_pdf(dn) }
 
-    customer = @customer
-    to = subject = nil
-
-    with_customer_locale(customer) do
-      if customer.email.present?
-        document_numbers = @delivery_notes.map(&:document_number).join(", ")
-        subject = I18n.t("mailers.delivery_note.bulk_subject", issuer_name: @issuer.short_name, document_numbers: document_numbers)
-        to = customer.email
-      end
-
+    with_customer_locale(@customer) do
+      document_numbers = @delivery_notes.map(&:document_number).join(", ")
+      subject = I18n.t("mailers.delivery_note.bulk_subject", issuer_name: @issuer.short_name, document_numbers: document_numbers)
       document_mail(to: to, subject: subject)
     end
   end

--- a/app/mailers/invoice_mailer.rb
+++ b/app/mailers/invoice_mailer.rb
@@ -7,18 +7,16 @@ class InvoiceMailer < ApplicationMailer
     }
 
     customer = @invoice.customer
-    to = cc = subject = nil
+    to = @invoice.email_recipients
+    cc = @invoice.email_cc_recipients
 
     with_customer_locale(customer) do
       if customer.invoice_email_auto_enabled
         subject = customer.invoice_email_auto_subject_template
                           .gsub("$CUST_ORDER$", sanitize_header_value(@invoice.cust_order))
                           .gsub("$CUST_REF$", sanitize_header_value(@invoice.cust_reference))
-        to = customer.invoice_email_auto_to
-        cc = customer.email if customer.email.present? && customer.email != to
-      elsif customer.email.present?
+      else
         subject = I18n.t("mailers.invoice.subject", issuer_name: @issuer.short_name, document_number: @invoice.document_number)
-        to = customer.email
       end
 
       document_mail(to: to, cc: cc, subject: subject)

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -11,6 +11,13 @@ class Customer < ApplicationRecord
   belongs_to :language
   has_many :sales_tax_rates, through: :sales_tax_customer_class
   has_many :invoices
+  has_many :customer_contacts, dependent: :destroy
+
+  enum :invoice_email_auto_contact_mode, {
+    replace_contacts: "replace_contacts",
+    cc_contacts: "cc_contacts",
+    additional: "additional"
+  }
 
   # Scopes for filtering
   scope :active, -> { where(active: true) }
@@ -18,6 +25,14 @@ class Customer < ApplicationRecord
 
   def used_in_invoices?
     invoices.exists?
+  end
+
+  def contacts_for_invoice(invoice)
+    customer_contacts.for_invoices.select { |c| c.applies_to_project?(invoice.project) }
+  end
+
+  def contacts_for_delivery_note(delivery_note)
+    customer_contacts.for_delivery_notes.select { |c| c.applies_to_project?(delivery_note.project) }
   end
 
   before_destroy :check_if_used

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -15,8 +15,7 @@ class Customer < ApplicationRecord
 
   enum :invoice_email_auto_contact_mode, {
     replace_contacts: "replace_contacts",
-    cc_contacts: "cc_contacts",
-    additional: "additional"
+    cc_contacts: "cc_contacts"
   }
 
   # Scopes for filtering

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -18,6 +18,18 @@ class Customer < ApplicationRecord
     cc_contacts: "cc_contacts"
   }
 
+  # Human-readable labels for the invoice_email_auto_contact_mode values.
+  # Single source of truth: customer form select + customer show page both
+  # read from here. Order matters: the form select uses it positionally.
+  INVOICE_EMAIL_AUTO_CONTACT_MODE_LABELS = {
+    "replace_contacts" => "Only auto address (ignore contacts)",
+    "cc_contacts"      => "Auto address in To, contacts in CC"
+  }.freeze
+
+  def invoice_email_auto_contact_mode_label
+    INVOICE_EMAIL_AUTO_CONTACT_MODE_LABELS[invoice_email_auto_contact_mode]
+  end
+
   # Scopes for filtering
   scope :active, -> { where(active: true) }
   scope :inactive, -> { where(active: false) }

--- a/app/models/customer_contact.rb
+++ b/app/models/customer_contact.rb
@@ -1,0 +1,42 @@
+class CustomerContact < ApplicationRecord
+  belongs_to :customer
+  has_and_belongs_to_many :projects, join_table: :customer_contact_projects
+
+  validates :name,  presence: true
+  validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }
+  validate :customer_must_be_visible_to_current_user, if: :will_save_change_to_customer_id?
+  validate :projects_belong_to_customer_or_unassigned
+  validate :projects_must_be_visible_to_current_user
+
+  scope :for_invoices,       -> { where(receives_invoice_emails: true) }
+  scope :for_delivery_notes, -> { where(receives_delivery_note_emails: true) }
+
+  # No projects assigned == applies to all projects of this customer.
+  def applies_to_project?(project)
+    projects.empty? || projects.include?(project)
+  end
+
+  private
+
+  def projects_belong_to_customer_or_unassigned
+    bad = projects.reject { |p| p.bill_to_customer_id.nil? || p.bill_to_customer_id == customer_id }
+    errors.add(:projects, "must belong to this customer or to no customer") if bad.any?
+  end
+
+  # Mirrors ScopedThroughCustomer: skip when Current.user is nil so seeds /
+  # console / jobs can build contacts freely.
+  def customer_must_be_visible_to_current_user
+    user = Current.user
+    return if user.nil?
+    return if customer_id && Customer.visible_to(user).where(id: customer_id).exists?
+    errors.add(:customer_id, "must be a customer you can access")
+  end
+
+  def projects_must_be_visible_to_current_user
+    user = Current.user
+    return if user.nil? || projects.empty?
+    visible_ids = Project.visible_to(user).where(id: projects.map(&:id)).pluck(:id).to_set
+    bad = projects.reject { |p| visible_ids.include?(p.id) }
+    errors.add(:projects, "must be projects you can access") if bad.any?
+  end
+end

--- a/app/models/delivery_note.rb
+++ b/app/models/delivery_note.rb
@@ -12,11 +12,25 @@ class DeliveryNote < ApplicationRecord
   default_scope { order(Arel.sql("id ASC")) }
 
   scope :email_unsent, -> {
-    joins(:customer)
-    .where(email_sent_at: nil)
-    .where("customers.email IS NOT NULL AND customers.email != ''")
+    where(email_sent_at: nil).where(<<~SQL.squish)
+      EXISTS (
+        SELECT 1 FROM customer_contacts cc
+        LEFT JOIN customer_contact_projects ccp ON ccp.customer_contact_id = cc.id
+        WHERE cc.customer_id = delivery_notes.customer_id
+          AND cc.receives_delivery_note_emails = TRUE
+          AND (ccp.project_id IS NULL OR ccp.project_id = delivery_notes.project_id)
+      )
+    SQL
   }
   scope :published, -> { where(published: true) }
+
+  def email_recipients
+    customer.contacts_for_delivery_note(self).map(&:email)
+  end
+
+  def emailable?
+    customer.contacts_for_delivery_note(self).any?
+  end
 
   def self.visible_to(user)
     return none if user.nil?

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -36,7 +36,8 @@ class Invoice < ApplicationRecord
 
   def email_cc_recipients
     return [] unless customer.invoice_email_auto_enabled? && customer.cc_contacts?
-    customer.contacts_for_invoice(self).map(&:email) - [ customer.invoice_email_auto_to ].compact_blank
+    auto_to = customer.invoice_email_auto_to.to_s.downcase.strip
+    customer.contacts_for_invoice(self).map(&:email).reject { |e| e.to_s.downcase.strip == auto_to }
   end
 
   def emailable?

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -9,12 +9,48 @@ class Invoice < ApplicationRecord
   default_scope { order(Arel.sql("id ASC")) }
 
   scope :email_unsent, -> {
-    joins(:customer)
-    .where(email_sent_at: nil)
-    .where("customers.email IS NOT NULL AND customers.email != '' OR customers.invoice_email_auto_enabled = true")
+    where(email_sent_at: nil).where(<<~SQL.squish)
+      EXISTS (
+        SELECT 1 FROM customer_contacts cc
+        LEFT JOIN customer_contact_projects ccp ON ccp.customer_contact_id = cc.id
+        WHERE cc.customer_id = invoices.customer_id
+          AND cc.receives_invoice_emails = TRUE
+          AND (ccp.project_id IS NULL OR ccp.project_id = invoices.project_id)
+      )
+      OR EXISTS (
+        SELECT 1 FROM customers c
+        WHERE c.id = invoices.customer_id AND c.invoice_email_auto_enabled = TRUE
+      )
+    SQL
   }
   scope :published, -> { where(published: true) }
   scope :unpaid, -> { where(paid_at: nil) }
+
+  # Recipients for a real outbound send. Honors invoice_email_auto_contact_mode
+  # when the customer's auto-email feature is on. Returns an array of email
+  # strings; callers compose them into mail.to / mail.cc.
+  def email_recipients
+    contacts = customer.contacts_for_invoice(self).map(&:email)
+    return contacts unless customer.invoice_email_auto_enabled?
+
+    auto = [ customer.invoice_email_auto_to ].compact_blank
+    case customer.invoice_email_auto_contact_mode
+    when "replace_contacts" then auto
+    when "additional"       then (auto + contacts).uniq
+    when "cc_contacts"      then auto # contacts go to cc, not to: — see InvoiceMailer
+    else auto
+    end
+  end
+
+  def email_cc_recipients
+    return [] unless customer.invoice_email_auto_enabled? && customer.cc_contacts?
+    customer.contacts_for_invoice(self).map(&:email) - [ customer.invoice_email_auto_to ].compact_blank
+  end
+
+  def emailable?
+    return true if customer.invoice_email_auto_enabled?
+    customer.contacts_for_invoice(self).any?
+  end
 
   def self.visible_to(user)
     return none if user.nil?

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -30,16 +30,8 @@ class Invoice < ApplicationRecord
   # when the customer's auto-email feature is on. Returns an array of email
   # strings; callers compose them into mail.to / mail.cc.
   def email_recipients
-    contacts = customer.contacts_for_invoice(self).map(&:email)
-    return contacts unless customer.invoice_email_auto_enabled?
-
-    auto = [ customer.invoice_email_auto_to ].compact_blank
-    case customer.invoice_email_auto_contact_mode
-    when "replace_contacts" then auto
-    when "additional"       then (auto + contacts).uniq
-    when "cc_contacts"      then auto # contacts go to cc, not to: — see InvoiceMailer
-    else auto
-    end
+    return customer.contacts_for_invoice(self).map(&:email) unless customer.invoice_email_auto_enabled?
+    [ customer.invoice_email_auto_to ].compact_blank
   end
 
   def email_cc_recipients

--- a/app/views/customer_contacts/_add_link.html.haml
+++ b/app/views/customer_contacts/_add_link.html.haml
@@ -1,0 +1,2 @@
+= turbo_frame_tag :new_customer_contact, class: "d-block py-2" do
+  = link_to "+ Add contact", new_customer_customer_contact_path(customer), class: "btn btn-sm btn-outline-primary"

--- a/app/views/customer_contacts/_form_fields.html.haml
+++ b/app/views/customer_contacts/_form_fields.html.haml
@@ -1,0 +1,31 @@
+- eligible_projects ||= Project.visible_to(Current.user).where("bill_to_customer_id = ? OR bill_to_customer_id IS NULL", customer.id).order(:matchcode)
+.row.align-items-start.gx-2
+  .col-md-2
+    = form.text_field :name, class: "form-control form-control-sm", required: true, autofocus: true, placeholder: "Name"
+    - if contact.errors[:name].any?
+      .invalid-feedback.d-block= contact.errors[:name].to_sentence
+  .col-md-3
+    = form.email_field :email, class: "form-control form-control-sm", required: true, placeholder: "Email"
+    - if contact.errors[:email].any?
+      .invalid-feedback.d-block= contact.errors[:email].to_sentence
+  .col-md-1.text-center
+    .form-check.d-inline-block
+      = form.check_box :receives_invoice_emails, class: "form-check-input"
+  .col-md-1.text-center
+    .form-check.d-inline-block
+      = form.check_box :receives_delivery_note_emails, class: "form-check-input"
+  .col-md-3
+    = form.select :project_ids,
+                  options_from_collection_for_select(eligible_projects, :id, :matchcode, contact.project_ids),
+                  { include_hidden: false },
+                  multiple: true, size: [eligible_projects.size, 4].min.clamp(2, 6),
+                  class: "form-select form-select-sm",
+                  style: "max-height: 7rem"
+    - if contact.errors[:projects].any?
+      .invalid-feedback.d-block= contact.errors[:projects].to_sentence
+  .col-md-2.text-end
+    = form.submit (contact.persisted? ? "Save" : "Add"), class: "btn btn-sm btn-primary"
+    - if contact.persisted?
+      = link_to "Cancel", customer_contact_path(contact), class: "btn btn-sm btn-link"
+    - else
+      = link_to "Cancel", new_customer_customer_contact_path(customer, cancel: 1), class: "btn btn-sm btn-link"

--- a/app/views/customer_contacts/_row.html.haml
+++ b/app/views/customer_contacts/_row.html.haml
@@ -4,12 +4,12 @@
     .col-md-3= mail_to contact.email
     .col-md-1.text-center
       - if contact.receives_invoice_emails?
-        %span.badge.bg-success Inv
+        %span.badge.bg-success Invoice
       - else
         %span.text-muted —
     .col-md-1.text-center
       - if contact.receives_delivery_note_emails?
-        %span.badge.bg-success DN
+        %span.badge.bg-success Del.Note
       - else
         %span.text-muted —
     .col-md-3

--- a/app/views/customer_contacts/_row.html.haml
+++ b/app/views/customer_contacts/_row.html.haml
@@ -1,0 +1,25 @@
+= turbo_frame_tag dom_id(contact), class: "contact-row d-block border-bottom py-2" do
+  .row.align-items-center.gx-2
+    .col-md-2.fw-medium= contact.name
+    .col-md-3= mail_to contact.email
+    .col-md-1.text-center
+      - if contact.receives_invoice_emails?
+        %span.badge.bg-success Inv
+      - else
+        %span.text-muted —
+    .col-md-1.text-center
+      - if contact.receives_delivery_note_emails?
+        %span.badge.bg-success DN
+      - else
+        %span.text-muted —
+    .col-md-3
+      - if contact.projects.any?
+        - contact.projects.each do |p|
+          %span.badge.bg-secondary.me-1= p.matchcode
+      - else
+        %span.text-muted All projects
+    .col-md-2.text-end
+      - if can?('customers.edit')
+        = list_action_link "Edit", edit_customer_contact_path(contact), :edit
+        = link_to "🗑", customer_contact_path(contact), class: "btn btn-sm btn-outline-danger py-0",
+                  data: { 'turbo-method': :delete, 'turbo-confirm': "Delete contact \"#{contact.name}\"?" }

--- a/app/views/customer_contacts/edit.html.haml
+++ b/app/views/customer_contacts/edit.html.haml
@@ -1,0 +1,3 @@
+= turbo_frame_tag dom_id(@contact), class: "d-block border-bottom py-2 bg-light" do
+  = form_with model: @contact do |form|
+    = render "customer_contacts/form_fields", form: form, contact: @contact, customer: @customer

--- a/app/views/customer_contacts/new.html.haml
+++ b/app/views/customer_contacts/new.html.haml
@@ -1,0 +1,3 @@
+= turbo_frame_tag :new_customer_contact, class: "d-block border-bottom py-2 bg-light" do
+  = form_with model: [@customer, @contact] do |form|
+    = render "customer_contacts/form_fields", form: form, contact: @contact, customer: @customer

--- a/app/views/customers/_contacts_table.html.haml
+++ b/app/views/customers/_contacts_table.html.haml
@@ -4,8 +4,8 @@
     .row.gx-2.pb-2.border-bottom.text-muted.small.fw-bold
       .col-md-2 Name
       .col-md-3 Email
-      .col-md-1.text-center Inv.
-      .col-md-1.text-center DN
+      .col-md-1.text-center Invoice
+      .col-md-1.text-center Del.Note
       .col-md-3 Projects
       .col-md-2.text-end &nbsp;
 

--- a/app/views/customers/_contacts_table.html.haml
+++ b/app/views/customers/_contacts_table.html.haml
@@ -1,0 +1,19 @@
+.card.mt-4#customer_contacts
+  .card-header Contacts
+  .card-body.pt-2
+    .row.gx-2.pb-2.border-bottom.text-muted.small.fw-bold
+      .col-md-2 Name
+      .col-md-3 Email
+      .col-md-1.text-center Inv.
+      .col-md-1.text-center DN
+      .col-md-3 Projects
+      .col-md-2.text-end &nbsp;
+
+    %div#customer_contacts_tbody
+      - if customer.customer_contacts.any?
+        = render partial: "customer_contacts/row", collection: customer.customer_contacts.includes(:projects), as: :contact
+      - else
+        .text-muted.py-2.small No contacts configured. The customer will not receive any emails unless an Automated Email is configured.
+
+    - if can?('customers.edit')
+      = render "customer_contacts/add_link", customer: customer

--- a/app/views/customers/_form.html.haml
+++ b/app/views/customers/_form.html.haml
@@ -48,10 +48,6 @@
         = f.collection_select :language_id, Language.all, :id, :title, { prompt: 'Select language...' }, {:class => 'form-select', :required => true}
     %hr
     .row.mb-3
-      = f.label :email, 'E-Mail', class: 'col-lg-2 col-md-3 col-form-label'
-      .col-lg-5
-        = f.text_field :email, :class => 'form-control'
-    .row.mb-3
       = f.label :invoice_email_auto_enabled, 'Auto. Invoice E-Mail', class: 'col-lg-2 col-md-3 col-form-label'
       .col-lg-1.col-md-2.col-sm-2
         .form-check
@@ -61,6 +57,15 @@
         = f.text_field :invoice_email_auto_to, {:class => 'form-control', :placeholder => 'To:'}
       .col-lg-4
         = f.text_field :invoice_email_auto_subject_template, {:class => 'form-control', :placeholder => 'Subject: XXXX $CUST_REF$ $CUST_ORDER$'}
+    .row.mb-3
+      = f.label :invoice_email_auto_contact_mode, 'Contacts mode', class: 'col-lg-2 col-md-3 col-form-label'
+      .col-lg-5
+        = f.select :invoice_email_auto_contact_mode,
+                   [['Replace contacts (To: auto only — current behaviour)', 'replace_contacts'],
+                    ['CC contacts (To: auto, CC: matching contacts)', 'cc_contacts'],
+                    ['Additional (To: auto + matching contacts)', 'additional']],
+                   {}, class: 'form-select'
+        .form-text Applies only when "Auto. Invoice E-Mail" is on. Contacts always receive the email when auto is off.
     %hr
     .row.mb-3
       = f.label :payment_terms_days, 'Payment terms (days)', class: 'col-lg-2 col-md-3 col-form-label'

--- a/app/views/customers/_form.html.haml
+++ b/app/views/customers/_form.html.haml
@@ -61,9 +61,9 @@
       = f.label :invoice_email_auto_contact_mode, 'Contacts mode', class: 'col-lg-2 col-md-3 col-form-label'
       .col-lg-5
         = f.select :invoice_email_auto_contact_mode,
-                   [['Replace contacts (To: auto only — current behaviour)', 'replace_contacts'],
-                    ['CC contacts (To: auto, CC: matching contacts)', 'cc_contacts'],
-                    ['Additional (To: auto + matching contacts)', 'additional']],
+                   [['Only auto address (ignore contacts)', 'replace_contacts'],
+                    ['Auto address in To, contacts in CC', 'cc_contacts'],
+                    ['Auto address and contacts both in To', 'additional']],
                    {}, class: 'form-select'
         .form-text Applies only when "Auto. Invoice E-Mail" is on. Contacts always receive the email when auto is off.
     %hr

--- a/app/views/customers/_form.html.haml
+++ b/app/views/customers/_form.html.haml
@@ -62,8 +62,7 @@
       .col-lg-5
         = f.select :invoice_email_auto_contact_mode,
                    [['Only auto address (ignore contacts)', 'replace_contacts'],
-                    ['Auto address in To, contacts in CC', 'cc_contacts'],
-                    ['Auto address and contacts both in To', 'additional']],
+                    ['Auto address in To, contacts in CC', 'cc_contacts']],
                    {}, class: 'form-select'
         .form-text Applies only when "Auto. Invoice E-Mail" is on. Contacts always receive the email when auto is off.
     %hr

--- a/app/views/customers/_form.html.haml
+++ b/app/views/customers/_form.html.haml
@@ -61,8 +61,7 @@
       = f.label :invoice_email_auto_contact_mode, 'Contacts mode', class: 'col-lg-2 col-md-3 col-form-label'
       .col-lg-5
         = f.select :invoice_email_auto_contact_mode,
-                   [['Only auto address (ignore contacts)', 'replace_contacts'],
-                    ['Auto address in To, contacts in CC', 'cc_contacts']],
+                   Customer::INVOICE_EMAIL_AUTO_CONTACT_MODE_LABELS.map { |value, label| [label, value] },
                    {}, class: 'form-select'
         .form-text Applies only when "Auto. Invoice E-Mail" is on. Contacts always receive the email when auto is off.
     %hr

--- a/app/views/customers/show.html.haml
+++ b/app/views/customers/show.html.haml
@@ -107,7 +107,7 @@
             .col-sm-3
               %strong Contacts mode:
             .col-sm-9
-              = @customer.invoice_email_auto_contact_mode.humanize
+              = @customer.invoice_email_auto_contact_mode_label
 
 = render "customers/contacts_table", customer: @customer
 

--- a/app/views/customers/show.html.haml
+++ b/app/views/customers/show.html.haml
@@ -64,9 +64,11 @@
       .card-body
         .row.mb-2
           .col-sm-4
-            %strong Email:
+            %strong Contacts:
           .col-sm-8
-            = @customer.email
+            = pluralize(@customer.customer_contacts.size, 'contact')
+            - if @customer.customer_contacts.any?
+              = link_to '(manage)', '#customer_contacts'
 
         .row.mb-2
           .col-sm-4
@@ -100,6 +102,14 @@
               %strong Subject Template:
             .col-sm-9
               = @customer.invoice_email_auto_subject_template
+
+          .row.mb-2
+            .col-sm-3
+              %strong Contacts mode:
+            .col-sm-9
+              = @customer.invoice_email_auto_contact_mode.humanize
+
+= render "customers/contacts_table", customer: @customer
 
 - if @customer.notes.present?
   .row.mt-4

--- a/app/views/delivery_notes/show.html.haml
+++ b/app/views/delivery_notes/show.html.haml
@@ -28,10 +28,10 @@
             .col-sm-8
               - if @delivery_note.email_sent_at
                 %span.badge.bg-success Sent #{l(@delivery_note.email_sent_at)}
-              - elsif @delivery_note.customer.email.present?
+              - elsif @delivery_note.emailable?
                 %span.badge.bg-warning Unsent
               - else
-                %span.badge.bg-secondary No Email Address
+                %span.badge.bg-secondary No Recipient
         - if @delivery_note.invoice
           .row.mb-2
             .col-sm-4
@@ -150,9 +150,14 @@
       = action_button 'Edit', edit_delivery_note_path(@delivery_note), :primary
     - if @delivery_note.published?
       = action_button 'PDF', pdf_delivery_note_path(@delivery_note), :success, { target: '_blank', data: { turbo: false } }
-      - if can_edit_dn && @delivery_note.customer&.email.present?
-        %button.btn.btn-warning{"data-action" => "click->generic-email-preview#open"}
-          Send E-Mail
+      - if can_edit_dn
+        - if @delivery_note.emailable?
+          %button.btn.btn-warning{"data-action" => "click->generic-email-preview#open"}
+            Send E-Mail
+        - else
+          %span{data: { 'bs-toggle': 'tooltip' }, title: 'No contact is configured to receive this delivery note. Add a contact on the customer with "Delivery Notes" enabled.'}
+            %button.btn.btn-warning{disabled: true}
+              Send E-Mail
       - if can_edit_dn && !@delivery_note.invoice
         = button_to 'Convert to Invoice', convert_to_invoice_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-info', confirm: 'Create an invoice draft from this delivery note?'
       - if can_edit_dn

--- a/app/views/invoices/show.html.haml
+++ b/app/views/invoices/show.html.haml
@@ -41,10 +41,10 @@
             .col-sm-8
               - if @invoice.email_sent_at
                 %span.badge.bg-success Sent #{l(@invoice.email_sent_at)}
-              - elsif @invoice.customer.email.present? || @invoice.customer.invoice_email_auto_enabled
+              - elsif @invoice.emailable?
                 %span.badge.bg-warning Unsent
               - else
-                %span.badge.bg-secondary No Email Address
+                %span.badge.bg-secondary No Recipient
 
           .row.mb-2
             .col-sm-4
@@ -174,9 +174,14 @@
       = action_button 'Edit', edit_invoice_path(@invoice), :primary
     - if @invoice.attachment
       = action_button 'PDF', @invoice.attachment, :success, { target: '_blank', data: { turbo: false } }
-      - if can_edit_invoice && (@invoice.customer&.email.present? || (@invoice.customer&.invoice_email_auto_enabled && @invoice.customer&.invoice_email_auto_to.present?))
-        %button.btn.btn-warning{"data-action" => "click->generic-email-preview#open"}
-          Send E-Mail
+      - if can_edit_invoice
+        - if @invoice.emailable?
+          %button.btn.btn-warning{"data-action" => "click->generic-email-preview#open"}
+            Send E-Mail
+        - else
+          %span{data: { 'bs-toggle': 'tooltip' }, title: 'No contact is configured to receive this invoice. Add a contact on the customer, or enable Automated E-Mail.'}
+            %button.btn.btn-warning{disabled: true}
+              Send E-Mail
     - else
       = action_button 'Preview', preview_invoice_path(@invoice), :info, { target: '_blank', data: { turbo: false } }
     - if !@invoice.published && can_edit_invoice

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,10 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
   resources :attachments, only: [ :show ]
-  resources :customers
+  resources :customers do
+    resources :customer_contacts, only: [ :new, :create ]
+  end
+  resources :customer_contacts, only: [ :show, :edit, :update, :destroy ]
   resources :invoices do
     member do
       get "preview"

--- a/db/migrate/20260525120001_create_customer_contacts.rb
+++ b/db/migrate/20260525120001_create_customer_contacts.rb
@@ -1,0 +1,18 @@
+class CreateCustomerContacts < ActiveRecord::Migration[8.1]
+  def change
+    create_table :customer_contacts do |t|
+      t.references :customer, null: false, foreign_key: true, index: true
+      t.string :name, null: false
+      t.string :email, null: false
+      t.boolean :receives_invoice_emails, null: false, default: false
+      t.boolean :receives_delivery_note_emails, null: false, default: false
+      t.timestamps
+    end
+
+    create_table :customer_contact_projects do |t|
+      t.references :customer_contact, null: false, foreign_key: true
+      t.references :project, null: false, foreign_key: true
+    end
+    add_index :customer_contact_projects, [ :customer_contact_id, :project_id ], unique: true, name: :index_customer_contact_projects_uniq
+  end
+end

--- a/db/migrate/20260525120002_backfill_customer_contacts_from_email.rb
+++ b/db/migrate/20260525120002_backfill_customer_contacts_from_email.rb
@@ -1,0 +1,28 @@
+class BackfillCustomerContactsFromEmail < ActiveRecord::Migration[8.1]
+  def up
+    # Use a lightweight inline model so this stays decoupled from app code
+    # that might change shape later.
+    customer = Class.new(ActiveRecord::Base) { self.table_name = "customers" }
+    contact  = Class.new(ActiveRecord::Base) { self.table_name = "customer_contacts" }
+
+    customer.where.not(email: [ nil, "" ]).find_each do |c|
+      next if contact.where(customer_id: c.id).exists?
+
+      name = c.name.presence || c.email.split("@", 2).first
+      contact.create!(
+        customer_id: c.id,
+        name: name,
+        email: c.email,
+        receives_invoice_emails: true,
+        receives_delivery_note_emails: true,
+        created_at: Time.current,
+        updated_at: Time.current
+      )
+    end
+  end
+
+  def down
+    # No-op: dropping the synthetic contacts on rollback would discard data
+    # the user may have edited since the backfill.
+  end
+end

--- a/db/migrate/20260525120003_remove_email_from_customers.rb
+++ b/db/migrate/20260525120003_remove_email_from_customers.rb
@@ -1,0 +1,5 @@
+class RemoveEmailFromCustomers < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :customers, :email, :string
+  end
+end

--- a/db/migrate/20260525120004_add_invoice_email_auto_contact_mode_to_customers.rb
+++ b/db/migrate/20260525120004_add_invoice_email_auto_contact_mode_to_customers.rb
@@ -1,0 +1,6 @@
+class AddInvoiceEmailAutoContactModeToCustomers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :customers, :invoice_email_auto_contact_mode, :string,
+               null: false, default: "replace_contacts"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_25_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_25_120004) do
   create_table "attachments", force: :cascade do |t|
     t.string "content_type"
     t.datetime "created_at", null: false
@@ -20,11 +20,30 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_25_120000) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "customer_contact_projects", force: :cascade do |t|
+    t.integer "customer_contact_id", null: false
+    t.integer "project_id", null: false
+    t.index ["customer_contact_id", "project_id"], name: "index_customer_contact_projects_uniq", unique: true
+    t.index ["customer_contact_id"], name: "index_customer_contact_projects_on_customer_contact_id"
+    t.index ["project_id"], name: "index_customer_contact_projects_on_project_id"
+  end
+
+  create_table "customer_contacts", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "customer_id", null: false
+    t.string "email", null: false
+    t.string "name", null: false
+    t.boolean "receives_delivery_note_emails", default: false, null: false
+    t.boolean "receives_invoice_emails", default: false, null: false
+    t.datetime "updated_at", null: false
+    t.index ["customer_id"], name: "index_customer_contacts_on_customer_id"
+  end
+
   create_table "customers", force: :cascade do |t|
     t.boolean "active", default: true, null: false
     t.text "address"
     t.datetime "created_at", null: false
-    t.string "email"
+    t.string "invoice_email_auto_contact_mode", default: "replace_contacts", null: false
     t.boolean "invoice_email_auto_enabled", default: false, null: false
     t.string "invoice_email_auto_subject_template", default: "", null: false
     t.string "invoice_email_auto_to", default: "", null: false
@@ -372,6 +391,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_25_120000) do
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 
+  add_foreign_key "customer_contact_projects", "customer_contacts"
+  add_foreign_key "customer_contact_projects", "projects"
+  add_foreign_key "customer_contacts", "customers"
   add_foreign_key "customers", "languages"
   add_foreign_key "customers", "teams"
   add_foreign_key "delivery_note_lines", "delivery_notes"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -136,7 +136,6 @@ if Rails.env.development?
       Poland
     ADDRESS
     customer.vat_id = 'PL0123456789'
-    customer.email = 'accounting-goodeu@example.com'
     customer.notes = 'Long-term client, monthly invoicing'
     customer.sales_tax_customer_class = eu_class
     customer.language = english
@@ -151,7 +150,6 @@ if Rails.env.development?
       Netherlands
     ADDRESS
     customer.vat_id = 'NL123456789B01'
-    customer.email = 'accounting-localnat@example.com'
     customer.notes = 'Project-based work'
     customer.sales_tax_customer_class = national_class
     customer.language = german
@@ -165,7 +163,6 @@ if Rails.env.development?
       New York, NY 10001
       United States
     ADDRESS
-    customer.email = 'ap-us@example.com'
     customer.notes = 'US-based client, quarterly invoicing'
     customer.sales_tax_customer_class = export_class
     customer.language = english
@@ -209,6 +206,56 @@ if Rails.env.development?
     project.bill_to_customer = nil  # Reusable project
     project.team = default_team
   end
+
+  # Two extra projects for GOODEU to demonstrate project-scoped contacts.
+  audit_project = Project.find_or_create_by(matchcode: 'AUDIT2026') do |project|
+    project.description = 'Audit 2026'
+    project.bill_to_customer = good_company
+    project.team = default_team
+  end
+
+  migration_project = Project.find_or_create_by(matchcode: 'MIGR2026') do |project|
+    project.description = 'Migration 2026'
+    project.bill_to_customer = good_company
+    project.team = default_team
+  end
+
+  # Customer contacts.
+  # GOODEU: three contacts demonstrating the project-scoping rules.
+  unless good_company.customer_contacts.exists?
+    good_company.customer_contacts.create!(
+      name: 'Accounting',
+      email: 'accounting-goodeu@example.com',
+      receives_invoice_emails: true,
+      receives_delivery_note_emails: true
+    )
+    good_company.customer_contacts.create!(
+      name: 'Audit Lead',
+      email: 'audit-lead@example.com',
+      receives_invoice_emails: true,
+      receives_delivery_note_emails: false,
+      projects: [ audit_project, migration_project ]
+    )
+    good_company.customer_contacts.create!(
+      name: 'Migration PM',
+      email: 'pm-migration@example.com',
+      receives_invoice_emails: false,
+      receives_delivery_note_emails: true,
+      projects: [ migration_project ]
+    )
+  end
+
+  unless local_company.customer_contacts.exists?
+    local_company.customer_contacts.create!(
+      name: 'Buchhaltung',
+      email: 'accounting-localnat@example.com',
+      receives_invoice_emails: true,
+      receives_delivery_note_emails: true
+    )
+  end
+
+  # USACORP is intentionally left without contacts to exercise the
+  # "no recipient" UX path.
 
   # Sample products
   Product.find_or_create_by(title: 'Software Development') do |product|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -140,6 +140,10 @@ if Rails.env.development?
     customer.sales_tax_customer_class = eu_class
     customer.language = english
     customer.team = default_team
+    customer.invoice_email_auto_enabled = true
+    customer.invoice_email_auto_to = 'invoices-good-eu@example.com'
+    customer.invoice_email_auto_subject_template = 'Invoice $CUST_REF$ ($CUST_ORDER$)'
+    customer.invoice_email_auto_contact_mode = 'cc_contacts'
   end
 
   local_company = Customer.find_or_create_by(matchcode: 'LOCALNAT') do |customer|

--- a/test/controllers/customer_contacts_controller_test.rb
+++ b/test/controllers/customer_contacts_controller_test.rb
@@ -1,0 +1,139 @@
+require "test_helper"
+
+class CustomerContactsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @customer = customers(:good_eu)
+    @contact  = customer_contacts(:good_eu_accounting)
+  end
+
+  # --- shape / Turbo Frame contract ----------------------------------------
+
+  test "new renders the new_customer_contact frame" do
+    get new_customer_customer_contact_path(@customer)
+    assert_response :success
+    assert_select "turbo-frame#new_customer_contact"
+  end
+
+  test "create on success appends row and replaces add-link with turbo-stream" do
+    assert_difference -> { @customer.customer_contacts.count }, +1 do
+      post customer_customer_contacts_path(@customer),
+           params: { customer_contact: { name: "Adam", email: "adam@example.com", receives_invoice_emails: true } },
+           headers: { Accept: "text/vnd.turbo-stream.html" }
+    end
+
+    assert_response :success
+    assert_includes response.media_type, "turbo-stream"
+    new_contact = @customer.customer_contacts.find_by(email: "adam@example.com")
+    assert_select %(turbo-stream[action="append"][target="customer_contacts_tbody"]) do
+      assert_select "turbo-frame##{ActionView::RecordIdentifier.dom_id(new_contact)}"
+    end
+    assert_select %(turbo-stream[action="replace"][target="new_customer_contact"])
+  end
+
+  test "create on validation failure re-renders the new frame with 422" do
+    assert_no_difference -> { @customer.customer_contacts.count } do
+      post customer_customer_contacts_path(@customer),
+           params: { customer_contact: { name: "", email: "not-an-email" } }
+    end
+
+    assert_response :unprocessable_content
+    assert_select "turbo-frame#new_customer_contact"
+  end
+
+  test "edit returns the row frame containing the form" do
+    get edit_customer_contact_path(@contact)
+    assert_response :success
+    assert_select "turbo-frame##{ActionView::RecordIdentifier.dom_id(@contact)}"
+    assert_select "input[name=?]", "customer_contact[name]"
+  end
+
+  test "update on success renders the read-only row partial inside the frame" do
+    patch customer_contact_path(@contact),
+          params: { customer_contact: { name: "Renamed Acct", email: @contact.email } }
+
+    assert_response :success
+    assert_select "turbo-frame##{ActionView::RecordIdentifier.dom_id(@contact)}"
+    assert_equal "Renamed Acct", @contact.reload.name
+  end
+
+  test "update on validation failure returns 422 with the frame" do
+    patch customer_contact_path(@contact),
+          params: { customer_contact: { name: "", email: "bad" } }
+
+    assert_response :unprocessable_content
+    assert_select "turbo-frame##{ActionView::RecordIdentifier.dom_id(@contact)}"
+    assert_equal "GOOD Accounting", @contact.reload.name
+  end
+
+  test "destroy removes the row via turbo-stream" do
+    contact_id = @contact.id
+    delete customer_contact_path(@contact), headers: { Accept: "text/vnd.turbo-stream.html" }
+
+    assert_response :success
+    assert_includes response.media_type, "turbo-stream"
+    assert_select %(turbo-stream[action="remove"][target="customer_contact_#{contact_id}"])
+    assert_nil CustomerContact.find_by(id: contact_id)
+  end
+
+  # --- permission + cross-team scoping -------------------------------------
+
+  test "user without customers.edit cannot create" do
+    sign_in_as users(:bob)  # bob has no group, so no permissions
+    post customer_customer_contacts_path(@customer),
+         params: { customer_contact: { name: "X", email: "x@example.com" } }
+    assert_response :redirect
+  end
+
+  test "user without customers.edit cannot update" do
+    sign_in_as users(:bob)
+    patch customer_contact_path(@contact),
+          params: { customer_contact: { name: "Hijacked" } }
+    assert_response :redirect
+    assert_equal "GOOD Accounting", @contact.reload.name
+  end
+
+  test "user without customers.edit cannot destroy" do
+    sign_in_as users(:bob)
+    assert_no_difference -> { CustomerContact.count } do
+      delete customer_contact_path(@contact)
+    end
+    assert_response :redirect
+  end
+
+  test "cross-team access returns 404 on a contact from a team the user isn't in" do
+    GroupMembership.create!(group: groups(:sales), user: users(:bob))
+    other_team = Team.create!(name: "Isolated")
+    other_customer = Customer.create!(
+      matchcode: "ISO", name: "Iso Co",
+      sales_tax_customer_class: sales_tax_customer_classes(:eu),
+      language: languages(:english),
+      team: other_team
+    )
+    other_contact = other_customer.customer_contacts.create!(name: "X", email: "x@example.com")
+
+    sign_in_as users(:bob)  # bob is in default + acme, not Isolated
+    get edit_customer_contact_path(other_contact)
+    # bob has customers.edit (via sales group), so the permission check passes,
+    # but the scoped lookup raises RecordNotFound which Rails maps to 404.
+    assert_response :not_found
+  end
+
+  test "create rejects forged project_id from a team the user can't see" do
+    # Put bob in the Sales group (customers.view + customers.edit, no bypass)
+    # so he stays restricted to default+acme teams.
+    GroupMembership.create!(group: groups(:sales), user: users(:bob))
+
+    other_team = Team.create!(name: "Pwn")
+    foreign_project = Project.create!(
+      matchcode: "PWNPRJ", description: "", bill_to_customer: nil, team: other_team
+    )
+
+    sign_in_as users(:bob)
+    post customer_customer_contacts_path(@customer),
+         params: { customer_contact: { name: "C", email: "c@example.com", project_ids: [ foreign_project.id ] } }
+
+    new_contact = @customer.customer_contacts.find_by(email: "c@example.com")
+    assert_not_nil new_contact, "expected the contact to be saved without the forged project"
+    assert_empty new_contact.projects, "expected no projects; got #{new_contact.projects.inspect}"
+  end
+end

--- a/test/controllers/invoices_controller_email_test.rb
+++ b/test/controllers/invoices_controller_email_test.rb
@@ -25,7 +25,7 @@ class InvoicesControllerEmailTest < ActionDispatch::IntegrationTest
     # Check that email was delivered with PDF attachment and timestamp was set
     assert_equal 1, ActionMailer::Base.deliveries.size
     delivered_mail = ActionMailer::Base.deliveries.last
-    assert_equal [ "customer@good-company.co.uk" ], delivered_mail.to
+    assert_equal [ "customer@good-company.co.uk", "proj001-lead@good-company.co.uk" ].sort, delivered_mail.to.sort
     assert_equal "My Example Invoice INV-2024-001", delivered_mail.subject
     assert_equal 1, delivered_mail.attachments.size
     assert_equal "test_invoice.pdf", delivered_mail.attachments.first.filename
@@ -57,27 +57,18 @@ class InvoicesControllerEmailTest < ActionDispatch::IntegrationTest
     assert_not_nil auto_invoice.email_sent_at
   end
 
-  test "send_email handles customer without email gracefully" do
+  test "send_email refuses to enqueue when no recipient is configured" do
     invoice = invoices(:no_email_invoice)
 
-    # Should still enqueue the job even if no email will be sent
-    assert_enqueued_emails 1 do
+    assert_enqueued_emails 0 do
       post send_email_invoice_path(invoice)
     end
 
     assert_redirected_to invoice
-    assert_equal "E-Mail queued for sending.", flash[:notice]
+    assert_equal "No recipient configured for this invoice.", flash[:alert]
 
-    # Process the enqueued job
-    perform_enqueued_jobs
-
-    # No email should be delivered for customer without email
-    # The mailer returns NullMail which doesn't get delivered
-    assert_equal 0, ActionMailer::Base.deliveries.size
-
-    # But email_sent_at should still be set (job completed successfully)
     invoice.reload
-    assert_not_nil invoice.email_sent_at
+    assert_nil invoice.email_sent_at
   end
 
   test "send_email only works for published invoices" do

--- a/test/fixtures/customer_contact_projects.yml
+++ b/test/fixtures/customer_contact_projects.yml
@@ -1,0 +1,3 @@
+good_eu_project_one_lead_to_one:
+  customer_contact_id: <%= ActiveRecord::FixtureSet.identify(:good_eu_project_one_lead) %>
+  project_id: <%= ActiveRecord::FixtureSet.identify(:one) %>

--- a/test/fixtures/customer_contacts.yml
+++ b/test/fixtures/customer_contacts.yml
@@ -1,0 +1,27 @@
+good_eu_accounting:
+  customer: good_eu
+  name: GOOD Accounting
+  email: customer@good-company.co.uk
+  receives_invoice_emails: true
+  receives_delivery_note_emails: true
+
+good_eu_project_one_lead:
+  customer: good_eu
+  name: PROJ001 Lead
+  email: proj001-lead@good-company.co.uk
+  receives_invoice_emails: true
+  receives_delivery_note_emails: false
+
+good_national_main:
+  customer: good_national
+  name: GOODNAT AP
+  email: billing@local-company.com
+  receives_invoice_emails: true
+  receives_delivery_note_emails: true
+
+auto_email_contact:
+  customer: auto_email_customer
+  name: Auto Email Backup
+  email: backup@autoemail.com
+  receives_invoice_emails: true
+  receives_delivery_note_emails: false

--- a/test/fixtures/customers.yml
+++ b/test/fixtures/customers.yml
@@ -7,7 +7,6 @@ good_eu:
     European Union
   vat_id: EU99999999
   notes: MyText
-  email: customer@good-company.co.uk
   sales_tax_customer_class: eu
   language: english
   active: true
@@ -22,7 +21,6 @@ good_national:
     NATIONAL COUNTRY
   vat_id: NAT9999999
   notes:
-  email: billing@local-company.com
   sales_tax_customer_class: national
   language: german
   active: true
@@ -36,10 +34,10 @@ auto_email_customer:
     12345 Email City
     EMAIL COUNTRY
   vat_id: AUTO123456
-  email: customer@autoemail.com
   invoice_email_auto_enabled: true
   invoice_email_auto_to: billing@autoemail.com
   invoice_email_auto_subject_template: "Invoice $CUST_ORDER$ - Ref: $CUST_REF$"
+  invoice_email_auto_contact_mode: cc_contacts
   sales_tax_customer_class: national
   language: english
   active: true

--- a/test/mailers/invoice_mailer_test.rb
+++ b/test/mailers/invoice_mailer_test.rb
@@ -60,6 +60,19 @@ class InvoiceMailerTest < ActionMailer::TestCase
     assert mail.cc.blank?, "expected mail.cc to be blank, got #{mail.cc.inspect}"
   end
 
+  test "customer_email with auto + cc_contacts deduplicates a contact whose email matches the auto address case-insensitively" do
+    customer = customers(:auto_email_customer)
+    customer.customer_contacts.create!(name: "Shouty", email: customer.invoice_email_auto_to.upcase, receives_invoice_emails: true)
+    invoice = invoices(:auto_email_invoice)
+
+    mail = InvoiceMailer.with(invoice: invoice).customer_email
+
+    assert_equal [ "billing@autoemail.com" ], mail.to
+    # backup@autoemail.com (from the auto_email_contact fixture) survives;
+    # the BILLING@AUTOEMAIL.COM contact was dropped from CC.
+    assert_equal [ "backup@autoemail.com" ], mail.cc
+  end
+
   test "customer_email with auto + cc_contacts but no matching contact omits cc" do
     customers(:auto_email_customer).customer_contacts.destroy_all
     invoice = invoices(:auto_email_invoice)

--- a/test/mailers/invoice_mailer_test.rb
+++ b/test/mailers/invoice_mailer_test.rb
@@ -60,15 +60,6 @@ class InvoiceMailerTest < ActionMailer::TestCase
     assert mail.cc.blank?, "expected mail.cc to be blank, got #{mail.cc.inspect}"
   end
 
-  test "customer_email with auto + additional mode puts auto and contacts both in To:" do
-    customers(:auto_email_customer).update!(invoice_email_auto_contact_mode: "additional")
-    invoice = invoices(:auto_email_invoice)
-    mail = InvoiceMailer.with(invoice: invoice).customer_email
-
-    assert_equal [ "billing@autoemail.com", "backup@autoemail.com" ].sort, mail.to.sort
-    assert mail.cc.blank?, "expected mail.cc to be blank, got #{mail.cc.inspect}"
-  end
-
   test "customer_email with auto + cc_contacts but no matching contact omits cc" do
     customers(:auto_email_customer).customer_contacts.destroy_all
     invoice = invoices(:auto_email_invoice)

--- a/test/mailers/invoice_mailer_test.rb
+++ b/test/mailers/invoice_mailer_test.rb
@@ -5,71 +5,84 @@ class InvoiceMailerTest < ActionMailer::TestCase
     ActionMailer::Base.deliveries.clear
   end
 
-  test "customer_email with regular customer email" do
+  test "customer_email puts all matching contacts in To:" do
     invoice = invoices(:published_invoice)
     mail = InvoiceMailer.with(invoice: invoice).customer_email
 
     assert_not_nil mail
-    assert_equal [ "customer@good-company.co.uk" ], mail.to
-    assert_nil mail.cc
-    assert_equal [ "from@example.com" ], mail.from  # from issuer fixture
-    assert_equal [ "bcc@example.com" ], mail.bcc    # from issuer fixture
-    assert_equal "My Example Invoice INV-2024-001", mail.subject
-
-    # Check attachment
-    assert_equal 1, mail.attachments.size
-    attachment = mail.attachments.first
-    assert_equal "test_invoice.pdf", attachment.filename
-    assert_equal "application/pdf", attachment.content_type
-  end
-
-  test "customer_email with auto email configuration ccs the regular customer email" do
-    invoice = invoices(:auto_email_invoice)
-    mail = InvoiceMailer.with(invoice: invoice).customer_email
-
-    assert_not_nil mail
-    assert_equal [ "billing@autoemail.com" ], mail.to
-    assert_equal [ "customer@autoemail.com" ], mail.cc
+    # good_eu has two contacts that match project `one`:
+    #   - good_eu_accounting (no projects → all)
+    #   - good_eu_project_one_lead (scoped to project `one`)
+    assert_equal [ "customer@good-company.co.uk", "proj001-lead@good-company.co.uk" ].sort, mail.to.sort
+    assert mail.cc.blank?, "expected mail.cc to be blank, got #{mail.cc.inspect}"
     assert_equal [ "from@example.com" ], mail.from
     assert_equal [ "bcc@example.com" ], mail.bcc
-    assert_equal "Invoice AUTO-ORDER-111 - Ref: AUTO-REF-999", mail.subject
+    assert_equal "My Example Invoice INV-2024-001", mail.subject
 
-    # Check attachment
     assert_equal 1, mail.attachments.size
-    attachment = mail.attachments.first
-    assert_equal "auto_invoice.pdf", attachment.filename
+    assert_equal "test_invoice.pdf", mail.attachments.first.filename
   end
 
-  test "customer_email with auto email but no regular customer email omits cc" do
-    customer = customers(:auto_email_customer)
-    customer.update!(email: nil)
-    invoice = invoices(:auto_email_invoice)
+  test "customer_email skips contacts whose project does not match the invoice's project" do
+    # good_eu_project_one_lead is scoped to project `one`. An invoice on
+    # project `two` should NOT include that contact.
+    invoice = Invoice.create!(
+      customer: customers(:good_eu),
+      project: projects(:two),
+      attachment: attachments(:invoice_pdf),
+      document_number: "INV-PROJ-FILTER",
+      published: true,
+      date: Date.current,
+      due_date: 30.days.from_now,
+      sum_net: 100.00,
+      sum_total: 121.00
+    )
 
+    mail = InvoiceMailer.with(invoice: invoice).customer_email
+    assert_equal [ "customer@good-company.co.uk" ], mail.to
+  end
+
+  test "customer_email with auto + cc_contacts mode keeps auto in To: and contacts in Cc:" do
+    invoice = invoices(:auto_email_invoice)
     mail = InvoiceMailer.with(invoice: invoice).customer_email
 
     assert_equal [ "billing@autoemail.com" ], mail.to
-    assert_nil mail.cc
+    assert_equal [ "backup@autoemail.com" ], mail.cc
+    assert_equal "Invoice AUTO-ORDER-111 - Ref: AUTO-REF-999", mail.subject
   end
 
-  test "customer_email with auto email matching regular customer email omits cc" do
-    customer = customers(:auto_email_customer)
-    customer.update!(email: customer.invoice_email_auto_to)
+  test "customer_email with auto + replace_contacts mode ignores contacts" do
+    customers(:auto_email_customer).update!(invoice_email_auto_contact_mode: "replace_contacts")
     invoice = invoices(:auto_email_invoice)
-
     mail = InvoiceMailer.with(invoice: invoice).customer_email
 
     assert_equal [ "billing@autoemail.com" ], mail.to
-    assert_nil mail.cc
+    assert mail.cc.blank?, "expected mail.cc to be blank, got #{mail.cc.inspect}"
   end
 
-  test "customer_email with customer without email returns NullMail" do
+  test "customer_email with auto + additional mode puts auto and contacts both in To:" do
+    customers(:auto_email_customer).update!(invoice_email_auto_contact_mode: "additional")
+    invoice = invoices(:auto_email_invoice)
+    mail = InvoiceMailer.with(invoice: invoice).customer_email
+
+    assert_equal [ "billing@autoemail.com", "backup@autoemail.com" ].sort, mail.to.sort
+    assert mail.cc.blank?, "expected mail.cc to be blank, got #{mail.cc.inspect}"
+  end
+
+  test "customer_email with auto + cc_contacts but no matching contact omits cc" do
+    customers(:auto_email_customer).customer_contacts.destroy_all
+    invoice = invoices(:auto_email_invoice)
+    mail = InvoiceMailer.with(invoice: invoice).customer_email
+
+    assert_equal [ "billing@autoemail.com" ], mail.to
+    assert mail.cc.blank?, "expected mail.cc to be blank, got #{mail.cc.inspect}"
+  end
+
+  test "customer_email with customer without contacts and no auto returns NullMail" do
     invoice = invoices(:no_email_invoice)
     mail = InvoiceMailer.with(invoice: invoice).customer_email
 
-    # ActionMailer returns NullMail when mail method returns nil
-    # The mail object is a MessageDelivery that wraps the actual message
     assert_instance_of ActionMailer::Parameterized::MessageDelivery, mail
-    # The underlying message should be NullMail
     assert_instance_of ActionMailer::Base::NullMail, mail.message
   end
 
@@ -82,7 +95,7 @@ class InvoiceMailerTest < ActionMailer::TestCase
     assert_match "Dear A Good Company B.V.", html_body
     assert_match "INV-2024-001", html_body
     assert_match invoice.due_date.to_s, html_body
-    assert_match "Example Company B.V.", html_body  # issuer legal_name from fixture
+    assert_match "Example Company B.V.", html_body
   end
 
   test "customer_email text template includes invoice details" do
@@ -94,7 +107,7 @@ class InvoiceMailerTest < ActionMailer::TestCase
     assert_match "Dear A Good Company B.V.", text_body
     assert_match "INV-2024-001", text_body
     assert_match invoice.due_date.to_s, text_body
-    assert_match "Example Company B.V.", text_body  # issuer legal_name from fixture
+    assert_match "Example Company B.V.", text_body
   end
 
   test "customer_email subject strips CRLF from user-controlled substitution values" do
@@ -111,10 +124,9 @@ class InvoiceMailerTest < ActionMailer::TestCase
   end
 
   test "customer_email subject template handles empty substitution values" do
-    # Create invoice with empty reference fields
     invoice = Invoice.create!(
       customer: customers(:auto_email_customer),
-      project: projects(:one),  # Add required project
+      project: projects(:one),
       attachment: attachments(:auto_email_pdf),
       document_number: "INV-EMPTY",
       published: true,
@@ -150,18 +162,15 @@ class InvoiceMailerTest < ActionMailer::TestCase
   end
 
   test "customer_email works in test environment without mailgun" do
-    # Verify we're using test delivery method, not mailgun
     assert_equal :test, ActionMailer::Base.delivery_method
 
     invoice = invoices(:published_invoice)
     mail = InvoiceMailer.with(invoice: invoice).customer_email
 
-    # Should not raise any mailgun-related errors
     assert_nothing_raised do
       mail.deliver_now
     end
 
-    # Verify it was added to deliveries
     assert_equal 1, ActionMailer::Base.deliveries.size
     delivered_mail = ActionMailer::Base.deliveries.last
     assert_equal mail.to, delivered_mail.to

--- a/test/models/customer_contact_test.rb
+++ b/test/models/customer_contact_test.rb
@@ -1,0 +1,110 @@
+require "test_helper"
+
+class CustomerContactTest < ActiveSupport::TestCase
+  setup { Current.user = nil }
+  teardown { Current.user = nil }
+
+  test "valid contact with name and email" do
+    contact = CustomerContact.new(customer: customers(:good_eu), name: "X", email: "x@example.com")
+    assert contact.valid?
+  end
+
+  test "requires name" do
+    contact = CustomerContact.new(customer: customers(:good_eu), email: "x@example.com")
+    assert_not contact.valid?
+    assert_includes contact.errors[:name], "can't be blank"
+  end
+
+  test "requires email and validates format" do
+    contact = CustomerContact.new(customer: customers(:good_eu), name: "X")
+    assert_not contact.valid?
+    assert_includes contact.errors[:email], "can't be blank"
+
+    contact.email = "not-an-email"
+    assert_not contact.valid?
+    assert_includes contact.errors[:email], "is invalid"
+  end
+
+  test "applies_to_project? returns true for any project when no projects assigned" do
+    contact = customer_contacts(:good_eu_accounting)
+    assert_empty contact.projects
+    assert contact.applies_to_project?(projects(:one))
+    assert contact.applies_to_project?(projects(:two))
+  end
+
+  test "applies_to_project? is true only for assigned projects" do
+    contact = customer_contacts(:good_eu_project_one_lead)
+    assert_equal [ projects(:one) ], contact.projects.to_a
+    assert contact.applies_to_project?(projects(:one))
+    assert_not contact.applies_to_project?(projects(:two))
+  end
+
+  test "projects_belong_to_customer_or_unassigned rejects another customer's project" do
+    # projects(:two) belongs to good_national, not good_eu
+    contact = CustomerContact.new(
+      customer: customers(:good_eu),
+      name: "X", email: "x@example.com",
+      projects: [ projects(:two) ]
+    )
+    assert_not contact.valid?
+    assert_includes contact.errors[:projects], "must belong to this customer or to no customer"
+  end
+
+  test "projects_belong_to_customer_or_unassigned accepts unassigned projects" do
+    contact = CustomerContact.new(
+      customer: customers(:good_eu),
+      name: "X", email: "x@example.com",
+      projects: [ projects(:reusable_project) ]
+    )
+    assert contact.valid?, contact.errors.full_messages.to_sentence
+  end
+
+  test "customer visibility check skipped when Current.user is nil (seeds context)" do
+    contact = CustomerContact.new(
+      customer: customers(:good_eu),
+      name: "X", email: "x@example.com"
+    )
+    assert_nil Current.user
+    assert contact.valid?
+  end
+
+  test "customer visibility check enforced when Current.user is set" do
+    other_team = Team.create!(name: "Other")
+    other_customer = Customer.create!(
+      matchcode: "OTH", name: "Other",
+      sales_tax_customer_class: sales_tax_customer_classes(:eu),
+      language: languages(:english),
+      team: other_team
+    )
+
+    Current.user = users(:bob)
+    contact = CustomerContact.new(customer: other_customer, name: "X", email: "x@example.com")
+    assert_not contact.valid?
+    assert_includes contact.errors[:customer_id], "must be a customer you can access"
+  end
+
+  test "projects visibility check enforced when Current.user is set" do
+    other_team = Team.create!(name: "Visibility Other")
+    other_customer = Customer.create!(
+      matchcode: "VOTH", name: "Visibility Other",
+      sales_tax_customer_class: sales_tax_customer_classes(:eu),
+      language: languages(:english),
+      team: other_team
+    )
+    foreign_project = Project.create!(
+      matchcode: "FOREIGN", description: "", bill_to_customer: other_customer, team: other_team
+    )
+
+    Current.user = users(:bob)
+    contact = CustomerContact.new(
+      customer: customers(:good_eu),
+      name: "X", email: "x@example.com",
+      projects: [ foreign_project ]
+    )
+    assert_not contact.valid?
+    # Bob can't see foreign_project, so both validations may fire; just check
+    # at least one signals the access problem.
+    assert (contact.errors[:projects].any? || contact.errors.full_messages.any? { |m| m.match?(/access/i) }),
+           contact.errors.full_messages.inspect
+  end
+end

--- a/test/models/customer_test.rb
+++ b/test/models/customer_test.rb
@@ -113,4 +113,43 @@ class CustomerTest < ActiveSupport::TestCase
     assert_includes Customer.inactive, inactive
     assert_not_includes Customer.inactive, customers(:good_eu)
   end
+
+  test "destroying a customer cascades to its customer contacts" do
+    customer = create_customer
+    customer.customer_contacts.create!(name: "X", email: "x@example.com")
+    contact_id = customer.customer_contacts.first.id
+
+    assert customer.destroy
+    assert_nil CustomerContact.find_by(id: contact_id)
+  end
+
+  test "contacts_for_invoice picks up no-project and matching-project contacts" do
+    invoice = invoices(:published_invoice)
+    contacts = invoice.customer.contacts_for_invoice(invoice)
+
+    assert_includes contacts.map(&:email), "customer@good-company.co.uk"      # no projects
+    assert_includes contacts.map(&:email), "proj001-lead@good-company.co.uk"  # project: one
+  end
+
+  test "contacts_for_invoice excludes contacts whose projects do not match" do
+    project_two_invoice = Invoice.create!(
+      customer: customers(:good_eu),
+      project: projects(:two),
+      attachment: attachments(:invoice_pdf),
+      document_number: "INV-PROJ2-FILTER",
+      published: true,
+      date: Date.current,
+      due_date: 30.days.from_now,
+      sum_net: 100, sum_total: 121
+    )
+
+    emails = project_two_invoice.customer.contacts_for_invoice(project_two_invoice).map(&:email)
+    assert_includes emails, "customer@good-company.co.uk"
+    assert_not_includes emails, "proj001-lead@good-company.co.uk"
+  end
+
+  test "contacts_for_invoice excludes contacts with receives_invoice_emails=false" do
+    customers(:good_eu).customer_contacts.update_all(receives_invoice_emails: false)
+    assert_empty customers(:good_eu).reload.contacts_for_invoice(invoices(:published_invoice))
+  end
 end

--- a/test/models/invoice_test.rb
+++ b/test/models/invoice_test.rb
@@ -161,4 +161,44 @@ class InvoiceTest < ActiveSupport::TestCase
     assert_includes years, 2022
     assert_not_includes years, nil
   end
+
+  # email_unsent + emailable? must agree (one is SQL, the other is Ruby).
+  test "email_unsent includes invoices whose customer has a matching contact" do
+    invoice = invoices(:published_invoice)
+    invoice.update_column(:email_sent_at, nil)
+    assert_includes Invoice.email_unsent, invoice
+    assert invoice.emailable?
+  end
+
+  test "email_unsent excludes invoices whose only contacts are project-scoped to a different project" do
+    customers(:good_eu).customer_contacts.where.not(id: customer_contacts(:good_eu_project_one_lead).id).destroy_all
+    invoice = Invoice.create!(
+      customer: customers(:good_eu),
+      project: projects(:two),
+      attachment: attachments(:invoice_pdf),
+      document_number: "INV-UNSENT-FILTER",
+      published: true,
+      date: Date.current, due_date: 30.days.from_now,
+      sum_net: 100, sum_total: 121
+    )
+
+    assert_not_includes Invoice.email_unsent, invoice
+    assert_not invoice.emailable?
+  end
+
+  test "email_unsent includes invoices whose customer has auto-email enabled even without contacts" do
+    customers(:auto_email_customer).customer_contacts.destroy_all
+    invoice = invoices(:auto_email_invoice)
+    invoice.update_column(:email_sent_at, nil)
+
+    assert_includes Invoice.email_unsent, invoice
+    assert invoice.emailable?
+  end
+
+  test "email_unsent excludes invoices with no contacts and no auto-email" do
+    invoice = invoices(:no_email_invoice)
+    invoice.update_column(:email_sent_at, nil)
+    assert_not_includes Invoice.email_unsent, invoice
+    assert_not invoice.emailable?
+  end
 end

--- a/test/system/customer_contacts_test.rb
+++ b/test/system/customer_contacts_test.rb
@@ -1,0 +1,120 @@
+require "application_system_test_case"
+
+# Locks in the Turbo Frame contract for the contacts table on the customer
+# show page (see plan §5 and §10). The contract:
+#   - per-row frame `dom_id(contact)` for inline view/edit
+#   - singleton frame `new_customer_contact` for the add form
+#   - new rows append to `#customer_contacts_tbody` via turbo-stream
+#   - validation failure re-renders the form inside its own frame (422)
+class CustomerContactsTest < ApplicationSystemTestCase
+  setup do
+    @customer = customers(:good_eu)
+    @accounting = customer_contacts(:good_eu_accounting)
+    @project_lead = customer_contacts(:good_eu_project_one_lead)
+  end
+
+  test "add row appends to the table and resets the add-link frame" do
+    visit customer_path(@customer)
+    assert_selector "#new_customer_contact a", text: "+ Add contact"
+
+    click_link "+ Add contact"
+    assert_selector "#new_customer_contact input[name='customer_contact[name]']"
+
+    within("#new_customer_contact") do
+      fill_in "customer_contact[name]", with: "New Person"
+      fill_in "customer_contact[email]", with: "new@example.com"
+      check "customer_contact[receives_invoice_emails]"
+      click_button "Add"
+    end
+
+    # Row appears, add-link resets, no page navigation.
+    new_contact = @customer.customer_contacts.find_by(email: "new@example.com")
+    assert_selector "##{ActionView::RecordIdentifier.dom_id(new_contact)}", text: "New Person"
+    assert_selector "#new_customer_contact a", text: "+ Add contact"
+    assert_current_path customer_path(@customer)
+  end
+
+  test "add row validation failure keeps the form inside the frame with errors" do
+    visit customer_path(@customer)
+    click_link "+ Add contact"
+
+    within("#new_customer_contact") do
+      # Both empty — fills happen before submit. Browser's "required" would
+      # block on real interaction, so we explicitly post empties via JS form
+      # submission would be brittle. Instead: use an invalid email format so
+      # client-side validation passes but server validation rejects.
+      fill_in "customer_contact[name]", with: "Edge Case"
+      fill_in "customer_contact[email]", with: "not-an-email-format"
+      click_button "Add"
+    end
+
+    # Frame still shows the form (not the add link).
+    assert_selector "#new_customer_contact input[name='customer_contact[email]']"
+    assert_no_selector "#new_customer_contact a", text: "+ Add contact"
+    assert_equal 0, @customer.customer_contacts.where(email: "not-an-email-format").count
+  end
+
+  test "edit row swaps to inputs inline and saves back to read-only" do
+    visit customer_path(@customer)
+
+    row = "##{ActionView::RecordIdentifier.dom_id(@accounting)}"
+    other_row = "##{ActionView::RecordIdentifier.dom_id(@project_lead)}"
+
+    within(row) { click_link "Edit" }
+    assert_selector "#{row} input[name='customer_contact[name]']"
+    # Other rows stay in view mode.
+    assert_no_selector "#{other_row} input[name='customer_contact[name]']"
+
+    within(row) do
+      fill_in "customer_contact[name]", with: "Accounting (Updated)"
+      click_button "Save"
+    end
+
+    assert_selector "#{row}", text: "Accounting (Updated)"
+    assert_no_selector "#{row} input[name='customer_contact[name]']"
+    assert_equal "Accounting (Updated)", @accounting.reload.name
+  end
+
+  test "cancel edit reverts the row without saving" do
+    visit customer_path(@customer)
+    row = "##{ActionView::RecordIdentifier.dom_id(@accounting)}"
+
+    within(row) { click_link "Edit" }
+    within(row) do
+      fill_in "customer_contact[name]", with: "Should Not Persist"
+      click_link "Cancel"
+    end
+
+    # Frame returns to read-only with original value.
+    assert_selector "#{row}", text: @accounting.name
+    assert_no_selector "#{row} input[name='customer_contact[name]']"
+    assert_equal @accounting.name, @accounting.reload.name
+  end
+
+  test "delete row removes only that row" do
+    visit customer_path(@customer)
+    row = "##{ActionView::RecordIdentifier.dom_id(@accounting)}"
+    other_row = "##{ActionView::RecordIdentifier.dom_id(@project_lead)}"
+
+    accept_confirm do
+      within(row) { click_link "🗑" }
+    end
+
+    assert_no_selector row
+    assert_selector other_row
+    assert_nil CustomerContact.find_by(id: @accounting.id)
+  end
+
+  test "project picker only offers this customer's projects and unassigned projects" do
+    visit customer_path(@customer)
+    click_link "+ Add contact"
+
+    options = within("#new_customer_contact") do
+      find("select[name='customer_contact[project_ids][]']").all("option").map(&:text)
+    end
+
+    assert_includes options, projects(:one).matchcode          # belongs to good_eu
+    assert_includes options, projects(:reusable_project).matchcode  # bill_to nil
+    assert_not_includes options, projects(:two).matchcode      # belongs to good_national
+  end
+end


### PR DESCRIPTION
## Summary

- Replaces `customer.email` with a `CustomerContact` has_many (name, email, per-document-type receive flags, optional HABTM project scope). Resolves #67.
- New `invoice_email_auto_contact_mode` enum on customer (`replace_contacts` / `cc_contacts` / `additional`) controls how the existing auto-email feature interacts with contacts. Default `replace_contacts` preserves today's auto-only behaviour.
- Inline per-row Turbo Frame edit on the customer show page. `customers.{view,edit}` permissions; no new `Permission` entries. Cross-team writes blocked by validations mirroring `ScopedThroughCustomer`.
- `Invoice#email_unsent` rewritten to a SQL `EXISTS` on contacts + project rule; `Invoice#emailable?` is the Ruby twin used at send time.
- `send_email` refuses to enqueue when no recipient resolves; show-page button renders disabled with a tooltip. Delivery-note bulk send partitions by `[customer_id, sorted-recipients]` so two DNs to the same customer with different project-scoped contacts don't leak recipients onto each other.
- Backfills one contact per customer with a non-blank email, then drops `customers.email`.
- Seeds: GOODEU now has 2 extra projects (AUDIT2026, MIGR2026) and 3 contacts exercising the project-scope rules; USACORP intentionally contactless to exercise the no-recipient UX.

Plan reference: posted as a comment on #67.

## Test plan

- [x] `bundle exec rails test` — 559 runs, 2031 assertions, 0 failures
- [x] `npm run lint` — clean
- [x] `pre-commit run --all-files` — clean
- [x] `bundle exec rails db:migrate && bundle exec rails db:seed` on fresh dev DB — GOODEU contacts render with expected projects
- [ ] Manual: bulk-send mixed-project DNs to a single customer with project-scoped contacts; confirm separate emails go out with the correct recipient sets per DN
- [ ] Manual: toggle the new `invoice_email_auto_contact_mode` select on auto_email_customer through all three values and re-preview an invoice; confirm To/Cc switch as expected
- [ ] Manual: try to delete a contact via inline trashcan; confirm only that row disappears, no reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)