### PR TITLE
Drop unstyled .document-* and .acceptance-document hooks

### DIFF
--- a/app/views/delivery_notes/show.html.haml
+++ b/app/views/delivery_notes/show.html.haml
@@ -8,7 +8,7 @@
   - else
     %span.badge.bg-success Booked
 
-.document-header.row.mb-2
+.row.mb-2
   .col-md-6
     .document-details
       - if @delivery_note.date
@@ -85,7 +85,7 @@
 
 
 - if @delivery_note.published?
-  .acceptance-document.mb-4
+  .mb-4
     .card
       .card-header.d-flex.justify-content-between.align-items-center
         %h5.mb-0 Acceptance Document
@@ -112,7 +112,7 @@
             Upload the signed acceptance document (PDF only)
 
 - if @delivery_note.prelude.present?
-  .document-prelude.mb-4
+  .mb-4
     .card
       .card-body
         = simple_format(@delivery_note.prelude)

--- a/app/views/invoices/show.html.haml
+++ b/app/views/invoices/show.html.haml
@@ -16,7 +16,7 @@
     - if sent
       %span.badge.bg-success Sent
 
-.document-header.row.mb-2
+.row.mb-2
   .col-md-6
     .document-details
       - if @invoice.date
@@ -118,7 +118,7 @@
             = link_to "Delivery Note #{@invoice.delivery_note.document_number || "##{@invoice.delivery_note.id}"}", @invoice.delivery_note
 
 - if @invoice.prelude.present?
-  .document-prelude.mb-4
+  .mb-4
     .card
       .card-body
         = simple_format(@invoice.prelude)
@@ -166,28 +166,27 @@
                   - else
                     = simple_format(line.description)
 
-.document-summary
-  .row.justify-content-end
-    .col-md-4
-      %table.table.table-sm
-        %tbody
-          %tr
-            %td.text-end
-              %strong Sum Net:
-            %td.text-end
-              %strong= format_currency(@invoice.sum_net)
-          - if @invoice.invoice_tax_classes.any?
-            - @invoice.invoice_tax_classes.each do |tax_class|
-              %tr
-                %td.text-end
-                  Tax (#{tax_class.rate}%):
-                %td.text-end
-                  = format_currency(tax_class.value)
-          %tr.table-dark
-            %td.text-end
-              %strong Sum Total:
-            %td.text-end
-              %strong= format_currency(@invoice.sum_total)
+.row.justify-content-end
+  .col-md-4
+    %table.table.table-sm
+      %tbody
+        %tr
+          %td.text-end
+            %strong Sum Net:
+          %td.text-end
+            %strong= format_currency(@invoice.sum_net)
+        - if @invoice.invoice_tax_classes.any?
+          - @invoice.invoice_tax_classes.each do |tax_class|
+            %tr
+              %td.text-end
+                Tax (#{tax_class.rate}%):
+              %td.text-end
+                = format_currency(tax_class.value)
+        %tr.table-dark
+          %td.text-end
+            %strong Sum Total:
+          %td.text-end
+            %strong= format_currency(@invoice.sum_total)
 
 = action_buttons_wrapper do
   - if @invoice.attachment


### PR DESCRIPTION
## Summary
- Four CSS class names on the invoice/delivery-note show pages (`.document-header`, `.document-prelude`, `.document-summary`, `.acceptance-document`) had no CSS, no JS, and no test selectors — pure leftover markers from the August 2025 invoice→document rename in `d361df1`.
- Removed them from the HAML; the surviving co-located utility classes (`.row.mb-2`, `.mb-4`) and child Bootstrap components carry all the actual styling.
- `.document-summary` had no other classes, so dropped its wrapper entirely and promoted the inner `.row.justify-content-end` up one level.

Sibling classes that *do* have CSS rules (`.document-details`, `.document-lines`, `.document-lines-table`, `.document-section-row`, `.document-text-row`, `.document-line-comment`) are untouched.

## Test plan
- [x] `bundle exec rails test test/controllers/invoices_controller_test.rb test/controllers/delivery_notes_controller_test.rb` — green
- [x] `bundle exec rails test test/system/invoice_edit_test.rb test/system/invoice_mark_paid_test.rb test/system/delivery_note_acceptance_upload_test.rb` — green
- [x] `pre-commit run --all-files` — green
- [ ] Eyeball invoice and delivery-note show pages in the browser to confirm no visual regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)