### PR TITLE
Mark Standard Goods as the default product tax class in seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -63,6 +63,7 @@ end
 # Sales tax product classes
 standard_product = SalesTaxProductClass.find_or_create_by(name: 'Standard Goods') do |stpc|
   stpc.indicator_code = 'STD'
+  stpc.is_default = true
 end
 
 # Sales tax rates (connecting customer and product classes)


### PR DESCRIPTION
## Summary
- Sets `is_default: true` on the `Standard Goods` `SalesTaxProductClass` in `db/seeds.rb` so `SalesTaxProductClass.default` resolves to it on freshly seeded databases.
- Only takes effect on first creation (`find_or_create_by` runs the block only when inserting). Existing databases need a manual update or `db:reset`.

## Test plan
- [ ] `bundle exec rails db:reset` on a dev DB and confirm `SalesTaxProductClass.default&.name == "Standard Goods"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)