### PR TITLE
Require matchcode NOT NULL with format validation

### DIFF
--- a/app/models/concerns/has_matchcode.rb
+++ b/app/models/concerns/has_matchcode.rb
@@ -1,0 +1,10 @@
+module HasMatchcode
+  extend ActiveSupport::Concern
+
+  MATCHCODE_FORMAT = /\A\S{2,}\z/
+
+  included do
+    validates :matchcode, presence: true, uniqueness: { case_sensitive: false },
+              format: { with: MATCHCODE_FORMAT }
+  end
+end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -1,10 +1,7 @@
 class Customer < ApplicationRecord
   include TeamOwned
+  include HasMatchcode
 
-  MATCHCODE_FORMAT = /\A\S{2,}\z/
-
-  validates :matchcode, presence: true, uniqueness: { case_sensitive: false },
-            format: { with: MATCHCODE_FORMAT }
   validates :name, presence: true
   validates :vat_id, presence: true, if: -> { sales_tax_customer_class&.vat_id_required? }
 

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -1,7 +1,10 @@
 class Customer < ApplicationRecord
   include TeamOwned
 
-  validates :matchcode, presence: true, uniqueness: { case_sensitive: false }
+  MATCHCODE_FORMAT = /\A\S{2,}\z/
+
+  validates :matchcode, presence: true, uniqueness: { case_sensitive: false },
+            format: { with: MATCHCODE_FORMAT }
   validates :name, presence: true
   validates :vat_id, presence: true, if: -> { sales_tax_customer_class&.vat_id_required? }
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -4,7 +4,10 @@ class Project < ApplicationRecord
   belongs_to :bill_to_customer, class_name: "Customer", optional: true
   has_many :invoices
 
-  validates :matchcode, presence: true, uniqueness: { case_sensitive: false }
+  MATCHCODE_FORMAT = /\A\S{2,}\z/
+
+  validates :matchcode, presence: true, uniqueness: { case_sensitive: false },
+            format: { with: MATCHCODE_FORMAT }
   validate :team_must_match_customer
 
   # Scopes for filtering

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,13 +1,10 @@
 class Project < ApplicationRecord
   include TeamOwned
+  include HasMatchcode
 
   belongs_to :bill_to_customer, class_name: "Customer", optional: true
   has_many :invoices
 
-  MATCHCODE_FORMAT = /\A\S{2,}\z/
-
-  validates :matchcode, presence: true, uniqueness: { case_sensitive: false },
-            format: { with: MATCHCODE_FORMAT }
   validate :team_must_match_customer
 
   # Scopes for filtering

--- a/db/migrate/20260526180000_require_matchcode_not_null.rb
+++ b/db/migrate/20260526180000_require_matchcode_not_null.rb
@@ -1,0 +1,14 @@
+class RequireMatchcodeNotNull < ActiveRecord::Migration[8.0]
+  def up
+    execute "UPDATE customers SET matchcode = 'CUST-' || id WHERE matchcode IS NULL"
+    execute "UPDATE projects  SET matchcode = 'PROJ-' || id WHERE matchcode IS NULL"
+
+    change_column_null :customers, :matchcode, false
+    change_column_null :projects, :matchcode, false
+  end
+
+  def down
+    change_column_null :customers, :matchcode, true
+    change_column_null :projects, :matchcode, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_26_172314) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_26_180000) do
   create_table "attachments", force: :cascade do |t|
     t.string "content_type"
     t.datetime "created_at", null: false
@@ -49,7 +49,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_26_172314) do
     t.string "invoice_email_auto_subject_template", default: "", null: false
     t.string "invoice_email_auto_to", default: "", null: false
     t.integer "language_id", null: false
-    t.string "matchcode"
+    t.string "matchcode", null: false
     t.text "name"
     t.text "notes"
     t.integer "payment_terms_days", default: 30, null: false
@@ -253,7 +253,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_26_172314) do
     t.datetime "created_at", null: false
     t.string "department"
     t.text "description"
-    t.string "matchcode"
+    t.string "matchcode", null: false
     t.integer "team_id", null: false
     t.datetime "updated_at", null: false
     t.index "LOWER(matchcode)", name: "index_projects_on_lower_matchcode", unique: true

--- a/test/models/customer_test.rb
+++ b/test/models/customer_test.rb
@@ -23,6 +23,21 @@ class CustomerTest < ActiveSupport::TestCase
     assert_includes customer.errors[:matchcode], "can't be blank"
   end
 
+  test "matchcode rejects whitespace and single character" do
+    [ "A", "AB C", " AB", "AB\t" ].each do |bad|
+      customer = build_customer(matchcode: bad)
+      assert_not customer.valid?, "expected #{bad.inspect} to be invalid"
+      assert_includes customer.errors[:matchcode], "is invalid"
+    end
+  end
+
+  test "matchcode allows mixed case and any length >= 2" do
+    customer = build_customer(matchcode: "aB")
+    assert customer.valid?, customer.errors.full_messages.inspect
+    customer = build_customer(matchcode: "MixedCaseLongMatchcode1234567890")
+    assert customer.valid?, customer.errors.full_messages.inspect
+  end
+
   test "requires name" do
     customer = build_customer(name: nil)
     assert_not customer.valid?

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -21,6 +21,21 @@ class ProjectTest < ActiveSupport::TestCase
     assert_not_nil @project.errors[:matchcode]
   end
 
+  test "matchcode rejects whitespace and single character" do
+    [ "A", "AB C", " AB", "AB\t" ].each do |bad|
+      @project.matchcode = bad
+      assert_not @project.valid?, "expected #{bad.inspect} to be invalid"
+      assert_includes @project.errors[:matchcode], "is invalid"
+    end
+  end
+
+  test "matchcode allows mixed case and any length >= 2" do
+    @project.matchcode = "aB"
+    assert @project.valid?, @project.errors.full_messages.inspect
+    @project.matchcode = "MixedCaseLongMatchcode1234567890"
+    assert @project.valid?, @project.errors.full_messages.inspect
+  end
+
   test "matchcode must be globally unique across all teams" do
     Project.create!(matchcode: "DUPE", team: teams(:default))
     duplicate = Project.new(matchcode: "DUPE", team: teams(:acme))


### PR DESCRIPTION
## Summary
- `Customer.matchcode` and `Project.matchcode` get a format validation: 2+ chars, no whitespace, mixed case allowed, no length cap (`/\A\S{2,}\z/`).
- Migration adds DB NOT NULL constraint on both columns, auto-backfilling any pre-existing NULL rows with `CUST-<id>` / `PROJ-<id>` stubs first so the migration stays safe.
- Forms already had `required: true`, so no view changes.

## Test plan
- [x] `bundle exec rails test test/models/customer_test.rb test/models/project_test.rb`
- [x] Migration round-trips cleanly (rollback + re-apply)
- [ ] Smoke: customer/project create with whitespace or 1-char matchcode is rejected by the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)