### PR TITLE
Add breadcrumb navigation, drop bottom Back buttons

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,11 @@ For testing against PostgreSQL (matches production environment):
 - To render a `datetime` column as date-only (e.g. `email_sent_at` in compact list rows), call `l(value.to_date)` — `l` on a `Time`/`DateTime` produces the time format.
 
 ### UI Helper Methods
+- `breadcrumbs(*items)` - Bootstrap breadcrumb row, rendered above `page_header` on every page except the dashboard (`root_path`) and `/account/*`. Each item is either `[label, path]` (link) or a plain label (non-link). The last item is always rendered as the active crumb with `aria-current="page"`, even if a path was supplied.
+  - Top-level resources start with the navbar label linked to its index: `['Customers', customers_path]`, `['Projects', projects_path]`, `['Delivery Notes', delivery_notes_path]`, `['Invoices', invoices_path]`.
+  - Configuration resources start with a non-link `'Configuration'` crumb (the dropdown has no destination) followed by the resource's navbar label, e.g. `breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], 'Edit'`.
+  - On edit pages append `'Edit'` as the active crumb; on new pages append `'New'`. On show pages the resource's identifier (matchcode / document number / name) is the active crumb.
+  - The bottom `action_buttons_wrapper` no longer contains a `Back` button — the breadcrumb is the navigation anchor. `action_buttons_wrapper` is reserved for workflow verbs (PDF, Send, Publish, Delete, Mark Paid, etc.). `cancel_button(resource)` on edit/new forms stays — it pairs with Submit, not navigation.
 - `page_header(title, action: nil, &status_block)` - The page-header row. Title left, optional inline status badges via block, optional right-aligned action. Build the action with `action_button(...)` — when its permission check fails it returns nil, which `page_header` renders as no action area.
 - `action_button(text, path, type = :primary, permission: nil, target: nil, data: nil)` - Styled buttons (primary, secondary, success, info, warning, danger). Returns `nil` when `permission:` is given and the current user lacks it.
 - `action_buttons_wrapper` - Container for the bottom-of-page workflow action row (Back, PDF, Send E-Mail, Publish, Delete, etc.).

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -32,6 +32,34 @@ module ApplicationHelper
     end
   end
 
+  # Renders a Bootstrap breadcrumb row above the page header.
+  #
+  # Items are either:
+  #   - [label, path]  → rendered as a link
+  #   - label          → rendered as plain text (non-link)
+  # The last item is always rendered as the active (current) crumb, regardless
+  # of whether a path was given.
+  #
+  #   = breadcrumbs ['Customers', customers_path], @customer.display_name
+  #   = breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], 'Edit'
+  def breadcrumbs(*items)
+    content_tag :nav, "aria-label": "breadcrumb" do
+      content_tag :ol, class: "breadcrumb border-bottom py-1 small mb-2" do
+        last_index = items.length - 1
+        items.each_with_index.map { |item, i|
+          label, path = Array(item)
+          if i == last_index
+            content_tag(:li, label, class: "breadcrumb-item active", "aria-current": "page")
+          elsif path
+            content_tag(:li, link_to(label, path), class: "breadcrumb-item")
+          else
+            content_tag(:li, label, class: "breadcrumb-item")
+          end
+        }.join.html_safe
+      end
+    end
+  end
+
   # Renders the page header row: title (left), optional inline status badges
   # (left, via the block), optional action button (right).
   #

--- a/app/views/customers/edit.html.haml
+++ b/app/views/customers/edit.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs ['Customers', customers_path], [@customer.matchcode, customer_path(@customer)], 'Edit'
 = page_header('Editing customer')
 
 = render 'form'

--- a/app/views/customers/index.html.haml
+++ b/app/views/customers/index.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs 'Customers'
 = page_header('Listing customers', action: action_button('+ New', new_customer_path, :info, permission: 'customers.edit'))
 
 .mb-3

--- a/app/views/customers/new.html.haml
+++ b/app/views/customers/new.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs ['Customers', customers_path], 'New'
 = page_header('New customer')
 
 = render 'form'

--- a/app/views/customers/show.html.haml
+++ b/app/views/customers/show.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs ['Customers', customers_path], @customer.matchcode
 = page_header("Customer #{@customer.matchcode}", action: action_button('Edit', edit_customer_path(@customer), permission: 'customers.edit')) do
   - unless @customer.active?
     %span.badge.bg-secondary.fs-6 Inactive
