### PR TITLE
Personalize document emails via CustomerContact.salutation_line

### DIFF
--- a/app/controllers/customer_contacts_controller.rb
+++ b/app/controllers/customer_contacts_controller.rb
@@ -77,7 +77,7 @@ class CustomerContactsController < ApplicationController
   end
 
   def contact_params
-    params.require(:customer_contact).permit(:name, :email, :receives_invoice_emails, :receives_delivery_note_emails)
+    params.require(:customer_contact).permit(:name, :email, :salutation_line, :receives_invoice_emails, :receives_delivery_note_emails)
   end
 
   # Server-side scope on project_ids: pick only IDs the user can see AND that

--- a/app/mailers/delivery_note_mailer.rb
+++ b/app/mailers/delivery_note_mailer.rb
@@ -7,6 +7,8 @@ class DeliveryNoteMailer < ApplicationMailer
     to = @delivery_note.email_recipients
 
     with_customer_locale(customer) do
+      @salutation = @delivery_note.email_salutation_contact&.salutation_line.presence
+
       subject = I18n.t("mailers.delivery_note.subject",
                        issuer_name: sanitize_header_value(@issuer.short_name),
                        document_number: sanitize_header_value(@delivery_note.document_number))

--- a/app/mailers/invoice_mailer.rb
+++ b/app/mailers/invoice_mailer.rb
@@ -11,6 +11,8 @@ class InvoiceMailer < ApplicationMailer
     cc = @invoice.email_cc_recipients
 
     with_customer_locale(customer) do
+      @salutation = @invoice.email_salutation_contact&.salutation_line.presence
+
       if customer.invoice_email_auto_enabled
         subject = customer.invoice_email_auto_subject_template
                           .gsub("$CUST_ORDER$", sanitize_header_value(@invoice.cust_order))

--- a/app/models/delivery_note.rb
+++ b/app/models/delivery_note.rb
@@ -28,6 +28,14 @@ class DeliveryNote < ApplicationRecord
     customer.contacts_for_delivery_note(self).map(&:email)
   end
 
+  # The contact whose salutation_line should personalize this delivery note's
+  # email, or nil to fall back to the I18n greeting. Returns the contact only
+  # when the To: line resolves to exactly one CustomerContact.
+  def email_salutation_contact
+    contacts = customer.contacts_for_delivery_note(self)
+    contacts.size == 1 ? contacts.first : nil
+  end
+
   def emailable?
     email_recipients.any?
   end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -48,6 +48,16 @@ class Invoice < ApplicationRecord
     customer.contacts_for_invoice(self).map(&:email).reject { |e| e.to_s.downcase.strip == auto_to }
   end
 
+  # The contact whose salutation_line should personalize this invoice's email,
+  # or nil to fall back to the I18n greeting. Returns the contact only when
+  # the To: line resolves to exactly one CustomerContact (i.e. auto-email is
+  # off and there's a single matching contact).
+  def email_salutation_contact
+    return nil if customer.invoice_email_auto_enabled?
+    contacts = customer.contacts_for_invoice(self)
+    contacts.size == 1 ? contacts.first : nil
+  end
+
   def emailable?
     email_recipients.any?
   end

--- a/app/views/customer_contacts/_form_fields.html.haml
+++ b/app/views/customer_contacts/_form_fields.html.haml
@@ -29,3 +29,9 @@
       = link_to "Cancel", customer_contact_path(contact), class: "btn btn-sm btn-link"
     - else
       = link_to "Cancel", new_customer_customer_contact_path(customer, cancel: 1), class: "btn btn-sm btn-link"
+.row.align-items-start.gx-2.mt-2
+  .col-md-5
+    = form.text_field :salutation_line, class: "form-control form-control-sm",
+                      placeholder: "Dear Mr. Huber,"
+    .form-text.small
+      = t("customer_contacts.salutation_line_hint", language_name: customer.language.title)

--- a/app/views/customer_contacts/_row.html.haml
+++ b/app/views/customer_contacts/_row.html.haml
@@ -23,3 +23,7 @@
         = list_action_link "Edit", edit_customer_contact_path(contact), :edit
         = link_to "🗑", customer_contact_path(contact), class: "btn btn-sm btn-outline-danger py-0",
                   data: { 'turbo-method': :delete, 'turbo-confirm': "Delete contact \"#{contact.name}\"?" }
+  - if contact.salutation_line.present?
+    .row.gx-2
+      .col-md-10.offset-md-2.small.text-muted.fst-italic
+        = contact.salutation_line

