### PR TITLE
Tighten publish/document-number guards on documents

### DIFF
--- a/app/controllers/delivery_notes_controller.rb
+++ b/app/controllers/delivery_notes_controller.rb
@@ -36,7 +36,8 @@ class DeliveryNotesController < ApplicationController
   # spec tells browsers to ignore 'unsafe-inline' — which would re-block the
   # mailer's inline <style> tags. Strip the nonce list for this action.
   before_action(only: :preview_email_raw) { request.content_security_policy_nonce_directives = [] }
-  before_action :require_unpublished, only: %i[edit update publish preview]
+  before_action :require_unpublished, only: %i[edit update destroy publish preview]
+  before_action :require_unnumbered, only: :destroy
   before_action :require_published, only: %i[pdf unpublish upload_acceptance delete_acceptance convert_to_invoice send_email]
   before_action :require_item_line, only: %i[publish preview preview_email]
 
@@ -104,11 +105,6 @@ class DeliveryNotesController < ApplicationController
 
   # DELETE /delivery_notes/1
   def destroy
-    if @delivery_note.published?
-      flash[:alert] = "Published delivery notes cannot be deleted."
-      redirect_to delivery_notes_path and return
-    end
-
     @delivery_note.destroy
     redirect_to delivery_notes_url
   end
@@ -345,6 +341,16 @@ class DeliveryNotesController < ApplicationController
 protected
   def set_delivery_note
     @delivery_note = DeliveryNote.visible_to(current_user).find(params[:id])
+  end
+
+  # Document numbers are issued from a gap-free sequence; once assigned they
+  # must not vanish, even if the delivery note was later unpublished.
+  def require_unnumbered
+    return true if @delivery_note.document_number.blank?
+
+    flash[:error] = "Delivery notes with an assigned document number can not be deleted."
+    redirect_to @delivery_note
+    false
   end
 
   def delivery_note_params

--- a/app/models/delivery_note.rb
+++ b/app/models/delivery_note.rb
@@ -8,6 +8,8 @@ class DeliveryNote < ApplicationRecord
   validates :customer_id, presence: true
   validates :delivery_start_date, presence: true
   validate :delivery_end_date_after_start_date
+  # Edits to published delivery notes are rejected by require_unpublished in
+  # the controller; this validation only guards the transition into published.
   validate :must_have_item_line_for_publish
   default_scope { order(Arel.sql("id ASC")) }
 

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -6,6 +6,8 @@ class Invoice < ApplicationRecord
   has_line_items :invoice_lines
 
   validates :customer_id, presence: true
+  # Edits to published invoices are rejected by require_unpublished in the
+  # controller; this validation only guards the transition into published.
   validate :must_have_item_line_for_publish
   default_scope { order(Arel.sql("id ASC")) }
 

--- a/test/controllers/delivery_notes_controller_test.rb
+++ b/test/controllers/delivery_notes_controller_test.rb
@@ -180,12 +180,28 @@ class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should not destroy published delivery note" do
+    published_note = delivery_notes(:published_delivery_note)
     assert_no_difference("DeliveryNote.count") do
-      delete delivery_note_url(delivery_notes(:published_delivery_note))
+      delete delivery_note_url(published_note)
     end
 
-    assert_redirected_to delivery_notes_url
-    assert_match "cannot be deleted", flash[:alert]
+    assert_redirected_to delivery_note_url(published_note)
+    assert_match "Published delivery notes can not be modified", flash[:error]
+  end
+
+  test "should not destroy numbered but unpublished delivery note" do
+    note = delivery_notes(:published_delivery_note)
+    # Simulate the "withdrawn but still numbered" state without going through
+    # unpublish (which currently clears document_number).
+    note.update_column(:published, false)
+    assert note.document_number.present?, "fixture should retain its number"
+
+    assert_no_difference("DeliveryNote.count") do
+      delete delivery_note_url(note)
+    end
+
+    assert_redirected_to delivery_note_url(note)
+    assert_match "assigned document number", flash[:error]
   end
 
   test "should get preview pdf" do

--- a/test/controllers/invoices_controller_test.rb
+++ b/test/controllers/invoices_controller_test.rb
@@ -557,4 +557,52 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
     # Should redirect to the invoice show page since there's no flash data
     assert_redirected_to invoice_url(invoice)
   end
+
+  test "should not edit published invoice" do
+    invoice = invoices(:published_invoice)
+    get edit_invoice_url(invoice)
+    assert_redirected_to invoice_url(invoice)
+    assert_match "Published invoices can not be modified", flash[:error]
+  end
+
+  test "should not update published invoice" do
+    invoice = invoices(:published_invoice)
+    original_ref = invoice.cust_reference
+
+    patch invoice_url(invoice), params: { invoice: { cust_reference: "HACKED" } }
+
+    assert_redirected_to invoice_url(invoice)
+    assert_match "Published invoices can not be modified", flash[:error]
+    assert_equal original_ref, invoice.reload.cust_reference
+  end
+
+  test "should not destroy published invoice" do
+    invoice = invoices(:published_invoice)
+    assert_no_difference("Invoice.count") do
+      delete invoice_url(invoice)
+    end
+    assert_redirected_to invoice_url(invoice)
+    assert_match "Published invoices can not be modified", flash[:error]
+  end
+
+  test "should not preview published invoice" do
+    invoice = invoices(:published_invoice)
+    get preview_invoice_url(invoice)
+    assert_redirected_to invoice_url(invoice)
+    assert_match "Published invoices can not be modified", flash[:error]
+  end
+
+  test "should not POST book on published invoice" do
+    invoice = invoices(:published_invoice)
+    # require_item_line fires before the inline require_unpublished in
+    # book POST, so a line is needed to reach the publish guard.
+    invoice.invoice_lines.create!(
+      type: "item", title: "x", rate: 1.0, quantity: 1.0,
+      sales_tax_product_class: sales_tax_product_classes(:standard), position: 1
+    )
+
+    post book_invoice_url(invoice), params: { save: "true" }
+    assert_redirected_to invoice_url(invoice)
+    assert_match "Published invoices can not be modified", flash[:error]
+  end
 end


### PR DESCRIPTION
## Summary
- Audit followups from the publish-guard review.
- Consolidate `DeliveryNotesController#destroy` onto the shared `require_unpublished` filter instead of an inline check, so the rejection path matches `InvoicesController#destroy` (same flash key, same redirect target, same wording).
- Add `require_unnumbered` on delivery-note `destroy`: a delivery note that has been assigned a document number cannot be deleted, even after being unpublished. Document numbers come from a gap-free sequence, so removing a numbered record would leave an audit gap. Today's `unpublish` clears `document_number`, so the new guard is primarily defense-in-depth — it also catches any future code path that produces a numbered-but-unpublished record.
- Document on `Invoice` and `DeliveryNote` that publish-immutability is enforced in the controllers (via `require_unpublished`); the model-level validation only guards the transition *into* published. Future contributors won't have to derive that from the controllers.
- Add brief invoice controller tests asserting `edit` / `update` / `destroy` / `preview` / `book` POST are rejected for published invoices, plus a delivery-note test for the new numbered-but-unpublished destroy guard.

## Test plan
- [x] `bundle exec rails test test/controllers/invoices_controller_test.rb test/controllers/delivery_notes_controller_test.rb` — 65 runs, 0 failures
- [x] `bundle exec rails test` — full suite, 639 runs, 0 failures
- [x] `pre-commit run --all-files` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)