### PR TITLE
Fix duplicate InvoiceTaxClass rows on initial invoice save

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -202,7 +202,6 @@ private
 
   def line_addedremoved(changed_item)
     self.update_sums
-    self.save
   end
 
   def set_defaults
@@ -220,8 +219,11 @@ private
     # Get required product class IDs from customer tax rates
     required_product_class_ids = customer_sales_tax_rates.map(&:sales_tax_product_class_id).to_set
 
-    # Get existing tax classes
-    existing_tax_classes = self.invoice_tax_classes.includes(:sales_tax_product_class).index_by(&:sales_tax_product_class_id)
+    # Walk the in-memory association target so we also see records built
+    # earlier in this same save cycle (e.g. via accepts_nested_attributes_for).
+    # Going through .includes here would issue a fresh SQL load and miss
+    # those, which previously caused duplicate InvoiceTaxClass rows.
+    existing_tax_classes = self.invoice_tax_classes.to_a.index_by(&:sales_tax_product_class_id)
 
     # Update/create required tax classes
     customer_sales_tax_rates.each do |cst|
@@ -235,7 +237,9 @@ private
         itc.rate = cst.rate
         itc.net = 0
         itc.total = 0
-        itc.save
+        # Only persist when the parent is already saved; otherwise the parent's
+        # autosave will write this record (with the correct FK) when it saves.
+        itc.save if itc.persisted?
       else
         # Create new tax class
         self.invoice_tax_classes << InvoiceTaxClass.new(

--- a/db/migrate/20260526172314_dedupe_and_index_invoice_tax_classes.rb
+++ b/db/migrate/20260526172314_dedupe_and_index_invoice_tax_classes.rb
@@ -1,0 +1,26 @@
+class DedupeAndIndexInvoiceTaxClasses < ActiveRecord::Migration[8.0]
+  # Pre-fix, setup_tax_classes could create duplicate (invoice_id,
+  # sales_tax_product_class_id) rows during the initial save of a draft
+  # invoice. Remove any existing duplicates (keep the lowest id per group),
+  # then enforce uniqueness so it can't recur.
+  def up
+    execute <<~SQL
+      DELETE FROM invoice_tax_classes
+      WHERE id NOT IN (
+        SELECT MIN(id)
+        FROM invoice_tax_classes
+        GROUP BY invoice_id, sales_tax_product_class_id
+      )
+    SQL
+
+    add_index :invoice_tax_classes,
+              [ :invoice_id, :sales_tax_product_class_id ],
+              unique: true,
+              name: "index_invoice_tax_classes_on_invoice_and_product_class"
+  end
+
+  def down
+    remove_index :invoice_tax_classes,
+                 name: "index_invoice_tax_classes_on_invoice_and_product_class"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_25_140000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_26_172314) do
   create_table "attachments", force: :cascade do |t|
     t.string "content_type"
     t.datetime "created_at", null: false
@@ -169,6 +169,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_25_140000) do
     t.decimal "total"
     t.datetime "updated_at", null: false
     t.decimal "value"
+    t.index ["invoice_id", "sales_tax_product_class_id"], name: "index_invoice_tax_classes_on_invoice_and_product_class", unique: true
   end
 
   create_table "invoices", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -346,6 +346,8 @@ if Rails.env.development?
       rate: 95.00,
       sales_tax_product_class: standard_product
     )
+
+    invoice.save!
   end
 
   unless Invoice.exists?(customer: local_company, project: consulting_project)
@@ -401,6 +403,8 @@ if Rails.env.development?
       sales_tax_product_class: standard_product,
       position: 3
     )
+
+    license_invoice.save!
   end
 
   # Sample invoice using a reusable project
@@ -518,6 +522,8 @@ if Rails.env.development?
       sales_tax_product_class: standard_product,
       position: 11
     )
+
+    complex_invoice.save!
   end
 
   # Booked invoice for 2025

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -631,27 +631,11 @@ if Rails.env.development?
       position: 3
     )
 