@@ -120,7 +121,6 @@
           = simple_format(@customer.notes)
 
 = action_buttons_wrapper do
-  = action_button 'Back', customers_path, :secondary
   - if can?('invoices.view')
     = action_button 'Invoices', invoices_path(customer_id: @customer.id, year: 'all'), :info, data: { turbo_prefetch: false }
   - if can?('delivery_notes.view')

--- a/app/views/delivery_notes/edit.html.haml
+++ b/app/views/delivery_notes/edit.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs ['Delivery Notes', delivery_notes_path], [(@delivery_note.document_number || "Draft ##{@delivery_note.id}"), delivery_note_path(@delivery_note)], 'Edit'
 = page_header('Editing delivery note draft')
 
 = render 'form'

--- a/app/views/delivery_notes/index.html.haml
+++ b/app/views/delivery_notes/index.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs 'Delivery Notes'
 = page_header('Listing delivery notes', action: action_button('+ New', new_delivery_note_path, :info, permission: 'delivery_notes.edit'))
 
 

--- a/app/views/delivery_notes/new.html.haml
+++ b/app/views/delivery_notes/new.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs ['Delivery Notes', delivery_notes_path], 'New'
 = page_header('New delivery note')
 
 = render 'form'

--- a/app/views/delivery_notes/show.html.haml
+++ b/app/views/delivery_notes/show.html.haml
@@ -1,5 +1,6 @@
 - can_edit_dn = can?('delivery_notes.edit')
 - edit_action = action_button('Edit', edit_delivery_note_path(@delivery_note), permission: 'delivery_notes.edit') unless @delivery_note.published?
