### PR TITLE
Drop H1 on breadcrumb pages, fold action into breadcrumb strip

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ For testing against PostgreSQL (matches production environment):
 - **Hide superseded badges.** On invoices, the header drops "Booked" once a more specific state (Sent/Paid/Overdue) applies. Sent stacks with Paid/Overdue (email and payment are independent).
 - **In detail grids and list columns, healthy data renders as plain text, not a badge.** Paid (with date), Sent (with timestamp) → plain text. Problem states (Unpaid, Unsent, Overdue, No Recipient) keep their badges.
 - **Hide the status column entirely when a list is filtered to a single state.** On the customers and projects lists, the Status column is only rendered when the filter is "All"; when filtered to Active or Inactive the column would be redundant (every row identical or empty), so the header and cells are omitted.
-- Use `fs-6` when a badge sits inline with an H1, otherwise it inflates to heading size.
+- Header badges sit inline with the active breadcrumb crumb (via the `breadcrumbs(...)` status block) at the default badge size — no `fs-` modifier needed.
 
 ### Status-row Action Buttons
 - On document show pages, "act on this status" controls (Send E-Mail, Mark Paid…, Mark Unpaid) sit inline at the right edge of their status row's `col-sm-8`, separating the status text/badge on the left from the action on the right. The row container is `.col-sm-8.d-flex.align-items-center.gap-2`.
@@ -185,12 +185,12 @@ For testing against PostgreSQL (matches production environment):
 - To render a `datetime` column as date-only (e.g. `email_sent_at` in compact list rows), call `l(value.to_date)` — `l` on a `Time`/`DateTime` produces the time format.
 
 ### UI Helper Methods
-- `breadcrumbs(*items)` - Bootstrap breadcrumb row, rendered above `page_header` on every page except the dashboard (`root_path`) and `/account/*`. Each item is either `[label, path]` (link) or a plain label (non-link). The last item is always rendered as the active crumb with `aria-current="page"`, even if a path was supplied.
+- `breadcrumbs(*items, action: nil, &status_block)` - Bootstrap breadcrumb strip that serves as the page header on every index/show/edit/new page (every page except the dashboard, `/account/*`, the sign-in / invite-acceptance flow, and the post-book confirmation). Each item is either `[label, path]` (link) or a plain label (non-link). The last item is always the active crumb with `aria-current="page"` (rendered `fw-semibold`), and it is the page identifier — there is no separate H1. The optional block yields inline status badges next to the active crumb; the optional `action:` is right-aligned on the same row (built with `action_button(...)`, which returns nil when its permission check fails — that renders as no action area).
   - Top-level resources start with the navbar label linked to its index: `['Customers', customers_path]`, `['Projects', projects_path]`, `['Delivery Notes', delivery_notes_path]`, `['Invoices', invoices_path]`.
   - Configuration resources start with a non-link `'Configuration'` crumb (the dropdown has no destination) followed by the resource's navbar label, e.g. `breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], 'Edit'`.
   - On edit pages append `'Edit'` as the active crumb; on new pages append `'New'`. On show pages the resource's identifier (matchcode / document number / name) is the active crumb.
   - The bottom `action_buttons_wrapper` no longer contains a `Back` button — the breadcrumb is the navigation anchor. `action_buttons_wrapper` is reserved for workflow verbs (PDF, Send, Publish, Delete, Mark Paid, etc.). `cancel_button(resource)` on edit/new forms stays — it pairs with Submit, not navigation.
-- `page_header(title, action: nil, &status_block)` - The page-header row. Title left, optional inline status badges via block, optional right-aligned action. Build the action with `action_button(...)` — when its permission check fails it returns nil, which `page_header` renders as no action area.
+- `page_header(title, action: nil, &status_block)` - Page-header row with an H1 title, optional inline status badges via the block, and optional right-aligned action. Only used on pages without breadcrumbs: dashboard (`home/index`), `/account/*`, the sign-in / invite-acceptance / "Book invoice" / "Invite generated" pages.
 - `action_button(text, path, type = :primary, permission: nil, target: nil, data: nil)` - Styled buttons (primary, secondary, success, info, warning, danger). Returns `nil` when `permission:` is given and the current user lacks it.
 - `action_buttons_wrapper` - Container for the bottom-of-page workflow action row (Back, PDF, Send E-Mail, Publish, Delete, etc.).
 - `destroy_link(resource, confirm_text)` - Smart delete links (trashcan on index, "Delete" on detail pages).

--- a/app/assets/stylesheets/bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.scss
@@ -87,6 +87,21 @@ body { padding-top: 60px; }
   display: inline;
 }
 
