### PR TITLE
Make customer VAT ID required only when its tax class demands one

### DIFF
--- a/app/controllers/sales_tax_customer_classes_controller.rb
+++ b/app/controllers/sales_tax_customer_classes_controller.rb
@@ -53,6 +53,6 @@ class SalesTaxCustomerClassesController < ApplicationController
 
 private
   def sales_tax_customer_classes_params
-    params.require(:sales_tax_customer_class).permit(:name, :invoice_note)
+    params.require(:sales_tax_customer_class).permit(:name, :invoice_note, :vat_id_required)
   end
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -3,6 +3,7 @@ class Customer < ApplicationRecord
 
   validates :matchcode, presence: true, uniqueness: { case_sensitive: false }
   validates :name, presence: true
+  validates :vat_id, presence: true, if: -> { sales_tax_customer_class&.vat_id_required? }
 
   # Set default language (English) for new customers
   before_validation :set_default_language, on: :create

--- a/app/services/invoice_booker.rb
+++ b/app/services/invoice_booker.rb
@@ -35,7 +35,9 @@ class InvoiceBooker
 
     error "no customer name" if empty_or_nil @invoice.customer_name
     error "no customer address" if empty_or_nil @invoice.customer_address
-    error "no customer vat id" if empty_or_nil @invoice.customer_vat_id
+    if @invoice.customer.sales_tax_customer_class.vat_id_required?
+      error "no customer vat id" if empty_or_nil @invoice.customer_vat_id
+    end
     @log << "Customer: #{@invoice.customer_name}, #{@invoice.customer_address.gsub("\n", ', ').gsub("\r", '')}"
     @log << "  VATID: #{@invoice.customer_vat_id}"
     @log << "Customer Order No: #{@invoice.cust_order}, Cust. Reference: #{@invoice.cust_reference}"

--- a/app/views/sales_tax_customer_classes/_form.html.haml
+++ b/app/views/sales_tax_customer_classes/_form.html.haml
@@ -18,6 +18,12 @@
       .col-sm-9
         = f.text_area :invoice_note, :class => 'form-control', :rows => 3
         %small.form-text.text-muted Appears on every invoice.
+    .row.mb-3
+      .col-sm-9.offset-sm-3
+        .form-check
+          = f.check_box :vat_id_required, class: 'form-check-input'
+          = f.label :vat_id_required, 'Customers in this class must have a VAT ID', class: 'form-check-label'
+        %small.form-text.text-muted Uncheck for export / non-EU / B2C classes where a VAT ID is not applicable.
 
   %br
 

--- a/app/views/sales_tax_customer_classes/show.html.haml
+++ b/app/views/sales_tax_customer_classes/show.html.haml
@@ -4,6 +4,9 @@
 %p
   %b Invoice note:
   = @sales_tax_customer_class.invoice_note
+%p
+  %b VAT ID required:
+  = @sales_tax_customer_class.vat_id_required? ? 'Yes' : 'No'
 
 = action_buttons_wrapper do
   - if can?('sales_tax.edit')

--- a/db/migrate/20260525140000_add_vat_id_required_to_sales_tax_customer_classes.rb
+++ b/db/migrate/20260525140000_add_vat_id_required_to_sales_tax_customer_classes.rb
@@ -1,0 +1,5 @@
+class AddVatIdRequiredToSalesTaxCustomerClasses < ActiveRecord::Migration[8.0]
+  def change
+    add_column :sales_tax_customer_classes, :vat_id_required, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_25_130000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_25_140000) do
   create_table "attachments", force: :cascade do |t|
     t.string "content_type"
     t.datetime "created_at", null: false
@@ -264,6 +264,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_25_130000) do
     t.text "invoice_note"
     t.string "name"
     t.datetime "updated_at", null: false
+    t.boolean "vat_id_required", default: true, null: false
   end
 
   create_table "sales_tax_product_classes", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -57,6 +57,7 @@ end
 
 export_class = SalesTaxCustomerClass.find_or_create_by(name: 'EXPORT') do |stcc|
   stcc.invoice_note = 'EXPORT TO NON-EU COUNTRY'
+  stcc.vat_id_required = false
 end
 
 # Sales tax product classes

