### PR TITLE
Print customer supplier number on invoices and delivery notes

### DIFF
--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -92,7 +92,7 @@ class CustomersController < ApplicationController
 private
   def customers_params
     params.require(:customer).permit(
-        :matchcode, :name, :address, :vat_id, :notes, :sales_tax_customer_class_id, :language_id, :payment_terms_days,
+        :matchcode, :name, :address, :vat_id, :supplier_number, :notes, :sales_tax_customer_class_id, :language_id, :payment_terms_days,
         :invoice_email_auto_to, :invoice_email_auto_subject_template, :invoice_email_auto_enabled, :invoice_email_auto_contact_mode, :active,
         :team_id
     )

--- a/app/services/delivery_note_renderer.rb
+++ b/app/services/delivery_note_renderer.rb
@@ -36,7 +36,7 @@ class DeliveryNoteRenderer
         xml_recipient.address @delivery_note.customer.name + "\n" + @delivery_note.customer.address
         xml_recipient.tag! "account-no", @delivery_note.customer.id
         xml_recipient.tag! "vat-id", @delivery_note.customer.vat_id
-        xml_recipient.tag! "supplier-no", @delivery_note.customer.supplier_number
+        xml_recipient.tag! "supplier-no", @delivery_note.customer.supplier_number if @delivery_note.customer.supplier_number.present?
       end
 
       xml_root.prelude @delivery_note.prelude

--- a/app/services/invoice_renderer.rb
+++ b/app/services/invoice_renderer.rb
@@ -42,7 +42,7 @@ class InvoiceRenderer
         xml_recipient.address @invoice.customer_name + "\n" + @invoice.customer_address
         xml_recipient.tag! "account-no", @invoice.customer_account_number
         xml_recipient.tag! "vat-id", @invoice.customer_vat_id
-        xml_recipient.tag! "supplier-no", @invoice.customer_supplier_number
+        xml_recipient.tag! "supplier-no", @invoice.customer_supplier_number if @invoice.customer_supplier_number.present?
       end
 
       xml_root.currency "EUR"

--- a/app/views/customers/_form.html.haml
+++ b/app/views/customers/_form.html.haml
@@ -39,6 +39,11 @@
       .col-sm-5
         = f.text_field :vat_id, :class => 'form-control'
     .row.mb-3
+      = f.label :supplier_number, 'Supplier No.', class: 'col-lg-2 col-md-3 col-form-label'
+      .col-sm-5
+        = f.text_field :supplier_number, :class => 'form-control'
+        .form-text Our supplier number with this customer. Printed on invoices and delivery notes when set.
+    .row.mb-3
       = f.label :sales_tax_customer_class_id, required: true, class: 'col-lg-2 col-md-3 col-form-label', label: "Sales Tax Class"
       .col-sm-5
         = f.collection_select :sales_tax_customer_class_id, SalesTaxCustomerClass.all, :id, :name, { prompt: 'Select tax class...' }, {:class => 'form-select', :required => true}

--- a/app/views/customers/show.html.haml
+++ b/app/views/customers/show.html.haml
@@ -39,6 +39,13 @@
           .col-sm-8
             = @customer.vat_id
 
+        - if @customer.supplier_number.present?
+          .row.mb-2
+            .col-sm-4
+              %strong Supplier No.:
+            .col-sm-8
+              = @customer.supplier_number
+
         .row.mb-2
           .col-sm-4
             %strong Sales Tax Class:

--- a/lib/foptemplate/delivery_note.xsl
+++ b/lib/foptemplate/delivery_note.xsl
@@ -161,6 +161,23 @@
                                             </fo:block>
                                         </fo:table-cell>
                                     </fo:table-row>
+                                    <xsl:if test="/document/recipient/supplier-no">
+                                        <fo:table-row line-height="130%">
+                                            <fo:table-cell>
+                                                <fo:block font-family="{$font-name-display}" xsl:use-attribute-sets="accent-color">
+                                                    <xsl:choose>
+                                                        <xsl:when test="/document/language = 'de'">Unsere Lieferantennr.:</xsl:when>
+                                                        <xsl:otherwise>Our Supplier No.:</xsl:otherwise>
+                                                    </xsl:choose>
+                                                </fo:block>
+                                            </fo:table-cell>
+                                            <fo:table-cell>
+                                                <fo:block>
+                                                    <xsl:value-of select="/document/recipient/supplier-no" />
+                                                </fo:block>
+                                            </fo:table-cell>
+                                        </fo:table-row>
+                                    </xsl:if>
                                 </fo:table-body>
                             </fo:table>
 