+// Action buttons rendered inside the breadcrumb header strip use the small
+// button sizing so they don't tower over the small-text breadcrumb trail.
+nav[aria-label="breadcrumb"] .btn {
+  --bs-btn-padding-y: 0.25rem;
+  --bs-btn-padding-x: 0.5rem;
+  --bs-btn-font-size: 0.875rem;
+  --bs-btn-border-radius: var(--bs-border-radius-sm);
+}
+
+// Reserve a constant row height for the breadcrumb strip so pages without an
+// action button don't render a shorter header than pages with one.
+nav[aria-label="breadcrumb"] > div {
+  min-height: 2.5rem;
+}
+
 .document-details .row {
   border-bottom: 1px solid var(--bs-border-color-translucent);
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -32,7 +32,10 @@ module ApplicationHelper
     end
   end
 
-  # Renders a Bootstrap breadcrumb row above the page header.
+  # Renders the breadcrumb strip that serves as the page header on every
+  # index/show/edit/new page. The active (last) crumb is the page identifier;
+  # optional status badges (via the block) sit next to it; an optional action:
+  # button is right-aligned on the same row.
   #
   # Items are either:
   #   - [label, path]  → rendered as a link
@@ -41,21 +44,29 @@ module ApplicationHelper
   # of whether a path was given.
   #
   #   = breadcrumbs ['Customers', customers_path], @customer.display_name
-  #   = breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], 'Edit'
-  def breadcrumbs(*items)
+  #   = breadcrumbs ['Customers', customers_path], @customer.matchcode, action: action_button('Edit', edit_customer_path(@customer)) do
+  #     - unless @customer.active?
+  #       %span.badge.bg-secondary Inactive
+  def breadcrumbs(*items, action: nil, &status_block)
     content_tag :nav, "aria-label": "breadcrumb" do
-      content_tag :ol, class: "breadcrumb border-bottom py-1 small mb-2" do
-        last_index = items.length - 1
-        items.each_with_index.map { |item, i|
-          label, path = Array(item)
-          if i == last_index
-            content_tag(:li, label, class: "breadcrumb-item active", "aria-current": "page")
-          elsif path
-            content_tag(:li, link_to(label, path), class: "breadcrumb-item")
-          else
-            content_tag(:li, label, class: "breadcrumb-item")
+      content_tag :div, class: "d-flex justify-content-between align-items-center flex-wrap gap-2 border-bottom py-1 mb-2" do
+        left = content_tag(:div, class: "d-flex align-items-center flex-wrap gap-2 small") do
+          ol = content_tag :ol, class: "breadcrumb mb-0" do
+            last_index = items.length - 1
+            items.each_with_index.map { |item, i|
+              label, path = Array(item)
+              if i == last_index
+                content_tag(:li, label, class: "breadcrumb-item active fw-semibold", "aria-current": "page")
+              elsif path
+                content_tag(:li, link_to(label, path), class: "breadcrumb-item")
+              else
+                content_tag(:li, label, class: "breadcrumb-item")
+              end
+            }.join.html_safe
           end
-        }.join.html_safe
+          ol + (status_block ? capture(&status_block) : "".html_safe)
+        end
+        left + (action || "".html_safe)
       end
     end
   end

--- a/app/views/customers/edit.html.haml
+++ b/app/views/customers/edit.html.haml
@@ -1,4 +1,3 @@
 = breadcrumbs ['Customers', customers_path], [@customer.matchcode, customer_path(@customer)], 'Edit'
-= page_header('Editing customer')
 
 = render 'form'

--- a/app/views/customers/index.html.haml
+++ b/app/views/customers/index.html.haml
@@ -1,5 +1,4 @@
-= breadcrumbs 'Customers'
-= page_header('Listing customers', action: action_button('+ New', new_customer_path, :info, permission: 'customers.edit'))
+= breadcrumbs 'Customers', action: action_button('+ New', new_customer_path, :info, permission: 'customers.edit')
 
 .mb-3
   .btn-toolbar.mb-3{:role=>"toolbar", "aria-label"=>"List toolbar"}

--- a/app/views/customers/new.html.haml
+++ b/app/views/customers/new.html.haml
@@ -1,4 +1,3 @@
 = breadcrumbs ['Customers', customers_path], 'New'
-= page_header('New customer')
 
 = render 'form'

--- a/app/views/customers/show.html.haml
+++ b/app/views/customers/show.html.haml
@@ -1,7 +1,6 @@
-= breadcrumbs ['Customers', customers_path], @customer.matchcode
-= page_header("Customer #{@customer.matchcode}", action: action_button('Edit', edit_customer_path(@customer), permission: 'customers.edit')) do
+= breadcrumbs ['Customers', customers_path], @customer.matchcode, action: action_button('Edit', edit_customer_path(@customer), permission: 'customers.edit') do
   - unless @customer.active?
-    %span.badge.bg-secondary.fs-6 Inactive
+    %span.badge.bg-secondary Inactive
 
 .row
   .col-md-6

--- a/app/views/delivery_notes/edit.html.haml
+++ b/app/views/delivery_notes/edit.html.haml
@@ -1,4 +1,3 @@
 = breadcrumbs ['Delivery Notes', delivery_notes_path], [(@delivery_note.document_number || "Draft ##{@delivery_note.id}"), delivery_note_path(@delivery_note)], 'Edit'
-= page_header('Editing delivery note draft')
 
 = render 'form'

--- a/app/views/delivery_notes/index.html.haml
+++ b/app/views/delivery_notes/index.html.haml
@@ -1,5 +1,4 @@
-= breadcrumbs 'Delivery Notes'
-= page_header('Listing delivery notes', action: action_button('+ New', new_delivery_note_path, :info, permission: 'delivery_notes.edit'))
+= breadcrumbs 'Delivery Notes', action: action_button('+ New', new_delivery_note_path, :info, permission: 'delivery_notes.edit')
 
 
 .bulk-select-container{data: { controller: 'bulk-select' }}

--- a/app/views/delivery_notes/new.html.haml
+++ b/app/views/delivery_notes/new.html.haml
@@ -1,4 +1,3 @@
 = breadcrumbs ['Delivery Notes', delivery_notes_path], 'New'
-= page_header('New delivery note')
 
 = render 'form'

--- a/app/views/delivery_notes/show.html.haml
+++ b/app/views/delivery_notes/show.html.haml
@@ -1,13 +1,12 @@
 - can_edit_dn = can?('delivery_notes.edit')
 - edit_action = action_button('Edit', edit_delivery_note_path(@delivery_note), permission: 'delivery_notes.edit') unless @delivery_note.published?
-= breadcrumbs ['Delivery Notes', delivery_notes_path], (@delivery_note.document_number || "Draft ##{@delivery_note.id}")
-= page_header("Delivery Note #{@delivery_note.document_number || "Draft ##{@delivery_note.id}"}", action: edit_action) do
+= breadcrumbs ['Delivery Notes', delivery_notes_path], (@delivery_note.document_number || "Draft ##{@delivery_note.id}"), action: edit_action do
   - if !@delivery_note.published?
-    %span.badge.bg-warning.fs-6 Draft
+    %span.badge.bg-warning Draft
   - elsif @delivery_note.email_sent_at.present?
-    %span.badge.bg-success.fs-6 Sent
+    %span.badge.bg-success Sent
   - else
-    %span.badge.bg-success.fs-6 Booked
+    %span.badge.bg-success Booked
 
 .document-header.row.mb-2
   .col-md-6

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,4 +1,3 @@
 = breadcrumbs 'Configuration', ['Groups', groups_path], [@group.name, group_path(@group)], 'Edit'
-= page_header("Editing group #{@group.name}")
 
 = render 'form'

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -1,5 +1,4 @@
-= breadcrumbs 'Configuration', 'Groups'
-= page_header('Groups', action: action_button('+ New', new_group_path, :info))
+= breadcrumbs 'Configuration', 'Groups', action: action_button('+ New', new_group_path, :info)
 
 %p.text-muted
   Groups bundle system-level permissions. A user inherits all permissions of every group they belong to.

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,4 +1,3 @@
 = breadcrumbs 'Configuration', ['Groups', groups_path], 'New'
-= page_header('New group')
 
 = render 'form'

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -1,5 +1,4 @@
-= breadcrumbs 'Configuration', ['Groups', groups_path], @group.name
-= page_header("Group \"#{@group.name}\"", action: action_button('Edit', edit_group_path(@group)))
+= breadcrumbs 'Configuration', ['Groups', groups_path], @group.name, action: action_button('Edit', edit_group_path(@group))
 
 .row
   .col-md-8

--- a/app/views/invoices/edit.html.haml
+++ b/app/views/invoices/edit.html.haml
@@ -1,4 +1,3 @@
 = breadcrumbs ['Invoices', invoices_path], [(@invoice.document_number || "Draft ##{@invoice.id}"), invoice_path(@invoice)], 'Edit'
-= page_header('Editing invoice draft')
 
 = render 'form'

--- a/app/views/invoices/index.html.haml
+++ b/app/views/invoices/index.html.haml
@@ -1,5 +1,4 @@
-= breadcrumbs 'Invoices'
-= page_header('Listing invoices', action: action_button('+ New', new_invoice_path, :info, permission: 'invoices.edit'))
+= breadcrumbs 'Invoices', action: action_button('+ New', new_invoice_path, :info, permission: 'invoices.edit')
 
 
 .bulk-select-container{data: { controller: 'bulk-select' }}

--- a/app/views/invoices/new.html.haml
+++ b/app/views/invoices/new.html.haml
@@ -1,4 +1,3 @@
 = breadcrumbs ['Invoices', invoices_path], 'New'
-= page_header('New invoice')
 
 = render 'form'

--- a/app/views/invoices/show.html.haml
+++ b/app/views/invoices/show.html.haml
@@ -1,21 +1,20 @@
 - can_edit_invoice = can?('invoices.edit')
 - edit_action = action_button('Edit', edit_invoice_path(@invoice), permission: 'invoices.edit') unless @invoice.published?
-= breadcrumbs ['Invoices', invoices_path], (@invoice.document_number || "Draft ##{@invoice.id}")
-= page_header("Invoice #{@invoice.document_number || "Draft ##{@invoice.id}"}", action: edit_action) do
+= breadcrumbs ['Invoices', invoices_path], (@invoice.document_number || "Draft ##{@invoice.id}"), action: edit_action do
   - if !@invoice.published?
-    %span.badge.bg-warning.fs-6 Draft
+    %span.badge.bg-warning Draft
   - else
     - sent = @invoice.email_sent_at.present?
     - paid = @invoice.paid?
     - overdue = @invoice.overdue?
     - unless sent || paid || overdue
-      %span.badge.bg-success.fs-6 Booked
+      %span.badge.bg-success Booked
     - if paid
-      %span.badge.bg-success.fs-6 Paid
+      %span.badge.bg-success Paid
     - elsif overdue
-      %span.badge.bg-danger.fs-6 Overdue
+      %span.badge.bg-danger Overdue
     - if sent
-      %span.badge.bg-success.fs-6 Sent
+      %span.badge.bg-success Sent
 
 .document-header.row.mb-2
   .col-md-6

--- a/app/views/issuer_companies/edit.html.haml
+++ b/app/views/issuer_companies/edit.html.haml
@@ -1,5 +1,4 @@
 = breadcrumbs 'Configuration', ['Issuer Company', issuer_company_path], 'Edit'
-= page_header('Edit Issuer Company')
 
 = form_with(model: @issuer_company, url: issuer_company_path, method: :patch, local: true, class: 'form', multipart: true) do |form|
   - if @issuer_company.errors.any?

--- a/app/views/issuer_companies/show.html.haml
+++ b/app/views/issuer_companies/show.html.haml
@@ -1,5 +1,4 @@
-= breadcrumbs 'Configuration', 'Issuer Company'
-= page_header('Issuer Company', action: action_button('Edit', edit_issuer_company_path, permission: 'issuer_company.edit'))
+= breadcrumbs 'Configuration', 'Issuer Company', action: action_button('Edit', edit_issuer_company_path, permission: 'issuer_company.edit')
 
 .row
   .col-md-6

--- a/app/views/jobs_status/show.html.haml
+++ b/app/views/jobs_status/show.html.haml
@@ -1,5 +1,4 @@
 = breadcrumbs 'Configuration', 'Background Jobs'
-= page_header('Background Jobs')
 
 - if @queue_adapter != :solid_queue
   .alert.alert-warning

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -1,4 +1,3 @@
 = breadcrumbs 'Configuration', ['Product Catalog', products_path], [@product.title, product_path(@product)], 'Edit'
-= page_header("Editing product #{@product.title}")
 
 = render 'form'

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -1,5 +1,4 @@
-= breadcrumbs 'Configuration', 'Product Catalog'
-= page_header('Listing products', action: action_button('+ New', new_product_path, :info, permission: 'products.edit'))
+= breadcrumbs 'Configuration', 'Product Catalog', action: action_button('+ New', new_product_path, :info, permission: 'products.edit')
 
 %table.table.table-striped.table-sm
   %tr

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -1,4 +1,3 @@
 = breadcrumbs 'Configuration', ['Product Catalog', products_path], 'New'
-= page_header('New product')
 
 = render 'form'

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -1,5 +1,4 @@
-= breadcrumbs 'Configuration', ['Product Catalog', products_path], @product.title
-= page_header("Product \"#{@product.title}\"", action: action_button('Edit', edit_product_path(@product), permission: 'products.edit'))
+= breadcrumbs 'Configuration', ['Product Catalog', products_path], @product.title, action: action_button('Edit', edit_product_path(@product), permission: 'products.edit')
 
 .row
   .col-md-8

--- a/app/views/projects/edit.html.haml
+++ b/app/views/projects/edit.html.haml
@@ -1,4 +1,3 @@
 = breadcrumbs ['Projects', projects_path], [@project.matchcode, project_path(@project)], 'Edit'
-= page_header('Editing project')
 
 = render 'form'

--- a/app/views/projects/index.html.haml
+++ b/app/views/projects/index.html.haml
@@ -1,5 +1,4 @@
-= breadcrumbs 'Projects'
-= page_header('Listing projects', action: action_button('+ New', new_project_path, :info, permission: 'projects.edit'))
+= breadcrumbs 'Projects', action: action_button('+ New', new_project_path, :info, permission: 'projects.edit')
 
 .mb-3
   .btn-toolbar.mb-3{:role=>"toolbar", "aria-label"=>"List toolbar"}

--- a/app/views/projects/new.html.haml
+++ b/app/views/projects/new.html.haml
@@ -1,4 +1,3 @@
 = breadcrumbs ['Projects', projects_path], 'New'
-= page_header('New project')
 
 = render 'form'

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -1,7 +1,6 @@
-= breadcrumbs ['Projects', projects_path], @project.matchcode
-= page_header("Project #{@project.matchcode}", action: action_button('Edit', edit_project_path(@project), permission: 'projects.edit')) do
+= breadcrumbs ['Projects', projects_path], @project.matchcode, action: action_button('Edit', edit_project_path(@project), permission: 'projects.edit') do
   - unless @project.active?
-    %span.badge.bg-secondary.fs-6 Inactive
+    %span.badge.bg-secondary Inactive
 
 .row
   .col-md-8

--- a/app/views/sales_tax_customer_classes/edit.html.haml
+++ b/app/views/sales_tax_customer_classes/edit.html.haml
@@ -1,4 +1,3 @@
 = breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], ['Customer Tax Classes', sales_tax_customer_classes_path], [@sales_tax_customer_class.name, sales_tax_customer_class_path(@sales_tax_customer_class)], 'Edit'
-= page_header('Editing Sales Tax Customer Class')
 
 = render 'form'

--- a/app/views/sales_tax_customer_classes/index.html.haml
+++ b/app/views/sales_tax_customer_classes/index.html.haml
@@ -1,5 +1,4 @@
-= breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], 'Customer Tax Classes'
-= page_header('Listing Sales Tax - Customer Classes', action: action_button('+ New', new_sales_tax_customer_class_path, :info, permission: 'sales_tax.edit'))
+= breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], 'Customer Tax Classes', action: action_button('+ New', new_sales_tax_customer_class_path, :info, permission: 'sales_tax.edit')
 
 %table.table.table-striped.table-sm
   %tr

