### PR TITLE
Allow Unicode letters in usernames

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  USERNAME_FORMAT = /\A[a-z0-9][a-z0-9_\-.]*\z/i
+  USERNAME_FORMAT = /\A[\p{L}\p{N}][\p{L}\p{N}_\-.]*\z/
 
   has_many :emails, class_name: "UserEmail", dependent: :destroy
   has_many :credentials, class_name: "UserCredential", dependent: :destroy

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -26,6 +26,18 @@ class UserTest < ActiveSupport::TestCase
     assert_includes user.errors[:username], "is invalid"
   end
 
+  test "username accepts unicode letters" do
+    user = User.new(username: "ärnö", full_name: "Ärnö Müller")
+    assert user.valid?, user.errors.full_messages.inspect
+    user.save!
+    assert_equal "ärnö", user.reload.username
+  end
+
+  test "username accepts non-latin letters" do
+    user = User.new(username: "宮本", full_name: "Miyamoto")
+    assert user.valid?, user.errors.full_messages.inspect
+  end
+
   test "blocked? reflects blocked_at" do
     assert_not users(:alice).blocked?
     assert users(:blocked_carol).blocked?


### PR DESCRIPTION
## Summary
- `USERNAME_FORMAT` now uses `\p{L}` (any Unicode letter) and `\p{N}` (any Unicode number) instead of `[a-z0-9]` with `/i`.
- Latin-with-diacritics, Cyrillic, CJK, etc. usernames are now valid.
- `normalizes :username, with: ->(v) { v.strip.downcase }` already handles Unicode case folding.

## Test plan
- [x] `bundle exec rails test test/models/user_test.rb` (new tests cover `ärnö` and `宮本`)
- [ ] Smoke: invite flow accepts a Unicode username and the resulting user can sign in

🤖 Generated with [Claude Code](https://claude.com/claude-code)