### PR TITLE
Drop dead .page-header class hook

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -80,7 +80,7 @@ module ApplicationHelper
   def page_header(title, action: nil, &status_block)
     content_tag :div, class: "d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2" do
       title_area = content_tag(:div, class: "d-flex align-items-center flex-wrap gap-2") do
-        header = content_tag(:h1, title, class: "page-header mb-0")
+        header = content_tag(:h1, title, class: "mb-0")
         status = status_block ? capture(&status_block) : "".html_safe
         header + status
       end


### PR DESCRIPTION
## Summary
- Sweep after PR #378 for orphaned project-local CSS classes / SCSS rules. Only one truly orphaned hook found: `.page-header` was applied to the H1 by the `page_header` helper, but no SCSS rule referenced it. Removed it from the helper; H1 keeps `mb-0`.
- Borderline class names left in place (semantic markup hooks with no current CSS but applied on document/mailer views): `.document-header`, `.document-prelude`, `.document-summary`, `.acceptance-document`, and the mailer-scoped classes defined inline in `layouts/mailer.html.haml`.

## Test plan
- [x] All 40 project-local SCSS class selectors cross-checked against views/helpers/JS — all still referenced
- [x] `bundle exec rails test test/controllers/` — 231 runs, 0 failures
- [x] `bundle exec rails test test/system/` — 65 runs, 0 failures
- [x] `pre-commit run --all-files` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)