--- a/app/views/sales_tax_customer_classes/new.html.haml
+++ b/app/views/sales_tax_customer_classes/new.html.haml
@@ -1,4 +1,3 @@
 = breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], ['Customer Tax Classes', sales_tax_customer_classes_path], 'New'
-= page_header('New Sales Tax Customer Class')
 
 = render 'form'

--- a/app/views/sales_tax_customer_classes/show.html.haml
+++ b/app/views/sales_tax_customer_classes/show.html.haml
@@ -1,5 +1,4 @@
-= breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], ['Customer Tax Classes', sales_tax_customer_classes_path], @sales_tax_customer_class.name
-= page_header("Customer Tax Class \"#{@sales_tax_customer_class.name}\"", action: action_button('Edit', edit_sales_tax_customer_class_path(@sales_tax_customer_class), permission: 'sales_tax.edit'))
+= breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], ['Customer Tax Classes', sales_tax_customer_classes_path], @sales_tax_customer_class.name, action: action_button('Edit', edit_sales_tax_customer_class_path(@sales_tax_customer_class), permission: 'sales_tax.edit')
 
 %p
   %b Name:

--- a/app/views/sales_tax_product_classes/edit.html.haml
+++ b/app/views/sales_tax_product_classes/edit.html.haml
@@ -1,4 +1,3 @@
 = breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], ['Product Tax Classes', sales_tax_product_classes_path], [@sales_tax_product_class.name, sales_tax_product_class_path(@sales_tax_product_class)], 'Edit'