+= breadcrumbs ['Delivery Notes', delivery_notes_path], (@delivery_note.document_number || "Draft ##{@delivery_note.id}")
 = page_header("Delivery Note #{@delivery_note.document_number || "Draft ##{@delivery_note.id}"}", action: edit_action) do
   - if !@delivery_note.published?
     %span.badge.bg-warning.fs-6 Draft
@@ -153,7 +154,6 @@
                     = simple_format(line.description)
 
 = action_buttons_wrapper do
-  = action_button 'Back', delivery_notes_path, :secondary
   - if @delivery_note.published?
     = action_button 'PDF', pdf_delivery_note_path(@delivery_note), :success, target: '_blank', data: { turbo: false }
     - if can_edit_dn && !@delivery_note.invoice

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs 'Configuration', ['Groups', groups_path], [@group.name, group_path(@group)], 'Edit'
 = page_header("Editing group #{@group.name}")
 
 = render 'form'

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs 'Configuration', 'Groups'
 = page_header('Groups', action: action_button('+ New', new_group_path, :info))
 
 %p.text-muted

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs 'Configuration', ['Groups', groups_path], 'New'
 = page_header('New group')
 
 = render 'form'

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs 'Configuration', ['Groups', groups_path], @group.name
 = page_header("Group \"#{@group.name}\"", action: action_button('Edit', edit_group_path(@group)))
 
 .row
@@ -48,6 +49,3 @@
           %ul.list-unstyled.mb-0
             - @members.each do |user|
               %li= link_to(user.username, user_path(user))
-
-= action_buttons_wrapper do
-  = action_button 'Back', groups_path, :secondary

--- a/app/views/invoices/edit.html.haml
+++ b/app/views/invoices/edit.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs ['Invoices', invoices_path], [(@invoice.document_number || "Draft ##{@invoice.id}"), invoice_path(@invoice)], 'Edit'
 = page_header('Editing invoice draft')
 
 = render 'form'

--- a/app/views/invoices/index.html.haml
+++ b/app/views/invoices/index.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs 'Invoices'
 = page_header('Listing invoices', action: action_button('+ New', new_invoice_path, :info, permission: 'invoices.edit'))
 
 

--- a/app/views/invoices/new.html.haml
+++ b/app/views/invoices/new.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs ['Invoices', invoices_path], 'New'
 = page_header('New invoice')
 
 = render 'form'

--- a/app/views/invoices/show.html.haml
+++ b/app/views/invoices/show.html.haml
@@ -1,5 +1,6 @@
 - can_edit_invoice = can?('invoices.edit')
 - edit_action = action_button('Edit', edit_invoice_path(@invoice), permission: 'invoices.edit') unless @invoice.published?
+= breadcrumbs ['Invoices', invoices_path], (@invoice.document_number || "Draft ##{@invoice.id}")
 = page_header("Invoice #{@invoice.document_number || "Draft ##{@invoice.id}"}", action: edit_action) do
   - if !@invoice.published?
     %span.badge.bg-warning.fs-6 Draft
@@ -188,7 +189,6 @@
               %strong= format_currency(@invoice.sum_total)
 
 = action_buttons_wrapper do
-  = action_button 'Back', invoices_path, :secondary
   - if @invoice.attachment
     = action_button 'PDF', @invoice.attachment, :success, target: '_blank', data: { turbo: false }
   - else

--- a/app/views/issuer_companies/edit.html.haml
+++ b/app/views/issuer_companies/edit.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs 'Configuration', ['Issuer Company', issuer_company_path], 'Edit'
 = page_header('Edit Issuer Company')
 
 = form_with(model: @issuer_company, url: issuer_company_path, method: :patch, local: true, class: 'form', multipart: true) do |form|

--- a/app/views/issuer_companies/show.html.haml
+++ b/app/views/issuer_companies/show.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs 'Configuration', 'Issuer Company'
 = page_header('Issuer Company', action: action_button('Edit', edit_issuer_company_path, permission: 'issuer_company.edit'))
 
 .row

--- a/app/views/jobs_status/show.html.haml
+++ b/app/views/jobs_status/show.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs 'Configuration', 'Background Jobs'
 = page_header('Background Jobs')
 
 - if @queue_adapter != :solid_queue

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs 'Configuration', ['Product Catalog', products_path], [@product.title, product_path(@product)], 'Edit'
 = page_header("Editing product #{@product.title}")
 
 = render 'form'

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs 'Configuration', 'Product Catalog'
 = page_header('Listing products', action: action_button('+ New', new_product_path, :info, permission: 'products.edit'))
 
 %table.table.table-striped.table-sm

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs 'Configuration', ['Product Catalog', products_path], 'New'
 = page_header('New product')
 
 = render 'form'

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs 'Configuration', ['Product Catalog', products_path], @product.title
 = page_header("Product \"#{@product.title}\"", action: action_button('Edit', edit_product_path(@product), permission: 'products.edit'))
 
 .row
@@ -29,6 +30,3 @@
             %strong Sales Tax Class:
           .col-sm-9
             = @product.sales_tax_product_class.name
-
-= action_buttons_wrapper do
-  = action_button 'Back', products_path, :secondary

--- a/app/views/projects/edit.html.haml
+++ b/app/views/projects/edit.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs ['Projects', projects_path], [@project.matchcode, project_path(@project)], 'Edit'
 = page_header('Editing project')
 
 = render 'form'

--- a/app/views/projects/index.html.haml
+++ b/app/views/projects/index.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs 'Projects'
 = page_header('Listing projects', action: action_button('+ New', new_project_path, :info, permission: 'projects.edit'))
 
 .mb-3

--- a/app/views/projects/new.html.haml
+++ b/app/views/projects/new.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs ['Projects', projects_path], 'New'
 = page_header('New project')
 
 = render 'form'

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs ['Projects', projects_path], @project.matchcode
 = page_header("Project #{@project.matchcode}", action: action_button('Edit', edit_project_path(@project), permission: 'projects.edit')) do
   - unless @project.active?
     %span.badge.bg-secondary.fs-6 Inactive
@@ -35,6 +36,3 @@
             %strong Team:
           .col-sm-9
             = @project.team&.name
-
-= action_buttons_wrapper do
-  = action_button 'Back', projects_path, :secondary

--- a/app/views/sales_tax_customer_classes/edit.html.haml
+++ b/app/views/sales_tax_customer_classes/edit.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], ['Customer Tax Classes', sales_tax_customer_classes_path], [@sales_tax_customer_class.name, sales_tax_customer_class_path(@sales_tax_customer_class)], 'Edit'
 = page_header('Editing Sales Tax Customer Class')
 
 = render 'form'

--- a/app/views/sales_tax_customer_classes/index.html.haml
+++ b/app/views/sales_tax_customer_classes/index.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], 'Customer Tax Classes'
 = page_header('Listing Sales Tax - Customer Classes', action: action_button('+ New', new_sales_tax_customer_class_path, :info, permission: 'sales_tax.edit'))
 
 %table.table.table-striped.table-sm

