### PR TITLE
Add "All" year filter to invoice and delivery note lists

### DIFF
--- a/app/controllers/delivery_notes_controller.rb
+++ b/app/controllers/delivery_notes_controller.rb
@@ -42,12 +42,14 @@ class DeliveryNotesController < ApplicationController
 
   # GET /delivery_notes
   def index
-    @selected_year = params[:year]&.to_i || Date.current.year
+    @selected_year = params[:year] == "all" ? "all" : (params[:year]&.to_i || Date.current.year)
     @email_filter = params[:email_filter] || "all"
 
     @delivery_notes = DeliveryNote.visible_to(current_user)
-                                  .in_year(@selected_year, include_drafts: @selected_year == Date.current.year)
                                   .reorder(Arel.sql("document_number DESC NULLS FIRST"))
+    unless @selected_year == "all"
+      @delivery_notes = @delivery_notes.in_year(@selected_year, include_drafts: @selected_year == Date.current.year)
+    end
 
     case @email_filter
     when "unsent"

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -42,12 +42,14 @@ class InvoicesController < ApplicationController
 
   # GET /invoices
   def index
-    @selected_year = params[:year]&.to_i || Date.current.year
+    @selected_year = params[:year] == "all" ? "all" : (params[:year]&.to_i || Date.current.year)
     @filter = params[:filter] || "all"
 
     @invoices = Invoice.visible_to(current_user)
-                       .in_year(@selected_year, include_drafts: @selected_year == Date.current.year)
                        .reorder(Arel.sql("document_number DESC NULLS FIRST"))
+    unless @selected_year == "all"
+      @invoices = @invoices.in_year(@selected_year, include_drafts: @selected_year == Date.current.year)
+    end
 
     case @filter
     when "unsent"

--- a/app/views/delivery_notes/index.html.haml
+++ b/app/views/delivery_notes/index.html.haml
@@ -15,6 +15,7 @@
         .btn-group.btn-group-sm.ms-auto.year-pagination{:role=>"group", "aria-label"=>"Year navigation"}
           - @available_years.each do |year|
             = link_to year, delivery_notes_path(year: year, email_filter: @email_filter), class: (@selected_year == year ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
+          = link_to 'All', delivery_notes_path(year: 'all', email_filter: @email_filter), class: (@selected_year == 'all' ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
 
   - if @email_filter == 'unsent' && @delivery_notes.any?
     %table.table.table-striped.table-sm

--- a/app/views/invoices/index.html.haml
+++ b/app/views/invoices/index.html.haml
@@ -16,6 +16,7 @@
         .btn-group.btn-group-sm.ms-auto.year-pagination{:role=>"group", "aria-label"=>"Year navigation"}
           - @available_years.each do |year|
             = link_to year, invoices_path(year: year, filter: @filter), class: (@selected_year == year ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
+          = link_to 'All', invoices_path(year: 'all', filter: @filter), class: (@selected_year == 'all' ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
 
   - if @filter == 'unsent' && @invoices.any?
     %table.table.table-striped.table-sm

--- a/test/controllers/delivery_notes_controller_test.rb
+++ b/test/controllers/delivery_notes_controller_test.rb
@@ -34,6 +34,13 @@ class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
     # Verify the page contains the 2023 note reference but not 2024
     assert_select "td", text: "2023-TEST"
     assert_select "td", text: "2024-TEST", count: 0
+
+    # Test "all" year filter — delivery notes from every year are shown
+    get delivery_notes_url(year: "all")
+    assert_response :success
+    assert_select "td", text: "2023-TEST"
+    assert_select "td", text: "2024-TEST"
+    assert_select ".year-pagination a.active", text: "All"
   end
 
   test "should include draft delivery notes with nil date in current year" do

--- a/test/controllers/invoices_controller_test.rb
+++ b/test/controllers/invoices_controller_test.rb
@@ -33,6 +33,13 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
     # Verify the page contains the 2023 invoice reference but not 2024
     assert_select "td", text: "2023-TEST"
     assert_select "td", text: "2024-TEST", count: 0
+
+    # Test "all" year filter — invoices from every year are shown
+    get invoices_url(year: "all")
+    assert_response :success
+    assert_select "td", text: "2023-TEST"
+    assert_select "td", text: "2024-TEST"
+    assert_select ".year-pagination a.active", text: "All"
   end
 
   test "should include draft invoices with nil date in current year" do


### PR DESCRIPTION
## Summary
- Adds an **All** chip to the year-navigation group on `/invoices` and `/delivery_notes`
- When selected, `year=all` skips the `in_year` scope so records from every year (including drafts with a nil date) are shown
- Controller tests cover the new branch on both lists

## Test plan
- [x] `bundle exec rails test test/controllers/invoices_controller_test.rb test/controllers/delivery_notes_controller_test.rb`
- [x] Manually click **All** on the invoices index and confirm cross-year records appear and the chip is active
- [x] Same on the delivery notes index

🤖 Generated with [Claude Code](https://claude.com/claude-code)