-= page_header('Editing Sales Tax Product Class')
 
 = render 'form'

--- a/app/views/sales_tax_product_classes/index.html.haml
+++ b/app/views/sales_tax_product_classes/index.html.haml
@@ -1,5 +1,4 @@
-= breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], 'Product Tax Classes'
-= page_header('Listing Sales Tax - Product Classes', action: action_button('+ New', new_sales_tax_product_class_path, :info, permission: 'sales_tax.edit'))
+= breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], 'Product Tax Classes', action: action_button('+ New', new_sales_tax_product_class_path, :info, permission: 'sales_tax.edit')
 
 %table.table.table-striped.table-sm
   %tr

--- a/app/views/sales_tax_product_classes/new.html.haml
+++ b/app/views/sales_tax_product_classes/new.html.haml
@@ -1,4 +1,3 @@
 = breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], ['Product Tax Classes', sales_tax_product_classes_path], 'New'
-= page_header('New Sales Tax Product Class')
 
 = render 'form'

--- a/app/views/sales_tax_product_classes/show.html.haml
+++ b/app/views/sales_tax_product_classes/show.html.haml
@@ -1,7 +1,6 @@
-= breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], ['Product Tax Classes', sales_tax_product_classes_path], @sales_tax_product_class.name
-= page_header("Product Tax Class \"#{@sales_tax_product_class.name}\"", action: action_button('Edit', edit_sales_tax_product_class_path(@sales_tax_product_class), permission: 'sales_tax.edit')) do
+= breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], ['Product Tax Classes', sales_tax_product_classes_path], @sales_tax_product_class.name, action: action_button('Edit', edit_sales_tax_product_class_path(@sales_tax_product_class), permission: 'sales_tax.edit') do
   - if @sales_tax_product_class.is_default?
