### PR TITLE
Link customer and project on document detail pages

### DIFF
--- a/app/views/delivery_notes/show.html.haml
+++ b/app/views/delivery_notes/show.html.haml
@@ -20,7 +20,7 @@
           .col-sm-4
             %strong Customer:
           .col-sm-8
-            = @delivery_note.customer.name
+            = link_to @delivery_note.customer.name, @delivery_note.customer
         - if @delivery_note.published?
           .row.mb-2
             .col-sm-4
@@ -51,7 +51,7 @@
               %strong Project:
             .col-sm-8
               - if @delivery_note.project
-                = @delivery_note.project.display_name
+                = link_to @delivery_note.project.display_name, @delivery_note.project
               - else
                 %em (Project ##{@delivery_note.project_id} - not found)
         - if @delivery_note.cust_reference.present?

--- a/app/views/invoices/show.html.haml
+++ b/app/views/invoices/show.html.haml
@@ -20,7 +20,7 @@
           .col-sm-4
             %strong Customer:
           .col-sm-8
-            = @invoice.customer_name || @invoice.customer.name
+            = link_to(@invoice.customer_name || @invoice.customer.name, @invoice.customer)
         .row.mb-2
           .col-sm-4
             %strong Payment Terms:
@@ -72,7 +72,7 @@
               %strong Project:
             .col-sm-8
               - if @invoice.project
-                = @invoice.project.display_name
+                = link_to @invoice.project.display_name, @invoice.project
               - else
                 %em (Project ##{@invoice.project_id} - not found)
         - if @invoice.cust_reference.present?


### PR DESCRIPTION
## Summary
- Wrap the customer name on the invoice and delivery note show pages with `link_to` so it navigates to the customer detail page.
- Wrap the project display name on both pages with `link_to` so it navigates to the project detail page (still suppressed when the project is missing).

## Test plan
- [x] `bundle exec rails test test/controllers/invoices_controller_test.rb test/controllers/delivery_notes_controller_test.rb`
- [ ] Open an invoice and a delivery note in the browser and confirm the customer/project labels are clickable and resolve to the correct detail pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)