### PR TITLE
Follow-up fixes from review of recent changes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -141,10 +141,16 @@ class ApplicationController < ActionController::Base
   end
 
   # Verifies a WebAuthn create-style assertion against the given challenge.
-  # Returns the credential on success; on WebAuthn::Error, renders a 422 JSON
-  # error and returns nil — callers should `return` on nil.
+  # Returns the credential on success; on a missing/malformed credential
+  # payload or WebAuthn::Error, renders a 422 JSON error and returns nil —
+  # callers should `return` on nil.
   def verify_webauthn_create(challenge)
-    credential = WebAuthn::Credential.from_create(params[:credential].to_unsafe_h)
+    payload = params[:credential]
+    unless payload.is_a?(ActionController::Parameters)
+      render json: { error: "Verification failed: missing credential payload" }, status: :unprocessable_content
+      return nil
+    end
+    credential = WebAuthn::Credential.from_create(payload.to_unsafe_h)
     credential.verify(challenge)
     credential
   rescue WebAuthn::Error => e

--- a/app/controllers/delivery_notes_controller.rb
+++ b/app/controllers/delivery_notes_controller.rb
@@ -282,7 +282,11 @@ class DeliveryNotesController < ApplicationController
 
   def send_email
     unless @delivery_note.emailable?
-      redirect_to @delivery_note, alert: "No recipient configured for this delivery note." and return
+      respond_to do |format|
+        format.html { redirect_to @delivery_note, alert: "No recipient configured for this delivery note." }
+        format.json { render json: { error: "No recipient configured for this delivery note." }, status: :unprocessable_content }
+      end
+      return
     end
     DeliveryNoteMailer.with(delivery_note: @delivery_note).customer_email.deliver_later
     @delivery_note.update_column(:email_sent_at, Time.current)

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -174,7 +174,11 @@ class InvoicesController < ApplicationController
 
   def send_email
     unless @invoice.emailable?
-      redirect_to @invoice, alert: "No recipient configured for this invoice." and return
+      respond_to do |format|
+        format.html { redirect_to @invoice, alert: "No recipient configured for this invoice." }
+        format.json { render json: { error: "No recipient configured for this invoice." }, status: :unprocessable_content }
+      end
+      return
     end
     InvoiceMailer.with(invoice: @invoice).customer_email.deliver_later
     @invoice.update_column(:email_sent_at, Time.current)

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -14,7 +14,7 @@ class ApplicationMailer < ActionMailer::Base
   end
 
   def build_default_from
-    "\"#{@issuer.short_name}\" <#{@issuer.document_email_from}>"
+    "\"#{sanitize_header_value(@issuer.short_name)}\" <#{sanitize_header_value(@issuer.document_email_from)}>"
   end
 
   # Send the standard document email envelope. From comes from the default

--- a/app/mailers/delivery_note_mailer.rb
+++ b/app/mailers/delivery_note_mailer.rb
@@ -7,7 +7,9 @@ class DeliveryNoteMailer < ApplicationMailer
     to = @delivery_note.email_recipients
 
     with_customer_locale(customer) do
-      subject = I18n.t("mailers.delivery_note.subject", issuer_name: @issuer.short_name, document_number: @delivery_note.document_number)
+      subject = I18n.t("mailers.delivery_note.subject",
+                       issuer_name: sanitize_header_value(@issuer.short_name),
+                       document_number: sanitize_header_value(@delivery_note.document_number))
       document_mail(to: to, subject: subject)
     end
   end
@@ -24,8 +26,10 @@ class DeliveryNoteMailer < ApplicationMailer
     @delivery_notes.each { |dn| attach_pdf(dn) }
 
     with_customer_locale(@customer) do
-      document_numbers = @delivery_notes.map(&:document_number).join(", ")
-      subject = I18n.t("mailers.delivery_note.bulk_subject", issuer_name: @issuer.short_name, document_numbers: document_numbers)
+      document_numbers = @delivery_notes.map { |dn| sanitize_header_value(dn.document_number) }.join(", ")
+      subject = I18n.t("mailers.delivery_note.bulk_subject",
+                       issuer_name: sanitize_header_value(@issuer.short_name),
+                       document_numbers: document_numbers)
       document_mail(to: to, subject: subject)
     end
   end

