### PR TITLE
Stop intercepting Turbo navigation in customers/projects index

### DIFF
--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -20,7 +20,11 @@ class CustomersController < ApplicationController
 
     respond_to do |format|
       format.html # index.html.erb
-      format.turbo_stream { render :filter_options }
+      # Only the searchable_dropdown Stimulus controller hits this branch; it sets
+      # X-Requested-With explicitly. Turbo's navigation Accept also lists turbo_stream,
+      # so without this guard the post-delete redirect would render dropdown options
+      # into a missing target and leave the index page stale.
+      format.turbo_stream { render :filter_options } if request.xhr?
       format.json {
         render json: @customers.map { |c|
           {

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -36,7 +36,11 @@ class ProjectsController < ApplicationController
 
     respond_to do |format|
       format.html # index.html.erb
-      format.turbo_stream { render :filter_options }
+      # Only the searchable_dropdown Stimulus controller hits this branch; it sets
+      # X-Requested-With explicitly. Turbo's navigation Accept also lists turbo_stream,
+      # so without this guard the post-delete redirect would render dropdown options
+      # into a missing target and leave the index page stale.
+      format.turbo_stream { render :filter_options } if request.xhr?
       format.json {
         render json: @projects.map { |project|
           {


### PR DESCRIPTION
## Summary
- Deleting a customer (or project) from the listing page silently no-op'd visually until a manual reload, because Turbo's post-DELETE redirect hit `format.turbo_stream { render :filter_options }` and got back a `turbo_stream.update customer-dropdown-menu` payload aimed at an element that only exists on invoice/delivery-note forms.
- Gate the turbo_stream branch on `request.xhr?` so Turbo navigation falls through to the HTML branch. The only legitimate caller — the `searchable_dropdown` Stimulus controller — already sends `X-Requested-With: XMLHttpRequest`, so dropdown loading is unaffected.

## Test plan
- [x] `bundle exec rails test test/controllers/customers_controller_test.rb test/controllers/projects_controller_test.rb` — 34 runs, 0 failures
- [x] Probe with Turbo navigation Accept header — now returns full HTML index for both controllers
- [x] Probe with dropdown XHR Accept header — still returns the turbo_stream partial
- [x] DELETE a customer + follow redirect — response is the rendered index page

🤖 Generated with [Claude Code](https://claude.com/claude-code)