### PR TITLE
Fix delivery note email preview: duplicate PDF render, send failure, button copy

### DIFF
--- a/app/controllers/delivery_notes_controller.rb
+++ b/app/controllers/delivery_notes_controller.rb
@@ -283,7 +283,10 @@ class DeliveryNotesController < ApplicationController
   def send_email
     DeliveryNoteMailer.with(delivery_note: @delivery_note).customer_email.deliver_later
     @delivery_note.update_column(:email_sent_at, Time.current)
-    redirect_to @delivery_note, notice: "E-Mail queued for sending."
+    respond_to do |format|
+      format.html { redirect_to @delivery_note, notice: "E-Mail queued for sending." }
+      format.json { head :ok }
+    end
   end
 
   def bulk_send_emails

--- a/app/controllers/delivery_notes_controller.rb
+++ b/app/controllers/delivery_notes_controller.rb
@@ -276,7 +276,7 @@ class DeliveryNotesController < ApplicationController
   end
 
   def preview_email_raw
-    mail = DeliveryNoteMailer.with(delivery_note: @delivery_note).customer_email
+    mail = DeliveryNoteMailer.with(delivery_note: @delivery_note, skip_attachments: true).customer_email
     render html: extract_html_body(mail).to_s.html_safe, layout: false
   end
 

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -175,7 +175,10 @@ class InvoicesController < ApplicationController
   def send_email
     InvoiceMailer.with(invoice: @invoice).customer_email.deliver_later
     @invoice.update_column(:email_sent_at, Time.current)
-    redirect_to @invoice, notice: "E-Mail queued for sending."
+    respond_to do |format|
+      format.html { redirect_to @invoice, notice: "E-Mail queued for sending." }
+      format.json { head :ok }
+    end
   end
 
   def mark_paid

--- a/app/javascript/controllers/generic_email_preview_controller.js
+++ b/app/javascript/controllers/generic_email_preview_controller.js
@@ -69,7 +69,7 @@ export default class extends Controller {
 
       if (response.ok) {
         // Success - show feedback and close modal
-        sendButton.textContent = 'Sent!'
+        sendButton.textContent = 'Queued!'
         sendButton.classList.remove('btn-success')
         sendButton.classList.add('btn-outline-success')
 

--- a/app/mailers/delivery_note_mailer.rb
+++ b/app/mailers/delivery_note_mailer.rb
@@ -1,7 +1,7 @@
 class DeliveryNoteMailer < ApplicationMailer
   def customer_email
     @delivery_note = params[:delivery_note]
-    attach_pdf(@delivery_note)
+    attach_pdf(@delivery_note) unless params[:skip_attachments]
 
     customer = @delivery_note.customer
     to = subject = nil

--- a/test/controllers/delivery_notes_controller_test.rb
+++ b/test/controllers/delivery_notes_controller_test.rb
@@ -337,6 +337,24 @@ class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
     assert json_response.key?("has_html_body")
   end
 
+  test "send_email returns 200 for JSON requests and marks email sent" do
+    note = delivery_notes(:published_delivery_note)
+    note.update_column(:email_sent_at, nil)
+
+    post send_email_delivery_note_url(note),
+         headers: { "Accept" => "application/json" }
+
+    assert_response :success
+    assert_not_nil note.reload.email_sent_at
+  end
+
+  test "send_email redirects for HTML requests" do
+    note = delivery_notes(:published_delivery_note)
+    post send_email_delivery_note_url(note)
+    assert_redirected_to delivery_note_url(note)
+    assert_match "E-Mail queued for sending.", flash[:notice]
+  end
+
   test "should bulk send emails to selected delivery notes" do
     published_note = delivery_notes(:published_delivery_note)
 

--- a/test/controllers/invoices_controller_email_test.rb
+++ b/test/controllers/invoices_controller_email_test.rb
@@ -118,6 +118,17 @@ class InvoicesControllerEmailTest < ActionDispatch::IntegrationTest
     assert_redirected_to invoice_path(invoice)
   end
 
+  test "send_email returns 200 for JSON requests" do
+    invoice = invoices(:published_invoice)
+
+    assert_enqueued_emails 1 do
+      post send_email_invoice_path(invoice), headers: { "Accept" => "application/json" }
+    end
+
+    assert_response :success
+    assert_not_nil invoice.reload.email_sent_at
+  end
+
   test "bulk_send_emails queues jobs for selected invoices" do
     invoice1 = invoices(:published_invoice)
     invoice2 = invoices(:auto_email_invoice)

--- a/test/mailers/delivery_note_mailer_test.rb
+++ b/test/mailers/delivery_note_mailer_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class DeliveryNoteMailerTest < ActionMailer::TestCase
+  def setup
+    ActionMailer::Base.deliveries.clear
+  end
+
+  test "customer_email attaches the rendered PDF by default" do
+    delivery_note = delivery_notes(:published_delivery_note)
+    mail = DeliveryNoteMailer.with(delivery_note: delivery_note).customer_email
+
+    assert_equal 1, mail.attachments.size
+    attachment = mail.attachments.first
+    assert_match(/DeliveryNote-#{delivery_note.document_number}\.pdf\z/, attachment.filename)
+    assert_equal "application/pdf", attachment.content_type
+  end
+
+  test "customer_email skips PDF rendering when skip_attachments is set" do
+    delivery_note = delivery_notes(:published_delivery_note)
+
+    # If attach_pdf were called, DeliveryNoteRenderer#render would be invoked.
+    # Replace it for the duration of this test so any unexpected call surfaces.
+    original = DeliveryNoteRenderer.instance_method(:render)
+    DeliveryNoteRenderer.define_method(:render) { raise "PDF should not be rendered" }
+    begin
+      mail = DeliveryNoteMailer.with(delivery_note: delivery_note, skip_attachments: true).customer_email
+      assert_not_nil mail.html_part
+      assert_equal 0, mail.attachments.size
+    ensure
+      DeliveryNoteRenderer.define_method(:render, original)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Skip Apache FOP rendering for the `preview_email_raw` iframe — the modal previously ran the renderer twice per open (once for the JSON metadata, once for the iframe body). Only the metadata path needs the attachment.
- Make `send_email` respond to JSON. The Stimulus modal posts with `Accept: application/json`; the previous `redirect_to` produced a 302 to `show`, which has no JSON template, so fetch followed the redirect and got a 406. The job was actually enqueued but the modal reported failure. Applies to both delivery notes and invoices since they share the JS controller.
- Rename the success-state button from "Sent!" to "Queued!" — `deliver_later` enqueues a Solid Queue job; nothing has been sent at that point. Matches the existing flash notice copy ("queued for sending").

## Test plan
- [x] `bundle exec rails test test/mailers/delivery_note_mailer_test.rb`
- [x] `bundle exec rails test test/controllers/delivery_notes_controller_test.rb test/controllers/invoices_controller_email_test.rb`
- [ ] Manual: open the email preview modal on a delivery note, confirm PDF render happens once (check Rails log for a single `FopRenderer` invocation).
- [ ] Manual: click Send in the preview modal, confirm the button shows "Queued!" without a console error and the page reloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)