--- a/app/mailers/invoice_mailer.rb
+++ b/app/mailers/invoice_mailer.rb
@@ -16,7 +16,9 @@ class InvoiceMailer < ApplicationMailer
                           .gsub("$CUST_ORDER$", sanitize_header_value(@invoice.cust_order))
                           .gsub("$CUST_REF$", sanitize_header_value(@invoice.cust_reference))
       else
-        subject = I18n.t("mailers.invoice.subject", issuer_name: @issuer.short_name, document_number: @invoice.document_number)
+        subject = I18n.t("mailers.invoice.subject",
+                         issuer_name: sanitize_header_value(@issuer.short_name),
+                         document_number: sanitize_header_value(@invoice.document_number))
       end
 
       document_mail(to: to, cc: cc, subject: subject)

--- a/app/mailers/overdue_invoices_mailer.rb
+++ b/app/mailers/overdue_invoices_mailer.rb
@@ -9,9 +9,8 @@ class OverdueInvoicesMailer < ApplicationMailer
     I18n.with_locale(I18n.default_locale) do
       mail(
         to: recipient,
-        from: "\"#{@issuer.short_name}\" <#{@issuer.document_email_from}>",
         subject: I18n.t("mailers.overdue_invoices.subject",
-                        issuer_name: @issuer.short_name,
+                        issuer_name: sanitize_header_value(@issuer.short_name),
                         count: @invoices.size)
       )
     end

--- a/app/models/concerns/year_filterable.rb
+++ b/app/models/concerns/year_filterable.rb
@@ -14,8 +14,10 @@ module YearFilterable
     end
 
     # Distinct years for which records with a `date` exist, newest first.
+    # Honors the current scope — callers chain visible_to(user) so the year
+    # chips don't leak years from teams the user can't see.
     def available_years
-      unscoped.where.not(date: nil).pluck(:date).map(&:year).uniq.sort.reverse
+      where.not(date: nil).pluck(:date).map(&:year).uniq.sort.reverse
     end
   end
 end

--- a/app/models/delivery_note.rb
+++ b/app/models/delivery_note.rb
@@ -29,7 +29,7 @@ class DeliveryNote < ApplicationRecord
   end
 
   def emailable?
-    customer.contacts_for_delivery_note(self).any?
+    email_recipients.any?
   end
 
   def self.visible_to(user)

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -8,18 +8,26 @@ class Invoice < ApplicationRecord
   validates :customer_id, presence: true
   default_scope { order(Arel.sql("id ASC")) }
 
+  # Mirror of emailable? in SQL — must agree.
+  # Auto-email branch needs a non-blank auto_to (the only To recipient).
+  # Contacts branch only applies when auto-email is OFF (when it's on, contacts
+  # go to CC, never To).
   scope :email_unsent, -> {
     where(email_sent_at: nil).where(<<~SQL.squish)
       EXISTS (
-        SELECT 1 FROM customer_contacts cc
-        LEFT JOIN customer_contact_projects ccp ON ccp.customer_contact_id = cc.id
-        WHERE cc.customer_id = invoices.customer_id
-          AND cc.receives_invoice_emails = TRUE
-          AND (ccp.project_id IS NULL OR ccp.project_id = invoices.project_id)
+        SELECT 1 FROM customers c
+        WHERE c.id = invoices.customer_id
+          AND c.invoice_email_auto_enabled = TRUE
+          AND COALESCE(TRIM(c.invoice_email_auto_to), '') <> ''
       )
       OR EXISTS (
-        SELECT 1 FROM customers c
-        WHERE c.id = invoices.customer_id AND c.invoice_email_auto_enabled = TRUE
+        SELECT 1 FROM customer_contacts cc
+        LEFT JOIN customer_contact_projects ccp ON ccp.customer_contact_id = cc.id
+        JOIN customers c ON c.id = cc.customer_id
+        WHERE cc.customer_id = invoices.customer_id
+          AND c.invoice_email_auto_enabled = FALSE
+          AND cc.receives_invoice_emails = TRUE
+          AND (ccp.project_id IS NULL OR ccp.project_id = invoices.project_id)
       )
     SQL
   }
