### PR TITLE
Let sales_tax.view users navigate to customer/product classes

### DIFF
--- a/app/views/sales_tax_rates/index.html.haml
+++ b/app/views/sales_tax_rates/index.html.haml
@@ -65,9 +65,6 @@
               \% &nbsp;
               %button{:type => :submit, :class => "btn"}
                 Create
-%br
-
-- if can?('sales_tax.edit')
-  %div
-    = link_to 'Edit Customer Classes', sales_tax_customer_classes_path, class: 'btn btn-outline-secondary me-2'
-    = link_to 'Edit Product Classes', sales_tax_product_classes_path, class: 'btn btn-outline-secondary'
+= action_buttons_wrapper do
+  = action_button 'Customer Classes', sales_tax_customer_classes_path, :secondary
+  = action_button 'Product Classes', sales_tax_product_classes_path, :secondary


### PR DESCRIPTION
## Summary
- The buttons at the bottom of the sales tax rates page were gated by `sales_tax.edit`, leaving view-only users with no way to reach the customer/product class index pages (the only entry points to them in the app).
- Reuse `action_buttons_wrapper` + `action_button :secondary` so the buttons match the rest of the app instead of using the one-off `btn btn-outline-secondary` styling.
- Drop the misleading "Edit" prefix — the buttons navigate to list pages, not edit forms.

## Test plan
- [ ] Sign in as a user with `sales_tax.view` (no `sales_tax.edit`) and confirm the Customer Classes / Product Classes buttons appear on `/sales_tax_rates` and link to the respective index pages.
- [ ] Sign in as a user with `sales_tax.edit` and confirm the same buttons still work.
- [ ] Visually confirm the button styling matches the rest of the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)