--- a/lib/foptemplate/invoice.xsl
+++ b/lib/foptemplate/invoice.xsl
@@ -207,21 +207,23 @@
                                             </fo:block>
                                         </fo:table-cell>
                                     </fo:table-row>
-                                    <fo:table-row line-height="130%">
-                                        <fo:table-cell>
-                                            <fo:block font-family="{$font-name-display}" xsl:use-attribute-sets="accent-color">
-                                                <xsl:choose>
-                                                    <xsl:when test="/document/language = 'de'">Ihre USt-IdNr.:</xsl:when>
-                                                    <xsl:otherwise>Your VAT ID:</xsl:otherwise>
-                                                </xsl:choose>
-                                            </fo:block>
-                                        </fo:table-cell>
-                                        <fo:table-cell>
-                                            <fo:block>
-                                                <xsl:value-of select="/document/recipient/vat-id" />
-                                            </fo:block>
-                                        </fo:table-cell>
-                                    </fo:table-row>
+                                    <xsl:if test="normalize-space(/document/recipient/vat-id) != ''">
+                                        <fo:table-row line-height="130%">
+                                            <fo:table-cell>
+                                                <fo:block font-family="{$font-name-display}" xsl:use-attribute-sets="accent-color">
+                                                    <xsl:choose>
+                                                        <xsl:when test="/document/language = 'de'">Ihre USt-IdNr.:</xsl:when>
+                                                        <xsl:otherwise>Your VAT ID:</xsl:otherwise>
+                                                    </xsl:choose>
+                                                </fo:block>
+                                            </fo:table-cell>
+                                            <fo:table-cell>
+                                                <fo:block>
+                                                    <xsl:value-of select="/document/recipient/vat-id" />
+                                                </fo:block>
+                                            </fo:table-cell>
+                                        </fo:table-row>
+                                    </xsl:if>
                                     <fo:table-row line-height="130%">
                                         <fo:table-cell>
                                             <fo:block font-family="{$font-name-display}" xsl:use-attribute-sets="accent-color">

