### PR TITLE
Deduplicate User#permissions at the database (#338)

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,6 +41,7 @@ class User < ApplicationRecord
     @permissions ||= GroupPermission
                       .joins(group: :group_memberships)
                       .where(group_memberships: { user_id: id })
+                      .distinct
                       .pluck(:permission)
                       .to_set
   end

--- a/test/models/user_permission_test.rb
+++ b/test/models/user_permission_test.rb
@@ -27,6 +27,38 @@ class UserPermissionTest < ActiveSupport::TestCase
     refute bob.permission?("groups.manage")
   end
 
+  test "User#permissions emits DISTINCT and dedupes across groups" do
+    bob = users(:bob)
+    overlap = Group.create!(name: "Overlap", description: "Test overlap group")
+    overlap.group_permissions.create!(permission: "customers.view")
+    overlap.group_permissions.create!(permission: "invoices.view")
+    bob.groups << groups(:sales)
+    bob.groups << overlap
+    bob.reload
+
+    assert bob.permission?("customers.view")
+    assert bob.permission?("invoices.view")
+
+    # Regression guard for #338: capture the SQL the production code
+    # actually issues and require it to deduplicate at the database
+    # level. Without DISTINCT, a user in two groups that both grant
+    # customers.view receives two rows for that key.
+    queries = []
+    callback = ->(_name, _start, _finish, _id, payload) {
+      sql = payload[:sql]
+      queries << sql if sql.include?("group_permissions") &&
+                        sql.include?("group_memberships")
+    }
+    ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+      bob.instance_variable_set(:@permissions, nil)
+      bob.permissions
+    end
+
+    refute_empty queries, "expected User#permissions to query group_permissions"
+    assert queries.any? { |q| q =~ /SELECT\s+DISTINCT/i },
+           "User#permissions must emit SELECT DISTINCT; got: #{queries.inspect}"
+  end
+
   test "visible_team_ids returns all teams for bypass users" do
     assert_equal Team.pluck(:id).sort, users(:alice).visible_team_ids.sort
   end


### PR DESCRIPTION
## Summary
- `User#permissions` joined `group_permissions → groups → group_memberships` without `DISTINCT`, so a user in N groups that each grant the same permission key received N rows. `.to_set` masked it on the Ruby side but the query/wire cost scaled with group count.
- Adds `.distinct` to push deduplication into the database.
- Regression test captures the SQL via `ActiveSupport::Notifications` and asserts `SELECT DISTINCT` so a future refactor that drops it fails CI.

Fixes #338.

## Test plan
- [x] New test fails before the fix (`User#permissions must emit SELECT DISTINCT; got: [SELECT "group_permissions"."permission" FROM ... ]`)
- [x] New test passes after the fix
- [x] `bundle exec rails test test/models/user_permission_test.rb test/integration/permissions_enforcement_test.rb test/models/permission_test.rb test/models/group_test.rb` → 35/35 pass
- [x] Full suite: `bundle exec rails test` → 615 runs, 0 failures
- [x] `pre-commit run --all-files` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)