--- a/app/views/delivery_note_mailer/customer_email.html.haml
+++ b/app/views/delivery_note_mailer/customer_email.html.haml
@@ -1,7 +1,10 @@
 - content_for :title, t('mailers.delivery_note.document_number', document_number: @delivery_note.document_number)
 
 .greeting
-  = t('mailers.delivery_note.greeting', customer_name: @delivery_note.customer.name)
+  - if @salutation.present?
+    = @salutation
+  - else
+    = t('mailers.delivery_note.greeting', customer_name: @delivery_note.customer.name)
 
 .main-message
   = t('mailers.delivery_note.main_message')

--- a/app/views/delivery_note_mailer/customer_email.text.haml
+++ b/app/views/delivery_note_mailer/customer_email.text.haml
@@ -1,4 +1,7 @@
-#{t('mailers.delivery_note.greeting', customer_name: @delivery_note.customer.name)}
+- if @salutation.present?
+  #{@salutation}
+- else
+  #{t('mailers.delivery_note.greeting', customer_name: @delivery_note.customer.name)}
 \
 #{t('mailers.delivery_note.main_message')}
 \

--- a/app/views/invoice_mailer/customer_email.html.haml
+++ b/app/views/invoice_mailer/customer_email.html.haml
@@ -1,7 +1,10 @@
 - content_for :title, t('mailers.invoice.document_number', document_number: @invoice.document_number)
 
 .greeting
-  = t('mailers.invoice.greeting', customer_name: @invoice.customer.name)
+  - if @salutation.present?
+    = @salutation
+  - else
+    = t('mailers.invoice.greeting', customer_name: @invoice.customer.name)
 
 .main-message
   = t('mailers.invoice.main_message')

--- a/app/views/invoice_mailer/customer_email.text.haml
+++ b/app/views/invoice_mailer/customer_email.text.haml
@@ -1,4 +1,7 @@
-#{t('mailers.invoice.greeting', customer_name: @invoice.customer.name)}
+- if @salutation.present?
+  #{@salutation}
+- else
+  #{t('mailers.invoice.greeting', customer_name: @invoice.customer.name)}
 \
 #{t('mailers.invoice.main_message')}
 \

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -48,3 +48,6 @@ de:
         - "Bestätigung der Leistungserbringung"
         - "Rücksendung des unterfertigten Lieferscheins per E-Mail"
       closing: "Vielen Dank für Ihr Vertrauen. Wir freuen uns auf die weitere Zusammenarbeit."
+
+  customer_contacts:
+    salutation_line_hint: "In der Sprache des Kunden verfassen: %{language_name}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -94,3 +94,6 @@ en:
         - "Sign the delivery note to confirm acceptance of the delivered services"
         - "Return the signed delivery note to us via email"
       closing: "Thank you for your business. We appreciate your continued partnership."
+
+  customer_contacts:
+    salutation_line_hint: "Write in the customer's language: %{language_name}"

--- a/db/migrate/20260525130000_add_salutation_line_to_customer_contacts.rb
+++ b/db/migrate/20260525130000_add_salutation_line_to_customer_contacts.rb
@@ -1,0 +1,5 @@
+class AddSalutationLineToCustomerContacts < ActiveRecord::Migration[8.1]
+  def change
+    add_column :customer_contacts, :salutation_line, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_25_120004) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_25_130000) do
   create_table "attachments", force: :cascade do |t|
     t.string "content_type"
     t.datetime "created_at", null: false
@@ -35,6 +35,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_25_120004) do
     t.string "name", null: false
     t.boolean "receives_delivery_note_emails", default: false, null: false
     t.boolean "receives_invoice_emails", default: false, null: false
+    t.string "salutation_line"
     t.datetime "updated_at", null: false
     t.index ["customer_id"], name: "index_customer_contacts_on_customer_id"
   end

--- a/test/mailers/delivery_note_mailer_test.rb
+++ b/test/mailers/delivery_note_mailer_test.rb
@@ -15,6 +15,46 @@ class DeliveryNoteMailerTest < ActionMailer::TestCase
     assert_equal "application/pdf", attachment.content_type
   end
 
