### PR TITLE
Fix customer-contacts inline style dropped by strict CSP (#332)

### DIFF
--- a/app/assets/stylesheets/utilities.css.scss
+++ b/app/assets/stylesheets/utilities.css.scss
@@ -121,3 +121,9 @@
   max-width: 480px;
   word-break: break-word;
 }
+
+// --- Customer contacts form ---
+// Caps the multi-select's height so it doesn't grow with the project list.
+.customer-contact-projects-select {
+  max-height: 7rem;
+}

--- a/app/views/customer_contacts/_form_fields.html.haml
+++ b/app/views/customer_contacts/_form_fields.html.haml
@@ -19,8 +19,7 @@
                   options_from_collection_for_select(eligible_projects, :id, :matchcode, contact.project_ids),
                   { include_hidden: false },
                   multiple: true, size: [eligible_projects.size, 4].min.clamp(2, 6),
-                  class: "form-select form-select-sm",
-                  style: "max-height: 7rem"
+                  class: "form-select form-select-sm customer-contact-projects-select"
     - if contact.errors[:projects].any?
       .invalid-feedback.d-block= contact.errors[:projects].to_sentence
   .col-md-2.text-end

--- a/test/integration/csp_inline_handlers_structure_test.rb
+++ b/test/integration/csp_inline_handlers_structure_test.rb
@@ -111,6 +111,22 @@ class CspInlineHandlersStructureTest < ActionDispatch::IntegrationTest
     assert_no_match(/\bstyle=['"]/, body, "no inline style attributes allowed on users show")
   end
 
+  test "customer_contacts new form carries no inline style attribute" do
+    get new_customer_customer_contact_path(customers(:good_eu))
+    assert_response :success
+    body = @response.body
+
+    assert_no_match(/\bstyle=['"]/, body, "no inline style attributes allowed on the new customer-contact form")
+  end
+
+  test "customer_contacts edit form carries no inline style attribute" do
+    get edit_customer_contact_path(customer_contacts(:good_eu_accounting))
+    assert_response :success
+    body = @response.body
+
+    assert_no_match(/\bstyle=['"]/, body, "no inline style attributes allowed on the edit customer-contact form")
+  end
+
   private
 
   def csp_nonce(response)


### PR DESCRIPTION
## Summary

- `app/views/customer_contacts/_form_fields.html.haml` shipped `style: "max-height: 7rem"` on the projects multi-select. Under the app's CSP (`style-src 'self' 'nonce-…'`, no `'unsafe-inline'`), the inline-style attribute is silently dropped, so the cap never applied.
- Replace the inline style with a `.customer-contact-projects-select` class in `utilities.css.scss`.
- Extend `test/integration/csp_inline_handlers_structure_test.rb` to load both the new and edit customer-contact forms and fail on any `style="…"` attribute — the existing structure test never visited this turbo-frame, which is why 667ea51 missed it.

Fixes #332.

## Test plan

- [x] `bundle exec rails test test/integration/csp_inline_handlers_structure_test.rb` — 12 runs, 0 failures
- [x] `bundle exec rails test test/controllers/customer_contacts_controller_test.rb test/integration/` — 68 runs, 0 failures
- [x] `pre-commit run --all-files` — clean
- [ ] Manual: open customer → contacts → New/Edit, confirm projects select height is capped (~7rem) without CSP violations in the console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)