### PR TITLE
Customer filter on invoice/delivery-note lists + quick links from customer page

### DIFF
--- a/app/assets/stylesheets/utilities.css.scss
+++ b/app/assets/stylesheets/utilities.css.scss
@@ -127,3 +127,12 @@
 .customer-contact-projects-select {
   max-height: 7rem;
 }
+
+// --- Customer filter on invoice/delivery-note index ---
+// Sized to fit a typical matchcode. The customer-filter Stimulus controller
+// swaps option text between matchcode (closed) and "MATCHCODE — Company Name"
+// (open); a fixed select width prevents toolbar reflow on swap. Browsers size
+// the open dropdown panel to the longest option independent of the select.
+.customer-filter select {
+  width: 10em;
+}

--- a/app/controllers/delivery_notes_controller.rb
+++ b/app/controllers/delivery_notes_controller.rb
@@ -44,6 +44,7 @@ class DeliveryNotesController < ApplicationController
   def index
     @selected_year = params[:year] == "all" ? "all" : (params[:year]&.to_i || Date.current.year)
     @email_filter = params[:email_filter] || "all"
+    @selected_customer_id = params[:customer_id].presence&.to_i
 
     @delivery_notes = DeliveryNote.visible_to(current_user)
                                   .reorder(Arel.sql("document_number DESC NULLS FIRST"))
@@ -56,7 +57,12 @@ class DeliveryNotesController < ApplicationController
       @delivery_notes = @delivery_notes.email_unsent.published
     end
 
+    @delivery_notes = @delivery_notes.where(customer_id: @selected_customer_id) if @selected_customer_id
+
     @available_years = DeliveryNote.visible_to(current_user).available_years
+    @available_customers = Customer.visible_to(current_user)
+                                   .where(id: DeliveryNote.visible_to(current_user).select(:customer_id))
+                                   .order(:name)
   end
 
   # GET /delivery_notes/1

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -44,6 +44,7 @@ class InvoicesController < ApplicationController
   def index
     @selected_year = params[:year] == "all" ? "all" : (params[:year]&.to_i || Date.current.year)
     @filter = params[:filter] || "all"
+    @selected_customer_id = params[:customer_id].presence&.to_i
 
     @invoices = Invoice.visible_to(current_user)
                        .reorder(Arel.sql("document_number DESC NULLS FIRST"))
@@ -58,7 +59,12 @@ class InvoicesController < ApplicationController
       @invoices = @invoices.unpaid.published
     end
 
+    @invoices = @invoices.where(customer_id: @selected_customer_id) if @selected_customer_id
+
     @available_years = Invoice.visible_to(current_user).available_years
+    @available_customers = Customer.visible_to(current_user)
+                                   .where(id: Invoice.visible_to(current_user).select(:customer_id))
+                                   .order(:name)
   end
 
   # GET /invoices/1

--- a/app/javascript/controllers/customer_filter_controller.js
+++ b/app/javascript/controllers/customer_filter_controller.js
@@ -1,0 +1,29 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["select"]
+
+  connect() {
+    this.collapse()
+  }
+
+  expand() {
+    this.swap("full")
+  }
+
+  collapse() {
+    this.swap("short")
+  }
+
+  submit() {
+    this.collapse()
+    this.element.closest("form").requestSubmit()
+  }
+
+  swap(key) {
+    this.selectTarget.querySelectorAll("option").forEach((opt) => {
+      const value = opt.dataset[key]
+      if (value !== undefined) opt.text = value
+    })
+  }
+}

--- a/app/views/customers/show.html.haml
+++ b/app/views/customers/show.html.haml
@@ -130,8 +130,8 @@
 = action_buttons_wrapper do
   = action_button 'Back', customers_path, :secondary
   - if can?('invoices.view')
-    = action_button 'Invoices', invoices_path(customer_id: @customer.id, year: 'all'), :info
+    = action_button 'Invoices', invoices_path(customer_id: @customer.id, year: 'all'), :info, data: { turbo_prefetch: false }
   - if can?('delivery_notes.view')
-    = action_button 'Delivery Notes', delivery_notes_path(customer_id: @customer.id, year: 'all'), :info
+    = action_button 'Delivery Notes', delivery_notes_path(customer_id: @customer.id, year: 'all'), :info, data: { turbo_prefetch: false }
   - if can?('customers.edit') && !@customer.used_in_invoices?
     = button_to 'Delete', @customer, method: :delete, class: 'btn btn-danger', data: { 'turbo-confirm': "Are you sure you want to delete customer \"#{@customer.matchcode}\" (#{@customer.name})?" }