@@ -41,8 +49,7 @@ class Invoice < ApplicationRecord
   end
 
   def emailable?
-    return true if customer.invoice_email_auto_enabled?
-    customer.contacts_for_invoice(self).any?
+    email_recipients.any?
   end
 
   def self.visible_to(user)

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -30,6 +30,7 @@
             %dt.col-sm-4 Blocked by
             %dd.col-sm-8= @user.blocked_by_user&.username || '—'
 
+    - can_manage_emails = can?('users.auto_confirm_email')
     .card.mb-3
       .card-header Emails
       %ul.list-group.list-group-flush
@@ -42,23 +43,26 @@
                   %span.badge.bg-success.ms-2 Confirmed
                 - else
                   %span.badge.bg-warning.ms-2 Pending
-              %div.btn-group
-                %button.btn.btn-sm.btn-outline-secondary{type: 'button', data: { action: 'click->toggle-visibility#toggle' }} Replace…
-                - if !(email.confirmed? && @user.confirmed_emails.count <= 1)
-                  = button_to 'Remove', user_email_path(user_id: @user, id: email), method: :delete,
-                      data: { turbo_confirm: "Remove email #{email.address}?" },
-                      class: 'btn btn-sm btn-outline-danger'
-            .mt-2.d-none{id: "replace-email-#{email.id}", data: { 'toggle-visibility-target': 'panel' }}
-              = form_with url: user_email_path(user_id: @user, id: email), method: :put, scope: :user_email, local: true do |f|
-                .input-group.input-group-sm
-                  = f.email_field :address, class: 'form-control', placeholder: 'replacement@example.com', required: true
-                  = f.submit 'Replace', class: 'btn btn-primary'
-      .card-body
-        = form_with url: user_emails_path(@user), method: :post, scope: :user_email, local: true do |f|
-          .input-group.input-group-sm
-            = f.email_field :address, class: 'form-control', placeholder: 'add@example.com', required: true
-            = f.submit 'Add email', class: 'btn btn-outline-primary'
-        .form-text Admin-added emails are confirmed immediately (no email verification needed).
+              - if can_manage_emails
+                %div.btn-group
+                  %button.btn.btn-sm.btn-outline-secondary{type: 'button', data: { action: 'click->toggle-visibility#toggle' }} Replace…
+                  - if !(email.confirmed? && @user.confirmed_emails.count <= 1)
+                    = button_to 'Remove', user_email_path(user_id: @user, id: email), method: :delete,
+                        data: { turbo_confirm: "Remove email #{email.address}?" },
+                        class: 'btn btn-sm btn-outline-danger'
+            - if can_manage_emails
+              .mt-2.d-none{id: "replace-email-#{email.id}", data: { 'toggle-visibility-target': 'panel' }}
+                = form_with url: user_email_path(user_id: @user, id: email), method: :put, scope: :user_email, local: true do |f|
+                  .input-group.input-group-sm
+                    = f.email_field :address, class: 'form-control', placeholder: 'replacement@example.com', required: true
+                    = f.submit 'Replace', class: 'btn btn-primary'
+      - if can_manage_emails
+        .card-body
+          = form_with url: user_emails_path(@user), method: :post, scope: :user_email, local: true do |f|
+            .input-group.input-group-sm
+              = f.email_field :address, class: 'form-control', placeholder: 'add@example.com', required: true
+              = f.submit 'Add email', class: 'btn btn-outline-primary'
+          .form-text Admin-added emails are confirmed immediately (no email verification needed).
 
   .col-md-6
     .card.mb-3
@@ -148,13 +152,15 @@
 
 = action_buttons_wrapper do
   - if @user.blocked?