--- a/lib/foptemplate/delivery_note.xsl
+++ b/lib/foptemplate/delivery_note.xsl
@@ -166,8 +166,8 @@
                                             <fo:table-cell>
                                                 <fo:block font-family="{$font-name-display}" xsl:use-attribute-sets="accent-color">
                                                     <xsl:choose>
-                                                        <xsl:when test="/document/language = 'de'">Unsere Lieferantennr.:</xsl:when>
-                                                        <xsl:otherwise>Our Supplier No.:</xsl:otherwise>
+                                                        <xsl:when test="/document/language = 'de'">Kreditorennr.:</xsl:when>
+                                                        <xsl:otherwise>Supplier No.:</xsl:otherwise>
                                                     </xsl:choose>
                                                 </fo:block>
                                             </fo:table-cell>

--- a/lib/foptemplate/invoice.xsl
+++ b/lib/foptemplate/invoice.xsl
@@ -242,8 +242,8 @@
                                             <fo:table-cell>
                                                 <fo:block font-family="{$font-name-display}" xsl:use-attribute-sets="accent-color">
                                                     <xsl:choose>
-                                                        <xsl:when test="/document/language = 'de'">Unsere Lieferantennr.:</xsl:when>
-                                                        <xsl:otherwise>Our Supplier No.:</xsl:otherwise>
+                                                        <xsl:when test="/document/language = 'de'">Kreditorennr.:</xsl:when>
+                                                        <xsl:otherwise>Supplier No.:</xsl:otherwise>
                                                     </xsl:choose>
                                                 </fo:block>
                                             </fo:table-cell>

--- a/lib/foptemplate/invoice.xsl
+++ b/lib/foptemplate/invoice.xsl
@@ -237,6 +237,23 @@
                                             </fo:block>
                                         </fo:table-cell>
                                     </fo:table-row>
+                                    <xsl:if test="/document/recipient/supplier-no">
+                                        <fo:table-row line-height="130%">
+                                            <fo:table-cell>
+                                                <fo:block font-family="{$font-name-display}" xsl:use-attribute-sets="accent-color">
+                                                    <xsl:choose>
+                                                        <xsl:when test="/document/language = 'de'">Unsere Lieferantennr.:</xsl:when>
+                                                        <xsl:otherwise>Our Supplier No.:</xsl:otherwise>
+                                                    </xsl:choose>
+                                                </fo:block>
+                                            </fo:table-cell>
+                                            <fo:table-cell>
+                                                <fo:block>
+                                                    <xsl:value-of select="/document/recipient/supplier-no" />
+                                                </fo:block>
+                                            </fo:table-cell>
+                                        </fo:table-row>
+                                    </xsl:if>
                                 </fo:table-body>
                             </fo:table>
 

--- a/test/controllers/customers_controller_test.rb
+++ b/test/controllers/customers_controller_test.rb
@@ -144,4 +144,25 @@ class CustomersControllerTest < ActionDispatch::IntegrationTest
     @customer.reload
     assert_not @customer.active?
   end
+
+  test "should persist supplier_number through the form" do
+    patch customer_url(@customer), params: {
+      customer: { supplier_number: "SUP-42" }
+    }
+    assert_redirected_to customer_url(@customer)
+    assert_equal "SUP-42", @customer.reload.supplier_number
+  end
+
+  test "show page renders supplier number row only when set" do
+    @customer.update!(supplier_number: nil)
+    get customer_url(@customer)
+    assert_response :success
+    assert_select "strong", text: "Supplier No.:", count: 0
+
+    @customer.update!(supplier_number: "SUP-99")
+    get customer_url(@customer)
+    assert_response :success
+    assert_select "strong", text: "Supplier No.:"
+    assert_select ".col-sm-8", text: /SUP-99/
+  end
 end

--- a/test/models/invoice_test.rb
+++ b/test/models/invoice_test.rb
@@ -69,11 +69,13 @@ class InvoiceTest < ActiveSupport::TestCase
 
   test "update_customer copies customer fields to the draft invoice on save" do
     invoice = invoices(:draft_invoice)
+    invoice.customer.update!(supplier_number: "SUP-001")
     invoice.save!
     assert_equal invoice.customer.name, invoice.customer_name
     assert_equal invoice.customer.address, invoice.customer_address
     assert_equal invoice.customer.id, invoice.customer_account_number.to_i
     assert_equal invoice.customer.vat_id, invoice.customer_vat_id
+    assert_equal "SUP-001", invoice.customer_supplier_number
     assert_equal invoice.customer.payment_terms_days, invoice.payment_terms_days
     assert_equal invoice.customer.sales_tax_customer_class.invoice_note, invoice.tax_note
   end

