### PR TITLE
Enforce globally unique matchcodes on customers and projects

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -1,7 +1,7 @@
 class Customer < ApplicationRecord
   include TeamOwned
 
-  validates :matchcode, presence: true
+  validates :matchcode, presence: true, uniqueness: { case_sensitive: false }
   validates :name, presence: true
 
   # Set default language (English) for new customers

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -4,7 +4,7 @@ class Project < ApplicationRecord
   belongs_to :bill_to_customer, class_name: "Customer", optional: true
   has_many :invoices
 
-  validates :matchcode, presence: true
+  validates :matchcode, presence: true, uniqueness: { case_sensitive: false }
   validate :team_must_match_customer
 
   # Scopes for filtering

--- a/db/migrate/20260525120000_add_unique_matchcode_indexes.rb
+++ b/db/migrate/20260525120000_add_unique_matchcode_indexes.rb
@@ -1,0 +1,7 @@
+class AddUniqueMatchcodeIndexes < ActiveRecord::Migration[8.0]
+  def change
+    remove_index :projects, :matchcode, name: "index_projects_on_matchcode"
+    add_index :customers, "LOWER(matchcode)", unique: true, name: "index_customers_on_lower_matchcode"
+    add_index :projects, "LOWER(matchcode)", unique: true, name: "index_projects_on_lower_matchcode"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_24_221140) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_25_120000) do
   create_table "attachments", force: :cascade do |t|
     t.string "content_type"
     t.datetime "created_at", null: false
@@ -38,6 +38,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_24_221140) do
     t.integer "team_id", null: false
     t.datetime "updated_at", null: false
     t.text "vat_id"
+    t.index "LOWER(matchcode)", name: "index_customers_on_lower_matchcode", unique: true
     t.index ["language_id"], name: "index_customers_on_language_id"
     t.index ["name"], name: "index_customers_on_name"
     t.index ["team_id"], name: "index_customers_on_team_id"
@@ -233,7 +234,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_24_221140) do
     t.string "matchcode"
     t.integer "team_id", null: false
     t.datetime "updated_at", null: false
-    t.index ["matchcode"], name: "index_projects_on_matchcode"
+    t.index "LOWER(matchcode)", name: "index_projects_on_lower_matchcode", unique: true
     t.index ["team_id"], name: "index_projects_on_team_id"
   end
 

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -13,15 +13,6 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should filter projects by active status and handle index properly" do
-    # Create inactive project
-    Project.create!(
-      matchcode: "INACTIVE",
-      description: "Inactive project",
-      active: false,
-      bill_to_customer: @customer,
-      team: teams(:default)
-    )
-
     # Test all filter options in a single request cycle
     [ "active", "inactive", "all" ].each do |filter_type|
       get projects_url(filter: filter_type)
@@ -300,7 +291,7 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
   test "should include reusable projects when include_reusable is true" do
     # Create a reusable project (no customer)
     reusable_project = Project.create!(
-      matchcode: "REUSABLE",
+      matchcode: "REUSABLE_INC",
       description: "Reusable project",
       bill_to_customer: nil,
       active: true,
@@ -332,7 +323,7 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
 
     # Create reusable project
     reusable_project = Project.create!(
-      matchcode: "REUSABLE",
+      matchcode: "REUSABLE_FILT",
       description: "Reusable project",
       bill_to_customer: nil,
       active: true,

--- a/test/models/customer_test.rb
+++ b/test/models/customer_test.rb
@@ -28,6 +28,20 @@ class CustomerTest < ActiveSupport::TestCase
     assert_includes customer.errors[:name], "can't be blank"
   end
 
+  test "matchcode must be globally unique across all teams" do
+    create_customer(matchcode: "DUPE", team: teams(:default))
+    duplicate = build_customer(matchcode: "DUPE", team: teams(:acme))
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:matchcode], "has already been taken"
+  end
+
+  test "matchcode uniqueness is case-insensitive" do
+    create_customer(matchcode: "Dupe", team: teams(:default))
+    duplicate = build_customer(matchcode: "DUPE", team: teams(:default))
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:matchcode], "has already been taken"
+  end
+
   test "set_default_language assigns English on create when language is not set" do
     customer = build_customer(language: nil)
     customer.valid?

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -21,6 +21,20 @@ class ProjectTest < ActiveSupport::TestCase
     assert_not_nil @project.errors[:matchcode]
   end
 
+  test "matchcode must be globally unique across all teams" do
+    Project.create!(matchcode: "DUPE", team: teams(:default))
+    duplicate = Project.new(matchcode: "DUPE", team: teams(:acme))
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:matchcode], "has already been taken"
+  end
+
+  test "matchcode uniqueness is case-insensitive" do
+    Project.create!(matchcode: "Dupe", team: teams(:default))
+    duplicate = Project.new(matchcode: "DUPE", team: teams(:default))
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:matchcode], "has already been taken"
+  end
+
   test "should be active by default" do
     new_project = Project.new(
       matchcode: "NEW_PROJECT",
@@ -40,7 +54,7 @@ class ProjectTest < ActiveSupport::TestCase
     )
 
     inactive_project = Project.create!(
-      matchcode: "INACTIVE",
+      matchcode: "INACTIVE_SCOPE",
       bill_to_customer: @customer,
       active: false,
       team: @customer.team


### PR DESCRIPTION
## Summary
- Customer and Project both declared `validates :matchcode, presence: true` only, so two customers (or two projects) could be saved with the same matchcode silently. Add case-insensitive uniqueness validation at the model layer.
- Add a `UNIQUE INDEX ... ON (LOWER(matchcode))` for both tables so direct inserts and race conditions are rejected at the database layer (defense in depth — the model validator alone has a TOCTOU window between two concurrent creates).
- Drop the redundant non-unique `index_projects_on_matchcode`; the new expression index serves the same equality lookups.

## Migration risk
Existing rows that share a matchcode will block the migration. Resolve duplicates before deploying.

In my local dev DB the duplicates were:
- `customers.matchcode = 'foo'` (id 4, 5)
- `projects.matchcode = 'APIDEV'` (id 3, 7)

If production has duplicates too, the deploy will fail at this migration the same way.

## Test plan
- [x] `bundle exec rails test` (534 runs, 1986 assertions, 0 failures)
- [ ] Manual: in production-like data, run the migration and confirm it succeeds (after de-duplicating).
- [ ] Manual: try to create two customers with matchcode `ACME` and `acme` via the UI — second submit should be rejected with `Matchcode has already been taken`.
- [ ] Same check for projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)