-    = button_to 'Unblock', unblock_user_path(@user), method: :post,
-        data: { turbo_confirm: "Unblock #{@user.username}?" },
-        class: 'btn btn-success'
-    = button_to 'Reset passkeys', reset_passkeys_user_path(@user), method: :post,
-        data: { turbo_confirm: "Delete all of #{@user.username}'s passkeys and email them an invite to register a new one?" },
-        class: 'btn btn-warning'
-  - elsif @user.id != current_user.id
+    - if can?('users.block')
+      = button_to 'Unblock', unblock_user_path(@user), method: :post,
+          data: { turbo_confirm: "Unblock #{@user.username}?" },
+          class: 'btn btn-success'
+    - if can?('users.reset_passkeys')
+      = button_to 'Reset passkeys', reset_passkeys_user_path(@user), method: :post,
+          data: { turbo_confirm: "Delete all of #{@user.username}'s passkeys and email them an invite to register a new one?" },
+          class: 'btn btn-warning'
+  - elsif @user.id != current_user.id && can?('users.block')
     = form_with url: block_user_path(@user), method: :post, local: true, class: 'd-inline-flex' do |f|
       .input-group.w-fixed-400
         = f.text_field :reason, class: 'form-control', placeholder: 'Reason (required)', required: true

--- a/test/controllers/delivery_notes_controller_test.rb
+++ b/test/controllers/delivery_notes_controller_test.rb
@@ -355,6 +355,18 @@ class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
     assert_match "E-Mail queued for sending.", flash[:notice]
   end
 
+  test "send_email returns an error status for JSON when no recipient is configured" do
+    note = delivery_notes(:published_delivery_note)
+    note.customer.customer_contacts.destroy_all
+    note.update_column(:email_sent_at, nil)
+
+    post send_email_delivery_note_url(note),
+         headers: { "Accept" => "application/json" }
+
+    assert_response :unprocessable_content
+    assert_nil note.reload.email_sent_at
+  end
+
   test "should bulk send emails to selected delivery notes" do
     published_note = delivery_notes(:published_delivery_note)
 

--- a/test/controllers/invites_controller_test.rb
+++ b/test/controllers/invites_controller_test.rb
@@ -41,4 +41,27 @@ class InvitesControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_content
     assert_match(/taken/i, JSON.parse(response.body)["error"])
   end
+
+  test "verify endpoint returns 422 (not 500) when credential payload is missing" do
+    post options_invite_path(token: "pending-signup-token"),
+         params: { username: "newuser", full_name: "New User", email: "newuser@example.com" },
+         as: :json
+    assert_response :success
+
+    post verify_invite_path(token: "pending-signup-token"), params: {}, as: :json
+    assert_response :unprocessable_content
+    assert_match(/credential|verification/i, JSON.parse(response.body)["error"])
+  end
+
+  test "verify endpoint returns 422 (not 500) when credential payload is a string" do
+    post options_invite_path(token: "pending-signup-token"),
+         params: { username: "newuser2", full_name: "New User", email: "newuser2@example.com" },
+         as: :json
+    assert_response :success
+
+    post verify_invite_path(token: "pending-signup-token"),
+         params: { credential: "not-a-hash" },
+         as: :json
+    assert_response :unprocessable_content
+  end
 end

--- a/test/controllers/invoices_controller_email_test.rb
+++ b/test/controllers/invoices_controller_email_test.rb
@@ -120,6 +120,17 @@ class InvoicesControllerEmailTest < ActionDispatch::IntegrationTest
     assert_not_nil invoice.reload.email_sent_at
   end
 