--- a/test/services/delivery_note_renderer_test.rb
+++ b/test/services/delivery_note_renderer_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class DeliveryNoteRendererTest < ActiveSupport::TestCase
+  setup do
+    @delivery_note = delivery_notes(:draft_delivery_note)
+    @issuer = issuer_companies(:one)
+  end
+
+  test "emits <supplier-no> when the customer has supplier_number set" do
+    @delivery_note.customer.update!(supplier_number: "SUP-DN-7")
+    xml = DeliveryNoteRenderer.new(@delivery_note, @issuer).emit_xml(nil)
+    assert_match %r{<supplier-no>SUP-DN-7</supplier-no>}, xml
+  end
+
+  test "omits <supplier-no> when the customer has no supplier_number" do
+    @delivery_note.customer.update!(supplier_number: nil)
+    xml = DeliveryNoteRenderer.new(@delivery_note, @issuer).emit_xml(nil)
+    assert_no_match %r{supplier-no}, xml
+  end
+
+  test "renders a valid PDF with and without supplier number (FOP smoke)" do
+    @delivery_note.customer.update!(supplier_number: "ACME-VEND-7")
+    pdf = DeliveryNoteRenderer.new(@delivery_note, @issuer).render
+    assert pdf.start_with?("%PDF"), "expected a PDF (got #{pdf[0, 16].inspect})"
+
+    @delivery_note.customer.update!(supplier_number: nil)
+    pdf = DeliveryNoteRenderer.new(@delivery_note, @issuer).render
+    assert pdf.start_with?("%PDF"), "expected a PDF (got #{pdf[0, 16].inspect})"
+  end
+end

--- a/test/services/invoice_renderer_test.rb
+++ b/test/services/invoice_renderer_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class InvoiceRendererTest < ActiveSupport::TestCase
+  setup do
+    @invoice = invoices(:draft_invoice)
+    @invoice.save! # populates customer snapshot columns via update_customer
+    @invoice.update_columns(due_date: Date.current + 30.days)
+    @issuer = issuer_companies(:one)
+  end
+
+  test "emits <supplier-no> when invoice has customer_supplier_number" do
+    @invoice.update_columns(customer_supplier_number: "SUP-123")
+    xml = InvoiceRenderer.new(@invoice, @issuer).emit_xml(nil)
+    assert_match %r{<supplier-no>SUP-123</supplier-no>}, xml
+  end
+
+  test "omits <supplier-no> when customer_supplier_number is blank" do
+    @invoice.update_columns(customer_supplier_number: nil)
+    xml = InvoiceRenderer.new(@invoice, @issuer).emit_xml(nil)
+    assert_no_match %r{supplier-no}, xml
+  end
+
+  test "renders a valid PDF with and without supplier number (FOP smoke)" do
+    @invoice.update_columns(customer_supplier_number: "ACME-VEND-7")
+    pdf = InvoiceRenderer.new(@invoice, @issuer).render
+    assert pdf.start_with?("%PDF"), "expected a PDF (got #{pdf[0, 16].inspect})"
+
+    @invoice.update_columns(customer_supplier_number: nil)
+    pdf = InvoiceRenderer.new(@invoice, @issuer).render
+    assert pdf.start_with?("%PDF"), "expected a PDF (got #{pdf[0, 16].inspect})"
+  end
+end


### PR DESCRIPTION
## Summary
- The DB columns (`customers.supplier_number`, `invoices.customer_supplier_number`) and the invoice-side snapshot in `Invoice#update_customer` existed since 2014, but the value never reached the UI or the PDFs. This PR wires it through.
- Customer form gains a "Supplier No." field; show page renders the row only when set. `CustomersController` permits `:supplier_number`.
- `InvoiceRenderer` / `DeliveryNoteRenderer` only emit `<supplier-no>` when the value is present, so the XSL templates can branch on a plain `xsl:if` for the element's existence.
- `invoice.xsl` (after "Our VAT ID") and `delivery_note.xsl` (after "Your Order No") gain a conditional row labelled "Supplier No." (EN) / "Kreditorennr." (DE). Nothing is printed when the customer has no supplier number.

## Test plan
- [x] `bundle exec rails test` — 598 runs, 2213 assertions, 0 failures
- [x] New `InvoiceRendererTest` covers XML emission with and without `customer_supplier_number`, plus an end-to-end FOP render of both cases
- [x] New `DeliveryNoteRendererTest` covers the same matrix for delivery notes
- [x] `CustomersControllerTest` round-trips the field through the form and verifies the show page renders the row only when set
- [x] Existing `invoice_test`'s `update_customer` assertion now also pins `customer_supplier_number`
- [ ] Manual: set a value on a customer, book/preview an invoice and a delivery note, confirm the row prints in EN and DE
- [ ] Manual: clear the value, confirm no row prints (and no empty label)

🤖 Generated with [Claude Code](https://claude.com/claude-code)