### PR TITLE
Use hardcoded token literal for last_year_invoice seed

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -636,7 +636,7 @@ if Rails.env.development?
     # sum_net / sum_total from the lines.
     last_year_invoice.save!
     last_year_invoice.due_date = last_year_invoice.date + last_year_invoice.customer.payment_terms_days.days
-    last_year_invoice.token = SecureRandom.base58(13)
+    last_year_invoice.token = 'lastyr2024tkn'
     last_year_invoice.published = true # Now publish the invoice
 
     # Create a sample PDF attachment


### PR DESCRIPTION
## Summary
- The two booked-invoice seeds were inconsistent: `current_year_invoice` used a hardcoded literal `'hxrwlxsspur'` while `last_year_invoice` called `SecureRandom.base58(13)`. Match the existing literal pattern so only `InvoiceBooker` does real token generation.
- Removes the only non-production caller of `SecureRandom.base58` for invoice tokens; the seeded token stays stable across reseeds, matching its sibling.

## Test plan
- [x] `bundle exec rails db:drop db:create db:migrate db:seed` runs cleanly
- [x] Both seeded booked invoices have their expected tokens
- [x] `bundle exec rails test` — 622 runs, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)