+  test "customer_email uses salutation_line when exactly one contact resolves as recipient" do
+    customer_contacts(:good_eu_accounting).update!(salutation_line: "Sehr geehrter Herr Huber,")
+
+    # good_eu_accounting is the sole contact with receives_delivery_note_emails: true.
+    delivery_note = delivery_notes(:published_delivery_note)
+    mail = DeliveryNoteMailer.with(delivery_note: delivery_note, skip_attachments: true).customer_email
+
+    assert_equal [ "customer@good-company.co.uk" ], mail.to
+    assert_match "Sehr geehrter Herr Huber,", mail.text_part.body.to_s
+    assert_match "Sehr geehrter Herr Huber,", mail.html_part.body.to_s
+    assert_no_match(/Dear A Good Company B\.V\./, mail.text_part.body.to_s)
+  end
+
+  test "customer_email falls back to greeting when the single resolved contact has no salutation_line" do
+    delivery_note = delivery_notes(:published_delivery_note)
+    mail = DeliveryNoteMailer.with(delivery_note: delivery_note, skip_attachments: true).customer_email
+
+    assert_equal [ "customer@good-company.co.uk" ], mail.to
+    assert_match "Dear A Good Company B.V.,", mail.text_part.body.to_s
+  end
+
+  test "customer_email falls back to greeting when multiple contacts match, even if both have salutation_line set" do
+    # Promote the project-one lead to also receive delivery notes; project one
+    # matches both contacts, so neither salutation wins.
+    customer_contacts(:good_eu_accounting).update!(salutation_line: "Sehr geehrter Herr A,")
+    customer_contacts(:good_eu_project_one_lead).update!(
+      salutation_line: "Sehr geehrter Herr B,",
+      receives_delivery_note_emails: true
+    )
+
+    delivery_note = delivery_notes(:published_delivery_note)
+    mail = DeliveryNoteMailer.with(delivery_note: delivery_note, skip_attachments: true).customer_email
+
+    assert_equal 2, mail.to.size
+    text_body = mail.text_part.body.to_s
+    assert_match "Dear A Good Company B.V.,", text_body
+    assert_no_match(/Sehr geehrter Herr A,/, text_body)
+    assert_no_match(/Sehr geehrter Herr B,/, text_body)
+  end
+
   test "customer_email skips PDF rendering when skip_attachments is set" do
     delivery_note = delivery_notes(:published_delivery_note)
 

--- a/test/mailers/invoice_mailer_test.rb
+++ b/test/mailers/invoice_mailer_test.rb
@@ -175,6 +175,82 @@ class InvoiceMailerTest < ActionMailer::TestCase
     assert_equal "Invoice  - Ref: ", mail.subject
   end
 
+  test "customer_email uses salutation_line when exactly one contact resolves as recipient" do
+    customer_contacts(:good_eu_accounting).update!(salutation_line: "Sehr geehrter Herr Huber,")
+
+    # Project `two` matches only good_eu_accounting (good_eu_project_one_lead
+    # is scoped to project `one`), so the To: line resolves to a single
+    # contact and its salutation_line wins.
+    invoice = Invoice.create!(
+      customer: customers(:good_eu),
+      project: projects(:two),
+      attachment: attachments(:invoice_pdf),
+      document_number: "INV-SALUT-1",
+      published: true,
+      date: Date.current,
+      due_date: 30.days.from_now,
+      sum_net: 100.00,
+      sum_total: 121.00
+    )
+
+    mail = InvoiceMailer.with(invoice: invoice).customer_email
+
+    assert_equal [ "customer@good-company.co.uk" ], mail.to
+    assert_match "Sehr geehrter Herr Huber,", mail.text_part.body.to_s
+    assert_match "Sehr geehrter Herr Huber,", mail.html_part.body.to_s
+    assert_no_match(/Dear A Good Company B\.V\./, mail.text_part.body.to_s)
+    assert_no_match(/Dear A Good Company B\.V\./, mail.html_part.body.to_s)
+  end
+
+  test "customer_email falls back to greeting when the single resolved contact has no salutation_line" do
+    invoice = Invoice.create!(
+      customer: customers(:good_eu),
+      project: projects(:two),
+      attachment: attachments(:invoice_pdf),
+      document_number: "INV-SALUT-NIL",
+      published: true,
+      date: Date.current,
+      due_date: 30.days.from_now,
+      sum_net: 100.00,
+      sum_total: 121.00
+    )
+
+    mail = InvoiceMailer.with(invoice: invoice).customer_email
+
+    assert_equal [ "customer@good-company.co.uk" ], mail.to
+    assert_match "Dear A Good Company B.V.,", mail.text_part.body.to_s
+    assert_match "Dear A Good Company B.V.,", mail.html_part.body.to_s
+  end
+
+  test "customer_email falls back to greeting when multiple contacts match, even if both have salutation_line set" do
+    customer_contacts(:good_eu_accounting).update!(salutation_line: "Sehr geehrter Herr A,")
+    customer_contacts(:good_eu_project_one_lead).update!(salutation_line: "Sehr geehrter Herr B,")
+
+    # published_invoice is on project `one` → both contacts match.
+    invoice = invoices(:published_invoice)
+    mail = InvoiceMailer.with(invoice: invoice).customer_email
+
+    assert_equal 2, mail.to.size
+    text_body = mail.text_part.body.to_s
+    assert_match "Dear A Good Company B.V.,", text_body
+    assert_no_match(/Sehr geehrter Herr A,/, text_body)
+    assert_no_match(/Sehr geehrter Herr B,/, text_body)
+  end
+
+  test "customer_email in auto-email replace_contacts mode falls back to greeting even with a single contact's salutation_line" do
+    customer = customers(:auto_email_customer)
+    customer.update!(invoice_email_auto_contact_mode: "replace_contacts")
+    customer_contacts(:auto_email_contact).update!(salutation_line: "Sehr geehrter Herr Auto,")
+
+    invoice = invoices(:auto_email_invoice)
+    mail = InvoiceMailer.with(invoice: invoice).customer_email
+
+    assert_equal [ "billing@autoemail.com" ], mail.to
+    text_body = mail.text_part.body.to_s
+    assert_no_match(/Sehr geehrter Herr Auto,/, text_body)
+    assert_match(/Auto Email Corp/, text_body)
+  end
+
   test "customer_email works in test environment without mailgun" do
     assert_equal :test, ActionMailer::Base.delivery_method
 