-    # Properly initialize the invoice by running the booking process
-    last_year_invoice.save! # Trigger before_save callbacks
+    # save! triggers before_save :update_sums, which auto-creates the
+    # InvoiceTaxClass row for the customer's product class and computes
+    # sum_net / sum_total from the lines.
+    last_year_invoice.save!
     last_year_invoice.due_date = last_year_invoice.date + last_year_invoice.customer.payment_terms_days.days
-
-    # Calculate and set tax classes for the booked invoice
-    net_amount = (24.0 * 95.00) + (16.0 * 95.00) + (8.0 * 85.00)
-    tax_amount = net_amount * 0.20 # 20% for national customer
-
-    last_year_invoice.invoice_tax_classes.create!(
-      sales_tax_product_class: standard_product,
-      name: standard_product.name,
-      indicator_code: standard_product.indicator_code,
-      rate: 20.0, # National customer has 20% VAT
-      net: net_amount,
-      value: tax_amount,
-      total: net_amount + tax_amount
-    )
-
-    # Set invoice totals and generate token, then publish
-    last_year_invoice.sum_net = net_amount
-    last_year_invoice.sum_total = net_amount + tax_amount # National customer with 20% VAT
     last_year_invoice.token = SecureRandom.base58(13)
     last_year_invoice.published = true # Now publish the invoice
 

--- a/test/controllers/invoices_controller_test.rb
+++ b/test/controllers/invoices_controller_test.rb
@@ -157,15 +157,11 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
     )
     invoice.update!(published: true)
 
-    # Add tax classes
-    tax_class = invoice.invoice_tax_classes.build(
-      sales_tax_product_class: sales_tax_product_classes(:standard),
-      rate: 19.0,
-      value: 38.0,
-      total: 238.0
-    )
-    tax_class.net = 200.0
-    tax_class.save!
+    # update_sums auto-created the tax class for the standard product class
+    # when the invoice was first saved. Populate it with the totals this
+    # test wants to render.
+    tax_class = invoice.invoice_tax_classes.find_by!(sales_tax_product_class: sales_tax_product_classes(:standard))
+    tax_class.update!(rate: 19.0, value: 38.0, total: 238.0, net: 200.0)
 
     get invoice_url(invoice)
     assert_response :success

--- a/test/unit/invoice_tax_calculator_test.rb
+++ b/test/unit/invoice_tax_calculator_test.rb
@@ -122,17 +122,35 @@ class InvoiceTaxCalculationTest < ActiveSupport::TestCase
     assert_not @invoice.has_items?
   end
 
-  test "clears existing tax classes before calculation" do
-    # Create some existing tax classes
-    @invoice.invoice_tax_classes.create!(
-      sales_tax_product_class: @product_class,
-      name: "Old Tax",
-      rate: 10.0,
-      net: 100.0,
-      total: 110.0
-    )
+  test "does not duplicate tax classes when saving an invoice with multiple item lines" do
+    # Building several item lines via nested attributes used to recurse through
+    # line_addedremoved → update_sums → setup_tax_classes on an unsaved parent
+    # and create one InvoiceTaxClass row per line for the same product class.
+    invoice = Invoice.new(customer: @customer, project: @project, cust_reference: "DUP-TEST")
+    invoice.invoice_lines_attributes = [
+      { type: "item", title: "L1", quantity: 1, rate: 100, sales_tax_product_class_id: @product_class.id },
+      { type: "item", title: "L2", quantity: 2, rate: 50,  sales_tax_product_class_id: @product_class.id },
+      { type: "item", title: "L3", quantity: 1, rate: 75,  sales_tax_product_class_id: @product_class.id }
+    ]
+    invoice.save!
+    invoice.reload
 