--- a/app/views/sales_tax_customer_classes/new.html.haml
+++ b/app/views/sales_tax_customer_classes/new.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], ['Customer Tax Classes', sales_tax_customer_classes_path], 'New'
 = page_header('New Sales Tax Customer Class')
 
 = render 'form'

--- a/app/views/sales_tax_customer_classes/show.html.haml
+++ b/app/views/sales_tax_customer_classes/show.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], ['Customer Tax Classes', sales_tax_customer_classes_path], @sales_tax_customer_class.name
 = page_header("Customer Tax Class \"#{@sales_tax_customer_class.name}\"", action: action_button('Edit', edit_sales_tax_customer_class_path(@sales_tax_customer_class), permission: 'sales_tax.edit'))
 
 %p
@@ -9,6 +10,3 @@
 %p
   %b VAT ID required:
   = @sales_tax_customer_class.vat_id_required? ? 'Yes' : 'No'
-
-= action_buttons_wrapper do
-  = action_button 'Back', sales_tax_customer_classes_path, :secondary

--- a/app/views/sales_tax_product_classes/edit.html.haml
+++ b/app/views/sales_tax_product_classes/edit.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], ['Product Tax Classes', sales_tax_product_classes_path], [@sales_tax_product_class.name, sales_tax_product_class_path(@sales_tax_product_class)], 'Edit'
 = page_header('Editing Sales Tax Product Class')
 
 = render 'form'

--- a/app/views/sales_tax_product_classes/index.html.haml
+++ b/app/views/sales_tax_product_classes/index.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], 'Product Tax Classes'
 = page_header('Listing Sales Tax - Product Classes', action: action_button('+ New', new_sales_tax_product_class_path, :info, permission: 'sales_tax.edit'))
 
 %table.table.table-striped.table-sm

--- a/app/views/sales_tax_product_classes/new.html.haml
+++ b/app/views/sales_tax_product_classes/new.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], ['Product Tax Classes', sales_tax_product_classes_path], 'New'
 = page_header('New Sales Tax Product Class')
 
 = render 'form'

--- a/app/views/sales_tax_product_classes/show.html.haml
+++ b/app/views/sales_tax_product_classes/show.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], ['Product Tax Classes', sales_tax_product_classes_path], @sales_tax_product_class.name
 = page_header("Product Tax Class \"#{@sales_tax_product_class.name}\"", action: action_button('Edit', edit_sales_tax_product_class_path(@sales_tax_product_class), permission: 'sales_tax.edit')) do
   - if @sales_tax_product_class.is_default?
     %span.badge.bg-success.fs-6 Default
@@ -8,6 +9,3 @@
 %p
   %b Indicator code:
   = @sales_tax_product_class.indicator_code
-
-= action_buttons_wrapper do
-  = action_button 'Back', sales_tax_product_classes_path, :secondary

--- a/app/views/sales_tax_rates/edit.html.haml
+++ b/app/views/sales_tax_rates/edit.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], [(@sales_tax_rate.sales_tax_customer_class&.name.to_s + ' / ' + @sales_tax_rate.sales_tax_product_class&.name.to_s), sales_tax_rate_path(@sales_tax_rate)], 'Edit'
 = page_header('Editing Sales Tax Rate')
 
 = render 'form'

--- a/app/views/sales_tax_rates/index.html.haml
+++ b/app/views/sales_tax_rates/index.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs 'Configuration', 'Sales Tax'
 = page_header('Listing Sales Tax Rates', action: action_button('+ New', new_sales_tax_rate_path, :info, permission: 'sales_tax.edit'))
 
 %table.table.table-striped.table-sm

--- a/app/views/sales_tax_rates/new.html.haml
+++ b/app/views/sales_tax_rates/new.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], 'New'
 = page_header('New Sales Tax Rate')
 
 = render 'form'

--- a/app/views/sales_tax_rates/show.html.haml
+++ b/app/views/sales_tax_rates/show.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], "#{@sales_tax_rate.sales_tax_customer_class&.name} / #{@sales_tax_rate.sales_tax_product_class&.name}"
 = page_header('Sales Tax Rate', action: action_button('Edit', edit_sales_tax_rate_path(@sales_tax_rate), permission: 'sales_tax.edit'))
 
 %p
@@ -9,6 +10,3 @@
 %p
   %b Rate:
   = @sales_tax_rate.rate
-
-= action_buttons_wrapper do
-  = action_button 'Back', sales_tax_rates_path, :secondary