--- a/test/models/customer_contact_test.rb
+++ b/test/models/customer_contact_test.rb
@@ -83,6 +83,18 @@ class CustomerContactTest < ActiveSupport::TestCase
     assert_includes contact.errors[:customer_id], "must be a customer you can access"
   end
 
+  test "salutation_line round-trips when set, and is nil-allowed" do
+    contact = CustomerContact.create!(
+      customer: customers(:good_eu),
+      name: "Salutation Person",
+      email: "salutation@example.com"
+    )
+    assert_nil contact.salutation_line
+
+    contact.update!(salutation_line: "Sehr geehrter Herr Huber,")
+    assert_equal "Sehr geehrter Herr Huber,", contact.reload.salutation_line
+  end
+
   test "projects visibility check enforced when Current.user is set" do
     other_team = Team.create!(name: "Visibility Other")
     other_customer = Customer.create!(

--- a/test/system/customer_contacts_test.rb
+++ b/test/system/customer_contacts_test.rb
@@ -105,6 +105,20 @@ class CustomerContactsTest < ApplicationSystemTestCase
     assert_nil CustomerContact.find_by(id: @accounting.id)
   end
 
+  test "salutation_line persists from the edit form and renders in the row" do
+    visit customer_path(@customer)
+    row = "##{ActionView::RecordIdentifier.dom_id(@accounting)}"
+
+    within(row) { click_link "Edit" }
+    within(row) do
+      fill_in "customer_contact[salutation_line]", with: "Sehr geehrter Herr Huber,"
+      click_button "Save"
+    end
+
+    assert_selector "#{row}", text: "Sehr geehrter Herr Huber,"
+    assert_equal "Sehr geehrter Herr Huber,", @accounting.reload.salutation_line
+  end
+
   test "project picker only offers this customer's projects and unassigned projects" do
     visit customer_path(@customer)
     click_link "+ Add contact"


### PR DESCRIPTION
## Summary
- Add nullable `salutation_line` column on `CustomerContact`.
- When a document email's To: line resolves to exactly one contact and that contact has `salutation_line` set, use it verbatim as the greeting; otherwise fall back to the existing `mailers.*.greeting` I18n key.
- Applies to invoice + delivery-note `customer_email` templates (text and HTML). Bulk delivery-note mailer is intentionally unchanged.
- Inline contact form gets a salutation input with a language hint (pulled from `customer.language.title`); saved value renders below the row.

## Test plan
- [x] `bundle exec rails test test/models/customer_contact_test.rb test/mailers/invoice_mailer_test.rb test/mailers/delivery_note_mailer_test.rb`
- [x] `bundle exec rails test test/system/customer_contacts_test.rb`
- [x] Full unit + system suite (590 + 61 runs, all green)
- [x] `pre-commit run --all-files`
- [ ] Manual smoke: edit a contact, fill salutation, send single-recipient invoice/DN preview; confirm greeting uses the salutation. Clear salutation or trigger a multi-contact case; confirm fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)