### PR TITLE
Split utilities.css.scss into per-feature files

### DIFF
--- a/app/assets/stylesheets/customer_contacts.css.scss
+++ b/app/assets/stylesheets/customer_contacts.css.scss
@@ -1,0 +1,6 @@
+// Customer contacts form (customer_contacts/_form_fields).
+// Caps the multi-select's height so it doesn't grow with the project list.
+
+.customer-contact-projects-select {
+  max-height: 7rem;
+}

--- a/app/assets/stylesheets/customer_filter.css.scss
+++ b/app/assets/stylesheets/customer_filter.css.scss
@@ -1,0 +1,10 @@
+// Customer filter on invoice/delivery-note index pages
+// (shared/_customer_filter, customer_filter_controller.js).
+//
+// Sized to fit a typical matchcode. The customer-filter Stimulus controller
+// swaps option text between matchcode (closed) and "MATCHCODE — Company Name"
+// (open); a fixed select width prevents toolbar reflow on swap. Browsers size
+// the open dropdown panel to the longest option independent of the select.
+.customer-filter select {
+  width: 10em;
+}

--- a/app/assets/stylesheets/dashboard.css.scss
+++ b/app/assets/stylesheets/dashboard.css.scss
@@ -1,0 +1,6 @@
+// Dashboard view (home/index).
+
+.dashboard-issuer-logo {
+  max-height: 80px;
+  max-width: 200px;
+}

--- a/app/assets/stylesheets/documents.css.scss
+++ b/app/assets/stylesheets/documents.css.scss
@@ -1,0 +1,15 @@
+// Document line tables on invoices/show and delivery_notes/show
+// (shared via the DocumentWithLines concern).
+
+.document-lines-table {
+  th.col-description { width: 55%; }
+  th.col-quantity    { width: 10%; }
+  th.col-rate        { width: 15%; }
+  th.col-tax-class   { width: 10%; }
+  th.col-amount      { width: 15%; }
+
+  td.document-section-row { padding: 12px 8px; }
+  td.document-text-row    { padding: 8px; }
+
+  .document-line-comment { margin-left: 20px; }
+}

--- a/app/assets/stylesheets/email_preview.css.scss
+++ b/app/assets/stylesheets/email_preview.css.scss
@@ -1,0 +1,29 @@
+// Email preview modal + iframe used by shared/_email_preview_modal
+// and generic_email_preview_controller.js.
+
+.email-preview-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1050;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.email-preview-modal-dialog {
+  max-width: 800px;
+  width: 90%;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.email-preview-iframe {
+  width: 100%;
+  height: 400px;
+  border: 1px solid #dee2e6;
+  border-radius: 0.375rem;
+}

--- a/app/assets/stylesheets/error_notification.css.scss
+++ b/app/assets/stylesheets/error_notification.css.scss
@@ -1,0 +1,27 @@
+// Error notification dropdown rendered by layouts/_navigation
+// and driven by error_notification_controller.js.
+
+.error-notification-dropdown {
+  width: 280px;
+  max-height: 300px;
+  overflow-y: auto;
+  z-index: 1050;
+  right: 0;
+  left: auto;
+}
+
+.error-notification-clear-all {
+  font-size: 0.75rem;
+}
+
+.error-notification-error-text {
+  min-width: 0;
+}
+
+.error-notification-error-message {
+  word-break: break-word;
+}
+
+.error-notification-clear-button {
+  min-width: 24px;
+}

--- a/app/assets/stylesheets/jobs_status.css.scss
+++ b/app/assets/stylesheets/jobs_status.css.scss
@@ -1,0 +1,6 @@
+// Jobs status table (jobs_status/show).
+
+.job-row-description {
+  max-width: 480px;
+  word-break: break-word;
+}

--- a/app/assets/stylesheets/mark_paid.css.scss
+++ b/app/assets/stylesheets/mark_paid.css.scss
@@ -1,0 +1,19 @@
+// Mark Paid modal used by shared/_mark_paid_modal.
+
+.mark-paid-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1050;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.mark-paid-modal-dialog {
+  max-width: 400px;
+  width: 90%;
+}

--- a/app/assets/stylesheets/searchable_dropdown.css.scss
+++ b/app/assets/stylesheets/searchable_dropdown.css.scss
@@ -41,3 +41,15 @@
     background-color: transparent;
   }
 }
+
+// Scrollable dropdown content panel used by the searchable-dropdown partial
+// and its customer-/project-specific instances (.dropdown-content is wrapped
+// inside .searchable-dropdown / .customer-dropdown / .project-dropdown).
+.searchable-dropdown,
+.customer-dropdown,
+.project-dropdown {
+  .dropdown-content {
+    max-height: 300px;
+    overflow-y: auto;
+  }
+}