-    %span.badge.bg-success.fs-6 Default
+    %span.badge.bg-success Default
 
 %p
   %b Name:

--- a/app/views/sales_tax_rates/edit.html.haml
+++ b/app/views/sales_tax_rates/edit.html.haml
@@ -1,4 +1,3 @@
 = breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], [(@sales_tax_rate.sales_tax_customer_class&.name.to_s + ' / ' + @sales_tax_rate.sales_tax_product_class&.name.to_s), sales_tax_rate_path(@sales_tax_rate)], 'Edit'
-= page_header('Editing Sales Tax Rate')
 
 = render 'form'

--- a/app/views/sales_tax_rates/index.html.haml
+++ b/app/views/sales_tax_rates/index.html.haml
@@ -1,5 +1,4 @@
-= breadcrumbs 'Configuration', 'Sales Tax'
-= page_header('Listing Sales Tax Rates', action: action_button('+ New', new_sales_tax_rate_path, :info, permission: 'sales_tax.edit'))
+= breadcrumbs 'Configuration', 'Sales Tax', action: action_button('+ New', new_sales_tax_rate_path, :info, permission: 'sales_tax.edit')
 
 %table.table.table-striped.table-sm
   %tr

--- a/app/views/sales_tax_rates/new.html.haml
+++ b/app/views/sales_tax_rates/new.html.haml
@@ -1,4 +1,3 @@
 = breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], 'New'
