### PR TITLE
Standardize show page headers, status badges, and inline row actions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,8 @@ For testing against PostgreSQL (matches production environment):
 - Stimulus controllers for interactive components (bulk-select, email-preview)
 - European-style date/time formatting throughout
 - Strict Content Security Policy — no inline styles in views. Put styling in CSS/SCSS files and apply via classes. Inline `style="..."` attributes are only allowed in email templates (rendered HTML email, not subject to the app CSP).
+- Bootstrap's JavaScript is NOT bundled — only its CSS. JS-driven components (modals, popovers, dropdowns, collapses, JS tooltips) require a custom Stimulus controller; `data-bs-toggle` / `data-bs-target` attributes do nothing on their own.
+- Established pattern: manually toggle `d-none`/`show` classes from a Stimulus controller (see `app/javascript/controllers/generic_email_preview_controller.js` and `app/javascript/controllers/modal_controller.js`).
 
 ### Status Badges
 - **Show only the deviation from the healthy default.** No badge means "normal."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,7 @@ For testing against PostgreSQL (matches production environment):
   - Invoice/Delivery Note lifecycle (Draft, Booked, Paid, Overdue, Sent) all get header badges — there's no implicit "good" lifecycle, every state is noteworthy.
 - **Hide superseded badges.** On invoices, the header drops "Booked" once a more specific state (Sent/Paid/Overdue) applies. Sent stacks with Paid/Overdue (email and payment are independent).
 - **In detail grids and list columns, healthy data renders as plain text, not a badge.** Paid (with date), Sent (with timestamp) → plain text. Problem states (Unpaid, Unsent, Overdue, No Recipient) keep their badges.
+- **Hide the status column entirely when a list is filtered to a single state.** On the customers and projects lists, the Status column is only rendered when the filter is "All"; when filtered to Active or Inactive the column would be redundant (every row identical or empty), so the header and cells are omitted.
 - Use `fs-6` when a badge sits inline with an H1, otherwise it inflates to heading size.
 
 ## Development Best Practices

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,14 @@ For testing against PostgreSQL (matches production environment):
 - European-style date/time formatting throughout
 - Strict Content Security Policy — no inline styles in views. Put styling in CSS/SCSS files and apply via classes. Inline `style="..."` attributes are only allowed in email templates (rendered HTML email, not subject to the app CSP).
 
+### Status Badges
+- **Show only the deviation from the healthy default.** No badge means "normal."
+  - Customer/Project Inactive, User Blocked → badge. Active state → nothing.
+  - Invoice/Delivery Note lifecycle (Draft, Booked, Paid, Overdue, Sent) all get header badges — there's no implicit "good" lifecycle, every state is noteworthy.
+- **Hide superseded badges.** On invoices, the header drops "Booked" once a more specific state (Sent/Paid/Overdue) applies. Sent stacks with Paid/Overdue (email and payment are independent).
+- **In detail grids and list columns, healthy data renders as plain text, not a badge.** Paid (with date), Sent (with timestamp) → plain text. Problem states (Unpaid, Unsent, Overdue, No Recipient) keep their badges.
+- Use `fs-6` when a badge sits inline with an H1, otherwise it inflates to heading size.
+
 ## Development Best Practices
 
 ### Running rails
@@ -167,11 +175,11 @@ For testing against PostgreSQL (matches production environment):
 - To render a `datetime` column as date-only (e.g. `email_sent_at` in compact list rows), call `l(value.to_date)` — `l` on a `Time`/`DateTime` produces the time format.
 
 ### UI Helper Methods
-- `action_buttons_wrapper` - Container for action button groups
-- `action_button(text, path, type)` - Styled buttons (primary, secondary, success, info, warning, danger)
-- `destroy_link(resource, confirm_text)` - Smart delete links (trashcan on index, "Delete" on detail pages)
-- `list_action_link(text, path, type)` - Compact buttons for table actions
-- `page_header_with_new_button` - Standard page headers with + New button
+- `page_header(title, action: nil, &status_block)` - The page-header row. Title left, optional inline status badges via block, optional right-aligned action. Build the action with `action_button(...)` — when its permission check fails it returns nil, which `page_header` renders as no action area.
+- `action_button(text, path, type = :primary, permission: nil, target: nil, data: nil)` - Styled buttons (primary, secondary, success, info, warning, danger). Returns `nil` when `permission:` is given and the current user lacks it.
+- `action_buttons_wrapper` - Container for the bottom-of-page workflow action row (Back, PDF, Send E-Mail, Publish, Delete, etc.).
+- `destroy_link(resource, confirm_text)` - Smart delete links (trashcan on index, "Delete" on detail pages).
+- `list_action_link(text, path, type)` - Compact buttons for in-table row actions.
 
 ### JavaScript/Stimulus Controllers
 - **ALWAYS implement `disconnect()` method** in Stimulus controllers that add event listeners

--- a/app/assets/stylesheets/utilities.css.scss
+++ b/app/assets/stylesheets/utilities.css.scss
@@ -73,6 +73,26 @@
   border-radius: 0.375rem;
 }
 