--- a/app/assets/stylesheets/utilities.css.scss
+++ b/app/assets/stylesheets/utilities.css.scss
@@ -1,5 +1,8 @@
-// Utility / scoped classes that replace inline style="..." attributes so
-// the app can run under a strict CSP without 'unsafe-inline' for style-src.
+// Cross-cutting utility classes that replace inline style="..." attributes
+// so the app can run under a strict CSP without 'unsafe-inline' for
+// style-src. Per-feature styles live in their own file named after the
+// controller, view, partial, or Stimulus controller that uses them — do
+// not add component-specific blocks here.
 
 // --- Reusable utilities ---
 

--- a/app/assets/stylesheets/utilities.css.scss
+++ b/app/assets/stylesheets/utilities.css.scss
@@ -18,114 +18,10 @@
 .w-fixed-400 { width: 400px; }
 .w-fixed-250 { width: 250px; }
 
-// --- Searchable dropdown scrollable content ---
-// (used by app/views/shared/_searchable_dropdown.html.haml etc.)
-.searchable-dropdown,
-.customer-dropdown,
-.project-dropdown {
-  .dropdown-content {
-    max-height: 300px;
-    overflow-y: auto;
-  }
-}
-
-// --- Document line tables (invoices show, delivery notes show) ---
-
-.document-lines-table {
-  th.col-description { width: 55%; }
-  th.col-quantity    { width: 10%; }
-  th.col-rate        { width: 15%; }
-  th.col-tax-class   { width: 10%; }
-  th.col-amount      { width: 15%; }
-
-  td.document-section-row { padding: 12px 8px; }
-  td.document-text-row    { padding: 8px; }
-
-  .document-line-comment { margin-left: 20px; }
-}
-
-// --- Email preview modal & iframe (invoices/show, delivery_notes/show) ---
-
-.email-preview-modal {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.5);
-  z-index: 1050;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.email-preview-modal-dialog {
-  max-width: 800px;
-  width: 90%;
-  max-height: 90vh;
-  overflow-y: auto;
-}
-
-.email-preview-iframe {
-  width: 100%;
-  height: 400px;
-  border: 1px solid #dee2e6;
-  border-radius: 0.375rem;
-}
-
-// --- Mark paid modal (invoices/show) ---
-
-.mark-paid-modal {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.5);
-  z-index: 1050;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.mark-paid-modal-dialog {
-  max-width: 400px;
-  width: 90%;
-}
-
-// --- Error notification dropdown (layout/_navigation) ---
-
-.error-notification-dropdown {
-  width: 280px;
-  max-height: 300px;
-  overflow-y: auto;
-  z-index: 1050;
-  right: 0;
-  left: auto;
-}
-
-.error-notification-clear-all {
-  font-size: 0.75rem;
-}
-
-.error-notification-error-text {
-  min-width: 0;
-}
-
-.error-notification-error-message {
-  word-break: break-word;
-}
-
-.error-notification-clear-button {
-  min-width: 24px;
-}
-
-// --- Dashboard ---
-
-.dashboard-issuer-logo {
-  max-height: 80px;
-  max-width: 200px;
-}
+// --- Issuer accent theme helpers ---
+// The --issuer-accent-color variable is injected once by the application
+// layout via ApplicationHelper#issuer_accent_color_style, so these helpers
+// work on every page.
 
 .text-issuer-accent {
   color: var(--issuer-accent-color) !important;
@@ -133,26 +29,4 @@
 
 .badge-issuer-accent {
   background-color: var(--issuer-accent-color);
-}
-
-// --- Jobs status ---
-
-.job-row-description {
-  max-width: 480px;
-  word-break: break-word;
-}
-
-// --- Customer contacts form ---
-// Caps the multi-select's height so it doesn't grow with the project list.
-.customer-contact-projects-select {
-  max-height: 7rem;
-}
-
-// --- Customer filter on invoice/delivery-note index ---
-// Sized to fit a typical matchcode. The customer-filter Stimulus controller
-// swaps option text between matchcode (closed) and "MATCHCODE — Company Name"
-// (open); a fixed select width prevents toolbar reflow on swap. Browsers size
-// the open dropdown panel to the longest option independent of the select.
-.customer-filter select {
-  width: 10em;
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -179,11 +179,12 @@ module ApplicationHelper
   # CSS variable from the active IssuerCompany's document_accent_color. Returns
   # nil (so the layout renders nothing) when no issuer or no accent color is
   # configured. document_accent_color is validated against a hex pattern on
-  # the model, so interpolating it into a CSS string is safe.
+  # the model; tag.style HTML-escapes the body as defense-in-depth so any
+  # bypass of that validation can't break out of the <style> context.
   def issuer_accent_color_style
     color = IssuerCompany.get_the_issuer!&.document_accent_color
     return unless color.present?
-    tag.style ":root { --issuer-accent-color: #{color}; }".html_safe,
+    tag.style ":root { --issuer-accent-color: #{color}; }",
               nonce: content_security_policy_nonce
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -174,4 +174,16 @@ module ApplicationHelper
       "generic-email-preview-send-url-value" => send("send_email_#{prefix}_path", resource)
     }
   end
+
+  # Emits a <style> tag in the layout head that sets the --issuer-accent-color
+  # CSS variable from the active IssuerCompany's document_accent_color. Returns
+  # nil (so the layout renders nothing) when no issuer or no accent color is
+  # configured. document_accent_color is validated against a hex pattern on
+  # the model, so interpolating it into a CSS string is safe.
+  def issuer_accent_color_style
+    color = IssuerCompany.get_the_issuer!&.document_accent_color
+    return unless color.present?
+    tag.style ":root { --issuer-accent-color: #{color}; }".html_safe,
+              nonce: content_security_policy_nonce
+  end
 end

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -40,7 +40,6 @@
             = image_tag png_logo_issuer_company_path, alt: @data[:issuer_company].legal_name, class: 'dashboard-issuer-logo'
 
         - if @data[:issuer_company].document_accent_color.present?
-          = tag.style ":root { --issuer-accent-color: #{@data[:issuer_company].document_accent_color}; }".html_safe, nonce: content_security_policy_nonce
           %h6.text-issuer-accent
             = @data[:issuer_company].legal_name
         - else

--- a/app/views/issuer_companies/show.html.haml
+++ b/app/views/issuer_companies/show.html.haml
@@ -104,7 +104,6 @@
             %strong Accent Color:
           .col-sm-8
             - if @issuer_company.document_accent_color.present?
-              = tag.style ":root { --issuer-accent-color: #{@issuer_company.document_accent_color}; }".html_safe, nonce: content_security_policy_nonce
               %span.badge.badge-issuer-accent
                 = @issuer_company.document_accent_color
             - else

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,6 +7,7 @@
     = csp_meta_tag
     = favicon_link_tag 'favicon.svg', type: 'image/svg+xml'
     = stylesheet_link_tag    "application", :media => "all"
+    = issuer_accent_color_style
     = javascript_importmap_tags
     = javascript_tag nonce: true do
       :plain

--- a/app/views/shared/_customer_filter.html.haml
+++ b/app/views/shared/_customer_filter.html.haml
@@ -2,7 +2,7 @@
 -#
 -# Renders a customer filter dropdown that shows only the matchcode in the
 -# closed state and "MATCHCODE — Company Name" while open. Width is set via
--# the .customer-filter rule in utilities.css.scss (CSP forbids inline style).
+-# the .customer-filter rule in customer_filter.css.scss (CSP forbids inline style).
 = form_with url: form_url, method: :get, local: true, class: 'me-2 customer-filter', data: { controller: 'customer-filter' } do
   - hidden_fields.each do |name, value|
     = hidden_field_tag name, value

--- a/test/integration/issuer_accent_color_test.rb
+++ b/test/integration/issuer_accent_color_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class IssuerAccentColorTest < ActionDispatch::IntegrationTest
+  test "layout head injects --issuer-accent-color on a non-dashboard page" do
+    get users_url
+    assert_response :success
+    assert_match(
+      %r{<style\b[^>]*\bnonce=['"][^'"]+['"][^>]*>\s*:root\s*\{\s*--issuer-accent-color:\s*\#3366cc;\s*\}\s*</style>},
+      @response.body,
+      "expected the layout to render a nonce'd style tag setting --issuer-accent-color"
+    )
+  end
+
+  test "layout omits the style tag when no accent color is configured" do
+    issuer_companies(:one).update!(document_accent_color: nil)
+    get users_url
+    assert_response :success
+    assert_no_match(/--issuer-accent-color/, @response.body)
+  end
+end


### PR DESCRIPTION
## Summary

- Inject `--issuer-accent-color` once from the application layout (via new `ApplicationHelper#issuer_accent_color_style`) so the two duplicated per-view inline `<style>` blocks (home/index, issuer_companies/show) can be removed. `.text-issuer-accent` / `.badge-issuer-accent` now work on every page.
- Split `app/assets/stylesheets/utilities.css.scss` into 8 feature-named files (`dashboard`, `documents`, `email_preview`, `mark_paid`, `error_notification`, `jobs_status`, `customer_contacts`, `customer_filter`) named after the controller/view/partial/Stimulus controller that drives each block. One block absorbed into existing `searchable_dropdown.css.scss`. Rules moved verbatim — no selector or property changes.
- Rewrite `utilities.css.scss` header to document the new convention so future component-specific blocks don't get added back here.

Follow-up tracked in #368 (cache `IssuerCompany.get_the_issuer!` per request — three callers per render now: `current_currency`, `page_title`, `issuer_accent_color_style`).

## Test plan

- [x] `bundle exec rails test` — 629 runs / 0 failures
- [x] `bundle exec rails assets:precompile` — clean
- [ ] Manual smoke on dashboard, an invoice show, a delivery-note show, mark-paid modal, error notification dropdown, customer filter on invoice index, issuer_companies/show — no visual regression
- [ ] DevTools spot-check: `getComputedStyle(document.documentElement).getPropertyValue('--issuer-accent-color').trim()` returns `#3366cc` on a non-dashboard page

🤖 Generated with [Claude Code](https://claude.com/claude-code)