-= page_header('New Sales Tax Rate')
 
 = render 'form'

--- a/app/views/sales_tax_rates/show.html.haml
+++ b/app/views/sales_tax_rates/show.html.haml
@@ -1,5 +1,4 @@
-= breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], "#{@sales_tax_rate.sales_tax_customer_class&.name} / #{@sales_tax_rate.sales_tax_product_class&.name}"
-= page_header('Sales Tax Rate', action: action_button('Edit', edit_sales_tax_rate_path(@sales_tax_rate), permission: 'sales_tax.edit'))
+= breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], "#{@sales_tax_rate.sales_tax_customer_class&.name} / #{@sales_tax_rate.sales_tax_product_class&.name}", action: action_button('Edit', edit_sales_tax_rate_path(@sales_tax_rate), permission: 'sales_tax.edit')
 
 %p
   %b Sales tax customer class:

--- a/app/views/teams/edit.html.haml
+++ b/app/views/teams/edit.html.haml
@@ -1,4 +1,3 @@
 = breadcrumbs 'Configuration', ['Teams', teams_path], [@team.name, team_path(@team)], 'Edit'
-= page_header("Editing team #{@team.name}")
 
 = render 'form'

--- a/app/views/teams/index.html.haml
+++ b/app/views/teams/index.html.haml
@@ -1,5 +1,4 @@
-= breadcrumbs 'Configuration', 'Teams'
-= page_header('Teams', action: action_button('+ New', new_team_path, :info))
+= breadcrumbs 'Configuration', 'Teams', action: action_button('+ New', new_team_path, :info)
 
 %p.text-muted
   Teams control which customers and projects a user can see. Every customer and project belongs to exactly one team.

