### PR TITLE
Surface CSRF failures with an actionable message

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ For testing against PostgreSQL (matches production environment):
 - Self-service under `/account/*`; admin under `/users` (block, reset passkeys, manage emails).
 - Tokens (invite, session, email confirmation) stored as SHA-256 digests via `DigestedToken`.
 - Rate limiting via `rack-attack` on unauthenticated endpoints (`config/initializers/rack_attack.rb`).
+- CSRF: `protect_from_forgery with: :exception` is rescued by `ApplicationController#handle_invalid_authenticity_token`. HTML requests render `app/views/errors/csrf_failure.html.haml` (status 422); JSON XHR requests return `{ "error": "..." }` with status 422. Do not replace this with a redirect or `window.location.reload()` — CSRF failures land on stale forms (login, invoice create, etc.) and an auto-reload silently discards whatever the user just typed. The error template prompts the user to click Reload themselves. New JSON XHR controllers must surface the server's `error` field in a visible alert (see `passkey_controller.js#showError`); never swallow it as `Request failed (422)`.
 
 ### PDF Generation
 - Uses Apache FOP (Formatting Objects Processor) for PDF generation

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,7 @@ class ApplicationController < ActionController::Base
   class PermissionDenied < StandardError; end
   class MissingPermissionCheck < StandardError; end
   rescue_from PermissionDenied, with: :deny_permission
+  rescue_from ActionController::InvalidAuthenticityToken, with: :handle_invalid_authenticity_token
 
   class << self
     def allow_unauthenticated_access(**options)
@@ -46,6 +47,21 @@ class ApplicationController < ActionController::Base
       format.json { render json: { error: "permission_denied" }, status: :forbidden }
       format.turbo_stream { redirect_to root_path, alert: "You don't have permission to access that page." }
       format.any  { head :forbidden }
+    end
+  end
+
+  # CSRF token check failed — usually a stale tab whose session rotated
+  # (sign-out in another tab, server-side session expiry, cookies cleared).
+  # Surface a clear, recovery-oriented message instead of Rails' default
+  # 422.html / dev exception page. The handler must not auto-reload the
+  # page: that would silently discard whatever the user just typed.
+  def handle_invalid_authenticity_token(exception)
+    message = "Your security token has expired. Reload this page to try again."
+    Rails.logger.warn "[csrf] InvalidAuthenticityToken on #{request.method} #{request.path} ua=#{request.user_agent.inspect}"
+    respond_to do |format|
+      format.json { render json: { error: message }, status: :unprocessable_content }
+      format.html { render "errors/csrf_failure", layout: "application", status: :unprocessable_content, locals: { message: message } }
+      format.any  { head :unprocessable_content }
     end
   end
 

--- a/app/views/errors/csrf_failure.html.haml
+++ b/app/views/errors/csrf_failure.html.haml
@@ -1,0 +1,18 @@
+- content_for :title, 'Session expired'
+
+.row.justify-content-center
+  .col-md-6
+    .card.border-warning
+      .card-body
+        %h1.h4.card-title Session expired
+        %p
+          = message
+        %p.text-muted.small
+          This usually happens when you signed out in another tab, or the page
+          sat open longer than the session allowed. Anything you just typed has
+          to be retyped after reloading &mdash; we deliberately do not refresh
+          the page for you.
+        .d-flex.gap-2
+          - reload_target = request.referer.presence || root_path
+          = link_to 'Reload page', reload_target, class: 'btn btn-primary'
+          = link_to 'Go to home', root_path, class: 'btn btn-outline-secondary'

--- a/test/integration/csrf_failure_test.rb
+++ b/test/integration/csrf_failure_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+# CSRF protection is disabled in the test environment by default
+# (config/environments/test.rb). These tests flip it back on so we can
+# exercise the rescue_from handler. Each test restores the original value.
+class CsrfFailureTest < ActionDispatch::IntegrationTest
+  skip_default_signin!
+
+  setup do
+    @original = ActionController::Base.allow_forgery_protection
+    ActionController::Base.allow_forgery_protection = true
+  end
+
+  teardown do
+    ActionController::Base.allow_forgery_protection = @original
+  end
+
+  test "JSON request with missing CSRF token returns a user-actionable error" do
+    # /session/options is the first call the passkey login JS makes.
+    # Without a valid CSRF token, the request must fail with a message
+    # the UI can show verbatim to the user.
+    post options_session_path, params: {}, as: :json
+
+    assert_response :unprocessable_content
+    body = JSON.parse(response.body)
+    assert body["error"].present?, "JSON CSRF failures must include an `error` field"
+    assert_match(/expired|reload/i, body["error"],
+                 "error message should explain the session/token expired and what to do")
+  end
+
+  test "HTML form with missing CSRF token renders a friendly session-expired page" do
+    # Drive a non-JSON form POST. The login form happens to be JSON-only,
+    # so use the sign-out endpoint which is a button_to (HTML POST).
+    user = users(:alice)
+    sign_in_as(user)
+
+    delete session_path, headers: { "Accept" => "text/html" }
+
+    assert_response :unprocessable_content
+    assert_select "h1, h2, h3", text: /session expired/i
+    assert_select "a[href]", text: /reload/i
+    # No auto-reload: forbid <meta http-equiv="refresh"> and inline scripts
+    # that would reload the page without user action.
+    assert_select 'meta[http-equiv="refresh"]', false,
+                  "must not auto-reload via meta refresh"
+    assert_no_match(/location\.reload|location\.href\s*=/i, response.body,
+                    "must not auto-reload via JS")
+  end
+end


### PR DESCRIPTION
## Summary
- Rescue `ActionController::InvalidAuthenticityToken` in `ApplicationController` instead of falling through to Rails' static `public/422.html`. JSON XHRs (passkey login, account/credentials, email send) now return `{ error: "Your security token has expired. Reload this page to try again." }` so `passkey_controller.js#showError` displays a readable message instead of the opaque `Request failed (422)`. HTML form rejections render a new "Session expired" page (`app/views/errors/csrf_failure.html.haml`) with a user-clicked Reload link.
- No auto-reload / redirect: that would silently discard whatever the user just typed (login username, half-written invoice, etc.). The template explicitly tells the user the page wasn't refreshed on purpose.
- `CLAUDE.md` documents the rescue + the no-auto-reload rule so future controllers don't reintroduce the foot-gun.

## Test plan
- [x] `bundle exec rails test test/integration/csrf_failure_test.rb` — JSON path returns 422 + `error` field; HTML path renders "Session expired" + Reload link, asserts no meta-refresh and no `location.reload` / `location.href =` in the body.
- [x] `bundle exec rails test` — 647 runs, 0 failures.
- [x] `pre-commit run --all-files` — passes.
- [ ] Smoke: open `/sessions/new` in two tabs, sign out in one, click "Sign in with passkey" in the other → red alert shows the expired-token message; reload restores normal behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)