### PR TITLE
Use real CSP nonce on issuer accent color style tag

### DIFF
--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -40,7 +40,7 @@
             = image_tag png_logo_issuer_company_path, alt: @data[:issuer_company].legal_name, class: 'dashboard-issuer-logo'
 
         - if @data[:issuer_company].document_accent_color.present?
-          = tag.style ":root { --issuer-accent-color: #{@data[:issuer_company].document_accent_color}; }".html_safe, nonce: true
+          = tag.style ":root { --issuer-accent-color: #{@data[:issuer_company].document_accent_color}; }".html_safe, nonce: content_security_policy_nonce
           %h6.text-issuer-accent
             = @data[:issuer_company].legal_name
         - else

--- a/app/views/issuer_companies/show.html.haml
+++ b/app/views/issuer_companies/show.html.haml
@@ -103,7 +103,7 @@
             %strong Accent Color:
           .col-sm-8
             - if @issuer_company.document_accent_color.present?
-              = tag.style ":root { --issuer-accent-color: #{@issuer_company.document_accent_color}; }".html_safe, nonce: true
+              = tag.style ":root { --issuer-accent-color: #{@issuer_company.document_accent_color}; }".html_safe, nonce: content_security_policy_nonce
               %span.badge.badge-issuer-accent
                 = @issuer_company.document_accent_color
             - else


### PR DESCRIPTION
## Summary
- `tag.style ..., nonce: true` doesn't resolve `true` to the active CSP nonce (unlike `javascript_tag`/`stylesheet_link_tag`); it emits literally `<style nonce="true">`. Under the strict CSP from 9d49450, the browser rejects the block — so the `--issuer-accent-color` custom property never applies and Safari logs a CSP violation.
- Switch the two call sites (`home/index.html.haml`, `issuer_companies/show.html.haml`) to `nonce: content_security_policy_nonce` so the rendered nonce matches the response header.

## Test plan
- [ ] Load the home page in Safari with an issuer accent color set — no CSP violation in the console; `.text-issuer-accent` shows the configured color.
- [ ] Visit Configuration → Issuer Company show page — the accent color badge renders in the configured color.
- [ ] `bundle exec rails test test/controllers/home_controller_test.rb test/controllers/issuer_companies_controller_test.rb test/integration/csp_inline_handlers_structure_test.rb` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)