### PR TITLE
Filter customer dropdowns to active customers (invoices + delivery notes)

### DIFF
--- a/app/controllers/delivery_notes_controller.rb
+++ b/app/controllers/delivery_notes_controller.rb
@@ -62,6 +62,7 @@ class DeliveryNotesController < ApplicationController
     @available_years = DeliveryNote.visible_to(current_user).available_years
     @available_customers = Customer.visible_to(current_user)
                                    .where(id: DeliveryNote.visible_to(current_user).select(:customer_id))
+                                   .where("active = ? OR id = ?", true, @selected_customer_id)
                                    .order(:name)
   end
 

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -64,6 +64,7 @@ class InvoicesController < ApplicationController
     @available_years = Invoice.visible_to(current_user).available_years
     @available_customers = Customer.visible_to(current_user)
                                    .where(id: Invoice.visible_to(current_user).select(:customer_id))
+                                   .where("active = ? OR id = ?", true, @selected_customer_id)
                                    .order(:name)
   end
 

--- a/test/controllers/delivery_notes_controller_test.rb
+++ b/test/controllers/delivery_notes_controller_test.rb
@@ -75,6 +75,43 @@ class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "customer dropdown excludes inactive customers" do
+    inactive = customers(:good_national)
+    inactive.update!(active: false)
+    DeliveryNote.create!(
+      customer: inactive,
+      project: projects(:one),
+      cust_reference: "INACTIVE-CUST-DN",
+      date: Date.current,
+      delivery_start_date: Date.current
+    )
+
+    get delivery_notes_url
+    assert_response :success
+    assert_select "select[name='customer_id']" do
+      assert_select "option[value=?]", inactive.id.to_s, count: 0
+    end
+  end
+
+  test "customer dropdown still includes inactive customer if currently selected" do
+    inactive = customers(:good_national)
+    inactive.update!(active: false)
+    DeliveryNote.create!(
+      customer: inactive,
+      project: projects(:one),
+      cust_reference: "INACTIVE-CUST-DN",
+      date: Date.current,
+      delivery_start_date: Date.current
+    )
+
+    get delivery_notes_url(customer_id: inactive.id)
+    assert_response :success
+    assert_select "select[name='customer_id']" do
+      assert_select "option[value=?][selected]", inactive.id.to_s
+    end
+    assert_select "td", text: "INACTIVE-CUST-DN"
+  end
+
   test "should include draft delivery notes with nil date in current year" do
     # Create a draft delivery note (no date)
     DeliveryNote.create!(

--- a/test/controllers/invoices_controller_test.rb
+++ b/test/controllers/invoices_controller_test.rb
@@ -72,6 +72,41 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "customer dropdown excludes inactive customers" do
+    inactive = customers(:good_national)
+    inactive.update!(active: false)
+    Invoice.create!(
+      customer: inactive,
+      project: projects(:test_project),
+      cust_reference: "INACTIVE-CUST-INV",
+      date: Date.current
+    )
+
+    get invoices_url
+    assert_response :success
+    assert_select "select[name='customer_id']" do
+      assert_select "option[value=?]", inactive.id.to_s, count: 0
+    end
+  end
+
+  test "customer dropdown still includes inactive customer if currently selected" do
+    inactive = customers(:good_national)
+    inactive.update!(active: false)
+    Invoice.create!(
+      customer: inactive,
+      project: projects(:test_project),
+      cust_reference: "INACTIVE-CUST-INV",
+      date: Date.current
+    )
+
+    get invoices_url(customer_id: inactive.id)
+    assert_response :success
+    assert_select "select[name='customer_id']" do
+      assert_select "option[value=?][selected]", inactive.id.to_s
+    end
+    assert_select "td", text: "INACTIVE-CUST-INV"
+  end
+
   test "should include draft invoices with nil date in current year" do
     current_year = Date.current.year
 


### PR DESCRIPTION
## Summary
- Invoice and delivery note customer filters now show only active customers.
- A currently-selected inactive customer is still included as an option so URL state remains consistent.
- Mirrored across both controllers since the two document types are intentionally parallel.

## Test plan
- [x] `bundle exec rails test test/controllers/invoices_controller_test.rb test/controllers/delivery_notes_controller_test.rb`
- [ ] Smoke: visit /invoices and /delivery_notes, confirm dropdown content
- [ ] Smoke: deactivate a customer, refresh — dropdown drops them; URL-pinned filter still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)