+  test "send_email returns an error status for JSON when no recipient is configured" do
+    invoice = invoices(:no_email_invoice)
+
+    assert_enqueued_emails 0 do
+      post send_email_invoice_path(invoice), headers: { "Accept" => "application/json" }
+    end
+
+    assert_response :unprocessable_content
+    assert_nil invoice.reload.email_sent_at
+  end
+
   test "bulk_send_emails queues jobs for selected invoices" do
     invoice1 = invoices(:published_invoice)
     invoice2 = invoices(:auto_email_invoice)

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -22,6 +22,41 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "show hides admin action affordances for users without the matching permissions" do
+    viewer = Group.create!(name: "Viewer")
+    viewer.permissions = %w[users.view]
+    bob = users(:bob)
+    bob.groups.clear
+    bob.groups << viewer
+    sign_in_as(bob)
+
+    get user_path(users(:blocked_carol))
+    assert_response :success
+    # No Reset passkeys / Unblock buttons.
+    assert_select "form[action=?]", reset_passkeys_user_path(users(:blocked_carol)), count: 0
+    assert_select "form[action=?]", unblock_user_path(users(:blocked_carol)), count: 0
+    # No email management UI.
+    assert_select "form[action=?]", user_emails_path(users(:blocked_carol)), count: 0
+    # No Block form on a non-blocked user.
+    get user_path(users(:alice))
+    assert_response :success
+    assert_select "form[action=?]", block_user_path(users(:alice)), count: 0
+  end
+
+  test "show exposes admin action affordances when the user has the matching permissions" do
+    sign_in_as(users(:alice))
+
+    get user_path(users(:blocked_carol))
+    assert_response :success
+    assert_select "form[action=?]", reset_passkeys_user_path(users(:blocked_carol))
+    assert_select "form[action=?]", unblock_user_path(users(:blocked_carol))
+    assert_select "form[action=?]", user_emails_path(users(:blocked_carol))
+
+    get user_path(users(:bob))
+    assert_response :success
+    assert_select "form[action=?]", block_user_path(users(:bob))
+  end
+
   test "block requires reason" do
     sign_in_as(users(:alice))
     post block_user_path(users(:bob))

--- a/test/mailers/invoice_mailer_test.rb
+++ b/test/mailers/invoice_mailer_test.rb
@@ -127,6 +127,16 @@ class InvoiceMailerTest < ActionMailer::TestCase
     assert_no_match(/[\r\n]/, mail.subject)
   end
 