--- a/app/views/teams/new.html.haml
+++ b/app/views/teams/new.html.haml
@@ -1,4 +1,3 @@
 = breadcrumbs 'Configuration', ['Teams', teams_path], 'New'
-= page_header('New team')
 
 = render 'form'

--- a/app/views/teams/show.html.haml
+++ b/app/views/teams/show.html.haml
@@ -1,5 +1,4 @@
-= breadcrumbs 'Configuration', ['Teams', teams_path], @team.name
-= page_header("Team \"#{@team.name}\"", action: action_button('Edit', edit_team_path(@team)))
+= breadcrumbs 'Configuration', ['Teams', teams_path], @team.name, action: action_button('Edit', edit_team_path(@team))
 
 .row
   .col-md-8

--- a/app/views/user_invites/index.html.haml
+++ b/app/views/user_invites/index.html.haml
@@ -1,7 +1,6 @@
 - content_for :title, 'Invites'
 
-= breadcrumbs 'Configuration', ['Users', users_path], 'Invites'
-= page_header('Invites', action: action_button('+ New', new_user_invite_path, :info))
+= breadcrumbs 'Configuration', ['Users', users_path], 'Invites', action: action_button('+ New', new_user_invite_path, :info)
 
 %table.table.table-striped.table-sm
   %thead

--- a/app/views/user_invites/new.html.haml
+++ b/app/views/user_invites/new.html.haml
@@ -1,7 +1,6 @@
 - content_for :title, 'New invite'
 
 = breadcrumbs 'Configuration', ['Users', users_path], ['Invites', user_invites_path], 'New'
-= page_header('Invite a new user')
 
 %p Click the button below to generate a one-time invite link. The link is valid for 24 hours. The next page will show the URL so you can copy it.
 

--- a/app/views/users/audit.html.haml
+++ b/app/views/users/audit.html.haml
@@ -1,7 +1,6 @@
 - content_for :title, "Audit log for #{@user.username}"
 
 = breadcrumbs 'Configuration', ['Users', users_path], [@user.username, user_path(@user)], 'Audit Log'
-= page_header("Audit log: #{@user.username}")
 
 %table.table.table-striped.table-sm
   %thead

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,7 +1,6 @@
 - content_for :title, 'Users'
 
-= breadcrumbs 'Configuration', 'Users'
-= page_header('Users', action: action_button('+ Invite user', new_user_invite_path, :info))
+= breadcrumbs 'Configuration', 'Users', action: action_button('+ Invite user', new_user_invite_path, :info)
 
 %table.table.table-striped.table-sm
   %thead

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,11 +1,10 @@
 - content_for :title, "User #{@user.username}"
 
-= breadcrumbs 'Configuration', ['Users', users_path], @user.username
-= page_header(@user.username) do
+= breadcrumbs 'Configuration', ['Users', users_path], @user.username do
   - if @user.blocked?
-    %span.badge.bg-danger.fs-6 Blocked
+    %span.badge.bg-danger Blocked
   - if @user.id == current_user.id
-    %span.badge.bg-info.fs-6 This is you
+    %span.badge.bg-info This is you
 
 .row
   .col-md-6

--- a/test/controllers/customers_controller_test.rb
+++ b/test/controllers/customers_controller_test.rb
@@ -14,7 +14,8 @@ class CustomersControllerTest < ActionDispatch::IntegrationTest
   test "should get show" do
     get customer_url(@customer)
     assert_response :success
-    assert_select "h1", text: /Customer/
+    assert_select ".breadcrumb-item", text: "Customers"
+    assert_select ".breadcrumb-item.active", text: @customer.matchcode
   end
 
   test "should get new" do
@@ -136,7 +137,7 @@ class CustomersControllerTest < ActionDispatch::IntegrationTest
   test "active customer shows no inactive badge on show page" do
     get customer_url(@customer)
     assert_response :success
-    assert_select ".page-header ~ .badge", count: 0
+    assert_select "nav[aria-label='breadcrumb'] .badge", count: 0
     assert_select ".badge", text: "Inactive", count: 0
   end
 

--- a/test/controllers/groups_controller_test.rb
+++ b/test/controllers/groups_controller_test.rb
@@ -4,7 +4,7 @@ class GroupsControllerTest < ActionDispatch::IntegrationTest
   test "admin can list groups" do
     get groups_path
     assert_response :success
