### PR TITLE
Show PNG logo on issuer detail page; drop always-green Active badge

### DIFF
--- a/app/assets/stylesheets/dashboard.css.scss
+++ b/app/assets/stylesheets/dashboard.css.scss
@@ -1,6 +1,0 @@
-// Dashboard view (home/index).
-
-.dashboard-issuer-logo {
-  max-height: 80px;
-  max-width: 200px;
-}

--- a/app/assets/stylesheets/issuer_companies.css.scss
+++ b/app/assets/stylesheets/issuer_companies.css.scss
@@ -1,0 +1,7 @@
+// Inline preview of the issuer's PNG logo on the dashboard and the
+// issuer-company detail page.
+
+.issuer-logo-preview {
+  max-height: 80px;
+  max-width: 200px;
+}

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -37,7 +37,7 @@
       .card-body
         - if @data[:issuer_company].png_logo.present?
           .mb-3.text-center
-            = image_tag png_logo_issuer_company_path, alt: @data[:issuer_company].legal_name, class: 'dashboard-issuer-logo'
+            = image_tag png_logo_issuer_company_path, alt: @data[:issuer_company].legal_name, class: 'issuer-logo-preview'
 
         - if @data[:issuer_company].document_accent_color.present?
           %h6.text-issuer-accent

--- a/app/views/issuer_companies/show.html.haml
+++ b/app/views/issuer_companies/show.html.haml
@@ -8,15 +8,6 @@
       .card-body
         .row.mb-2
           .col-sm-4
-            %strong Active:
-          .col-sm-8
-            - if @issuer_company.active?
-              %span.badge.bg-success Yes
-            - else
-              %span.badge.bg-danger No
-
-        .row.mb-2
-          .col-sm-4
             %strong Short Name:
           .col-sm-8
             = @issuer_company.short_name
@@ -124,7 +115,7 @@
             %strong PNG Logo:
           .col-sm-8
             - if @issuer_company.png_logo.present?
-              %span.badge.bg-success Logo uploaded
+              = image_tag png_logo_issuer_company_path, alt: @issuer_company.legal_name, class: 'issuer-logo-preview'
             - else
               %em No logo set
 


### PR DESCRIPTION
## Summary
- Detail page now renders the issuer's PNG logo inline (was a "Logo uploaded" badge).
- Dropped the "Active: Yes/No" row: every caller loads the issuer via `IssuerCompany.get_the_issuer!` (`where(active: true)`) and the edit form doesn't permit `:active`, so the badge could only ever say "Yes" — exactly the always-green badge the status-badge rule in CLAUDE.md says to drop. The `active` column + unique index stay; they enforce "at most one active issuer" at the DB level, which is a constraint, not user-facing state.
- Moved the existing `.dashboard-issuer-logo` rule into a new `issuer_companies.css.scss` as `.issuer-logo-preview`, shared by the dashboard and the detail page. Deleted the now-empty `dashboard.css.scss`.

## Test plan
- [ ] `bundle exec rails test test/controllers/issuer_companies_controller_test.rb` passes (verified locally: 10 runs, 0 failures).
- [ ] Visit `/issuer_company`: PNG logo renders inline at ≤80×200 px; no Active row.
- [ ] Visit `/` (dashboard): logo still renders the same as before.
- [ ] With no PNG logo uploaded, the detail page shows "No logo set".

🤖 Generated with [Claude Code](https://claude.com/claude-code)