+  test "customer_email strips CRLF from issuer-controlled short_name in subject and From" do
+    IssuerCompany.get_the_issuer!.update!(short_name: "Evil\r\nX-Injected: yes")
+    invoice = invoices(:published_invoice)
+    mail = InvoiceMailer.with(invoice: invoice).customer_email
+
+    assert_no_match(/[\r\n]/, mail.subject)
+    assert_no_match(/[\r\n]/, mail.from.join)
+    assert_no_match(/[\r\n]/, mail["from"].decoded)
+  end
+
   test "customer_email subject template handles empty substitution values" do
     invoice = Invoice.create!(
       customer: customers(:auto_email_customer),

--- a/test/models/invoice_test.rb
+++ b/test/models/invoice_test.rb
@@ -162,6 +162,34 @@ class InvoiceTest < ActiveSupport::TestCase
     assert_not_includes years, nil
   end
 
+  test "available_years honors the surrounding scope (no cross-team year leak)" do
+    acme = teams(:acme)
+    acme_customer = Customer.create!(
+      matchcode: "ACME_YEAR_LEAK",
+      name: "Acme Year Leak",
+      sales_tax_customer_class: sales_tax_customer_classes(:eu),
+      language: languages(:english),
+      team: acme
+    )
+    Invoice.create!(
+      customer: acme_customer,
+      project: projects(:one),
+      attachment: attachments(:invoice_pdf),
+      document_number: "INV-ACME-YEAR",
+      published: true,
+      date: Date.new(2019, 1, 15),
+      due_date: Date.new(2019, 2, 15),
+      sum_net: 100, sum_total: 121
+    )
+
+    # blocked_carol has no team membership; she should see no invoices and
+    # therefore no years.
+    assert_empty Invoice.visible_to(users(:blocked_carol)).available_years
+
+    # Unscoped, the year shows up (sanity check that the fixture took).
+    assert_includes Invoice.available_years, 2019
+  end
+
   # email_unsent + emailable? must agree (one is SQL, the other is Ruby).
   test "email_unsent includes invoices whose customer has a matching contact" do
     invoice = invoices(:published_invoice)

--- a/test/models/invoice_test.rb
+++ b/test/models/invoice_test.rb
@@ -201,4 +201,39 @@ class InvoiceTest < ActiveSupport::TestCase
     assert_not_includes Invoice.email_unsent, invoice
     assert_not invoice.emailable?
   end
+
+  test "emailable? is false when auto-email is enabled but auto_to is blank" do
+    customer = customers(:auto_email_customer)
+    customer.update_columns(invoice_email_auto_to: "")
+    customer.customer_contacts.destroy_all
+
+    invoice = invoices(:auto_email_invoice)
+    invoice.update_column(:email_sent_at, nil)
+
+    assert_not invoice.emailable?
+    assert_not_includes Invoice.email_unsent, invoice
+  end
+
+  test "emailable? is false in cc_contacts mode when auto_to is blank, even if contacts exist" do
+    customer = customers(:auto_email_customer)
+    customer.update_columns(invoice_email_auto_to: "", invoice_email_auto_contact_mode: "cc_contacts")
+
+    invoice = invoices(:auto_email_invoice)
+    invoice.update_column(:email_sent_at, nil)
+
+    assert_not invoice.emailable?
+    assert_not_includes Invoice.email_unsent, invoice
+  end
+
+  test "emailable? is false when auto_to is whitespace-only" do
+    customer = customers(:auto_email_customer)
+    customer.update_columns(invoice_email_auto_to: "   ")
+    customer.customer_contacts.destroy_all
+
+    invoice = invoices(:auto_email_invoice)
+    invoice.update_column(:email_sent_at, nil)
+
+    assert_not invoice.emailable?
+    assert_not_includes Invoice.email_unsent, invoice
+  end
 end


### PR DESCRIPTION
Bug-fix sweep from a review of the last five days of changes. Five focused commits.

## Commits

- **f015267** Fix false "Queued!" toast and silently-marked-sent invoices.
  Two coupled bugs: `send_email`'s no-recipient branch ignored the JSON `Accept` header (the JS fetch followed the redirect to a 200, reported "Queued!"), and `Invoice#emailable?` returned true whenever auto-email was enabled without checking that `invoice_email_auto_to` was non-blank. `emailable?` now aligns with `email_recipients.any?` and the SQL `email_unsent` scope is rewritten to match.
- **8cb591b** Stop `YearFilterable.available_years` from leaking years across teams. `unscoped` discarded `visible_to(current_user)` chained ahead of it; the year-chip UI leaked years from teams the user can't see.
- **9c45ee4** Gate the Block/Unblock/Reset passkeys buttons and the email management forms in `users#show` by `can?`. Server-side checks still 403 the click; this aligns the UI.
- **178ce82** Apply `sanitize_header_value` to issuer-controlled `short_name` (admin-editable) in every mailer's Subject and From header. Previously only the `\$CUST_ORDER\$` / `\$CUST_REF\$` substitutions in `InvoiceMailer` were sanitised.
- **632fea9** `verify_webauthn_create` now returns 422 on missing/malformed `params[:credential]` instead of bubbling `NoMethodError` to a 500 — restoring the documented contract.

## Remaining items filed as issues

Lower-priority and deploy-time items from the same review:

- #332 Customer contacts form inline style blocked by strict CSP
- #334 Matchcode unique-index migration has no duplicate-detection step
- #336 Delivery-note item-line validation may break old published records on unpublish/republish
- #337 Default SalesTaxProductClass can be nil; downstream booking fails
- #338 User#permissions SQL lacks DISTINCT
- #339 reset_session not called on login/logout; webauthn pending-state keys persist
- #340 passkey_controller.js: bfcache pageshow branch lacks a test
- #341 WebauthnPendingStore unscoped to session: two-tab race overwrites nonce
- #342 Bulk delivery-note send partitions recipients case-sensitively
- #343 Invoice has no must_have_item_line guard (parity with DeliveryNote)
- #344 Email contact dedup: missing tests for whitespace, dup contacts, and contact-list .uniq
- #345 email_sent_at is now stamped at enqueue, not delivery — no observability for failed sends
- #346 Auth cookie rename forces a hard logout with no user-facing notice
- #347 Customer#sync_project_teams uses update_all, skipping team_assignment authz

## Test plan

- [x] `bundle exec rails test` — full suite passes (582 runs, 0 failures, 0 errors).
- [ ] Manual: open the email preview modal on an invoice whose customer has no contacts → modal should report a clear error, not "Queued!".
- [ ] Manual: as a `users.view`-only user, visit `/users/:id` → Block/Unblock/Reset passkeys/email management UI should not render.
- [ ] Manual: as a non-bypass user with no team membership, visit `/invoices` → no year chips should appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)