-    assert_select "h1", text: "Groups"
+    assert_select ".breadcrumb-item.active", text: "Groups"
   end
 
   test "non-admin is denied" do

--- a/test/controllers/issuer_companies_controller_test.rb
+++ b/test/controllers/issuer_companies_controller_test.rb
@@ -8,13 +8,13 @@ class IssuerCompaniesControllerTest < ActionDispatch::IntegrationTest
   test "should get show" do
     get issuer_company_url
     assert_response :success
-    assert_select "h1", text: "Issuer Company"
+    assert_select ".breadcrumb-item.active", text: "Issuer Company"
   end
 
   test "should get edit" do
     get edit_issuer_company_url
     assert_response :success
-    assert_select "h1", text: "Edit Issuer Company"
+    assert_select ".breadcrumb-item.active", text: "Edit"
     assert_select "form"
   end
 

--- a/test/controllers/jobs_status_controller_test.rb
+++ b/test/controllers/jobs_status_controller_test.rb
@@ -16,7 +16,7 @@ class JobsStatusControllerTest < ActionDispatch::IntegrationTest
   test "renders an empty status page" do
     get jobs_status_path
     assert_response :success
-    assert_select "h1", text: "Background Jobs"
+    assert_select ".breadcrumb-item.active", text: "Background Jobs"
     assert_select ".card-header", text: "Worker Processes"
     assert_select ".card-header", text: "Recurring Tasks"
     assert_select ".card-header", text: "Recently Failed Jobs"

--- a/test/controllers/teams_controller_test.rb
+++ b/test/controllers/teams_controller_test.rb
@@ -4,7 +4,7 @@ class TeamsControllerTest < ActionDispatch::IntegrationTest
   test "admin can list teams" do
     get teams_path
     assert_response :success
-    assert_select "h1", text: "Teams"
+    assert_select ".breadcrumb-item.active", text: "Teams"
   end
 
   test "non-admin is denied" do

--- a/test/system/invoice_edit_test.rb
+++ b/test/system/invoice_edit_test.rb
@@ -9,7 +9,7 @@ class InvoiceEditTest < ApplicationSystemTestCase
 
     # Verify we're on the edit page with correct form
     assert_current_path("/invoices/#{invoices(:draft_invoice).id}/edit")
-    assert_text "Editing invoice draft"
+    assert_selector ".breadcrumb-item.active", text: "Edit"
     assert_field "invoice_cust_reference"
     assert_field "invoice_cust_order"
     assert_field "invoice_prelude"
@@ -267,7 +267,7 @@ class InvoiceEditTest < ApplicationSystemTestCase
     end
 
     # Click outside the dropdown
-    find("h1").click
+    find(".breadcrumb-item.active").click
 
     within(".customer-dropdown") do
       # Dropdown should be closed

--- a/test/system/user_invites_test.rb
+++ b/test/system/user_invites_test.rb
@@ -3,7 +3,7 @@ require "application_system_test_case"
 class UserInvitesTest < ApplicationSystemTestCase
   test "generating an invite URL renders the token page" do
     visit new_user_invite_path
-    assert_selector "h1", text: "Invite a new user"
+    assert_selector ".breadcrumb-item.active", text: "New"
 
     click_button "Generate invite URL"
 


### PR DESCRIPTION
## Summary
- Every index/show/edit/new view previously rendered breadcrumbs and a duplicate H1; the active crumb already conveyed the page identity. This PR merges the two by extending `breadcrumbs(*items)` with `action:` and a status-badge block, then drops `page_header` from every view that had breadcrumbs.
- `page_header` stays for the breadcrumb-less pages (dashboard, `account/*`, sign-in, invite flow, "Book invoice", "Invite generated").
- Active crumb gets `fw-semibold` but keeps the small text size PR #372 deliberately settled on. Action buttons inside the breadcrumb strip get `btn-sm` sizing via Bootstrap CSS variables; the row has a `min-height` so pages without an action button stay the same height as those with one.
- Header badges drop `fs-6` (there's no H1 to align with anymore). CLAUDE.md and the few tests that asserted on `h1` / `.page-header` are updated to the new selectors.

## Test plan
- [x] `bundle exec rails test` — 627 runs, 0 failures
- [x] `bundle exec rails test test/system/` — 65 runs, 0 failures
- [x] `pre-commit run --all-files` — clean
- [ ] Eyeball one of each: invoice show (across draft/booked/paid/overdue/sent states), customer show (active + inactive), user show (self + blocked), and any index page — confirm the strip reads as a single header row with badges + small action button right-aligned

🤖 Generated with [Claude Code](https://claude.com/claude-code)