### PR TITLE
Reset framework session on login, logout, and block

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -119,8 +119,14 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  # Tears down all browser-side auth state: the signed auth cookie AND the
+  # Rails framework session (`_abt_session`). Rotating the framework session
+  # ensures WebAuthn pending-state nonces — and any other session-stored
+  # keys — cannot leak across users sharing a browser. Every caller wants
+  # both; do not split.
   def reset_auth_cookie
     cookies.delete(AUTH_COOKIE)
+    reset_session
   end
 
   def read_auth_token
@@ -158,7 +164,12 @@ class ApplicationController < ActionController::Base
     nil
   end
 
+  # Rotates the framework session on every successful authentication.
+  # Defends against session fixation and clears any pending-state keys
+  # left by prior WebAuthn flows. Callers MUST finish reading any
+  # session-tied state (e.g. webauthn_consume) BEFORE calling this.
   def sign_in_user!(user)
+    reset_session
     session_record, plaintext = UserSession.create_for!(user: user, request: request)
     cookies.signed.permanent[AUTH_COOKIE] = {
       value: plaintext,

--- a/test/controllers/account/blocks_controller_test.rb
+++ b/test/controllers/account/blocks_controller_test.rb
@@ -28,4 +28,17 @@ class Account::BlocksControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to new_session_path
     assert_not users(:alice).reload.blocked?
   end
+
+  test "self-block clears the framework session" do
+    sign_in_as(users(:alice))
+    # Seed a webauthn credential-add nonce in the framework session.
+    post options_account_credentials_path, params: { nickname: "x" }, as: :json
+    assert_response :success
+    assert session[:webauthn_credential_add_nonce].present?,
+      "options should have stashed a credential_add nonce in the framework session"
+
+    post account_block_path
+    assert session[:webauthn_credential_add_nonce].blank?,
+      "self-block must clear the framework session"
+  end
 end

--- a/test/controllers/account/sessions_controller_test.rb
+++ b/test/controllers/account/sessions_controller_test.rb
@@ -22,4 +22,16 @@ class Account::SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to new_session_path
     assert current.reload.terminated_at.present?
   end
+
+  test "destroying current session clears the framework session" do
+    current = sign_in_as(users(:alice))
+    post options_account_credentials_path, params: { nickname: "x" }, as: :json
+    assert_response :success
+    assert session[:webauthn_credential_add_nonce].present?,
+      "options should have stashed a credential_add nonce in the framework session"
+
+    delete account_session_path(current)
+    assert session[:webauthn_credential_add_nonce].blank?,
+      "destroying the current session must clear the framework session"
+  end
 end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -32,4 +32,20 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to new_session_path
     assert cookies[ApplicationController::AUTH_COOKIE].blank?
   end
+
+  test "destroy clears the framework session" do
+    # Seed a webauthn login nonce in the framework session — simulates an
+    # abandoned login flow that left state behind, exactly the scenario
+    # issue #339 describes.
+    post options_session_path, params: { username: "alice" }, as: :json
+    assert_response :success
+    assert session[:webauthn_login_nonce].present?,
+      "options should have stashed a login nonce in the framework session"
+
+    sign_in_as(users(:alice))
+    delete session_path
+    assert_redirected_to new_session_path
+    assert session[:webauthn_login_nonce].blank?,
+      "logout must clear the framework session"
+  end
 end


### PR DESCRIPTION
## Summary

- `reset_auth_cookie` now also calls `reset_session`, so the `_abt_session` framework cookie is rotated on logout, self-block, current-session destroy, and the no-session / blocked branches of `ApplicationController#authenticate`.
- `sign_in_user!` rotates the session too, defending against session fixation and clearing any WebAuthn pending-state nonces left by prior flows.

Fixes #339.

## Test plan

- [x] `bundle exec rails test` — 614 runs / 2266 assertions / 0 failures
- [x] New integration tests in `sessions_controller_test`, `account/blocks_controller_test`, `account/sessions_controller_test` each seed a real WebAuthn nonce via the production `options` endpoint, then assert the nonce is gone after destroy / block. Confirmed (by stashing the production change) that the tests fail without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)