### PR TITLE
Rephrase belongs_to required-field error message

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,6 +37,14 @@ en:
     formats:
       default: "%d.%m.%Y %H:%M"
 
+  # Override Rails' default belongs_to required message ("must exist"),
+  # which reads as a database/lookup error to end users. Required
+  # belongs_to fields render as <select> dropdowns in our forms, so
+  # phrase the failure as a selection problem instead.
+  errors:
+    messages:
+      required: "must be selected"
+
   mailers:
     overdue_invoices:
       subject: "[%{issuer_name}] %{count} overdue invoice(s)"


### PR DESCRIPTION
Rails' default "must exist" for required belongs_to associations reads as a database/lookup error to end users. The fields are rendered as <select> dropdowns in our forms, so override the errors.messages.required key globally to "must be selected".

Renders as "Team must be selected" / "Sales tax customer class must be selected" instead of "Team must exist".