--- a/app/views/customers/show.html.haml
+++ b/app/views/customers/show.html.haml
@@ -129,5 +129,9 @@
 
 = action_buttons_wrapper do
   = action_button 'Back', customers_path, :secondary
+  - if can?('invoices.view')
+    = action_button 'Invoices', invoices_path(customer_id: @customer.id, year: 'all'), :info
+  - if can?('delivery_notes.view')
+    = action_button 'Delivery Notes', delivery_notes_path(customer_id: @customer.id, year: 'all'), :info
   - if can?('customers.edit') && !@customer.used_in_invoices?
     = button_to 'Delete', @customer, method: :delete, class: 'btn btn-danger', data: { 'turbo-confirm': "Are you sure you want to delete customer \"#{@customer.matchcode}\" (#{@customer.name})?" }

--- a/app/views/delivery_notes/index.html.haml
+++ b/app/views/delivery_notes/index.html.haml
@@ -2,20 +2,30 @@
 
 
 .bulk-select-container{data: { controller: 'bulk-select' }}
-  = form_with url: bulk_send_emails_delivery_notes_path, method: :post, local: true, id: 'bulk-email-form' do |form|
-    .btn-toolbar.mb-3{:role=>"toolbar", "aria-label"=>"List toolbar"}
-      .btn-group.btn-group-sm.me-2.email-filter{:role=>"group", "aria-label"=>"E-Mail status"}
-        = link_to 'All', delivery_notes_path(year: @selected_year, email_filter: 'all'), class: (@email_filter == 'all' ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
-        = link_to 'Unsent', delivery_notes_path(year: @selected_year, email_filter: 'unsent'), class: (@email_filter == 'unsent' ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
+  -# Empty body — checkboxes + submit attach via form="bulk-email-form".
+  -# Sibling forms (customer filter) live outside so they aren't nested in HTML.
+  = form_with url: bulk_send_emails_delivery_notes_path, method: :post, local: true, id: 'bulk-email-form' do
+    -# intentionally empty
 
-      - if @email_filter == 'unsent'
-        = form.submit 'Send Selected Emails', class: 'btn btn-warning btn-sm me-2 align-self-start', disabled: true, data: { confirm: 'Are you sure you want to send emails for the selected delivery notes?', 'bulk-select-target': 'submitButton' }
+  .btn-toolbar.mb-3{:role=>"toolbar", "aria-label"=>"List toolbar"}
+    .btn-group.btn-group-sm.me-2.email-filter{:role=>"group", "aria-label"=>"E-Mail status"}
+      = link_to 'All', delivery_notes_path(year: @selected_year, email_filter: 'all', customer_id: @selected_customer_id), class: (@email_filter == 'all' ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
+      = link_to 'Unsent', delivery_notes_path(year: @selected_year, email_filter: 'unsent', customer_id: @selected_customer_id), class: (@email_filter == 'unsent' ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
 
-      - if @available_years.any?
-        .btn-group.btn-group-sm.ms-auto.year-pagination{:role=>"group", "aria-label"=>"Year navigation"}
-          - @available_years.each do |year|
-            = link_to year, delivery_notes_path(year: year, email_filter: @email_filter), class: (@selected_year == year ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
-          = link_to 'All', delivery_notes_path(year: 'all', email_filter: @email_filter), class: (@selected_year == 'all' ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
+    = render 'shared/customer_filter',
+        form_url: delivery_notes_path,
+        customers: @available_customers,
+        selected_customer_id: @selected_customer_id,
+        hidden_fields: { year: @selected_year, email_filter: @email_filter }
+
+    - if @email_filter == 'unsent'
+      = submit_tag 'Send Selected Emails', form: 'bulk-email-form', class: 'btn btn-warning btn-sm me-2 align-self-start', disabled: true, data: { confirm: 'Are you sure you want to send emails for the selected delivery notes?', 'bulk-select-target': 'submitButton' }
+
+    - if @available_years.any?
+      .btn-group.btn-group-sm.ms-auto.year-pagination{:role=>"group", "aria-label"=>"Year navigation"}
+        - @available_years.each do |year|
+          = link_to year, delivery_notes_path(year: year, email_filter: @email_filter, customer_id: @selected_customer_id), class: (@selected_year == year ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
+        = link_to 'All', delivery_notes_path(year: 'all', email_filter: @email_filter, customer_id: @selected_customer_id), class: (@selected_year == 'all' ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
 
   - if @email_filter == 'unsent' && @delivery_notes.any?
     %table.table.table-striped.table-sm

--- a/app/views/invoices/index.html.haml
+++ b/app/views/invoices/index.html.haml
@@ -2,21 +2,31 @@
 
 
 .bulk-select-container{data: { controller: 'bulk-select' }}
-  = form_with url: bulk_send_emails_invoices_path, method: :post, local: true, id: 'bulk-email-form' do |form|
-    .btn-toolbar.mb-3{:role=>"toolbar", "aria-label"=>"List toolbar"}
-      .btn-group.btn-group-sm.me-2.invoice-filter{:role=>"group", "aria-label"=>"Filter"}
-        = link_to 'All', invoices_path(year: @selected_year, filter: 'all'), class: (@filter == 'all' ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
-        = link_to 'Unsent', invoices_path(year: @selected_year, filter: 'unsent'), class: (@filter == 'unsent' ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
-        = link_to 'Unpaid', invoices_path(year: @selected_year, filter: 'unpaid'), class: (@filter == 'unpaid' ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
+  -# Empty body — checkboxes + submit attach via form="bulk-email-form".
+  -# Sibling forms (customer filter) live outside so they aren't nested in HTML.
+  = form_with url: bulk_send_emails_invoices_path, method: :post, local: true, id: 'bulk-email-form' do
+    -# intentionally empty
 
-      - if @filter == 'unsent'
-        = form.submit 'Send Selected Emails', class: 'btn btn-warning btn-sm me-2 align-self-start', disabled: true, data: { confirm: 'Are you sure you want to send emails for the selected invoices?', 'bulk-select-target': 'submitButton' }
+  .btn-toolbar.mb-3{:role=>"toolbar", "aria-label"=>"List toolbar"}
+    .btn-group.btn-group-sm.me-2.invoice-filter{:role=>"group", "aria-label"=>"Filter"}
+      = link_to 'All', invoices_path(year: @selected_year, filter: 'all', customer_id: @selected_customer_id), class: (@filter == 'all' ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
+      = link_to 'Unsent', invoices_path(year: @selected_year, filter: 'unsent', customer_id: @selected_customer_id), class: (@filter == 'unsent' ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
+      = link_to 'Unpaid', invoices_path(year: @selected_year, filter: 'unpaid', customer_id: @selected_customer_id), class: (@filter == 'unpaid' ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
 
-      - if @available_years.any?
-        .btn-group.btn-group-sm.ms-auto.year-pagination{:role=>"group", "aria-label"=>"Year navigation"}
-          - @available_years.each do |year|
-            = link_to year, invoices_path(year: year, filter: @filter), class: (@selected_year == year ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
-          = link_to 'All', invoices_path(year: 'all', filter: @filter), class: (@selected_year == 'all' ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
+    = render 'shared/customer_filter',
+        form_url: invoices_path,
+        customers: @available_customers,
+        selected_customer_id: @selected_customer_id,
+        hidden_fields: { year: @selected_year, filter: @filter }
+
+    - if @filter == 'unsent'
+      = submit_tag 'Send Selected Emails', form: 'bulk-email-form', class: 'btn btn-warning btn-sm me-2 align-self-start', disabled: true, data: { confirm: 'Are you sure you want to send emails for the selected invoices?', 'bulk-select-target': 'submitButton' }
+
+    - if @available_years.any?
+      .btn-group.btn-group-sm.ms-auto.year-pagination{:role=>"group", "aria-label"=>"Year navigation"}
+        - @available_years.each do |year|
+          = link_to year, invoices_path(year: year, filter: @filter, customer_id: @selected_customer_id), class: (@selected_year == year ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
+        = link_to 'All', invoices_path(year: 'all', filter: @filter, customer_id: @selected_customer_id), class: (@selected_year == 'all' ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
 
   - if @filter == 'unsent' && @invoices.any?
     %table.table.table-striped.table-sm

--- a/app/views/shared/_customer_filter.html.haml
+++ b/app/views/shared/_customer_filter.html.haml
@@ -1,0 +1,14 @@
+-# Locals: form_url, customers, selected_customer_id, hidden_fields (Hash<Symbol, String>)
+-#
+-# Renders a customer filter dropdown that shows only the matchcode in the
+-# closed state and "MATCHCODE — Company Name" while open. Width is set via
+-# the .customer-filter rule in utilities.css.scss (CSP forbids inline style).
+= form_with url: form_url, method: :get, local: true, class: 'me-2 customer-filter', data: { controller: 'customer-filter' } do
+  - hidden_fields.each do |name, value|
+    = hidden_field_tag name, value
+  %select.form-select.form-select-sm{name: 'customer_id', 'aria-label': 'Filter by customer', data: { 'customer-filter-target': 'select', action: 'mousedown->customer-filter#expand focus->customer-filter#expand blur->customer-filter#collapse change->customer-filter#submit' }}
+    %option{value: '', data: { short: 'All', full: 'All customers' }, selected: selected_customer_id.nil?}
+      All
+    - customers.each do |c|
+      %option{value: c.id, data: { short: c.matchcode, full: "#{c.matchcode} — #{c.name}" }, selected: c.id == selected_customer_id}
+        = c.matchcode

--- a/test/controllers/customers_controller_test.rb
+++ b/test/controllers/customers_controller_test.rb
@@ -157,6 +157,13 @@ class CustomersControllerTest < ActionDispatch::IntegrationTest
     assert_equal "SUP-42", @customer.reload.supplier_number
   end
 
+  test "show page links to invoices and delivery notes filtered to this customer across all years" do
+    get customer_url(@customer)
+    assert_response :success
+    assert_select "a[href=?]", invoices_path(customer_id: @customer.id, year: "all"), text: /Invoices/
+    assert_select "a[href=?]", delivery_notes_path(customer_id: @customer.id, year: "all"), text: /Delivery Notes/
+  end
+
   test "show page renders supplier number row only when set" do
     @customer.update!(supplier_number: nil)
     get customer_url(@customer)

--- a/test/controllers/customers_controller_test.rb
+++ b/test/controllers/customers_controller_test.rb
@@ -160,8 +160,8 @@ class CustomersControllerTest < ActionDispatch::IntegrationTest
   test "show page links to invoices and delivery notes filtered to this customer across all years" do
     get customer_url(@customer)
     assert_response :success
-    assert_select "a[href=?]", invoices_path(customer_id: @customer.id, year: "all"), text: /Invoices/
-    assert_select "a[href=?]", delivery_notes_path(customer_id: @customer.id, year: "all"), text: /Delivery Notes/
+    assert_select "a[href=?][data-turbo-prefetch=?]", invoices_path(customer_id: @customer.id, year: "all"), "false", text: /Invoices/
+    assert_select "a[href=?][data-turbo-prefetch=?]", delivery_notes_path(customer_id: @customer.id, year: "all"), "false", text: /Delivery Notes/
   end
 
   test "show page renders supplier number row only when set" do

--- a/test/controllers/delivery_notes_controller_test.rb
+++ b/test/controllers/delivery_notes_controller_test.rb
@@ -43,6 +43,38 @@ class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
     assert_select ".year-pagination a.active", text: "All"
   end
 
+  test "should filter delivery notes by customer" do
+    DeliveryNote.create!(
+      customer: customers(:good_eu),
+      project: projects(:one),
+      cust_reference: "EU-CUSTOMER-DN",
+      date: Date.current,
+      delivery_start_date: Date.current
+    )
+    DeliveryNote.create!(
+      customer: customers(:good_national),
+      project: projects(:one),
+      cust_reference: "NATIONAL-CUSTOMER-DN",
+      date: Date.current,
+      delivery_start_date: Date.current
+    )
+
+    get delivery_notes_url(customer_id: customers(:good_eu).id)
+    assert_response :success
+    assert_select "td", text: "EU-CUSTOMER-DN"
+    assert_select "td", text: "NATIONAL-CUSTOMER-DN", count: 0
+  end
+
+  test "index renders customer dropdown" do
+    get delivery_notes_url
+    assert_response :success
+    assert_select "select[name='customer_id']" do
+      assert_select "option[value='']"
+      customer = customers(:good_eu)
+      assert_select "option[value=?][data-full=?]", customer.id.to_s, "#{customer.matchcode} — #{customer.name}", text: customer.matchcode
+    end
+  end
+
   test "should include draft delivery notes with nil date in current year" do
     # Create a draft delivery note (no date)
     DeliveryNote.create!(

--- a/test/controllers/invoices_controller_test.rb
+++ b/test/controllers/invoices_controller_test.rb
@@ -42,6 +42,36 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
     assert_select ".year-pagination a.active", text: "All"
   end
 
+  test "should filter invoices by customer" do
+    Invoice.create!(
+      customer: customers(:good_eu),
+      project: projects(:test_project),
+      cust_reference: "EU-CUSTOMER-INV",
+      date: Date.current
+    )
+    Invoice.create!(
+      customer: customers(:good_national),
+      project: projects(:test_project),
+      cust_reference: "NATIONAL-CUSTOMER-INV",
+      date: Date.current
+    )
+
+    get invoices_url(customer_id: customers(:good_eu).id)
+    assert_response :success
+    assert_select "td", text: "EU-CUSTOMER-INV"
+    assert_select "td", text: "NATIONAL-CUSTOMER-INV", count: 0
+  end
+
+  test "index renders customer dropdown" do
+    get invoices_url
+    assert_response :success
+    assert_select "select[name='customer_id']" do
+      assert_select "option[value='']"
+      customer = customers(:good_eu)
+      assert_select "option[value=?][data-full=?]", customer.id.to_s, "#{customer.matchcode} — #{customer.name}", text: customer.matchcode
+    end
+  end
+
   test "should include draft invoices with nil date in current year" do
     current_year = Date.current.year
 

--- a/test/system/customer_filter_test.rb
+++ b/test/system/customer_filter_test.rb
@@ -1,0 +1,40 @@
+require "application_system_test_case"
+
+class CustomerFilterTest < ApplicationSystemTestCase
+  test "invoice index customer dropdown expands on focus" do
+    Invoice.create!(
+      customer: customers(:good_eu),
+      project: projects(:test_project),
+      cust_reference: "FILTER-TEST",
+      date: Date.current
+    )
+
+    visit invoices_url
+
+    select_css = "select[name='customer_id']"
+    assert_selector select_css
+
+    good_eu = customers(:good_eu)
+    option_selector = "#{select_css} option[value='#{good_eu.id}']"
+    expected_full = "#{good_eu.matchcode} — #{good_eu.name}"
+
+    # Closed state: option text is matchcode only.
+    assert_equal good_eu.matchcode, page.evaluate_script("document.querySelector(#{option_selector.to_json}).text")
+
+    # The Stimulus action listens for focus on the select.
+    page.execute_script(<<~JS)
+      const el = document.querySelector(#{select_css.to_json});
+      el.dispatchEvent(new Event('focus', { bubbles: true }));
+    JS
+
+    assert_equal expected_full, page.evaluate_script("document.querySelector(#{option_selector.to_json}).text")
+
+    # Blur collapses back to matchcode.
+    page.execute_script(<<~JS)
+      const el = document.querySelector(#{select_css.to_json});
+      el.dispatchEvent(new Event('blur', { bubbles: true }));
+    JS
+
+    assert_equal good_eu.matchcode, page.evaluate_script("document.querySelector(#{option_selector.to_json}).text")
+  end
+end


### PR DESCRIPTION
## Summary
- New customer-filter dropdown on the invoice and delivery-note index pages. Closed state shows the matchcode; opening the dropdown swaps each option to `MATCHCODE — Company Name` via a small Stimulus controller. Width is set via `.customer-filter select` in `utilities.css.scss` (CSP forbids inline style). Year/email-status links thread `customer_id` through so the selection sticks.
- Customer show page now has `Invoices` and `Delivery Notes` quick links (gated by the matching view permission) that jump to the corresponding list filtered to that customer with `year=all`. Both links carry `data-turbo-prefetch=false` so hovering doesn't fire those (non-cheap) index queries.
- Fixed an HTML correctness issue I introduced while restructuring: the bulk-email `form_with` was called without a block and never closed, swallowing the rest of the toolbar (including the customer-filter form's `data-controller`). It now uses an explicit empty `do` block.

## Test plan
- [x] `bundle exec rails test test/controllers/invoices_controller_test.rb test/controllers/delivery_notes_controller_test.rb test/controllers/customers_controller_test.rb test/controllers/invoices_controller_email_test.rb test/controllers/invoices_controller_paid_test.rb`
- [x] `bundle exec rails test test/system/customer_filter_test.rb test/system/invoice_lines_test.rb test/system/invoice_edit_test.rb` — covers focus→expand, blur→collapse in real headless Chromium
- [x] `pre-commit run` (rubocop, trailing whitespace, EOF, merge-conflict markers) clean
- [x] `npm run lint`
- [ ] Click around the invoice and delivery-note index pages: change the customer dropdown (submits on change), toggle year/All-year/filter to confirm `customer_id` carries through, verify the dropdown stays narrow and the toolbar fits one line at desktop widths
- [ ] Open a customer detail page, click `Invoices` and `Delivery Notes` quick links, confirm `customer_id` and `year=all` are applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)