+// --- Mark paid modal (invoices/show) ---
+
+.mark-paid-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1050;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.mark-paid-modal-dialog {
+  max-width: 400px;
+  width: 90%;
+}
+
 // --- Error notification dropdown (layout/_navigation) ---
 
 .error-notification-dropdown {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -133,4 +133,17 @@ module ApplicationHelper
   def app_version
     Rails.application.config.x.app_version
   end
+
+  # Stimulus data attributes that wire an element up to the
+  # generic-email-preview controller for a given Invoice or DeliveryNote.
+  # Relies on the routes following the {action}_{resource}_path convention.
+  def email_preview_data(resource)
+    prefix = resource.class.name.underscore
+    {
+      controller: "generic-email-preview",
+      "generic-email-preview-preview-url-value" => send("preview_email_#{prefix}_path", resource),
+      "generic-email-preview-raw-preview-url-value" => send("preview_email_raw_#{prefix}_path", resource),
+      "generic-email-preview-send-url-value" => send("send_email_#{prefix}_path", resource)
+    }
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -44,11 +44,15 @@ module ApplicationHelper
     end
   end
 
-  def page_header_with_edit_button(title, edit_path, permission: nil)
-    content_tag :div, class: "d-flex justify-content-between align-items-center mb-3" do
-      header = content_tag(:h1, title, class: "page-header mb-0")
+  def page_header_with_edit_button(title, edit_path, permission: nil, &status_block)
+    content_tag :div, class: "d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2" do
+      title_area = content_tag(:div, class: "d-flex align-items-center flex-wrap gap-2") do
+        header = content_tag(:h1, title, class: "page-header mb-0")
+        status = status_block ? capture(&status_block) : "".html_safe
+        header + status
+      end
       button = (permission.nil? || can?(permission)) ? link_to("Edit", edit_path, class: "btn btn-primary") : "".html_safe
-      header + button
+      title_area + button
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -32,32 +32,21 @@ module ApplicationHelper
     end
   end
 
-  # If `permission:` is given, the +New / Edit button is hidden unless the
-  # current user holds that key. The header itself always renders so users
-  # with .view-only access still see the page heading. Controllers gate the
-  # actual action server-side; this just keeps the UI honest.
-  def page_header_with_new_button(title, new_path, permission: nil)
-    content_tag :div, class: "d-flex justify-content-between align-items-center mb-3" do
-      header = content_tag(:h1, title, class: "page-header mb-0")
-      button = (permission.nil? || can?(permission)) ? link_to("+ New", new_path, class: "btn btn-info") : "".html_safe
-      header + button
-    end
-  end
-
-  def page_header_with_edit_button(title, edit_path, permission: nil, &status_block)
+  # Renders the page header row: title (left), optional inline status badges
+  # (left, via the block), optional action button (right).
+  #
+  # action: a pre-rendered button (use action_button with permission: to get a
+  #   nil-when-denied result), or nil for no action area.
+  # status_block: yields zero or more inline badges next to the title.
+  def page_header(title, action: nil, &status_block)
     content_tag :div, class: "d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2" do
       title_area = content_tag(:div, class: "d-flex align-items-center flex-wrap gap-2") do
         header = content_tag(:h1, title, class: "page-header mb-0")
         status = status_block ? capture(&status_block) : "".html_safe
         header + status
       end
-      button = (permission.nil? || can?(permission)) ? link_to("Edit", edit_path, class: "btn btn-primary") : "".html_safe
-      title_area + button
+      title_area + (action || "".html_safe)
     end
-  end
-
-  def page_header(title)
-    content_tag(:h1, title, class: "page-header mb-3")
   end
 
   def list_action_link(text, path, type = :default, options = {})
@@ -102,7 +91,8 @@ module ApplicationHelper
     content_tag :div, class: "d-flex gap-2 mb-3 mt-3", &block
   end
 
-  def action_button(text, path, type = :primary, options = {})
+  def action_button(text, path, type = :primary, permission: nil, target: nil, data: nil)
+    return nil if permission && !can?(permission)
     css_class = case type
     when :primary
       "btn btn-primary"
@@ -120,7 +110,7 @@ module ApplicationHelper
       "btn btn-primary"
     end
 
-    link_to(text, path, options.merge(class: css_class))
+    link_to(text, path, class: css_class, target: target, data: data)
   end
 
   def cancel_button(resource)

--- a/app/javascript/controllers/generic_email_preview_controller.js
+++ b/app/javascript/controllers/generic_email_preview_controller.js
@@ -1,7 +1,7 @@
-import { Controller } from "@hotwired/stimulus"
+import ModalController from "controllers/modal_controller"
 
 // Reusable base class for email preview functionality
-export default class extends Controller {
+export default class extends ModalController {
   static targets = ["modal", "content"]
   static values = {
     previewUrl: String,     // URL to fetch preview metadata as JSON
@@ -22,32 +22,8 @@ export default class extends Controller {
   }
 
   open(event) {
-    this.modalTarget.classList.remove('d-none')
-    this.modalTarget.classList.add('show')
-    document.body.classList.add('modal-open')
-
-    // Load content
+    super.open()
     this.loadContent()
-  }
-
-  close() {
-    this.modalTarget.classList.add('d-none')
-    this.modalTarget.classList.remove('show')
-    document.body.classList.remove('modal-open')
-  }
-
-  // Close modal when clicking backdrop
-  closeOnBackdrop(event) {
-    if (event.target === this.modalTarget) {
-      this.close()
-    }
-  }
-
-  // Close modal on Escape key
-  closeOnEscape(event) {
-    if (event.key === 'Escape') {
-      this.close()
-    }
   }
 
   async sendEmail() {

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -1,0 +1,32 @@
+// Reusable base controller for modal dialogs (open/close + backdrop/escape dismissal)
+import { Controller } from "@hotwired/stimulus"
+
+export default class ModalController extends Controller {
+  static targets = ["modal"]
+
+  open() {
+    this.modalTarget.classList.remove("d-none")
+    this.modalTarget.classList.add("show")
+    document.body.classList.add("modal-open")
+  }
+
+  close() {
+    this.modalTarget.classList.add("d-none")
+    this.modalTarget.classList.remove("show")
+    document.body.classList.remove("modal-open")
+  }
+
+  // Close modal when clicking backdrop
+  closeOnBackdrop(event) {
+    if (event.target === this.modalTarget) {
+      this.close()
+    }
+  }
+
+  // Close modal on Escape key
+  closeOnEscape(event) {
+    if (event.key === "Escape") {
+      this.close()
+    }
+  }
+}

--- a/app/views/account/credentials/index.html.haml
+++ b/app/views/account/credentials/index.html.haml
@@ -1,6 +1,6 @@
 - content_for :title, 'My passkeys'
 
-= page_header_with_new_button('My passkeys', new_account_credential_path)
+= page_header('My passkeys', action: action_button('+ New', new_account_credential_path, :info))
 
 %table.table.table-striped.table-sm
   %thead

--- a/app/views/customers/edit.html.haml
+++ b/app/views/customers/edit.html.haml
@@ -1,3 +1,3 @@
-%h1.page-header Editing customer
+= page_header('Editing customer')
 
 = render 'form'

--- a/app/views/customers/index.html.haml
+++ b/app/views/customers/index.html.haml
@@ -1,4 +1,4 @@
-= page_header_with_new_button('Listing customers', new_customer_path, permission: 'customers.edit')
+= page_header('Listing customers', action: action_button('+ New', new_customer_path, :info, permission: 'customers.edit'))
 
 .mb-3
   .btn-toolbar.mb-3{:role=>"toolbar", "aria-label"=>"List toolbar"}

--- a/app/views/customers/index.html.haml
+++ b/app/views/customers/index.html.haml
@@ -20,9 +20,7 @@
     %tr
       %td= link_to customer.matchcode, customer
       %td
-        - if customer.active?
-          %span.badge.bg-success Active
-        - else
+        - unless customer.active?
           %span.badge.bg-secondary Inactive
       %td= customer.name
       %td= customer.team&.name

--- a/app/views/customers/index.html.haml
+++ b/app/views/customers/index.html.haml
@@ -7,10 +7,12 @@
       = link_to 'Active', customers_path(filter: 'active'), class: (params[:filter] == 'active' ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
       = link_to 'Inactive', customers_path(filter: 'inactive'), class: (params[:filter] == 'inactive' ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
 
+- show_status_column = params[:filter] == 'all'
 %table.table.table-striped.table-sm
   %tr
     %th{:width => "10%"} Matchcode
-    %th{:width => "7%"} Status
+    - if show_status_column
+      %th{:width => "7%"} Status
     %th Name
     %th{:width => "10%"} Team
     %th{:width => "3%"}
@@ -19,9 +21,10 @@
   - @customers.each do |customer|
     %tr
       %td= link_to customer.matchcode, customer
-      %td
-        - unless customer.active?
-          %span.badge.bg-secondary Inactive
+      - if show_status_column
+        %td
+          - unless customer.active?
+            %span.badge.bg-secondary Inactive
       %td= customer.name
       %td= customer.team&.name
       %td

--- a/app/views/customers/new.html.haml
+++ b/app/views/customers/new.html.haml
@@ -1,3 +1,3 @@
-%h1.page-header New customer
+= page_header('New customer')
 
 = render 'form'

--- a/app/views/customers/show.html.haml
+++ b/app/views/customers/show.html.haml
@@ -1,4 +1,4 @@
-= page_header_with_edit_button("Customer #{@customer.matchcode}", edit_customer_path(@customer), permission: 'customers.edit') do
+= page_header("Customer #{@customer.matchcode}", action: action_button('Edit', edit_customer_path(@customer), permission: 'customers.edit')) do
   - unless @customer.active?
     %span.badge.bg-secondary.fs-6 Inactive
 

--- a/app/views/customers/show.html.haml
+++ b/app/views/customers/show.html.haml
@@ -1,12 +1,11 @@
-= page_header_with_edit_button("Customer #{@customer.matchcode}", edit_customer_path(@customer), permission: 'customers.edit')
+= page_header_with_edit_button("Customer #{@customer.matchcode}", edit_customer_path(@customer), permission: 'customers.edit') do
+  - unless @customer.active?
+    %span.badge.bg-secondary.fs-6 Inactive
 
 .row
   .col-md-6
     .card
-      .card-header.d-flex.justify-content-between.align-items-center
-        %span Basic Information
-        - unless @customer.active?
-          %span.badge.bg-secondary Inactive
+      .card-header Basic Information
       .card-body
         .row.mb-2
           .col-sm-4

--- a/app/views/delivery_notes/edit.html.haml
+++ b/app/views/delivery_notes/edit.html.haml
@@ -1,3 +1,3 @@
-%h1.page-header Editing delivery note draft
+= page_header('Editing delivery note draft')
 
 = render 'form'

--- a/app/views/delivery_notes/index.html.haml
+++ b/app/views/delivery_notes/index.html.haml
@@ -1,4 +1,4 @@
-= page_header_with_new_button('Listing delivery notes', new_delivery_note_path, permission: 'delivery_notes.edit')
+= page_header('Listing delivery notes', action: action_button('+ New', new_delivery_note_path, :info, permission: 'delivery_notes.edit'))
 
 
 .bulk-select-container{data: { controller: 'bulk-select' }}

--- a/app/views/delivery_notes/new.html.haml
+++ b/app/views/delivery_notes/new.html.haml
@@ -1,3 +1,3 @@
-%h1.page-header New delivery note
+= page_header('New delivery note')
 
 = render 'form'

--- a/app/views/delivery_notes/show.html.haml
+++ b/app/views/delivery_notes/show.html.haml
@@ -8,177 +8,160 @@
   - else
     %span.badge.bg-success.fs-6 Booked
 
-.email-delivery_note-preview-wrapper{"data-controller" => "generic-email-preview", "data-generic-email-preview-preview-url-value" => preview_email_delivery_note_path(@delivery_note), "data-generic-email-preview-raw-preview-url-value" => preview_email_raw_delivery_note_path(@delivery_note), "data-generic-email-preview-send-url-value" => send_email_delivery_note_path(@delivery_note)}
-  .document-header.row.mb-2
-    .col-md-6
-      .document-details
-        - if @delivery_note.date
-          .row.mb-2
-            .col-sm-4
-              %strong Date:
-            .col-sm-8
-              = l(@delivery_note.date)
+.document-header.row.mb-2
+  .col-md-6
+    .document-details
+      - if @delivery_note.date
         .row.mb-2
           .col-sm-4
-            %strong Customer:
+            %strong Date:
           .col-sm-8
-            = link_to @delivery_note.customer.name, @delivery_note.customer
-        - if @delivery_note.published?
-          .row.mb-2
-            .col-sm-4
-              %strong Email Status:
-            .col-sm-8.d-flex.align-items-center.gap-2
-              - if @delivery_note.email_sent_at
-                Sent #{l(@delivery_note.email_sent_at)}
-              - elsif @delivery_note.emailable?
-                %span.badge.bg-warning Unsent
+            = l(@delivery_note.date)
+      .row.mb-2
+        .col-sm-4
+          %strong Customer:
+        .col-sm-8
+          = link_to @delivery_note.customer.name, @delivery_note.customer
+      - if @delivery_note.published?
+        .row.mb-2
+          .col-sm-4
+            %strong Email Status:
+          .col-sm-8.d-flex.align-items-center.gap-2{data: email_preview_data(@delivery_note)}
+            - if @delivery_note.email_sent_at
+              Sent #{l(@delivery_note.email_sent_at)}
+            - elsif @delivery_note.emailable?
+              %span.badge.bg-warning Unsent
+            - else
+              %span.badge.bg-secondary No Recipient
+            - if can_edit_dn
+              - if @delivery_note.emailable?
+                %button.btn.btn-sm.btn-warning{data: {action: 'click->generic-email-preview#open'}}
+                  Send E-Mail
               - else
-                %span.badge.bg-secondary No Recipient
-              - if can_edit_dn
-                - if @delivery_note.emailable?
-                  %button.btn.btn-sm.btn-warning{"data-action" => "click->generic-email-preview#open"}
+                %span{data: {'bs-toggle': 'tooltip'}, title: 'No contact is configured to receive this delivery note. Add a contact on the customer with "Delivery Notes" enabled.'}
+                  %button.btn.btn-sm.btn-warning{disabled: true}
                     Send E-Mail
-                - else
-                  %span{data: { 'bs-toggle': 'tooltip' }, title: 'No contact is configured to receive this delivery note. Add a contact on the customer with "Delivery Notes" enabled.'}
-                    %button.btn.btn-sm.btn-warning{disabled: true}
-                      Send E-Mail
-        - if @delivery_note.invoice
-          .row.mb-2
-            .col-sm-4
-              %strong Invoice:
-            .col-sm-8
-              = link_to "Invoice #{@delivery_note.invoice.document_number || "##{@delivery_note.invoice.id}"}", @delivery_note.invoice
-              - if @delivery_note.invoice.published?
-                %span.badge.bg-success.ms-2 Booked
-              - else
-                %span.badge.bg-warning.ms-2 Draft
+            = render 'shared/email_preview_modal', title: "Preview - Delivery Note #{@delivery_note.document_number}"
+      - if @delivery_note.invoice
+        .row.mb-2
+          .col-sm-4
+            %strong Invoice:
+          .col-sm-8
+            = link_to "Invoice #{@delivery_note.invoice.document_number || "##{@delivery_note.invoice.id}"}", @delivery_note.invoice
+            - if @delivery_note.invoice.published?
+              %span.badge.bg-success.ms-2 Booked
+            - else
+              %span.badge.bg-warning.ms-2 Draft
 
-    .col-md-6
-      .document-details
-        - if @delivery_note.project_id.present?
-          .row.mb-2
-            .col-sm-4
-              %strong Project:
-            .col-sm-8
-              - if @delivery_note.project
-                = link_to @delivery_note.project.display_name, @delivery_note.project
-              - else
-                %em (Project ##{@delivery_note.project_id} - not found)
-        - if @delivery_note.cust_reference.present?
-          .row.mb-2
-            .col-sm-4
-              %strong Reference:
-            .col-sm-8
-              = @delivery_note.cust_reference
-        - if @delivery_note.cust_order.present?
-          .row.mb-2
-            .col-sm-4
-              %strong Order No:
-            .col-sm-8
-              = @delivery_note.cust_order
-        - if @delivery_note.delivery_timeframe.present?
-          .row.mb-2
-            .col-sm-4
-              %strong Delivery Period:
-            .col-sm-8
-              = @delivery_note.delivery_timeframe
+  .col-md-6
+    .document-details
+      - if @delivery_note.project_id.present?
+        .row.mb-2
+          .col-sm-4
+            %strong Project:
+          .col-sm-8
+            - if @delivery_note.project
+              = link_to @delivery_note.project.display_name, @delivery_note.project
+            - else
+              %em (Project ##{@delivery_note.project_id} - not found)
+      - if @delivery_note.cust_reference.present?
+        .row.mb-2
+          .col-sm-4
+            %strong Reference:
+          .col-sm-8
+            = @delivery_note.cust_reference
+      - if @delivery_note.cust_order.present?
+        .row.mb-2
+          .col-sm-4
+            %strong Order No:
+          .col-sm-8
+            = @delivery_note.cust_order
+      - if @delivery_note.delivery_timeframe.present?
+        .row.mb-2
+          .col-sm-4
+            %strong Delivery Period:
+          .col-sm-8
+            = @delivery_note.delivery_timeframe
 
 
-  - if @delivery_note.published?
-    .acceptance-document.mb-4
-      .card
-        .card-header.d-flex.justify-content-between.align-items-center
-          %h5.mb-0 Acceptance Document
-        .card-body
-          - if @delivery_note.acceptance_attachment
-            .mb-3
-              .d-flex.align-items-center
-                %i.fas.fa-file-pdf.text-danger.me-2
-                = link_to @delivery_note.acceptance_attachment.filename, @delivery_note.acceptance_attachment, class: 'me-auto', target: '_blank'
-                %small.text-muted.ms-2
-                  = "Uploaded #{l(@delivery_note.acceptance_attachment.created_at)}"
-            .d-flex.gap-2
-              = form_with url: upload_acceptance_delivery_note_path(@delivery_note), method: :post, multipart: true, local: true, class: 'd-flex align-items-center', data: { controller: 'file-upload-validation' } do |form|
-                .me-2
-                  = form.file_field :acceptance_pdf, accept: 'application/pdf', class: 'form-control form-control-sm w-fixed-250', data: { file_upload_validation_target: 'fileInput' }
-                = form.submit 'Replace', class: 'btn btn-warning btn-sm', data: { file_upload_validation_target: 'submitButton' }
-              = button_to 'Delete', delete_acceptance_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-outline-danger btn-sm', confirm: 'Are you sure you want to delete the acceptance document?'
-          - else
+- if @delivery_note.published?
+  .acceptance-document.mb-4
+    .card
+      .card-header.d-flex.justify-content-between.align-items-center
+        %h5.mb-0 Acceptance Document
+      .card-body
+        - if @delivery_note.acceptance_attachment
+          .mb-3
+            .d-flex.align-items-center
+              %i.fas.fa-file-pdf.text-danger.me-2
+              = link_to @delivery_note.acceptance_attachment.filename, @delivery_note.acceptance_attachment, class: 'me-auto', target: '_blank'
+              %small.text-muted.ms-2
+                = "Uploaded #{l(@delivery_note.acceptance_attachment.created_at)}"
+          .d-flex.gap-2
             = form_with url: upload_acceptance_delivery_note_path(@delivery_note), method: :post, multipart: true, local: true, class: 'd-flex align-items-center', data: { controller: 'file-upload-validation' } do |form|
-              .me-3
-                = form.file_field :acceptance_pdf, accept: 'application/pdf', class: 'form-control w-auto', data: { file_upload_validation_target: 'fileInput' }
-              = form.submit 'Upload PDF', class: 'btn btn-primary btn-sm', data: { file_upload_validation_target: 'submitButton' }
-            %small.text-muted.d-block.mt-2
-              Upload the signed acceptance document (PDF only)
+              .me-2
+                = form.file_field :acceptance_pdf, accept: 'application/pdf', class: 'form-control form-control-sm w-fixed-250', data: { file_upload_validation_target: 'fileInput' }
+              = form.submit 'Replace', class: 'btn btn-warning btn-sm', data: { file_upload_validation_target: 'submitButton' }
+            = button_to 'Delete', delete_acceptance_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-outline-danger btn-sm', confirm: 'Are you sure you want to delete the acceptance document?'
+        - else
+          = form_with url: upload_acceptance_delivery_note_path(@delivery_note), method: :post, multipart: true, local: true, class: 'd-flex align-items-center', data: { controller: 'file-upload-validation' } do |form|
+            .me-3
+              = form.file_field :acceptance_pdf, accept: 'application/pdf', class: 'form-control w-auto', data: { file_upload_validation_target: 'fileInput' }
+            = form.submit 'Upload PDF', class: 'btn btn-primary btn-sm', data: { file_upload_validation_target: 'submitButton' }
+          %small.text-muted.d-block.mt-2
+            Upload the signed acceptance document (PDF only)
 
-  - if @delivery_note.prelude.present?
-    .document-prelude.mb-4
-      .card
-        .card-body
-          = simple_format(@delivery_note.prelude)
+- if @delivery_note.prelude.present?
+  .document-prelude.mb-4
+    .card
+      .card-body
+        = simple_format(@delivery_note.prelude)
 
-  .document-lines.mb-2
-    %table.table.table-bordered.document-lines-table
-      %thead
-        %tr
-          %th.text-end.col-quantity Quantity
-          %th Description
-      %tbody
-        - @delivery_note.delivery_note_lines.each do |line|
-          - case line.type
-          - when 'item'
-            %tr
-              %td.text-end
-                = number_with_precision(line.quantity, precision: 2, strip_insignificant_zeros: true)
-              %td
-                %strong= line.title
-                - if line.description.present?
-                  %br
-                  %small.text-muted= simple_format(line.description, {}, wrapper_tag: 'span')
-                =#line.delivery_time
-          - when 'subheading'
-            %tr
-              %td.fw-bold.table-secondary.document-section-row{colspan: 5}
-                = line.title
-          - when 'text', 'plain'
-            %tr
-              %td.document-text-row{colspan: 5}
-                - if line.title.present?
-                  %div= line.title
-                - if line.description.present?
-                  %div.text-muted.document-line-comment
-                    - if line.type == 'plain'
-                      %pre.mb-0.font-monospace.text-pre-wrap= line.description
-                    - else
-                      = simple_format(line.description)
+.document-lines.mb-2
+  %table.table.table-bordered.document-lines-table
+    %thead
+      %tr
+        %th.text-end.col-quantity Quantity
+        %th Description
+    %tbody
+      - @delivery_note.delivery_note_lines.each do |line|
+        - case line.type
+        - when 'item'
+          %tr
+            %td.text-end
+              = number_with_precision(line.quantity, precision: 2, strip_insignificant_zeros: true)
+            %td
+              %strong= line.title
+              - if line.description.present?
+                %br
+                %small.text-muted= simple_format(line.description, {}, wrapper_tag: 'span')
+              =#line.delivery_time
+        - when 'subheading'
+          %tr
+            %td.fw-bold.table-secondary.document-section-row{colspan: 5}
+              = line.title
+        - when 'text', 'plain'
+          %tr
+            %td.document-text-row{colspan: 5}
+              - if line.title.present?
+                %div= line.title
+              - if line.description.present?
+                %div.text-muted.document-line-comment
+                  - if line.type == 'plain'
+                    %pre.mb-0.font-monospace.text-pre-wrap= line.description
+                  - else
+                    = simple_format(line.description)
 
-  = action_buttons_wrapper do
-    = action_button 'Back', delivery_notes_path, :secondary
-    - if @delivery_note.published?
-      = action_button 'PDF', pdf_delivery_note_path(@delivery_note), :success, target: '_blank', data: { turbo: false }
-      - if can_edit_dn && !@delivery_note.invoice
-        = button_to 'Convert to Invoice', convert_to_invoice_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-info', confirm: 'Create an invoice draft from this delivery note?'
-      - if can_edit_dn
-        = button_to 'Unpublish', unpublish_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-outline-secondary', confirm: 'Are you sure you want to revert this delivery note to draft status?'
-    - else
-      = action_button 'Preview', preview_delivery_note_path(@delivery_note), :info, target: '_blank', data: { turbo: false }
-      - if can_edit_dn
-        = button_to 'Publish', publish_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-warning'
-        = destroy_link(@delivery_note, "Are you sure you want to delete delivery note \"#{@delivery_note.document_number || "##{@delivery_note.id}"}\"?")
-
-  // Email Preview Modal
-  .modal.d-none.email-preview-modal{"data-generic-email-preview-target" => "modal", "data-action" => "click->generic-email-preview#closeOnBackdrop keydown@window->generic-email-preview#closeOnEscape"}
-    .modal-dialog.modal-lg.email-preview-modal-dialog
-      .modal-content
-        .modal-header.d-flex.justify-content-between.align-items-center
-          %h5.modal-title.mb-0
-            Preview - Delivery Note #{@delivery_note.document_number}
-          .d-flex.align-items-center
-            %button.btn.btn-success.btn-sm.me-2{"data-action" => "click->generic-email-preview#sendEmail"}
-              Send E-Mail
-            %button.btn-close{"type" => "button", "data-action" => "click->generic-email-preview#close", "aria-label" => "Close"}
-        .modal-body{"data-generic-email-preview-target" => "content"}
-          .text-center
-            .spinner-border{"role" => "status"}
-              %span.visually-hidden Loading...
-            %p Loading email preview...
+= action_buttons_wrapper do
+  = action_button 'Back', delivery_notes_path, :secondary
+  - if @delivery_note.published?
+    = action_button 'PDF', pdf_delivery_note_path(@delivery_note), :success, target: '_blank', data: { turbo: false }
+    - if can_edit_dn && !@delivery_note.invoice
+      = button_to 'Convert to Invoice', convert_to_invoice_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-info', confirm: 'Create an invoice draft from this delivery note?'
+    - if can_edit_dn
+      = button_to 'Unpublish', unpublish_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-outline-secondary', confirm: 'Are you sure you want to revert this delivery note to draft status?'
+  - else
+    = action_button 'Preview', preview_delivery_note_path(@delivery_note), :info, target: '_blank', data: { turbo: false }
+    - if can_edit_dn
+      = button_to 'Publish', publish_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-warning'
+      = destroy_link(@delivery_note, "Are you sure you want to delete delivery note \"#{@delivery_note.document_number || "##{@delivery_note.id}"}\"?")

--- a/app/views/delivery_notes/show.html.haml
+++ b/app/views/delivery_notes/show.html.haml
@@ -1,14 +1,21 @@
+- can_edit_dn = can?('delivery_notes.edit')
 %div
-  .document-header.row.mb-2
-    .col-md-6
-      %h1.h2.mb-3
+  .d-flex.justify-content-between.align-items-center.mb-3.flex-wrap.gap-2
+    .d-flex.align-items-center.flex-wrap.gap-2
+      %h1.h2.mb-0
         Delivery Note
         = @delivery_note.document_number || "Draft \##{@delivery_note.id}"
-        - if not @delivery_note.published?
-          %span.badge.bg-warning.ms-2 Draft
-        - else
-          %span.badge.bg-success.ms-2 Booked
+      - if !@delivery_note.published?
+        %span.badge.bg-warning.fs-6 Draft
+      - elsif @delivery_note.email_sent_at.present?
+        %span.badge.bg-success.fs-6 Sent
+      - else
+        %span.badge.bg-success.fs-6 Booked
+    - if !@delivery_note.published && can_edit_dn
+      = action_button 'Edit', edit_delivery_note_path(@delivery_note), :primary
 
+  .document-header.row.mb-2
+    .col-md-6
       .document-details
         - if @delivery_note.date
           .row.mb-2
@@ -44,7 +51,7 @@
                 %span.badge.bg-warning.ms-2 Draft
 
     .col-md-6
-      .document-details.mt-md-5
+      .document-details
         - if @delivery_note.project_id.present?
           .row.mb-2
             .col-sm-4
@@ -143,11 +150,8 @@
                       = simple_format(line.description)
 
 .email-delivery_note-preview-wrapper{"data-controller" => "generic-email-preview", "data-generic-email-preview-preview-url-value" => preview_email_delivery_note_path(@delivery_note), "data-generic-email-preview-raw-preview-url-value" => preview_email_raw_delivery_note_path(@delivery_note), "data-generic-email-preview-send-url-value" => send_email_delivery_note_path(@delivery_note)}
-  - can_edit_dn = can?('delivery_notes.edit')
   = action_buttons_wrapper do
     = action_button 'Back', delivery_notes_path, :secondary
-    - if !@delivery_note.published && can_edit_dn
-      = action_button 'Edit', edit_delivery_note_path(@delivery_note), :primary
     - if @delivery_note.published?
       = action_button 'PDF', pdf_delivery_note_path(@delivery_note), :success, { target: '_blank', data: { turbo: false } }
       - if can_edit_dn

--- a/app/views/delivery_notes/show.html.haml
+++ b/app/views/delivery_notes/show.html.haml
@@ -8,7 +8,7 @@
   - else
     %span.badge.bg-success.fs-6 Booked
 
-%div
+.email-delivery_note-preview-wrapper{"data-controller" => "generic-email-preview", "data-generic-email-preview-preview-url-value" => preview_email_delivery_note_path(@delivery_note), "data-generic-email-preview-raw-preview-url-value" => preview_email_raw_delivery_note_path(@delivery_note), "data-generic-email-preview-send-url-value" => send_email_delivery_note_path(@delivery_note)}
   .document-header.row.mb-2
     .col-md-6
       .document-details
@@ -27,13 +27,21 @@
           .row.mb-2
             .col-sm-4
               %strong Email Status:
-            .col-sm-8
+            .col-sm-8.d-flex.align-items-center.gap-2
               - if @delivery_note.email_sent_at
                 Sent #{l(@delivery_note.email_sent_at)}
               - elsif @delivery_note.emailable?
                 %span.badge.bg-warning Unsent
               - else
                 %span.badge.bg-secondary No Recipient
+              - if can_edit_dn
+                - if @delivery_note.emailable?
+                  %button.btn.btn-sm.btn-warning{"data-action" => "click->generic-email-preview#open"}
+                    Send E-Mail
+                - else
+                  %span{data: { 'bs-toggle': 'tooltip' }, title: 'No contact is configured to receive this delivery note. Add a contact on the customer with "Delivery Notes" enabled.'}
+                    %button.btn.btn-sm.btn-warning{disabled: true}
+                      Send E-Mail
         - if @delivery_note.invoice
           .row.mb-2
             .col-sm-4
@@ -144,19 +152,10 @@
                     - else
                       = simple_format(line.description)
 
-.email-delivery_note-preview-wrapper{"data-controller" => "generic-email-preview", "data-generic-email-preview-preview-url-value" => preview_email_delivery_note_path(@delivery_note), "data-generic-email-preview-raw-preview-url-value" => preview_email_raw_delivery_note_path(@delivery_note), "data-generic-email-preview-send-url-value" => send_email_delivery_note_path(@delivery_note)}
   = action_buttons_wrapper do
     = action_button 'Back', delivery_notes_path, :secondary
     - if @delivery_note.published?
       = action_button 'PDF', pdf_delivery_note_path(@delivery_note), :success, target: '_blank', data: { turbo: false }
-      - if can_edit_dn
-        - if @delivery_note.emailable?
-          %button.btn.btn-warning{"data-action" => "click->generic-email-preview#open"}
-            Send E-Mail
-        - else
-          %span{data: { 'bs-toggle': 'tooltip' }, title: 'No contact is configured to receive this delivery note. Add a contact on the customer with "Delivery Notes" enabled.'}
-            %button.btn.btn-warning{disabled: true}
-              Send E-Mail
       - if can_edit_dn && !@delivery_note.invoice
         = button_to 'Convert to Invoice', convert_to_invoice_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-info', confirm: 'Create an invoice draft from this delivery note?'
       - if can_edit_dn

--- a/app/views/delivery_notes/show.html.haml
+++ b/app/views/delivery_notes/show.html.haml
@@ -29,7 +29,7 @@
               %strong Email Status:
             .col-sm-8
               - if @delivery_note.email_sent_at
-                %span.badge.bg-success Sent #{l(@delivery_note.email_sent_at)}
+                Sent #{l(@delivery_note.email_sent_at)}
               - elsif @delivery_note.emailable?
                 %span.badge.bg-warning Unsent
               - else

--- a/app/views/delivery_notes/show.html.haml
+++ b/app/views/delivery_notes/show.html.haml
@@ -35,10 +35,10 @@
               %span.badge.bg-secondary No Recipient
             - if can_edit_dn
               - if @delivery_note.emailable?
-                %button.btn.btn-sm.btn-warning{data: {action: 'click->generic-email-preview#open'}}
+                %button.btn.btn-sm.btn-warning.ms-auto{data: {action: 'click->generic-email-preview#open'}}
                   Send E-Mail
               - else
-                %span{data: {'bs-toggle': 'tooltip'}, title: 'No contact is configured to receive this delivery note. Add a contact on the customer with "Delivery Notes" enabled.'}
+                %span.ms-auto{data: {'bs-toggle': 'tooltip'}, title: 'No contact is configured to receive this delivery note. Add a contact on the customer with "Delivery Notes" enabled.'}
                   %button.btn.btn-sm.btn-warning{disabled: true}
                     Send E-Mail
             = render 'shared/email_preview_modal', title: "Preview - Delivery Note #{@delivery_note.document_number}"

--- a/app/views/delivery_notes/show.html.haml
+++ b/app/views/delivery_notes/show.html.haml
@@ -1,19 +1,14 @@
 - can_edit_dn = can?('delivery_notes.edit')
-%div
-  .d-flex.justify-content-between.align-items-center.mb-3.flex-wrap.gap-2
-    .d-flex.align-items-center.flex-wrap.gap-2
-      %h1.h2.mb-0
-        Delivery Note
-        = @delivery_note.document_number || "Draft \##{@delivery_note.id}"
-      - if !@delivery_note.published?
-        %span.badge.bg-warning.fs-6 Draft
-      - elsif @delivery_note.email_sent_at.present?
-        %span.badge.bg-success.fs-6 Sent
-      - else
-        %span.badge.bg-success.fs-6 Booked
-    - if !@delivery_note.published && can_edit_dn
-      = action_button 'Edit', edit_delivery_note_path(@delivery_note), :primary
+- edit_action = action_button('Edit', edit_delivery_note_path(@delivery_note), permission: 'delivery_notes.edit') unless @delivery_note.published?
+= page_header("Delivery Note #{@delivery_note.document_number || "Draft ##{@delivery_note.id}"}", action: edit_action) do
+  - if !@delivery_note.published?
+    %span.badge.bg-warning.fs-6 Draft
+  - elsif @delivery_note.email_sent_at.present?
+    %span.badge.bg-success.fs-6 Sent
+  - else
+    %span.badge.bg-success.fs-6 Booked
 
+%div
   .document-header.row.mb-2
     .col-md-6
       .document-details
@@ -153,7 +148,7 @@
   = action_buttons_wrapper do
     = action_button 'Back', delivery_notes_path, :secondary
     - if @delivery_note.published?
-      = action_button 'PDF', pdf_delivery_note_path(@delivery_note), :success, { target: '_blank', data: { turbo: false } }
+      = action_button 'PDF', pdf_delivery_note_path(@delivery_note), :success, target: '_blank', data: { turbo: false }
       - if can_edit_dn
         - if @delivery_note.emailable?
           %button.btn.btn-warning{"data-action" => "click->generic-email-preview#open"}
@@ -167,7 +162,7 @@
       - if can_edit_dn
         = button_to 'Unpublish', unpublish_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-outline-secondary', confirm: 'Are you sure you want to revert this delivery note to draft status?'
     - else
-      = action_button 'Preview', preview_delivery_note_path(@delivery_note), :info, { target: '_blank', data: { turbo: false } }
+      = action_button 'Preview', preview_delivery_note_path(@delivery_note), :info, target: '_blank', data: { turbo: false }
       - if can_edit_dn
         = button_to 'Publish', publish_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-warning'
         = destroy_link(@delivery_note, "Are you sure you want to delete delivery note \"#{@delivery_note.document_number || "##{@delivery_note.id}"}\"?")

--- a/app/views/delivery_notes/show.html.haml
+++ b/app/views/delivery_notes/show.html.haml
@@ -22,6 +22,36 @@
           %strong Customer:
         .col-sm-8
           = link_to @delivery_note.customer.name, @delivery_note.customer
+      - if @delivery_note.project_id.present?
+        .row.mb-2
+          .col-sm-4
+            %strong Project:
+          .col-sm-8
+            - if @delivery_note.project
+              = link_to @delivery_note.project.display_name, @delivery_note.project
+            - else
+              %em (Project ##{@delivery_note.project_id} - not found)
+      - if @delivery_note.cust_order.present?
+        .row.mb-2
+          .col-sm-4
+            %strong Order No:
+          .col-sm-8
+            = @delivery_note.cust_order
+      - if @delivery_note.cust_reference.present?
+        .row.mb-2
+          .col-sm-4
+            %strong Reference:
+          .col-sm-8
+            = @delivery_note.cust_reference
+
+  .col-md-6
+    .document-details
+      - if @delivery_note.delivery_timeframe.present?
+        .row.mb-2
+          .col-sm-4
+            %strong Delivery Period:
+          .col-sm-8
+            = @delivery_note.delivery_timeframe
       - if @delivery_note.published?
         .row.mb-2
           .col-sm-4
@@ -52,36 +82,6 @@
               %span.badge.bg-success.ms-2 Booked
             - else
               %span.badge.bg-warning.ms-2 Draft
-
-  .col-md-6
-    .document-details
-      - if @delivery_note.project_id.present?
-        .row.mb-2
-          .col-sm-4
-            %strong Project:
-          .col-sm-8
-            - if @delivery_note.project
-              = link_to @delivery_note.project.display_name, @delivery_note.project
-            - else
-              %em (Project ##{@delivery_note.project_id} - not found)
-      - if @delivery_note.cust_reference.present?
-        .row.mb-2
-          .col-sm-4
-            %strong Reference:
-          .col-sm-8
-            = @delivery_note.cust_reference
-      - if @delivery_note.cust_order.present?
-        .row.mb-2
-          .col-sm-4
-            %strong Order No:
-          .col-sm-8
-            = @delivery_note.cust_order
-      - if @delivery_note.delivery_timeframe.present?
-        .row.mb-2
-          .col-sm-4
-            %strong Delivery Period:
-          .col-sm-8
-            = @delivery_note.delivery_timeframe
 
 
 - if @delivery_note.published?

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,5 +1,3 @@
-%h1.page-header
-  Editing group
-  = @group.name
+= page_header("Editing group #{@group.name}")
 
 = render 'form'

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -1,4 +1,4 @@
-= page_header_with_new_button('Groups', new_group_path)
+= page_header('Groups', action: action_button('+ New', new_group_path, :info))
 
 %p.text-muted
   Groups bundle system-level permissions. A user inherits all permissions of every group they belong to.

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,3 +1,3 @@
-%h1.page-header New group
+= page_header('New group')
 
 = render 'form'

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -1,4 +1,4 @@
-= page_header_with_edit_button("Group \"#{@group.name}\"", edit_group_path(@group))
+= page_header("Group \"#{@group.name}\"", action: action_button('Edit', edit_group_path(@group)))
 
 .row
   .col-md-8

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -1,4 +1,4 @@
-%h1.page-header Business Dashboard
+= page_header('Business Dashboard')
 
 .row
   .col-md-8

--- a/app/views/invoices/book.html.haml
+++ b/app/views/invoices/book.html.haml
@@ -1,4 +1,4 @@
-%h1.page-header Book invoice
+= page_header('Book invoice')
 
 Document Number:
 = @invoice.document_number

--- a/app/views/invoices/edit.html.haml
+++ b/app/views/invoices/edit.html.haml
@@ -1,3 +1,3 @@
-%h1.page-header Editing invoice draft
+= page_header('Editing invoice draft')
 
 = render 'form'

--- a/app/views/invoices/index.html.haml
+++ b/app/views/invoices/index.html.haml
@@ -1,4 +1,4 @@
-= page_header_with_new_button('Listing invoices', new_invoice_path, permission: 'invoices.edit')
+= page_header('Listing invoices', action: action_button('+ New', new_invoice_path, :info, permission: 'invoices.edit'))
 
 
 .bulk-select-container{data: { controller: 'bulk-select' }}

--- a/app/views/invoices/index.html.haml
+++ b/app/views/invoices/index.html.haml
@@ -89,7 +89,7 @@
           %td
             - if invoice.published?
               - if invoice.paid?
-                %span.badge.bg-success Paid #{l(invoice.paid_at)}
+                = l(invoice.paid_at.to_date)
               - elsif invoice.overdue?
                 %span.badge.bg-danger Overdue
               - else

--- a/app/views/invoices/new.html.haml
+++ b/app/views/invoices/new.html.haml
@@ -1,3 +1,3 @@
-%h1.page-header New invoice
+= page_header('New invoice')
 
 = render 'form'

--- a/app/views/invoices/show.html.haml
+++ b/app/views/invoices/show.html.haml
@@ -82,10 +82,10 @@
               %span.badge.bg-secondary No Recipient
             - if can_edit_invoice && @invoice.attachment
               - if @invoice.emailable?
-                %button.btn.btn-sm.btn-warning{data: {action: 'click->generic-email-preview#open'}}
+                %button.btn.btn-sm.btn-warning.ms-auto{data: {action: 'click->generic-email-preview#open'}}
                   Send E-Mail
               - else
-                %span{data: {'bs-toggle': 'tooltip'}, title: 'No contact is configured to receive this invoice. Add a contact on the customer, or enable Automated E-Mail.'}
+                %span.ms-auto{data: {'bs-toggle': 'tooltip'}, title: 'No contact is configured to receive this invoice. Add a contact on the customer, or enable Automated E-Mail.'}
                   %button.btn.btn-sm.btn-warning{disabled: true}
                     Send E-Mail
             = render 'shared/email_preview_modal', title: "Preview - Invoice #{@invoice.document_number}"

--- a/app/views/invoices/show.html.haml
+++ b/app/views/invoices/show.html.haml
@@ -76,7 +76,7 @@
               %strong Email Status:
             .col-sm-8
               - if @invoice.email_sent_at
-                %span.badge.bg-success Sent #{l(@invoice.email_sent_at)}
+                Sent #{l(@invoice.email_sent_at)}
               - elsif @invoice.emailable?
                 %span.badge.bg-warning Unsent
               - else
@@ -87,7 +87,7 @@
               %strong Payment Status:
             .col-sm-8
               - if @invoice.paid?
-                %span.badge.bg-success Paid #{l(@invoice.paid_at)}
+                Paid #{l(@invoice.paid_at.to_date)}
               - elsif @invoice.overdue?
                 %span.badge.bg-danger Overdue
               - else

--- a/app/views/invoices/show.html.haml
+++ b/app/views/invoices/show.html.haml
@@ -1,27 +1,22 @@
 - can_edit_invoice = can?('invoices.edit')
-%div
-  .d-flex.justify-content-between.align-items-center.mb-3.flex-wrap.gap-2
-    .d-flex.align-items-center.flex-wrap.gap-2
-      %h1.h2.mb-0
-        Invoice
-        = @invoice.document_number || "Draft \##{@invoice.id}"
-      - if !@invoice.published?
-        %span.badge.bg-warning.fs-6 Draft
-      - else
-        - sent = @invoice.email_sent_at.present?
-        - paid = @invoice.paid?
-        - overdue = @invoice.overdue?
-        - unless sent || paid || overdue
-          %span.badge.bg-success.fs-6 Booked
-        - if paid
-          %span.badge.bg-success.fs-6 Paid
-        - elsif overdue
-          %span.badge.bg-danger.fs-6 Overdue
-        - if sent
-          %span.badge.bg-success.fs-6 Sent
-    - if !@invoice.published && can_edit_invoice
-      = action_button 'Edit', edit_invoice_path(@invoice), :primary
+- edit_action = action_button('Edit', edit_invoice_path(@invoice), permission: 'invoices.edit') unless @invoice.published?
+= page_header("Invoice #{@invoice.document_number || "Draft ##{@invoice.id}"}", action: edit_action) do
+  - if !@invoice.published?
+    %span.badge.bg-warning.fs-6 Draft
+  - else
+    - sent = @invoice.email_sent_at.present?
+    - paid = @invoice.paid?
+    - overdue = @invoice.overdue?
+    - unless sent || paid || overdue
+      %span.badge.bg-success.fs-6 Booked
+    - if paid
+      %span.badge.bg-success.fs-6 Paid
+    - elsif overdue
+      %span.badge.bg-danger.fs-6 Overdue
+    - if sent
+      %span.badge.bg-success.fs-6 Sent
 
+%div
   .document-header.row.mb-2
     .col-md-6
       .document-details
@@ -181,7 +176,7 @@
   = action_buttons_wrapper do
     = action_button 'Back', invoices_path, :secondary
     - if @invoice.attachment
-      = action_button 'PDF', @invoice.attachment, :success, { target: '_blank', data: { turbo: false } }
+      = action_button 'PDF', @invoice.attachment, :success, target: '_blank', data: { turbo: false }
       - if can_edit_invoice
         - if @invoice.emailable?
           %button.btn.btn-warning{"data-action" => "click->generic-email-preview#open"}
@@ -191,7 +186,7 @@
             %button.btn.btn-warning{disabled: true}
               Send E-Mail
     - else
-      = action_button 'Preview', preview_invoice_path(@invoice), :info, { target: '_blank', data: { turbo: false } }
+      = action_button 'Preview', preview_invoice_path(@invoice), :info, target: '_blank', data: { turbo: false }
     - if !@invoice.published && can_edit_invoice
       = button_to 'Test Booking', book_invoice_path(@invoice, :save => false), method: :post, class: 'btn btn-warning'
       = destroy_link(@invoice, "Are you sure you want to delete invoice \"#{@invoice.document_number || "##{@invoice.id}"}\"?")

--- a/app/views/invoices/show.html.haml
+++ b/app/views/invoices/show.html.haml
@@ -93,13 +93,20 @@
         .row.mb-2
           .col-sm-4
             %strong Payment Status:
-          .col-sm-8
+          .col-sm-8.d-flex.align-items-center.gap-2{data: {controller: 'modal'}}
             - if @invoice.paid?
               Paid #{l(@invoice.paid_at.to_date)}
             - elsif @invoice.overdue?
               %span.badge.bg-danger Overdue
             - else
               %span.badge.bg-warning Unpaid
+            - if can_edit_invoice
+              - if @invoice.paid?
+                = button_to 'Mark Unpaid', mark_unpaid_invoice_path(@invoice), method: :post, class: 'btn btn-sm btn-outline-secondary ms-auto', data: { 'turbo-confirm': 'Mark this invoice as unpaid?' }
+              - else
+                %button.btn.btn-sm.btn-success.ms-auto{data: {action: 'click->modal#open'}}
+                  Mark Paid…
+                = render 'shared/mark_paid_modal', invoice: @invoice
 
       - if @invoice.delivery_note
         .row.mb-2
@@ -189,10 +196,3 @@
   - if !@invoice.published && can_edit_invoice
     = button_to 'Test Booking', book_invoice_path(@invoice, :save => false), method: :post, class: 'btn btn-warning'
     = destroy_link(@invoice, "Are you sure you want to delete invoice \"#{@invoice.document_number || "##{@invoice.id}"}\"?")
-  - if @invoice.published? && can_edit_invoice
-    - if @invoice.paid?
-      = button_to 'Mark Unpaid', mark_unpaid_invoice_path(@invoice), method: :post, class: 'btn btn-outline-secondary', data: { 'turbo-confirm': 'Mark this invoice as unpaid?' }
-    - else
-      = form_with url: mark_paid_invoice_path(@invoice), method: :post, local: true, class: 'd-flex gap-1 align-items-center' do |f|
-        = f.date_field :paid_at, value: Date.current, class: 'form-control form-control-sm w-auto'
-        = f.submit 'Mark Paid', class: 'btn btn-success'

--- a/app/views/invoices/show.html.haml
+++ b/app/views/invoices/show.html.haml
@@ -16,200 +16,183 @@
     - if sent
       %span.badge.bg-success.fs-6 Sent
 
-.email-preview-wrapper{"data-controller" => "generic-email-preview", "data-generic-email-preview-preview-url-value" => preview_email_invoice_path(@invoice), "data-generic-email-preview-raw-preview-url-value" => preview_email_raw_invoice_path(@invoice), "data-generic-email-preview-send-url-value" => send_email_invoice_path(@invoice)}
-  .document-header.row.mb-2
-    .col-md-6
-      .document-details
-        - if @invoice.date
-          .row.mb-2
-            .col-sm-4
-              %strong Date:
-            .col-sm-8
-              = l(@invoice.date)
+.document-header.row.mb-2
+  .col-md-6
+    .document-details
+      - if @invoice.date
         .row.mb-2
           .col-sm-4
-            %strong Customer:
+            %strong Date:
           .col-sm-8
-            = link_to(@invoice.customer_name || @invoice.customer.name, @invoice.customer)
-        - if @invoice.project_id.present?
-          .row.mb-2
-            .col-sm-4
-              %strong Project:
-            .col-sm-8
-              - if @invoice.project
-                = link_to @invoice.project.display_name, @invoice.project
-              - else
-                %em (Project ##{@invoice.project_id} - not found)
-        - if @invoice.cust_order.present?
-          .row.mb-2
-            .col-sm-4
-              %strong Order No:
-            .col-sm-8
-              = @invoice.cust_order
-        - if @invoice.cust_reference.present?
-          .row.mb-2
-            .col-sm-4
-              %strong Reference:
-            .col-sm-8
-              = @invoice.cust_reference
+            = l(@invoice.date)
+      .row.mb-2
+        .col-sm-4
+          %strong Customer:
+        .col-sm-8
+          = link_to(@invoice.customer_name || @invoice.customer.name, @invoice.customer)
+      - if @invoice.project_id.present?
+        .row.mb-2
+          .col-sm-4
+            %strong Project:
+          .col-sm-8
+            - if @invoice.project
+              = link_to @invoice.project.display_name, @invoice.project
+            - else
+              %em (Project ##{@invoice.project_id} - not found)
+      - if @invoice.cust_order.present?
+        .row.mb-2
+          .col-sm-4
+            %strong Order No:
+          .col-sm-8
+            = @invoice.cust_order
+      - if @invoice.cust_reference.present?
+        .row.mb-2
+          .col-sm-4
+            %strong Reference:
+          .col-sm-8
+            = @invoice.cust_reference
 
-    .col-md-6
-      .document-details
-        - if @invoice.due_date
-          .row.mb-2
-            .col-sm-4
-              %strong Due Date:
-            .col-sm-8
-              = l(@invoice.due_date)
-              %span.text-muted.ms-2 (#{@invoice.payment_terms_days} days net)
-        - else
-          .row.mb-2
-            .col-sm-4
-              %strong Payment Terms:
-            .col-sm-8
-              = @invoice.payment_terms_days
-              days net
-
-        - if @invoice.published?
-          .row.mb-2
-            .col-sm-4
-              %strong Email Status:
-            .col-sm-8.d-flex.align-items-center.gap-2
-              - if @invoice.email_sent_at
-                Sent #{l(@invoice.email_sent_at)}
-              - elsif @invoice.emailable?
-                %span.badge.bg-warning Unsent
-              - else
-                %span.badge.bg-secondary No Recipient
-              - if can_edit_invoice && @invoice.attachment
-                - if @invoice.emailable?
-                  %button.btn.btn-sm.btn-warning{"data-action" => "click->generic-email-preview#open"}
-                    Send E-Mail
-                - else
-                  %span{data: { 'bs-toggle': 'tooltip' }, title: 'No contact is configured to receive this invoice. Add a contact on the customer, or enable Automated E-Mail.'}
-                    %button.btn.btn-sm.btn-warning{disabled: true}
-                      Send E-Mail
-
-          .row.mb-2
-            .col-sm-4
-              %strong Payment Status:
-            .col-sm-8
-              - if @invoice.paid?
-                Paid #{l(@invoice.paid_at.to_date)}
-              - elsif @invoice.overdue?
-                %span.badge.bg-danger Overdue
-              - else
-                %span.badge.bg-warning Unpaid
-
-        - if @invoice.delivery_note
-          .row.mb-2
-            .col-sm-4
-              %strong Source:
-            .col-sm-8
-              = link_to "Delivery Note #{@invoice.delivery_note.document_number || "##{@invoice.delivery_note.id}"}", @invoice.delivery_note
-
-  - if @invoice.prelude.present?
-    .document-prelude.mb-4
-      .card
-        .card-body
-          = simple_format(@invoice.prelude)
-
-  .document-lines.mb-2
-    %table.table.table-bordered.document-lines-table
-      %thead
-        %tr
-          %th.col-description Description
-          %th.text-end.col-quantity Quantity
-          %th.text-end.col-rate Rate
-          %th.text-center.col-tax-class Tax Class
-          %th.text-end.col-amount Amount
-      %tbody
-        - @invoice.invoice_lines.each do |line|
-          - case line.type
-          - when 'item'
-            %tr
-              %td
-                %strong= line.title
-                - if line.description.present?
-                  %br
-                  %small.text-muted= simple_format(line.description, {}, wrapper_tag: 'span')
-              %td.text-end
-                = number_with_precision(line.quantity, precision: 2, strip_insignificant_zeros: true)
-              %td.text-end
-                = format_currency(line.rate)
-              %td.text-center
-                %small= line.sales_tax_product_class&.name
-              %td.text-end
-                %strong= format_currency(line.amount || (line.quantity * line.rate))
-          - when 'subheading'
-            %tr
-              %td.fw-bold.table-secondary.document-section-row{colspan: 5}
-                = line.title
-          - when 'text', 'plain'
-            %tr
-              %td.document-text-row{colspan: 5}
-                - if line.title.present?
-                  %div= line.title
-                - if line.description.present?
-                  %div.text-muted.document-line-comment
-                    - if line.type == 'plain'
-                      %pre.mb-0.font-monospace.text-pre-wrap= line.description
-                    - else
-                      = simple_format(line.description)
-
-  .document-summary
-    .row.justify-content-end
-      .col-md-4
-        %table.table.table-sm
-          %tbody
-            %tr
-              %td.text-end
-                %strong Sum Net:
-              %td.text-end
-                %strong= format_currency(@invoice.sum_net)
-            - if @invoice.invoice_tax_classes.any?
-              - @invoice.invoice_tax_classes.each do |tax_class|
-                %tr
-                  %td.text-end
-                    Tax (#{tax_class.rate}%):
-                  %td.text-end
-                    = format_currency(tax_class.value)
-            %tr.table-dark
-              %td.text-end
-                %strong Sum Total:
-              %td.text-end
-                %strong= format_currency(@invoice.sum_total)
-
-  = action_buttons_wrapper do
-    = action_button 'Back', invoices_path, :secondary
-    - if @invoice.attachment
-      = action_button 'PDF', @invoice.attachment, :success, target: '_blank', data: { turbo: false }
-    - else
-      = action_button 'Preview', preview_invoice_path(@invoice), :info, target: '_blank', data: { turbo: false }
-    - if !@invoice.published && can_edit_invoice
-      = button_to 'Test Booking', book_invoice_path(@invoice, :save => false), method: :post, class: 'btn btn-warning'
-      = destroy_link(@invoice, "Are you sure you want to delete invoice \"#{@invoice.document_number || "##{@invoice.id}"}\"?")
-    - if @invoice.published? && can_edit_invoice
-      - if @invoice.paid?
-        = button_to 'Mark Unpaid', mark_unpaid_invoice_path(@invoice), method: :post, class: 'btn btn-outline-secondary', data: { 'turbo-confirm': 'Mark this invoice as unpaid?' }
+  .col-md-6
+    .document-details
+      - if @invoice.due_date
+        .row.mb-2
+          .col-sm-4
+            %strong Due Date:
+          .col-sm-8
+            = l(@invoice.due_date)
+            %span.text-muted.ms-2 (#{@invoice.payment_terms_days} days net)
       - else
-        = form_with url: mark_paid_invoice_path(@invoice), method: :post, local: true, class: 'd-flex gap-1 align-items-center' do |f|
-          = f.date_field :paid_at, value: Date.current, class: 'form-control form-control-sm w-auto'
-          = f.submit 'Mark Paid', class: 'btn btn-success'
+        .row.mb-2
+          .col-sm-4
+            %strong Payment Terms:
+          .col-sm-8
+            = @invoice.payment_terms_days
+            days net
 
-  // Email Preview Modal
-  .modal.d-none.email-preview-modal{"data-generic-email-preview-target" => "modal", "data-action" => "click->generic-email-preview#closeOnBackdrop keydown@window->generic-email-preview#closeOnEscape"}
-    .modal-dialog.modal-lg.email-preview-modal-dialog
-      .modal-content
-        .modal-header.d-flex.justify-content-between.align-items-center
-          %h5.modal-title.mb-0
-            Preview - Invoice #{@invoice.document_number}
-          .d-flex.align-items-center
-            %button.btn.btn-success.btn-sm.me-2{"data-action" => "click->generic-email-preview#sendEmail"}
-              Send E-Mail
-            %button.btn-close{"type" => "button", "data-action" => "click->generic-email-preview#close", "aria-label" => "Close"}
-        .modal-body{"data-generic-email-preview-target" => "content"}
-          .text-center
-            .spinner-border{"role" => "status"}
-              %span.visually-hidden Loading...
-            %p Loading email preview...
+      - if @invoice.published?
+        .row.mb-2
+          .col-sm-4
+            %strong Email Status:
+          .col-sm-8.d-flex.align-items-center.gap-2{data: email_preview_data(@invoice)}
+            - if @invoice.email_sent_at
+              Sent #{l(@invoice.email_sent_at)}
+            - elsif @invoice.emailable?
+              %span.badge.bg-warning Unsent
+            - else
+              %span.badge.bg-secondary No Recipient
+            - if can_edit_invoice && @invoice.attachment
+              - if @invoice.emailable?
+                %button.btn.btn-sm.btn-warning{data: {action: 'click->generic-email-preview#open'}}
+                  Send E-Mail
+              - else
+                %span{data: {'bs-toggle': 'tooltip'}, title: 'No contact is configured to receive this invoice. Add a contact on the customer, or enable Automated E-Mail.'}
+                  %button.btn.btn-sm.btn-warning{disabled: true}
+                    Send E-Mail
+            = render 'shared/email_preview_modal', title: "Preview - Invoice #{@invoice.document_number}"
+
+        .row.mb-2
+          .col-sm-4
+            %strong Payment Status:
+          .col-sm-8
+            - if @invoice.paid?
+              Paid #{l(@invoice.paid_at.to_date)}
+            - elsif @invoice.overdue?
+              %span.badge.bg-danger Overdue
+            - else
+              %span.badge.bg-warning Unpaid
+
+      - if @invoice.delivery_note
+        .row.mb-2
+          .col-sm-4
+            %strong Source:
+          .col-sm-8
+            = link_to "Delivery Note #{@invoice.delivery_note.document_number || "##{@invoice.delivery_note.id}"}", @invoice.delivery_note
+
+- if @invoice.prelude.present?
+  .document-prelude.mb-4
+    .card
+      .card-body
+        = simple_format(@invoice.prelude)
+
+.document-lines.mb-2
+  %table.table.table-bordered.document-lines-table
+    %thead
+      %tr
+        %th.col-description Description
+        %th.text-end.col-quantity Quantity
+        %th.text-end.col-rate Rate
+        %th.text-center.col-tax-class Tax Class
+        %th.text-end.col-amount Amount
+    %tbody
+      - @invoice.invoice_lines.each do |line|
+        - case line.type
+        - when 'item'
+          %tr
+            %td
+              %strong= line.title
+              - if line.description.present?
+                %br
+                %small.text-muted= simple_format(line.description, {}, wrapper_tag: 'span')
+            %td.text-end
+              = number_with_precision(line.quantity, precision: 2, strip_insignificant_zeros: true)
+            %td.text-end
+              = format_currency(line.rate)
+            %td.text-center
+              %small= line.sales_tax_product_class&.name
+            %td.text-end
+              %strong= format_currency(line.amount || (line.quantity * line.rate))
+        - when 'subheading'
+          %tr
+            %td.fw-bold.table-secondary.document-section-row{colspan: 5}
+              = line.title
+        - when 'text', 'plain'
+          %tr
+            %td.document-text-row{colspan: 5}
+              - if line.title.present?
+                %div= line.title
+              - if line.description.present?
+                %div.text-muted.document-line-comment
+                  - if line.type == 'plain'
+                    %pre.mb-0.font-monospace.text-pre-wrap= line.description
+                  - else
+                    = simple_format(line.description)
+
+.document-summary
+  .row.justify-content-end
+    .col-md-4
+      %table.table.table-sm
+        %tbody
+          %tr
+            %td.text-end
+              %strong Sum Net:
+            %td.text-end
+              %strong= format_currency(@invoice.sum_net)
+          - if @invoice.invoice_tax_classes.any?
+            - @invoice.invoice_tax_classes.each do |tax_class|
+              %tr
+                %td.text-end
+                  Tax (#{tax_class.rate}%):
+                %td.text-end
+                  = format_currency(tax_class.value)
+          %tr.table-dark
+            %td.text-end
+              %strong Sum Total:
+            %td.text-end
+              %strong= format_currency(@invoice.sum_total)
+
+= action_buttons_wrapper do
+  = action_button 'Back', invoices_path, :secondary
+  - if @invoice.attachment
+    = action_button 'PDF', @invoice.attachment, :success, target: '_blank', data: { turbo: false }
+  - else
+    = action_button 'Preview', preview_invoice_path(@invoice), :info, target: '_blank', data: { turbo: false }
+  - if !@invoice.published && can_edit_invoice
+    = button_to 'Test Booking', book_invoice_path(@invoice, :save => false), method: :post, class: 'btn btn-warning'
+    = destroy_link(@invoice, "Are you sure you want to delete invoice \"#{@invoice.document_number || "##{@invoice.id}"}\"?")
+  - if @invoice.published? && can_edit_invoice
+    - if @invoice.paid?
+      = button_to 'Mark Unpaid', mark_unpaid_invoice_path(@invoice), method: :post, class: 'btn btn-outline-secondary', data: { 'turbo-confirm': 'Mark this invoice as unpaid?' }
+    - else
+      = form_with url: mark_paid_invoice_path(@invoice), method: :post, local: true, class: 'd-flex gap-1 align-items-center' do |f|
+        = f.date_field :paid_at, value: Date.current, class: 'form-control form-control-sm w-auto'
+        = f.submit 'Mark Paid', class: 'btn btn-success'

--- a/app/views/invoices/show.html.haml
+++ b/app/views/invoices/show.html.haml
@@ -1,14 +1,29 @@
+- can_edit_invoice = can?('invoices.edit')
 %div
-  .document-header.row.mb-2
-    .col-md-6
-      %h1.h2.mb-3
+  .d-flex.justify-content-between.align-items-center.mb-3.flex-wrap.gap-2
+    .d-flex.align-items-center.flex-wrap.gap-2
+      %h1.h2.mb-0
         Invoice
         = @invoice.document_number || "Draft \##{@invoice.id}"
-        - if not @invoice.published?
-          %span.badge.bg-warning.ms-2 Draft
-        - else
-          %span.badge.bg-success.ms-2 Booked
+      - if !@invoice.published?
+        %span.badge.bg-warning.fs-6 Draft
+      - else
+        - sent = @invoice.email_sent_at.present?
+        - paid = @invoice.paid?
+        - overdue = @invoice.overdue?
+        - unless sent || paid || overdue
+          %span.badge.bg-success.fs-6 Booked
+        - if paid
+          %span.badge.bg-success.fs-6 Paid
+        - elsif overdue
+          %span.badge.bg-danger.fs-6 Overdue
+        - if sent
+          %span.badge.bg-success.fs-6 Sent
+    - if !@invoice.published && can_edit_invoice
+      = action_button 'Edit', edit_invoice_path(@invoice), :primary
 
+  .document-header.row.mb-2
+    .col-md-6
       .document-details
         - if @invoice.date
           .row.mb-2
@@ -44,7 +59,7 @@
               = @invoice.cust_reference
 
     .col-md-6
-      .document-details.mt-md-5
+      .document-details
         - if @invoice.due_date
           .row.mb-2
             .col-sm-4
@@ -163,11 +178,8 @@
                 %strong= format_currency(@invoice.sum_total)
 
 .email-preview-wrapper{"data-controller" => "generic-email-preview", "data-generic-email-preview-preview-url-value" => preview_email_invoice_path(@invoice), "data-generic-email-preview-raw-preview-url-value" => preview_email_raw_invoice_path(@invoice), "data-generic-email-preview-send-url-value" => send_email_invoice_path(@invoice)}
-  - can_edit_invoice = can?('invoices.edit')
   = action_buttons_wrapper do
     = action_button 'Back', invoices_path, :secondary
-    - if !@invoice.published && can_edit_invoice
-      = action_button 'Edit', edit_invoice_path(@invoice), :primary
     - if @invoice.attachment
       = action_button 'PDF', @invoice.attachment, :success, { target: '_blank', data: { turbo: false } }
       - if can_edit_invoice

--- a/app/views/invoices/show.html.haml
+++ b/app/views/invoices/show.html.haml
@@ -16,7 +16,7 @@
     - if sent
       %span.badge.bg-success.fs-6 Sent
 
-%div
+.email-preview-wrapper{"data-controller" => "generic-email-preview", "data-generic-email-preview-preview-url-value" => preview_email_invoice_path(@invoice), "data-generic-email-preview-raw-preview-url-value" => preview_email_raw_invoice_path(@invoice), "data-generic-email-preview-send-url-value" => send_email_invoice_path(@invoice)}
   .document-header.row.mb-2
     .col-md-6
       .document-details
@@ -74,13 +74,21 @@
           .row.mb-2
             .col-sm-4
               %strong Email Status:
-            .col-sm-8
+            .col-sm-8.d-flex.align-items-center.gap-2
               - if @invoice.email_sent_at
                 Sent #{l(@invoice.email_sent_at)}
               - elsif @invoice.emailable?
                 %span.badge.bg-warning Unsent
               - else
                 %span.badge.bg-secondary No Recipient
+              - if can_edit_invoice && @invoice.attachment
+                - if @invoice.emailable?
+                  %button.btn.btn-sm.btn-warning{"data-action" => "click->generic-email-preview#open"}
+                    Send E-Mail
+                - else
+                  %span{data: { 'bs-toggle': 'tooltip' }, title: 'No contact is configured to receive this invoice. Add a contact on the customer, or enable Automated E-Mail.'}
+                    %button.btn.btn-sm.btn-warning{disabled: true}
+                      Send E-Mail
 
           .row.mb-2
             .col-sm-4
@@ -172,19 +180,10 @@
               %td.text-end
                 %strong= format_currency(@invoice.sum_total)
 
-.email-preview-wrapper{"data-controller" => "generic-email-preview", "data-generic-email-preview-preview-url-value" => preview_email_invoice_path(@invoice), "data-generic-email-preview-raw-preview-url-value" => preview_email_raw_invoice_path(@invoice), "data-generic-email-preview-send-url-value" => send_email_invoice_path(@invoice)}
   = action_buttons_wrapper do
     = action_button 'Back', invoices_path, :secondary
     - if @invoice.attachment
       = action_button 'PDF', @invoice.attachment, :success, target: '_blank', data: { turbo: false }
-      - if can_edit_invoice
-        - if @invoice.emailable?
-          %button.btn.btn-warning{"data-action" => "click->generic-email-preview#open"}
-            Send E-Mail
-        - else
-          %span{data: { 'bs-toggle': 'tooltip' }, title: 'No contact is configured to receive this invoice. Add a contact on the customer, or enable Automated E-Mail.'}
-            %button.btn.btn-warning{disabled: true}
-              Send E-Mail
     - else
       = action_button 'Preview', preview_invoice_path(@invoice), :info, target: '_blank', data: { turbo: false }
     - if !@invoice.published && can_edit_invoice

--- a/app/views/issuer_companies/show.html.haml
+++ b/app/views/issuer_companies/show.html.haml
@@ -1,4 +1,4 @@
-= page_header_with_edit_button('Issuer Company', edit_issuer_company_path, permission: 'issuer_company.edit')
+= page_header('Issuer Company', action: action_button('Edit', edit_issuer_company_path, permission: 'issuer_company.edit'))
 
 .row
   .col-md-6

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -1,5 +1,3 @@
-%h1.page-header
-  Editing product
-  = @product.title
+= page_header("Editing product #{@product.title}")
 
 = render 'form'

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -1,4 +1,4 @@
-= page_header_with_new_button('Listing products', new_product_path, permission: 'products.edit')
+= page_header('Listing products', action: action_button('+ New', new_product_path, :info, permission: 'products.edit'))
 
 %table.table.table-striped.table-sm
   %tr

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -1,3 +1,3 @@
-%h1.page-header New product
+= page_header('New product')
 
 = render 'form'

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -1,4 +1,4 @@
-= page_header_with_edit_button("Product \"#{@product.title}\"", edit_product_path(@product), permission: 'products.edit')
+= page_header("Product \"#{@product.title}\"", action: action_button('Edit', edit_product_path(@product), permission: 'products.edit'))
 
 .row
   .col-md-8

--- a/app/views/projects/edit.html.haml
+++ b/app/views/projects/edit.html.haml
@@ -1,3 +1,3 @@
-%h1.page-header Editing project
+= page_header('Editing project')
 
 = render 'form'

--- a/app/views/projects/index.html.haml
+++ b/app/views/projects/index.html.haml
@@ -1,4 +1,4 @@
-= page_header_with_new_button('Listing projects', new_project_path, permission: 'projects.edit')
+= page_header('Listing projects', action: action_button('+ New', new_project_path, :info, permission: 'projects.edit'))
 
 .mb-3
   .btn-toolbar.mb-3{:role=>"toolbar", "aria-label"=>"List toolbar"}

--- a/app/views/projects/index.html.haml
+++ b/app/views/projects/index.html.haml
@@ -7,10 +7,12 @@
       = link_to 'Active', projects_path(filter: 'active'), class: (params[:filter] == 'active' ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
       = link_to 'Inactive', projects_path(filter: 'inactive'), class: (params[:filter] == 'inactive' ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
 
+- show_status_column = params[:filter] == 'all'
 %table.table.table-striped.table-sm
   %tr
     %th{:width => "10%"} Matchcode
-    %th{:width => "7%"} Status
+    - if show_status_column
+      %th{:width => "7%"} Status
     %th Name
     %th Bill to customer
     %th{:width => "10%"} Team
@@ -20,9 +22,10 @@
   - @projects.each do |project|
     %tr
       %td= link_to project.matchcode, project
-      %td
-        - unless project.active?
-          %span.badge.bg-secondary Inactive
+      - if show_status_column
+        %td
+          - unless project.active?
+            %span.badge.bg-secondary Inactive
       %td= project.description
       %td= project.bill_to_customer.try(:matchcode)
       %td= project.team&.name

--- a/app/views/projects/index.html.haml
+++ b/app/views/projects/index.html.haml
@@ -21,9 +21,7 @@
     %tr
       %td= link_to project.matchcode, project
       %td
-        - if project.active?
-          %span.badge.bg-success Active
-        - else
+        - unless project.active?
           %span.badge.bg-secondary Inactive
       %td= project.description
       %td= project.bill_to_customer.try(:matchcode)

--- a/app/views/projects/new.html.haml
+++ b/app/views/projects/new.html.haml
@@ -1,3 +1,3 @@
-%h1.page-header New project
+= page_header('New project')
 
 = render 'form'

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -1,4 +1,4 @@
-= page_header_with_edit_button("Project #{@project.matchcode}", edit_project_path(@project), permission: 'projects.edit') do
+= page_header("Project #{@project.matchcode}", action: action_button('Edit', edit_project_path(@project), permission: 'projects.edit')) do
   - unless @project.active?
     %span.badge.bg-secondary.fs-6 Inactive
 

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -1,12 +1,11 @@
-= page_header_with_edit_button("Project #{@project.matchcode}", edit_project_path(@project), permission: 'projects.edit')
+= page_header_with_edit_button("Project #{@project.matchcode}", edit_project_path(@project), permission: 'projects.edit') do
+  - unless @project.active?
+    %span.badge.bg-secondary.fs-6 Inactive
 
 .row
   .col-md-8
     .card
-      .card-header.d-flex.justify-content-between.align-items-center
-        %span Project Information
-        - unless @project.active?
-          %span.badge.bg-secondary Inactive
+      .card-header Project Information
       .card-body
         .row.mb-2
           .col-sm-3

--- a/app/views/sales_tax_customer_classes/edit.html.haml
+++ b/app/views/sales_tax_customer_classes/edit.html.haml
@@ -1,3 +1,3 @@
-%h1.page-header Editing Sales Tax Customer Class
+= page_header('Editing Sales Tax Customer Class')
 
 = render 'form'

--- a/app/views/sales_tax_customer_classes/index.html.haml
+++ b/app/views/sales_tax_customer_classes/index.html.haml
@@ -1,4 +1,4 @@
-= page_header_with_new_button('Listing Sales Tax - Customer Classes', new_sales_tax_customer_class_path, permission: 'sales_tax.edit')
+= page_header('Listing Sales Tax - Customer Classes', action: action_button('+ New', new_sales_tax_customer_class_path, :info, permission: 'sales_tax.edit'))
 
 %table.table.table-striped.table-sm
   %tr

--- a/app/views/sales_tax_customer_classes/new.html.haml
+++ b/app/views/sales_tax_customer_classes/new.html.haml
@@ -1,3 +1,3 @@
-%h1.page-header New Sales Tax Customer Class
+= page_header('New Sales Tax Customer Class')
 
 = render 'form'

--- a/app/views/sales_tax_customer_classes/show.html.haml
+++ b/app/views/sales_tax_customer_classes/show.html.haml
@@ -1,3 +1,5 @@
+= page_header_with_edit_button("Customer Tax Class \"#{@sales_tax_customer_class.name}\"", edit_sales_tax_customer_class_path(@sales_tax_customer_class), permission: 'sales_tax.edit')
+
 %p
   %b Name:
   = @sales_tax_customer_class.name
@@ -9,6 +11,4 @@
   = @sales_tax_customer_class.vat_id_required? ? 'Yes' : 'No'
 
 = action_buttons_wrapper do
-  - if can?('sales_tax.edit')
-    = action_button 'Edit', edit_sales_tax_customer_class_path(@sales_tax_customer_class), :primary
   = action_button 'Back', sales_tax_customer_classes_path, :secondary

--- a/app/views/sales_tax_customer_classes/show.html.haml
+++ b/app/views/sales_tax_customer_classes/show.html.haml
@@ -1,4 +1,4 @@
-= page_header_with_edit_button("Customer Tax Class \"#{@sales_tax_customer_class.name}\"", edit_sales_tax_customer_class_path(@sales_tax_customer_class), permission: 'sales_tax.edit')
+= page_header("Customer Tax Class \"#{@sales_tax_customer_class.name}\"", action: action_button('Edit', edit_sales_tax_customer_class_path(@sales_tax_customer_class), permission: 'sales_tax.edit'))
 
 %p
   %b Name:

--- a/app/views/sales_tax_product_classes/edit.html.haml
+++ b/app/views/sales_tax_product_classes/edit.html.haml
@@ -1,3 +1,3 @@
-%h1.page-header Editing Sales Tax Product Class
+= page_header('Editing Sales Tax Product Class')
 
 = render 'form'

--- a/app/views/sales_tax_product_classes/index.html.haml
+++ b/app/views/sales_tax_product_classes/index.html.haml
@@ -1,4 +1,4 @@
-= page_header_with_new_button('Listing Sales Tax - Product Classes', new_sales_tax_product_class_path, permission: 'sales_tax.edit')
+= page_header('Listing Sales Tax - Product Classes', action: action_button('+ New', new_sales_tax_product_class_path, :info, permission: 'sales_tax.edit'))
 
 %table.table.table-striped.table-sm
   %tr

--- a/app/views/sales_tax_product_classes/new.html.haml
+++ b/app/views/sales_tax_product_classes/new.html.haml
@@ -1,3 +1,3 @@
-%h1.page-header New Sales Tax Product Class
+= page_header('New Sales Tax Product Class')
 
 = render 'form'

--- a/app/views/sales_tax_product_classes/show.html.haml
+++ b/app/views/sales_tax_product_classes/show.html.haml
@@ -1,4 +1,4 @@
-= page_header_with_edit_button("Product Tax Class \"#{@sales_tax_product_class.name}\"", edit_sales_tax_product_class_path(@sales_tax_product_class), permission: 'sales_tax.edit') do
+= page_header("Product Tax Class \"#{@sales_tax_product_class.name}\"", action: action_button('Edit', edit_sales_tax_product_class_path(@sales_tax_product_class), permission: 'sales_tax.edit')) do
   - if @sales_tax_product_class.is_default?
     %span.badge.bg-success.fs-6 Default
 

--- a/app/views/sales_tax_product_classes/show.html.haml
+++ b/app/views/sales_tax_product_classes/show.html.haml
@@ -1,17 +1,13 @@
+= page_header_with_edit_button("Product Tax Class \"#{@sales_tax_product_class.name}\"", edit_sales_tax_product_class_path(@sales_tax_product_class), permission: 'sales_tax.edit') do
+  - if @sales_tax_product_class.is_default?
+    %span.badge.bg-success.fs-6 Default
+
 %p
   %b Name:
   = @sales_tax_product_class.name
 %p
   %b Indicator code:
   = @sales_tax_product_class.indicator_code
-%p
-  %b Default:
-  - if @sales_tax_product_class.is_default?
-    %span.badge.bg-success Yes
-  - else
-    No
 
 = action_buttons_wrapper do
-  - if can?('sales_tax.edit')
-    = action_button 'Edit', edit_sales_tax_product_class_path(@sales_tax_product_class), :primary
   = action_button 'Back', sales_tax_product_classes_path, :secondary

--- a/app/views/sales_tax_rates/edit.html.haml
+++ b/app/views/sales_tax_rates/edit.html.haml
@@ -1,3 +1,3 @@
-%h1.page-header Editing Sales Tax Rate
+= page_header('Editing Sales Tax Rate')
 
 = render 'form'

--- a/app/views/sales_tax_rates/index.html.haml
+++ b/app/views/sales_tax_rates/index.html.haml
@@ -1,4 +1,4 @@
-= page_header_with_new_button('Listing Sales Tax Rates', new_sales_tax_rate_path, permission: 'sales_tax.edit')
+= page_header('Listing Sales Tax Rates', action: action_button('+ New', new_sales_tax_rate_path, :info, permission: 'sales_tax.edit'))
 
 %table.table.table-striped.table-sm
   %tr

--- a/app/views/sales_tax_rates/new.html.haml
+++ b/app/views/sales_tax_rates/new.html.haml
@@ -1,3 +1,3 @@
-%h1.page-header New Sales Tax Rate
+= page_header('New Sales Tax Rate')
 
 = render 'form'

--- a/app/views/sales_tax_rates/show.html.haml
+++ b/app/views/sales_tax_rates/show.html.haml
@@ -11,4 +11,4 @@
   = @sales_tax_rate.rate
 
 = action_buttons_wrapper do
-  = action_button 'Back', sales_tax_rate_path, :secondary
+  = action_button 'Back', sales_tax_rates_path, :secondary

--- a/app/views/sales_tax_rates/show.html.haml
+++ b/app/views/sales_tax_rates/show.html.haml
@@ -1,3 +1,5 @@
+= page_header_with_edit_button('Sales Tax Rate', edit_sales_tax_rate_path(@sales_tax_rate), permission: 'sales_tax.edit')
+
 %p
   %b Sales tax customer class:
   = @sales_tax_rate.sales_tax_customer_class_id
@@ -9,6 +11,4 @@
   = @sales_tax_rate.rate
 
 = action_buttons_wrapper do
-  - if can?('sales_tax.edit')
-    = action_button 'Edit', edit_sales_tax_rate_path(@sales_tax_rate), :primary
   = action_button 'Back', sales_tax_rate_path, :secondary

--- a/app/views/sales_tax_rates/show.html.haml
+++ b/app/views/sales_tax_rates/show.html.haml
@@ -1,4 +1,4 @@
-= page_header_with_edit_button('Sales Tax Rate', edit_sales_tax_rate_path(@sales_tax_rate), permission: 'sales_tax.edit')
+= page_header('Sales Tax Rate', action: action_button('Edit', edit_sales_tax_rate_path(@sales_tax_rate), permission: 'sales_tax.edit'))
 
 %p
   %b Sales tax customer class:

--- a/app/views/shared/_email_preview_modal.html.haml
+++ b/app/views/shared/_email_preview_modal.html.haml
@@ -1,0 +1,20 @@
+-# Shared modal for the generic-email-preview Stimulus controller.
+-# Caller must render this inside the element that carries
+-# data-controller="generic-email-preview" (see email_preview_data helper).
+-#
+-# Locals:
+-#   title - the modal heading text, e.g. "Preview - Invoice 2026-0042"
+.modal.d-none.email-preview-modal{data: {'generic-email-preview-target': 'modal', action: 'click->generic-email-preview#closeOnBackdrop keydown@window->generic-email-preview#closeOnEscape'}}
+  .modal-dialog.modal-lg.email-preview-modal-dialog
+    .modal-content
+      .modal-header.d-flex.justify-content-between.align-items-center
+        %h5.modal-title.mb-0= title
+        .d-flex.align-items-center
+          %button.btn.btn-success.btn-sm.me-2{data: {action: 'click->generic-email-preview#sendEmail'}}
+            Send E-Mail
+          %button.btn-close{type: 'button', data: {action: 'click->generic-email-preview#close'}, 'aria-label': 'Close'}
+      .modal-body{data: {'generic-email-preview-target': 'content'}}
+        .text-center
+          .spinner-border{role: 'status'}
+            %span.visually-hidden Loading...
+          %p Loading email preview...

--- a/app/views/shared/_mark_paid_modal.html.haml
+++ b/app/views/shared/_mark_paid_modal.html.haml
@@ -1,0 +1,20 @@
+-# Shared modal for marking an invoice paid. Caller must render this inside
+-# the element carrying data-controller="modal".
+-#
+-# Locals:
+-#   invoice - the Invoice being marked paid
+.modal.d-none.mark-paid-modal{data: {"modal-target": "modal", action: "click->modal#closeOnBackdrop keydown@window->modal#closeOnEscape"}}
+  .modal-dialog.mark-paid-modal-dialog
+    .modal-content
+      .modal-header.d-flex.justify-content-between.align-items-center
+        %h5.modal-title.mb-0 Mark invoice paid
+        %button.btn-close{type: "button", data: {action: "click->modal#close"}, "aria-label": "Close"}
+      .modal-body
+        = form_with url: mark_paid_invoice_path(invoice), method: :post, local: true do |f|
+          .mb-3
+            = f.label :paid_at, "Paid on", class: "form-label"
+            = f.date_field :paid_at, value: Date.current, class: "form-control", required: true
+          .text-end
+            %button.btn.btn-secondary.me-2{type: "button", data: {action: "click->modal#close"}}
+              Cancel
+            = f.submit "Mark Paid", class: "btn btn-success"

--- a/app/views/teams/edit.html.haml
+++ b/app/views/teams/edit.html.haml
@@ -1,5 +1,3 @@
-%h1.page-header
-  Editing team
-  = @team.name
+= page_header("Editing team #{@team.name}")
 
 = render 'form'

--- a/app/views/teams/index.html.haml
+++ b/app/views/teams/index.html.haml
@@ -1,4 +1,4 @@
-= page_header_with_new_button('Teams', new_team_path)
+= page_header('Teams', action: action_button('+ New', new_team_path, :info))
 
 %p.text-muted
   Teams control which customers and projects a user can see. Every customer and project belongs to exactly one team.

--- a/app/views/teams/new.html.haml
+++ b/app/views/teams/new.html.haml
@@ -1,3 +1,3 @@
-%h1.page-header New team
+= page_header('New team')
 
 = render 'form'

--- a/app/views/teams/show.html.haml
+++ b/app/views/teams/show.html.haml
@@ -1,4 +1,4 @@
-= page_header_with_edit_button("Team \"#{@team.name}\"", edit_team_path(@team))
+= page_header("Team \"#{@team.name}\"", action: action_button('Edit', edit_team_path(@team)))
 
 .row
   .col-md-8

--- a/app/views/user_invites/index.html.haml
+++ b/app/views/user_invites/index.html.haml
@@ -1,6 +1,6 @@
 - content_for :title, 'Invites'
 
-= page_header_with_new_button('Invites', new_user_invite_path)
+= page_header('Invites', action: action_button('+ New', new_user_invite_path, :info))
 
 %table.table.table-striped.table-sm
   %thead

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,8 +1,6 @@
 - content_for :title, 'Users'
 
-.d-flex.justify-content-between.align-items-center.mb-3
-  %h1.page-header.mb-0 Users
-  = link_to '+ Invite user', new_user_invite_path, class: 'btn btn-info'
+= page_header('Users', action: action_button('+ Invite user', new_user_invite_path, :info))
 
 %table.table.table-striped.table-sm
   %thead

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -18,8 +18,6 @@
         %td
           - if user.blocked?
             %span.badge.bg-danger Blocked
-          - else
-            %span.badge.bg-success Active
         %td= l(user.created_at)
         %td= list_action_link('View', user_path(user), :show)
 

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,7 +1,6 @@
 - content_for :title, "User #{@user.username}"
 
-.d-flex.align-items-center.flex-wrap.gap-2.mb-3
-  %h1.page-header.mb-0= @user.username
+= page_header(@user.username) do
   - if @user.blocked?
     %span.badge.bg-danger.fs-6 Blocked
   - if @user.id == current_user.id

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,14 +1,11 @@
 - content_for :title, "User #{@user.username}"
 
-.d-flex.justify-content-between.align-items-center.mb-3
-  .d-flex.align-items-center.gap-2
-    %h1.page-header.mb-0= @user.username
-    - if @user.id == current_user.id
-      %span.badge.bg-info.fs-6 This is you
+.d-flex.align-items-center.flex-wrap.gap-2.mb-3
+  %h1.page-header.mb-0= @user.username
   - if @user.blocked?
     %span.badge.bg-danger.fs-6 Blocked
-  - else
-    %span.badge.bg-success.fs-6 Active
+  - if @user.id == current_user.id
+    %span.badge.bg-info.fs-6 This is you
 
 .row
   .col-md-6

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -814,13 +814,84 @@ if Rails.env.development?
     delivery_note_de.update!(published: true, document_number: 'LN20250001')
   end
 
+  # Delivery note that has been converted to an invoice. Pairs with the
+  # API-DEV-2025-Q1 draft invoice above (same customer/project), so the
+  # Invoice link on the dn detail page and the Source link on the invoice
+  # detail page both render.
+  unless DeliveryNote.exists?(customer: export_company, project: api_project)
+    converted_dn = DeliveryNote.create!(
+      customer: export_company,
+      project: api_project,
+      cust_reference: 'API-DEV-2025-Q1',
+      cust_order: 'PO-API-5589',
+      prelude: 'Delivery of completed API development work — phases 1 through 3',
+      date: 3.days.ago.to_date,
+      delivery_start_date: 6.weeks.ago.to_date,
+      delivery_end_date: 3.days.ago.to_date,
+      published: false
+    )
+
+    converted_dn.delivery_note_lines.create!(
+      type: 'subheading',
+      title: 'Phase 1: Setup and Planning',
+      position: 1
+    )
+
+    converted_dn.delivery_note_lines.create!(
+      type: 'item',
+      title: 'Repository, CI/CD, and API design',
+      description: 'Project scaffolding, OpenAPI specification, deployment pipelines',
+      quantity: 1,
+      position: 2
+    )
+
+    converted_dn.delivery_note_lines.create!(
+      type: 'subheading',
+      title: 'Phase 2: Core Development',
+      position: 3
+    )
+
+    converted_dn.delivery_note_lines.create!(
+      type: 'item',
+      title: 'Authentication and CRUD endpoints',
+      description: 'JWT, role-based access, validation, error handling',
+      quantity: 1,
+      position: 4
+    )
+
+    converted_dn.delivery_note_lines.create!(
+      type: 'subheading',
+      title: 'Phase 3: Integration and Testing',
+      position: 5
+    )
+
+    converted_dn.delivery_note_lines.create!(
+      type: 'item',
+      title: 'Integration tests and project handover',
+      description: 'End-to-end tests, third-party integrations, delivery coordination',
+      quantity: 1,
+      position: 6
+    )
+
+    converted_dn.delivery_note_lines.create!(
+      type: 'text',
+      title: 'All deliverables accepted by the client.',
+      position: 7
+    )
+
+    converted_dn.update!(published: true, document_number: 'LN20250002')
+
+    api_invoice = Invoice.find_by(customer: export_company, project: api_project, cust_reference: 'API-DEV-2025-Q1')
+    converted_dn.update!(invoice: api_invoice) if api_invoice
+  end
+
   # Update document number sequence for delivery notes
   dn_delivery = DocumentNumber.find_by_code('delivery_note')
   if dn_delivery && dn_delivery.last_date.nil?
     # Initialize the sequence with the seeded delivery note numbers
-    dn_delivery.last_date = 5.days.ago.to_date
-    dn_delivery.sequence = 1 # Next number after LN20250001 would be LN20250002
-    dn_delivery.last_number = 'LN20250001'
+    dn_delivery.last_date = 3.days.ago.to_date
+    dn_delivery.sequence = 2 # Next number after LN20250002 would be LN20250003
+    dn_delivery.last_number = 'LN20250002'
     dn_delivery.save!
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -174,6 +174,23 @@ if Rails.env.development?
     customer.team = default_team
   end
 
+  # Former customer, kept for historical invoice references but no longer
+  # billable. Demonstrates the Inactive state in the UI.
+  Customer.find_or_create_by(matchcode: 'OLDCLIENT') do |customer|
+    customer.name = 'Old Client GmbH'
+    customer.address = <<~ADDRESS.strip
+      Hauptstraße 1
+      1010 Wien
+      Austria
+    ADDRESS
+    customer.vat_id = 'ATU99999999'
+    customer.notes = 'Engagement ended 2024'
+    customer.sales_tax_customer_class = eu_class
+    customer.language = german
+    customer.team = default_team
+    customer.active = false
+  end
+
   # Sample projects
   webapp_project = Project.find_or_create_by(matchcode: 'WEBAPP') do |project|
     project.description = 'Web Application Development'
@@ -223,6 +240,15 @@ if Rails.env.development?
     project.description = 'Migration 2026'
     project.bill_to_customer = good_company
     project.team = default_team
+  end
+
+  # Discontinued reusable project, kept for historical reference. Demonstrates
+  # the Inactive state.
+  Project.find_or_create_by(matchcode: 'LEGACY') do |project|
+    project.description = 'Legacy System (decommissioned)'
+    project.bill_to_customer = nil
+    project.team = default_team
+    project.active = false
   end
 
   # Customer contacts.

--- a/test/controllers/customers_controller_test.rb
+++ b/test/controllers/customers_controller_test.rb
@@ -136,14 +136,15 @@ class CustomersControllerTest < ActionDispatch::IntegrationTest
   test "active customer shows no inactive badge on show page" do
     get customer_url(@customer)
     assert_response :success
-    assert_select ".card-header .badge", count: 0
+    assert_select ".page-header ~ .badge", count: 0
+    assert_select ".badge", text: "Inactive", count: 0
   end
 
   test "inactive customer shows inactive badge on show page" do
     @customer.update!(active: false)
     get customer_url(@customer)
     assert_response :success
-    assert_select ".card-header .badge.bg-secondary", text: "Inactive"
+    assert_select ".badge.bg-secondary", text: "Inactive"
   end
 
   test "should allow updating customer active status" do

--- a/test/controllers/invoices_controller_paid_test.rb
+++ b/test/controllers/invoices_controller_paid_test.rb
@@ -80,9 +80,10 @@ class InvoicesControllerPaidTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select ".badge.bg-warning", text: "Unpaid"
-    assert_select "form[action=\"#{mark_paid_invoice_path(invoice)}\"]"
-    assert_select "input[type='date'][name='paid_at']"
-    assert_select 'input[type="submit"][value="Mark Paid"]'
+    assert_select "button", text: /Mark Paid/
+    assert_select ".mark-paid-modal form[action=?]", mark_paid_invoice_path(invoice)
+    assert_select ".mark-paid-modal input[type='date'][name='paid_at']"
+    assert_select ".mark-paid-modal input[type='submit'][value='Mark Paid']"
   end
 
   test "show page exposes paid status with mark unpaid button when paid" do
@@ -93,7 +94,8 @@ class InvoicesControllerPaidTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select ".badge.bg-success", text: /Paid/
-    assert_select "form[action=\"#{mark_unpaid_invoice_path(invoice)}\"]"
+    assert_select "form[action=?]", mark_unpaid_invoice_path(invoice)
+    assert_select "form[action=?] button[type='submit']", mark_unpaid_invoice_path(invoice), text: "Mark Unpaid"
   end
 
   test "show page does not show payment status for draft invoices" do

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -37,14 +37,14 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
   test "should show project" do
     get project_url(@project)
     assert_response :success
-    assert_select ".card-header .badge", count: 0
+    assert_select ".badge", text: "Inactive", count: 0
   end
 
   test "should show inactive badge on project page" do
     @project.update!(active: false)
     get project_url(@project)
     assert_response :success
-    assert_select ".card-header .badge.bg-secondary", text: "Inactive"
+    assert_select ".badge.bg-secondary", text: "Inactive"
   end
 
   test "should get new" do

--- a/test/system/email_preview_test.rb
+++ b/test/system/email_preview_test.rb
@@ -9,7 +9,7 @@ class EmailPreviewTest < ApplicationSystemTestCase
   test "email preview URLs use correct paths for subdirectory deployment" do
     visit invoice_path(@invoice)
 
-    email_wrapper = find(".email-preview-wrapper")
+    email_wrapper = find("[data-controller='generic-email-preview']")
 
     preview_url = email_wrapper["data-generic-email-preview-preview-url-value"]
     raw_preview_url = email_wrapper["data-generic-email-preview-raw-preview-url-value"]
@@ -63,7 +63,7 @@ class EmailPreviewTest < ApplicationSystemTestCase
   test "delivery note email preview URLs use correct paths for subdirectory deployment" do
     visit delivery_note_path(@delivery_note)
 
-    email_wrapper = find(".email-delivery_note-preview-wrapper")
+    email_wrapper = find("[data-controller='generic-email-preview']")
 
     preview_url = email_wrapper["data-generic-email-preview-preview-url-value"]
     raw_preview_url = email_wrapper["data-generic-email-preview-raw-preview-url-value"]

--- a/test/system/invoice_mark_paid_test.rb
+++ b/test/system/invoice_mark_paid_test.rb
@@ -1,0 +1,63 @@
+require "application_system_test_case"
+
+class InvoiceMarkPaidTest < ApplicationSystemTestCase
+  setup do
+    @invoice = invoices(:published_invoice)
+  end
+
+  test "mark paid via inline modal on unpaid invoice" do
+    @invoice.update!(paid_at: nil)
+
+    visit invoice_path(@invoice)
+
+    # The trigger lives in the Payment Status row, not the bottom action row.
+    # Modal starts hidden via d-none.
+    assert_selector ".mark-paid-modal", visible: :hidden
+    click_on "Mark Paid…"
+
+    # Modal opens (d-none removed).
+    assert_selector ".mark-paid-modal", visible: :visible
+
+    within ".mark-paid-modal" do
+      fill_in "paid_at", with: Date.current.strftime("%Y-%m-%d")
+      click_on "Mark Paid"
+    end
+
+    # Redirect back to show page with the invoice now marked paid.
+    assert_text(/Paid/)
+    # No "Unpaid" badge (the bare word "Unpaid" still appears inside the
+    # "Mark Unpaid" button that's now rendered).
+    assert_no_selector ".badge.bg-warning", text: "Unpaid"
+    assert_equal Date.current, @invoice.reload.paid_at.to_date
+  end
+
+  test "mark unpaid via inline button on paid invoice" do
+    @invoice.update!(paid_at: Date.current)
+
+    visit invoice_path(@invoice)
+
+    accept_confirm do
+      click_on "Mark Unpaid"
+    end
+
+    assert_text "Unpaid", wait: 5
+    assert_nil @invoice.reload.paid_at
+  end
+
+  test "cancel button closes the mark paid modal" do
+    @invoice.update!(paid_at: nil)
+
+    visit invoice_path(@invoice)
+
+    click_on "Mark Paid…"
+    assert_selector ".mark-paid-modal", visible: :visible
+
+    within ".mark-paid-modal" do
+      click_on "Cancel"
+    end
+
+    assert_selector ".mark-paid-modal", visible: :hidden
+    assert_text "Unpaid"
+    assert_nil @invoice.reload.paid_at
+  end
+end


### PR DESCRIPTION
## Summary

Sweeps the show pages (and adjacent areas) into a consistent visual language: a single parameterized header helper, deviation-only status badges, plain-text rendering for healthy data, and contextual actions inline with the rows they belong to.

**Header helper**
- Replaces `page_header_with_new_button` / `page_header_with_edit_button` with one `page_header(title, action:, &status_block)`.
- `action_button` gains `permission:` (returns `nil` when denied; `page_header` treats `nil` as no action area) and explicit `target:` / `data:` named params instead of a positional options hash.
- All 22 raw `%h1.page-header` usages (new/edit/book pages, dashboard) move onto the helper. Invoice and delivery-note bespoke headers fold in too (H1 size shifts from `.h2` to default `.page-header`).

**Status badge convention** (documented in `CLAUDE.md` "UI Framework"/"Status Badges")
- Only render the deviation: Inactive (customers/projects), Blocked (users) — Active gets no badge.
- On invoices, the lifecycle cluster (`Draft → Booked → Paid/Overdue + Sent`) suppresses "Booked" once a more specific state applies.
- In detail-grid rows and list columns, healthy data (Paid date, Sent timestamp) renders as plain text; only problem states (Unpaid, Unsent, Overdue, No Recipient) keep their badges.
- Status column on customers/projects index hides entirely when filtered to a single state.

**Inline row actions on invoice / delivery-note show pages**
- Send E-Mail button moves from the bottom action row into the Email Status row (`btn-sm`, `ms-auto`, right-aligned). Same modal, now triggered inline.
- Mark Paid / Mark Unpaid move from the bottom action row into the Payment Status row. Mark Paid opens a new modal containing the date field (preserves layout); Mark Unpaid is a one-click inline confirm.
- Email-preview wrapper div eliminated — the Stimulus controller now lives on the existing `col-sm-8` of the status row via a new `email_preview_data(resource)` helper. Modal extracted to `app/views/shared/_email_preview_modal`.
- New `ModalController` Stimulus base class holds the `open` / `close` / `closeOnBackdrop` / `closeOnEscape` toggle logic; `GenericEmailPreviewController` now extends it.
- `CLAUDE.md` clarifies that Bootstrap's JS is not bundled — only Stimulus.

**Other**
- Bug fix: `sales_tax_rates/show` Back button targeted `sales_tax_rate_path` (singular, requires `:id`); fixed to `sales_tax_rates_path`.
- Delivery-note detail page columns reworked to mirror invoice layout (identity-side left, timing/workflow/cross-document right).
- Seeds: added an inactive customer (`OLDCLIENT`) + inactive project (`LEGACY`) for UI demo, plus a converted delivery note (`LN20250002`) linked to the existing API-DEV draft invoice.

## Test plan
- [x] Full test suite green: 621 runs / 2318 assertions / 0 failures
- [x] `pre-commit run --all-files` clean
- [x] New system test `invoice_mark_paid_test.rb`: open modal → submit → paid; inline Mark Unpaid reverts; Cancel closes modal without submit
- [x] Existing system test `email_preview_test.rb` updated for the dropped wrapper class; still green (4 tests / 34 assertions)
- [ ] Manual: visit a draft invoice (no published row), a booked unpaid invoice (Mark Paid modal renders), a paid invoice (inline Mark Unpaid button), a customer with auto-email disabled and no contacts (disabled Send button + tooltip)
- [ ] Manual: customer/project list with Active/Inactive/All filters — Status column hidden except on All
- [ ] Manual: inactive customer (`OLDCLIENT`) and inactive project (`LEGACY`) from seeds render with Inactive badge; converted delivery note (`LN20250002`) shows Invoice link

🤖 Generated with [Claude Code](https://claude.com/claude-code)