### PR TITLE
Right-align Mark Unpaid in the Payment Status row

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,13 @@ For testing against PostgreSQL (matches production environment):
 - **Hide the status column entirely when a list is filtered to a single state.** On the customers and projects lists, the Status column is only rendered when the filter is "All"; when filtered to Active or Inactive the column would be redundant (every row identical or empty), so the header and cells are omitted.
 - Use `fs-6` when a badge sits inline with an H1, otherwise it inflates to heading size.
 
+### Status-row Action Buttons
+- On document show pages, "act on this status" controls (Send E-Mail, Mark Paid…, Mark Unpaid) sit inline at the right edge of their status row's `col-sm-8`, separating the status text/badge on the left from the action on the right. The row container is `.col-sm-8.d-flex.align-items-center.gap-2`.
+- `ms-auto` must go on the actual flex child:
+  - Direct `%button` → put `ms-auto` on the button.
+  - Disabled-tooltip variant (a `%span` wrapping a disabled `%button`) → put `ms-auto` on the wrapping `%span`.
+  - `button_to` → the generated `<form class="button_to">` is the flex child, so `ms-auto` on the inner button has no effect. Pass it on the form instead: `button_to ..., form: { class: 'button_to ms-auto' }` (keep the `button_to` class — `bootstrap_and_overrides.css.scss` styles it).
+
 ## Development Best Practices
 
 ### Running rails

--- a/app/views/invoices/show.html.haml
+++ b/app/views/invoices/show.html.haml
@@ -102,7 +102,9 @@
               %span.badge.bg-warning Unpaid
             - if can_edit_invoice
               - if @invoice.paid?
-                = button_to 'Mark Unpaid', mark_unpaid_invoice_path(@invoice), method: :post, class: 'btn btn-sm btn-outline-secondary ms-auto', data: { 'turbo-confirm': 'Mark this invoice as unpaid?' }
+                -# button_to wraps the button in a form; the form is the flex
+                -# child, so ms-auto must go on the form to push it right.
+                = button_to 'Mark Unpaid', mark_unpaid_invoice_path(@invoice), method: :post, class: 'btn btn-sm btn-outline-secondary', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Mark this invoice as unpaid?' }
               - else
                 %button.btn.btn-sm.btn-success.ms-auto{data: {action: 'click->modal#open'}}
                   Mark Paid…


### PR DESCRIPTION
## Summary
- `button_to` wraps the submit button in `<form class=\"button_to\">`, so the form is the flex child of `.col-sm-8.d-flex` — `ms-auto` on the inner button has no effect on the form's position. Pass it via `form: { class: 'button_to ms-auto' }` instead.
- Mark Paid… (plain `%button`) was already right-aligned; only Mark Unpaid (the `button_to` case) needed fixing.
- Adds a system test that asserts both action buttons sit at the right edge of the Payment Status row via `getBoundingClientRect`.
- Documents the pattern in `CLAUDE.md` under a new **Status-row Action Buttons** subsection, including the `button_to` gotcha.

## Test plan
- [ ] `bundle exec rails test test/system/invoice_payment_button_layout_test.rb` passes
- [ ] `bundle exec rails test test/system/invoice_mark_paid_test.rb test/controllers/invoices_controller_paid_test.rb` still passes
- [ ] On a paid invoice show page, "Mark Unpaid" sits at the right edge of the Payment Status row, aligned with "Send E-Mail" above
- [ ] On an unpaid invoice show page, "Mark Paid…" remains at the right edge (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)