--- a/app/views/teams/edit.html.haml
+++ b/app/views/teams/edit.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs 'Configuration', ['Teams', teams_path], [@team.name, team_path(@team)], 'Edit'
 = page_header("Editing team #{@team.name}")
 
 = render 'form'

--- a/app/views/teams/index.html.haml
+++ b/app/views/teams/index.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs 'Configuration', 'Teams'
 = page_header('Teams', action: action_button('+ New', new_team_path, :info))
 
 %p.text-muted

--- a/app/views/teams/new.html.haml
+++ b/app/views/teams/new.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs 'Configuration', ['Teams', teams_path], 'New'
 = page_header('New team')
 
 = render 'form'

--- a/app/views/teams/show.html.haml
+++ b/app/views/teams/show.html.haml
@@ -1,3 +1,4 @@
+= breadcrumbs 'Configuration', ['Teams', teams_path], @team.name
 = page_header("Team \"#{@team.name}\"", action: action_button('Edit', edit_team_path(@team)))
 
 .row
@@ -39,6 +40,3 @@
           %ul.list-unstyled.mb-0
             - @members.each do |user|
               %li= link_to(user.username, user_path(user))
-
-= action_buttons_wrapper do
-  = action_button 'Back', teams_path, :secondary

--- a/app/views/user_invites/index.html.haml
+++ b/app/views/user_invites/index.html.haml
@@ -1,5 +1,6 @@
 - content_for :title, 'Invites'
 
+= breadcrumbs 'Configuration', ['Users', users_path], 'Invites'
 = page_header('Invites', action: action_button('+ New', new_user_invite_path, :info))
 
 %table.table.table-striped.table-sm
@@ -25,6 +26,3 @@
           - else
             %span.badge.bg-warning Pending
         %td= invite.used_by_user&.username || '—'
-
-.mt-4
-  = link_to 'Back to users', users_path, class: 'btn btn-secondary'

--- a/app/views/user_invites/new.html.haml
+++ b/app/views/user_invites/new.html.haml
@@ -1,5 +1,6 @@
 - content_for :title, 'New invite'
 
+= breadcrumbs 'Configuration', ['Users', users_path], ['Invites', user_invites_path], 'New'
 = page_header('Invite a new user')
 
 %p Click the button below to generate a one-time invite link. The link is valid for 24 hours. The next page will show the URL so you can copy it.

--- a/app/views/user_invites/show_invite.html.haml
+++ b/app/views/user_invites/show_invite.html.haml
@@ -1,5 +1,6 @@
 - content_for :title, 'Invite generated'
 
+= breadcrumbs 'Configuration', ['Users', users_path], ['Invites', user_invites_path], 'Generated'
 = page_header('Invite generated')
 
 .alert.alert-info
@@ -12,5 +13,4 @@
       %code= @invite_url
 
 = action_buttons_wrapper do
-  = action_button('Back to invites', user_invites_path, :secondary)
   = action_button('Generate another', new_user_invite_path, :primary)

--- a/app/views/users/audit.html.haml
+++ b/app/views/users/audit.html.haml
@@ -1,5 +1,6 @@
 - content_for :title, "Audit log for #{@user.username}"
 
+= breadcrumbs 'Configuration', ['Users', users_path], [@user.username, user_path(@user)], 'Audit Log'
 = page_header("Audit log: #{@user.username}")
 
 %table.table.table-striped.table-sm
@@ -20,6 +21,3 @@
         %td
           %code.small= event.ip_address
         %td.small= event.metadata.is_a?(Hash) ? event.metadata.except('username').to_a.map { |k,v| "#{k}=#{v}" }.join(', ') : event.metadata.to_s
-
-.mt-4
-  = link_to 'Back to user', user_path(@user), class: 'btn btn-secondary'

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,5 +1,6 @@
 - content_for :title, 'Users'
 
+= breadcrumbs 'Configuration', 'Users'
 = page_header('Users', action: action_button('+ Invite user', new_user_invite_path, :info))
 
 %table.table.table-striped.table-sm

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,5 +1,6 @@
 - content_for :title, "User #{@user.username}"
 
+= breadcrumbs 'Configuration', ['Users', users_path], @user.username
 = page_header(@user.username) do
   - if @user.blocked?
     %span.badge.bg-danger.fs-6 Blocked
@@ -164,4 +165,3 @@
             data: { turbo_confirm: "Block #{@user.username}? All sessions will be terminated." }
 
   = action_button('View audit log', audit_user_path(@user), :secondary)