-    # Add an item line
+    assert_equal 1, invoice.invoice_tax_classes.size
+    itc = invoice.invoice_tax_classes.first
+    assert_equal @product_class.id, itc.sales_tax_product_class_id
+    assert_equal 275.0, itc.net # 100 + 100 + 75
+    assert_equal 275.0, invoice.sum_net
+  end
+
+  test "refreshes stale name/rate on existing tax classes when product class changes" do
+    # @invoice was auto-set-up with one InvoiceTaxClass for @product_class.
+    # Simulate the product class metadata changing after the invoice exists,
+    # and verify the next update_sums pass picks up the new values.
+    itc = @invoice.invoice_tax_classes.find_by!(sales_tax_product_class: @product_class)
+    original_rate = itc.rate
+
+    @product_class.update!(name: "Renamed Goods", indicator_code: "RNM")
+
     @invoice.invoice_lines.create!(
       type: "item",
       title: "Product",
@@ -141,14 +159,13 @@ class InvoiceTaxCalculationTest < ActiveSupport::TestCase
       sales_tax_product_class: @product_class,
       position: 1
     )
+    @invoice.save!
 
-    @invoice.save
-
-    # Old tax classes should be gone, new ones created
-    @invoice.reload
-    tax_classes = @invoice.invoice_tax_classes
-    assert_not_empty tax_classes
-    assert_not tax_classes.any? { |tc| tc.name == "Old Tax" }
+    itc.reload
+    assert_equal "Renamed Goods", itc.name
+    assert_equal "RNM", itc.indicator_code
+    assert_equal original_rate, itc.rate
+    assert_equal 50.0, itc.net
   end
 
   test "generates detailed log output" do


### PR DESCRIPTION
## Summary
- `setup_tax_classes` looked up existing rows through `.includes(...).index_by(...)`, which issues a fresh SQL load and misses records built earlier in the same save cycle. Combined with `line_addedremoved` calling both `update_sums` and `self.save`, the second pass on an unsaved invoice didn't see the in-memory tax class and built another one — producing two `invoice_tax_classes` rows per product class on first save (visible as e.g. two "Standard Goods 20%" rows on the invoice detail page).
- Walks the loaded association target instead, and drops the inner `self.save` in `line_addedremoved` so the recursive `update_sums` no longer happens.
- Adds a unique index on `(invoice_id, sales_tax_product_class_id)`. The migration removes any existing duplicates first (keeps the lowest id per group); for unpublished invoices the next save will refresh sums automatically.
- Adjusts seeds that previously relied on the implicit save from `line_addedremoved` to call `invoice.save!` explicitly, and reworks two pre-existing tests that set up scenarios by inserting a duplicate row (which the unique index now rejects). Adds a regression test exercising the nested-attributes create path.

## Audit query for production
Run this before applying the migration to see which invoices currently have duplicates:

```sql
SELECT
  itc.invoice_id,
  i.document_number,
  i.published,
  itc.sales_tax_product_class_id,
  COUNT(*)                                                AS duplicate_count,
  STRING_AGG(itc.id::text,  ', ' ORDER BY itc.id)         AS row_ids,
  STRING_AGG(itc.net::text, ', ' ORDER BY itc.id)         AS nets,
  i.sum_net
FROM invoice_tax_classes itc
JOIN invoices i ON i.id = itc.invoice_id
GROUP BY itc.invoice_id, i.document_number, i.published,
         itc.sales_tax_product_class_id, i.sum_net
HAVING COUNT(*) > 1
ORDER BY i.published DESC, itc.invoice_id;
```

Inspect published rows manually — if their `nets` differ, the kept row's net may not match what the booked PDF reflects.

## Test plan
- [x] `bundle exec rails test` — 622 runs, 0 failures
- [x] New regression test `test_does_not_duplicate_tax_classes_when_saving_an_invoice_with_multiple_item_lines` passes
- [x] Reworked refresh-metadata test passes
- [x] Migration applies cleanly on a dev DB with pre-existing duplicates (invoice 6 in seeds)
- [ ] Smoke check on a copy of production: run the audit query, then apply the migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)