### PR TITLE
Hide active status on customer and project detail pages

### DIFF
--- a/app/views/customers/show.html.haml
+++ b/app/views/customers/show.html.haml
@@ -3,18 +3,11 @@
 .row
   .col-md-6
     .card
-      .card-header
-        Basic Information
+      .card-header.d-flex.justify-content-between.align-items-center
+        %span Basic Information
+        - unless @customer.active?
+          %span.badge.bg-secondary Inactive
       .card-body
-        .row.mb-2
-          .col-sm-4
-            %strong Active:
-          .col-sm-8
-            - if @customer.active?
-              %span.badge.bg-success Yes
-            - else
-              %span.badge.bg-danger No
-
         .row.mb-2
           .col-sm-4
             %strong Matchcode:

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -3,8 +3,10 @@
 .row
   .col-md-8
     .card
-      .card-header
-        Project Information
+      .card-header.d-flex.justify-content-between.align-items-center
+        %span Project Information
+        - unless @project.active?
+          %span.badge.bg-secondary Inactive
       .card-body
         .row.mb-2
           .col-sm-3
@@ -28,15 +30,6 @@
               %small.text-muted (#{@project.bill_to_customer.matchcode})
             - else
               %span.text-muted No customer (reusable project)
-
-        .row.mb-2
-          .col-sm-3
-            %strong Status:
-          .col-sm-9
-            - if @project.active?
-              %span.badge.bg-success Active
-            - else
-              %span.badge.bg-secondary Inactive
 
         .row.mb-2
           .col-sm-3

--- a/test/controllers/customers_controller_test.rb
+++ b/test/controllers/customers_controller_test.rb
@@ -133,10 +133,17 @@ class CustomersControllerTest < ActionDispatch::IntegrationTest
     assert_select "td", text: "INACTIVE", count: 0
   end
 
-  test "should show active status in show page" do
+  test "active customer shows no inactive badge on show page" do
     get customer_url(@customer)
     assert_response :success
-    assert_select "span.badge.bg-success", text: "Yes"
+    assert_select ".card-header .badge", count: 0
+  end
+
+  test "inactive customer shows inactive badge on show page" do
+    @customer.update!(active: false)
+    get customer_url(@customer)
+    assert_response :success
+    assert_select ".card-header .badge.bg-secondary", text: "Inactive"
   end
 
   test "should allow updating customer active status" do

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -37,14 +37,14 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
   test "should show project" do
     get project_url(@project)
     assert_response :success
-    assert_select ".badge.bg-success", text: "Active"
+    assert_select ".card-header .badge", count: 0
   end
 
-  test "should show inactive status on project page" do
+  test "should show inactive badge on project page" do
     @project.update!(active: false)
     get project_url(@project)
     assert_response :success
-    assert_select ".badge.bg-secondary", text: "Inactive"
+    assert_select ".card-header .badge.bg-secondary", text: "Inactive"
   end
 
   test "should get new" do


### PR DESCRIPTION
## Summary
- Replace the always-visible Status/Active row on customer and project show pages with an "Inactive" badge in the card header, shown only when the record is inactive.
- Active records render no badge — the goal is a cleaner detail page since most records are active.
- Updated controller tests to match the new badge location and behavior.

## Test plan
- [x] `bundle exec rails test test/controllers/projects_controller_test.rb test/controllers/customers_controller_test.rb`
- [x] Visually confirm active customer/project show pages no longer display the row
- [x] Visually confirm inactive customer/project show pages display the right-aligned badge in the card header

🤖 Generated with [Claude Code](https://claude.com/claude-code)