-  = action_button('Back to list', users_path, :secondary)

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -17,4 +17,62 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_equal first_call, second_call
     assert_equal "test-version", second_call
   end
+
+  test "breadcrumbs renders a nav with aria-label" do
+    html = Nokogiri::HTML.fragment(breadcrumbs([ "Customers", "/customers" ], "Acme"))
+    nav = html.at_css("nav")
+    assert_not_nil nav
+    assert_equal "breadcrumb", nav["aria-label"]
+    assert_not_nil nav.at_css("ol.breadcrumb")
+  end
+
+  test "breadcrumbs renders link items for [label, path] pairs except the last" do
+    html = Nokogiri::HTML.fragment(breadcrumbs([ "Customers", "/customers" ], "Acme"))
+    items = html.css("li.breadcrumb-item")
+    assert_equal 2, items.length
+
+    first = items[0]
+    assert_includes first["class"], "breadcrumb-item"
+    refute_includes first["class"].to_s.split, "active"
+    link = first.at_css("a")
+    assert_not_nil link
+    assert_equal "Customers", link.text
+    assert_equal "/customers", link["href"]
+  end
+
+  test "breadcrumbs renders the last item as active with aria-current=page" do
+    html = Nokogiri::HTML.fragment(breadcrumbs([ "Customers", "/customers" ], "Acme"))
+    last = html.css("li.breadcrumb-item").last
+    assert_includes last["class"].split, "active"
+    assert_equal "page", last["aria-current"]
+    assert_nil last.at_css("a")
+    assert_equal "Acme", last.text.strip
+  end
+
+  test "breadcrumbs forces the last item to be active even if a path is given" do
+    html = Nokogiri::HTML.fragment(breadcrumbs([ "Customers", "/customers" ], [ "Acme", "/customers/1" ]))
+    last = html.css("li.breadcrumb-item").last
+    assert_includes last["class"].split, "active"
+    assert_equal "page", last["aria-current"]
+    assert_nil last.at_css("a")
+    assert_equal "Acme", last.text.strip
+  end
+
+  test "breadcrumbs renders plain-label middle crumbs without a link" do
+    html = Nokogiri::HTML.fragment(breadcrumbs("Configuration", [ "Sales Tax", "/sales_tax_rates" ], "Edit"))
+    items = html.css("li.breadcrumb-item")
+    assert_equal 3, items.length
+
+    config = items[0]
+    refute_includes config["class"].to_s.split, "active"
+    assert_nil config.at_css("a"), "non-link middle item should not contain an <a>"
+    assert_equal "Configuration", config.text.strip
+
+    sales = items[1]
+    assert_not_nil sales.at_css("a")
+    assert_equal "/sales_tax_rates", sales.at_css("a")["href"]
+
+    last = items[2]
+    assert_includes last["class"].split, "active"
+  end
 end


### PR DESCRIPTION
## Summary
- New `breadcrumbs(*items)` helper in `ApplicationHelper` renders a Bootstrap 5.3 nav row above `page_header`. Items are `[label, path]` for links or plain labels for non-link crumbs; the last item is always rendered as active with `aria-current="page"`.
- Applied across every index/show/edit/new view except the dashboard (`root_path`) and `/account/*`. Configuration resources start with a non-link `Configuration` crumb; sales-tax sub-resources route through `Sales Tax` so the rates landing page (where the sibling cross-links live) stays reachable.
- Bottom `Back` button removed from show pages — the breadcrumb is now the navigation anchor. `cancel_button(resource)` on edit/new forms stays since it pairs with Submit.
- Styling is utility-only (no new SCSS, so this won't collide with parallel CSS work): `border-bottom py-1 small mb-2` keeps the row flush with the H1 below.

Completes the deferred half of #366 (consistent navigation/edit placement on detail pages). CLAUDE.md updated to document the helper and the new `action_buttons_wrapper`-no-Back rule.

## Test plan
- [x] `bundle exec rails test` — 626 runs, 2348 assertions, 0 failures (includes 5 new helper unit tests)
- [x] `bundle exec rails test test/system/` — 65 runs, 0 failures
- [x] `pre-commit run --all-files` — clean
- [ ] Manual visual smoke test — verify the `border-bottom py-1 small mb-2` density on long pages (invoice/delivery-note show), and that breadcrumb links navigate as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)