### PR TITLE
Match Upload PDF button to block-user row layout

### DIFF
--- a/app/views/delivery_notes/show.html.haml
+++ b/app/views/delivery_notes/show.html.haml
@@ -98,17 +98,17 @@
               = link_to @delivery_note.acceptance_attachment.filename, @delivery_note.acceptance_attachment, class: 'me-auto', target: '_blank'
               %small.text-muted.ms-2
                 = "Uploaded #{l(@delivery_note.acceptance_attachment.created_at)}"
-          .d-flex.gap-2
-            = form_with url: upload_acceptance_delivery_note_path(@delivery_note), method: :post, multipart: true, local: true, class: 'd-flex align-items-center', data: { controller: 'file-upload-validation' } do |form|
-              .me-2
-                = form.file_field :acceptance_pdf, accept: 'application/pdf', class: 'form-control form-control-sm w-fixed-250', data: { file_upload_validation_target: 'fileInput' }
-              = form.submit 'Replace', class: 'btn btn-warning btn-sm', data: { file_upload_validation_target: 'submitButton' }
-            = button_to 'Delete', delete_acceptance_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-outline-danger btn-sm', confirm: 'Are you sure you want to delete the acceptance document?'
+          .d-flex.gap-2.align-items-center
+            = form_with url: upload_acceptance_delivery_note_path(@delivery_note), method: :post, multipart: true, local: true, data: { controller: 'file-upload-validation' } do |form|
+              .input-group.w-fixed-400
+                = form.file_field :acceptance_pdf, accept: 'application/pdf', class: 'form-control', data: { file_upload_validation_target: 'fileInput' }
+                = form.submit 'Replace', class: 'btn btn-warning', data: { file_upload_validation_target: 'submitButton' }
+            = button_to 'Delete', delete_acceptance_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-outline-danger', confirm: 'Are you sure you want to delete the acceptance document?'
         - else
-          = form_with url: upload_acceptance_delivery_note_path(@delivery_note), method: :post, multipart: true, local: true, class: 'd-flex align-items-center', data: { controller: 'file-upload-validation' } do |form|
-            .me-3
-              = form.file_field :acceptance_pdf, accept: 'application/pdf', class: 'form-control w-auto', data: { file_upload_validation_target: 'fileInput' }
-            = form.submit 'Upload PDF', class: 'btn btn-primary btn-sm', data: { file_upload_validation_target: 'submitButton' }
+          = form_with url: upload_acceptance_delivery_note_path(@delivery_note), method: :post, multipart: true, local: true, data: { controller: 'file-upload-validation' } do |form|
+            .input-group.w-fixed-400
+              = form.file_field :acceptance_pdf, accept: 'application/pdf', class: 'form-control', data: { file_upload_validation_target: 'fileInput' }
+              = form.submit 'Upload PDF', class: 'btn btn-primary', data: { file_upload_validation_target: 'submitButton' }
           %small.text-muted.d-block.mt-2
             Upload the signed acceptance document (PDF only)
 


### PR DESCRIPTION
## Summary
- Reworks the acceptance-document Upload PDF / Replace forms on the delivery notes show page to use a Bootstrap `input-group` shell with a fixed width, matching the block-user pattern on the users show page.
- Drops the mismatched `btn-sm` + `form-control-sm`/`w-auto` sizing on the upload form (which made the small button look wrong next to a full-size file input).
- Brings the sibling Delete button up to default size to stay visually consistent with its row.

## Test plan
- [x] `bundle exec rails test test/controllers/delivery_notes_controller_test.rb` — 37 runs, 0 failures
- [x] `bundle exec rails test test/system/` — 65 runs, 0 failures (covers `delivery_note_acceptance_upload_test.rb`)
- [x] `pre-commit run --all-files` — all hooks pass
- [ ] Manual: visit a published delivery note without an acceptance document, confirm the file input and Upload PDF button align at the same height inside the card.
- [ ] Manual: upload a PDF, confirm Replace + Delete render at matching heights.

Generated with [Claude Code](https://claude.com/claude-code)