--- a/test/controllers/attachments_controller_test.rb
+++ b/test/controllers/attachments_controller_test.rb
@@ -38,6 +38,7 @@ class AttachmentsControllerTest < ActionDispatch::IntegrationTest
     outside_customer = Customer.create!(
       matchcode: "OUT",
       name: "Outside Co.",
+      vat_id: "EU141414141",
       sales_tax_customer_class: sales_tax_customer_classes(:eu),
       language: languages(:english),
       team: other_team

--- a/test/controllers/customer_contacts_controller_test.rb
+++ b/test/controllers/customer_contacts_controller_test.rb
@@ -105,6 +105,7 @@ class CustomerContactsControllerTest < ActionDispatch::IntegrationTest
     other_team = Team.create!(name: "Isolated")
     other_customer = Customer.create!(
       matchcode: "ISO", name: "Iso Co",
+      vat_id: "EU131313131",
       sales_tax_customer_class: sales_tax_customer_classes(:eu),
       language: languages(:english),
       team: other_team

--- a/test/controllers/customers_controller_test.rb
+++ b/test/controllers/customers_controller_test.rb
@@ -43,6 +43,7 @@ class CustomersControllerTest < ActionDispatch::IntegrationTest
         customer: {
           matchcode: "TEST123",
           name: "Test Company",
+          vat_id: "EU181818181",
           sales_tax_customer_class_id: @customer.sales_tax_customer_class_id,
           team_id: teams(:default).id
         }
@@ -56,6 +57,7 @@ class CustomersControllerTest < ActionDispatch::IntegrationTest
     unused_customer = Customer.create!(
       matchcode: "UNUSED",
       name: "Unused Customer",
+      vat_id: "EU191919191",
       sales_tax_customer_class: @customer.sales_tax_customer_class,
       team: teams(:default)
     )
@@ -88,6 +90,7 @@ class CustomersControllerTest < ActionDispatch::IntegrationTest
     unused_customer = Customer.create!(
       matchcode: "UNUSED2",
       name: "Another Unused Customer",
+      vat_id: "EU202020202",
       sales_tax_customer_class: @customer.sales_tax_customer_class,
       team: teams(:default)
     )
@@ -103,6 +106,7 @@ class CustomersControllerTest < ActionDispatch::IntegrationTest
     Customer.create!(
       matchcode: "INACTIVE",
       name: "Inactive Customer",
+      vat_id: "EU212121212",
       active: false,
       sales_tax_customer_class: @customer.sales_tax_customer_class,
       team: teams(:default)

--- a/test/controllers/teams_controller_test.rb
+++ b/test/controllers/teams_controller_test.rb
@@ -35,6 +35,7 @@ class TeamsControllerTest < ActionDispatch::IntegrationTest
     Customer.create!(
       matchcode: "IN_USE_TEAM",
       name: "In Use",
+      vat_id: "EU151515151",
       sales_tax_customer_class: sales_tax_customer_classes(:eu),
       language: languages(:english),
       team: teams(:acme)

--- a/test/fixtures/sales_tax_customer_classes.yml
+++ b/test/fixtures/sales_tax_customer_classes.yml
@@ -9,3 +9,4 @@ eu:
 restoftheworld:
   name: EXPORT
   invoice_note: 'EXPORT TO NON-EU COUNTRY'
+  vat_id_required: false

--- a/test/integration/invoice_language_test.rb
+++ b/test/integration/invoice_language_test.rb
@@ -114,11 +114,38 @@ class InvoiceLanguageTest < ActionDispatch::IntegrationTest
     assert_valid_pdf_response
   end
 
+  def test_pdf_generation_for_export_customer_without_vat_id
+    # Customers in tax classes that don't require a VAT ID (export / non-EU /
+    # B2C) must be able to render an invoice PDF. Regression test for the
+    # invoice_booker check that previously rejected any blank customer_vat_id.
+    export_customer = Customer.create!(
+      name: "USA Corporation Inc.",
+      matchcode: "USACORP_TEST",
+      address: "123 Business Ave\nNew York, NY 10001\nUnited States",
+      sales_tax_customer_class: sales_tax_customer_classes(:restoftheworld),
+      language: languages(:english),
+      team: teams(:default)
+    )
+    assert_nil export_customer.vat_id
+
+    invoice = Invoice.create!(customer: export_customer, project: @project)
+    invoice.invoice_lines.create!(
+      type: "item", title: "Service", quantity: 1, rate: 100.00,
+      sales_tax_product_class_id: sales_tax_product_classes(:standard).id
+    )
+
+    get preview_invoice_path(invoice)
+    assert_response :success
+    assert_equal "application/pdf", response.content_type
+    assert_valid_pdf_response
+  end
+
   def test_customer_language_assignment_defaults_to_english
     customer = Customer.create!(
       name: "Test Customer",
       matchcode: "TEST",
       address: "Test Address",
+      vat_id: "EN111111111",
       sales_tax_customer_class: sales_tax_customer_classes(:national),
       team: teams(:default)
     )

--- a/test/models/customer_contact_test.rb
+++ b/test/models/customer_contact_test.rb
@@ -72,6 +72,7 @@ class CustomerContactTest < ActiveSupport::TestCase
     other_team = Team.create!(name: "Other")
     other_customer = Customer.create!(
       matchcode: "OTH", name: "Other",
+      vat_id: "EU101010101",
       sales_tax_customer_class: sales_tax_customer_classes(:eu),
       language: languages(:english),
       team: other_team
@@ -99,6 +100,7 @@ class CustomerContactTest < ActiveSupport::TestCase
     other_team = Team.create!(name: "Visibility Other")
     other_customer = Customer.create!(
       matchcode: "VOTH", name: "Visibility Other",
+      vat_id: "EU121212121",
       sales_tax_customer_class: sales_tax_customer_classes(:eu),
       language: languages(:english),
       team: other_team

--- a/test/models/customer_team_scoping_test.rb
+++ b/test/models/customer_team_scoping_test.rb
@@ -10,6 +10,7 @@ class CustomerTeamScopingTest < ActiveSupport::TestCase
     acme_customer = Customer.create!(
       matchcode: "ACME_ONLY",
       name: "Acme Only",
+      vat_id: "EU111111111",
       sales_tax_customer_class: sales_tax_customer_classes(:eu),
       language: languages(:english),
       team: teams(:acme)
@@ -30,6 +31,7 @@ class CustomerTeamScopingTest < ActiveSupport::TestCase
       customer = Customer.new(
         matchcode: "AS_BOB",
         name: "Bob Customer",
+        vat_id: "EU222222222",
         sales_tax_customer_class: sales_tax_customer_classes(:eu),
         language: languages(:english),
         team: teams(:acme)
@@ -43,6 +45,7 @@ class CustomerTeamScopingTest < ActiveSupport::TestCase
       customer2 = Customer.new(
         matchcode: "BAD_BOB",
         name: "Bob Bad",
+        vat_id: "EU333333333",
         sales_tax_customer_class: sales_tax_customer_classes(:eu),
         language: languages(:english),
         team: other_team
@@ -60,6 +63,7 @@ class CustomerTeamScopingTest < ActiveSupport::TestCase
       customer = Customer.new(
         matchcode: "AS_ALICE",
         name: "Alice Customer",
+        vat_id: "EU444444444",
         sales_tax_customer_class: sales_tax_customer_classes(:eu),
         language: languages(:english),
         team: other_team
@@ -75,6 +79,7 @@ class CustomerTeamScopingTest < ActiveSupport::TestCase
     customer = Customer.new(
       matchcode: "SYS",
       name: "System Customer",
+      vat_id: "EU555555555",
       sales_tax_customer_class: sales_tax_customer_classes(:eu),
       language: languages(:english),
       team: other_team

--- a/test/models/customer_test.rb
+++ b/test/models/customer_test.rb
@@ -5,6 +5,7 @@ class CustomerTest < ActiveSupport::TestCase
     Customer.new({
       matchcode: "TEST",
       name: "Test Customer",
+      vat_id: "EU000000000",
       sales_tax_customer_class: sales_tax_customer_classes(:eu),
       language: languages(:english),
       team: teams(:default),
@@ -26,6 +27,17 @@ class CustomerTest < ActiveSupport::TestCase
     customer = build_customer(name: nil)
     assert_not customer.valid?
     assert_includes customer.errors[:name], "can't be blank"
+  end
+
+  test "requires vat_id when its sales_tax_customer_class requires one" do
+    customer = build_customer(vat_id: nil, sales_tax_customer_class: sales_tax_customer_classes(:eu))
+    assert_not customer.valid?
+    assert_includes customer.errors[:vat_id], "can't be blank"
+  end
+
+  test "allows blank vat_id when its sales_tax_customer_class does not require one" do
+    customer = build_customer(vat_id: nil, sales_tax_customer_class: sales_tax_customer_classes(:restoftheworld))
+    assert customer.valid?, customer.errors.full_messages.inspect
   end
 
   test "matchcode must be globally unique across all teams" do

--- a/test/models/invoice_test.rb
+++ b/test/models/invoice_test.rb
@@ -167,6 +167,7 @@ class InvoiceTest < ActiveSupport::TestCase
     acme_customer = Customer.create!(
       matchcode: "ACME_YEAR_LEAK",
       name: "Acme Year Leak",
+      vat_id: "EU161616161",
       sales_tax_customer_class: sales_tax_customer_classes(:eu),
       language: languages(:english),
       team: acme

--- a/test/models/project_team_scoping_test.rb
+++ b/test/models/project_team_scoping_test.rb
@@ -5,6 +5,7 @@ class ProjectTeamScopingTest < ActiveSupport::TestCase
     acme_customer = Customer.create!(
       matchcode: "ACME_CUST",
       name: "Acme Co.",
+      vat_id: "EU666666666",
       sales_tax_customer_class: sales_tax_customer_classes(:eu),
       language: languages(:english),
       team: teams(:acme)
@@ -39,6 +40,7 @@ class ProjectTeamScopingTest < ActiveSupport::TestCase
     acme_customer = Customer.create!(
       matchcode: "ACME_CUST2",
       name: "Acme 2",
+      vat_id: "EU777777777",
       sales_tax_customer_class: sales_tax_customer_classes(:eu),
       language: languages(:english),
       team: teams(:acme)

--- a/test/models/sales_tax_customer_class_test.rb
+++ b/test/models/sales_tax_customer_class_test.rb
@@ -24,7 +24,8 @@ class SalesTaxCustomerClassTest < ActiveSupport::TestCase
       name: "Test Customer",
       sales_tax_customer_class: klass,
       language: languages(:english),
-      team: teams(:default)
+      team: teams(:default),
+      vat_id: "EU171717171"
     )
     assert_raises(ActiveRecord::DeleteRestrictionError) { klass.destroy }
   end
@@ -32,5 +33,10 @@ class SalesTaxCustomerClassTest < ActiveSupport::TestCase
   test "destroy succeeds when no rates or customers reference the class" do
     klass = SalesTaxCustomerClass.create!(name: "Test Region")
     assert klass.destroy
+  end
+
+  test "vat_id_required defaults to true for new classes" do
+    klass = SalesTaxCustomerClass.new(name: "Defaults")
+    assert klass.vat_id_required?
   end
 end

--- a/test/models/scoped_through_customer_test.rb
+++ b/test/models/scoped_through_customer_test.rb
@@ -13,6 +13,7 @@ class ScopedThroughCustomerTest < ActiveSupport::TestCase
     @other_customer = Customer.create!(
       matchcode: "OTHER",
       name: "Other Co",
+      vat_id: "EU888888888",
       sales_tax_customer_class: sales_tax_customer_classes(:eu),
       language: languages(:english),
       team: @other_team

--- a/test/models/team_test.rb
+++ b/test/models/team_test.rb
@@ -25,6 +25,7 @@ class TeamTest < ActiveSupport::TestCase
     Customer.create!(
       matchcode: "INUSE",
       name: "In Use Co.",
+      vat_id: "EU999999999",
       sales_tax_customer_class: sales_tax_customer_classes(:eu),
       language: languages(:english),
       team: team

--- a/test/services/invoice_booker_test.rb
+++ b/test/services/invoice_booker_test.rb
@@ -76,6 +76,33 @@ class InvoiceBookerTest < ActiveSupport::TestCase
     assert_equal 30, invoice.payment_terms_days
   end
 
+  test "booker requires a customer vat_id when the class requires one" do
+    customer = customers(:good_eu)
+    customer.update_columns(vat_id: nil)
+
+    invoice = Invoice.create!(customer: customer, project: projects(:test_project), cust_reference: "NOVATID-EU")
+
+    booker = InvoiceBooker.new(invoice, issuer_companies(:one))
+    booker.book(false)
+
+    assert_includes booker.log, "E: no customer vat id"
+  end
+
+  test "booker does not require a customer vat_id when the class does not require one" do
+    customer = customers(:good_eu)
+    customer.update_columns(
+      sales_tax_customer_class_id: sales_tax_customer_classes(:restoftheworld).id,
+      vat_id: nil
+    )
+
+    invoice = Invoice.create!(customer: customer, project: projects(:test_project), cust_reference: "NOVATID-EXPORT")
+
+    booker = InvoiceBooker.new(invoice, issuer_companies(:one))
+    booker.book(false)
+
+    assert_not_includes booker.log, "E: no customer vat id"
+  end
+
   test "booker derives due_date from invoice's persisted payment_terms_days" do
     customer = customers(:good_eu)
     customer.update!(payment_terms_days: 21)


### PR DESCRIPTION
## Summary
- Adds `vat_id_required` (default `true`) to `SalesTaxCustomerClass`. Existing classes keep current behavior; the EXPORT seed is flipped to `false`.
- `Customer` validates `vat_id` presence conditionally on its class.
- `InvoiceBooker` no longer rejects blank `customer_vat_id` when the class does not require it — so export / non-EU / B2C customers can finally be previewed and booked.
- `invoice.xsl` wraps the recipient "Your VAT ID:" row in an `xsl:if` so it disappears when the value is blank.

## Background
`InvoiceBooker#book` had a hard `error "no customer vat id" if empty_or_nil @invoice.customer_vat_id`. Because preview also runs the booker (inside a rolled-back transaction), customers without a VAT ID could never get a PDF — not in preview, not at booking time. The shipped USACORP seed customer demonstrates the bug. Now the requirement is driven by the customer's tax class, which is the natural place to encode "is a VAT ID legally meaningful for this customer".

## Test plan
- [x] `bundle exec rails test` — 600 runs, 0 failures.
- [x] New regression test in `test/integration/invoice_language_test.rb` actually FOP-renders an invoice for an export customer with no VAT ID and asserts a valid PDF.
- [x] New unit tests cover the SalesTaxCustomerClass default, the conditional Customer validation, and both booker branches.
- [ ] Manual: visit Configuration → Sales Tax → Customer Classes and toggle the new checkbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)