### PR TITLE
Document strict CSP and inline-style policy in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,7 @@ For testing against PostgreSQL (matches production environment):
 - Turbo for SPA-like interactions without JavaScript complexity
 - Stimulus controllers for interactive components (bulk-select, email-preview)
 - European-style date/time formatting throughout
+- Strict Content Security Policy — no inline styles in views. Put styling in CSS/SCSS files and apply via classes. Inline `style="..."` attributes are only allowed in email templates (rendered HTML email, not subject to the app CSP).
 
 ## Development Best Practices
 


### PR DESCRIPTION
## Summary
- Add a CLAUDE.md note under UI Framework that the app runs under a strict CSP, so views must not use inline `style` attributes — styling belongs in CSS/SCSS via classes. Email templates are the only exception, since rendered HTML email is not subject to the app CSP.

## Test plan
- [ ] N/A — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)