### PR TITLE
Move show-page actions into the breadcrumb strip

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,16 +186,54 @@ For testing against PostgreSQL (matches production environment):
 - To render a `datetime` column as date-only (e.g. `email_sent_at` in compact list rows), call `l(value.to_date)` — `l` on a `Time`/`DateTime` produces the time format.
 
 ### UI Helper Methods
-- `breadcrumbs(*items, action: nil, &status_block)` - Bootstrap breadcrumb strip that serves as the page header on every index/show/edit/new page (every page except the dashboard, `/account/*`, the sign-in / invite-acceptance flow, and the post-book confirmation). Each item is either `[label, path]` (link) or a plain label (non-link). The last item is always the active crumb with `aria-current="page"` (rendered `fw-semibold`), and it is the page identifier — there is no separate H1. The optional block yields inline status badges next to the active crumb; the optional `action:` is right-aligned on the same row (built with `action_button(...)`, which returns nil when its permission check fails — that renders as no action area).
+- `breadcrumbs(*items, action: nil, actions: nil, &status_block)` - Bootstrap breadcrumb strip that serves as the page header on every index/show/edit/new page (every page except the dashboard, `/account/*`, the sign-in / invite-acceptance flow, and the post-book confirmation). Each item is either `[label, path]` (link) or a plain label (non-link). The last item is always the active crumb with `aria-current="page"` (rendered `fw-semibold`), and it is the page identifier — there is no separate H1. The optional block yields inline status badges next to the active crumb. The right cluster carries optional secondary `actions:` (array — `nil` entries are compacted out) followed by the primary `action:` (rightmost). Buttons are built with `action_button(...)` or the per-verb helpers from `ActionButtonsHelper` (see "Button Glyphs" below).
   - Top-level resources start with the navbar label linked to its index: `['Customers', customers_path]`, `['Projects', projects_path]`, `['Delivery Notes', delivery_notes_path]`, `['Invoices', invoices_path]`.
   - Configuration resources start with a non-link `'Configuration'` crumb (the dropdown has no destination) followed by the resource's navbar label, e.g. `breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], 'Edit'`.
   - On edit pages append `'Edit'` as the active crumb; on new pages append `'New'`. On show pages the resource's identifier (matchcode / document number / name) is the active crumb.
-  - The bottom `action_buttons_wrapper` no longer contains a `Back` button — the breadcrumb is the navigation anchor. `action_buttons_wrapper` is reserved for workflow verbs (PDF, Send, Publish, Delete, Mark Paid, etc.). `cancel_button(resource)` on edit/new forms stays — it pairs with Submit, not navigation.
-- `page_header(title, action: nil, &status_block)` - Page-header row with an H1 title, optional inline status badges via the block, and optional right-aligned action. Only used on pages without breadcrumbs: dashboard (`home/index`), `/account/*`, the sign-in / invite-acceptance / "Book invoice" / "Invite generated" pages.
-- `action_button(text, path, type = :primary, permission: nil, target: nil, data: nil)` - Styled buttons (primary, secondary, success, info, warning, danger). Returns `nil` when `permission:` is given and the current user lacks it.
-- `action_buttons_wrapper` - Container for the bottom-of-page workflow action row (Back, PDF, Send E-Mail, Publish, Delete, etc.).
-- `destroy_link(resource, confirm_text)` - Smart delete links (trashcan on index, "Delete" on detail pages).
+  - The bottom `action_buttons_wrapper` is gone from show pages — every workflow verb (PDF, Preview, Publish, Convert to Invoice, Delete, etc.) moves into `actions:` on the breadcrumb. Status-row buttons (Send E-Mail, Mark Paid, Mark Unpaid, Book Invoice…) stay inline with their status row. `cancel_button(resource)` on edit/new forms stays — it pairs with Submit, not navigation.
+- `page_header(title, action: nil, &status_block)` - Page-header row with an H1 title, optional inline status badges via the block, and optional right-aligned action. Only used on pages without breadcrumbs: dashboard (`home/index`), `/account/*`, the sign-in / invite-acceptance / "Invite generated" pages.
+- `action_button(text, path, type = :primary, permission: nil, target: nil, data: nil, title: nil)` - Styled buttons (primary, secondary, success, info, warning, danger). Returns `nil` when `permission:` is given and the current user lacks it. Pass `title:` on glyph-only buttons — the helper applies it as both `title=` (hover tooltip) and `aria-label=` (screen-reader name).
+- `action_buttons_wrapper` - Container for the bottom-of-page workflow action row. Only used by `issuer_companies/edit` and `user_invites/show_invite` now.
+- `destroy_link(resource, confirm_text)` - Compact `🗑` outline link for the **Actions** column on index pages. On detail pages use `delete_button(resource)` instead.
 - `list_action_link(text, path, type)` - Compact buttons for in-table row actions.
+- Per-verb helpers in `ActionButtonsHelper` (`delete_button`, `pdf_button`, `preview_button`, `publish_button`, `unpublish_button`, `convert_to_invoice_button`, `unblock_button`, `reset_passkeys_button`, `audit_log_button`) — see "Button Glyphs" below for the full mapping and policy.
+
+### Button Glyphs (Show-page Actions)
+
+Glyphs on action buttons are space-savers, not decoration. Three tiers:
+
+- **Text only** when the label is already short and universally clear: `Edit`, `+ New`, `Cancel`, `Save`, `Reset passkeys`. Don't prefix with a glyph.
+- **Glyph + text** for less-familiar workflow actions where the glyph aids scanning but the text is still required: `🚀 Publish`, `🚀 Convert to Invoice`, etc.
+- **Glyph only with `title:`** for actions whose glyph is universally understood and whose label is fully replaceable: `🗑` Delete, `📄` PDF, `👁` Preview. Always pass `title:` to set both the hover tooltip and the screen-reader `aria-label`.
+
+Label-shortening rule: when a glyph already carries the verb concept and the remaining noun/state is clear, drop the leading verb in the label. So `Mark Paid` → `✅ Paid` (✅ = the verb, "Paid" = the state). Keep `🚀 Publish`, `📥 Upload PDF` full when the verb/object isn't carried by the glyph alone.
+
+Glyph reuse is intentional when the action archetype is the same:
+- 🚀 = "promote forward" (Publish + Convert to Invoice)
+- ✅ = "positive state change" (Paid + Unblock)
+- ↩ / ↩️ = "revert state" (Unpaid + Unpublish) — Unicode-distinct but visually similar; they never coexist on the same page
+
+Established mapping — extend this table; don't invent new glyphs for existing verbs:
+
+| Verb | Render | Tier | Helper |
+|---|---|---|---|
+| Edit | `Edit` | text-only | `action_button` |
+| + New | `+ New` | text-only | `action_button` |
+| Cancel | `Cancel` | text-only | `cancel_button` |
+| Reset passkeys | `Reset passkeys` | text-only | `reset_passkeys_button` |
+| Delete | `🗑` (title "Delete") | glyph-only | `delete_button` |
+| PDF | `📄` (title "PDF") | glyph-only | `pdf_button` |
+| Preview | `👁` (title "Preview") | glyph-only | `preview_button` |
+| Mark Paid | `✅ Paid` | glyph + shortened text | (status-row, inline) |
+| Mark Unpaid | `↩ Unpaid` | glyph + shortened text | (status-row, inline) |
+| Send e-mail | `✉️ Send` | glyph + text | (status-row, inline) |
+| Publish | `🚀 Publish` | glyph + text | `publish_button` |
+| Unpublish | `↩️ Unpublish` | glyph + text | `unpublish_button` |
+| Convert to Invoice | `🚀 Convert to Invoice` | glyph + text | `convert_to_invoice_button` |
+| Upload PDF | `📥 Upload PDF` | glyph + text | (form, inline) |
+| Block | `🚫 Block` | glyph + text | (form-with-reason, inline) |
+| Unblock | `✅ Unblock` | glyph + text | `unblock_button` |
+| Audit log | `📋 Audit log` | glyph + text | `audit_log_button` |
 
 ### JavaScript/Stimulus Controllers
 - **ALWAYS implement `disconnect()` method** in Stimulus controllers that add event listeners

--- a/app/helpers/action_buttons_helper.rb
+++ b/app/helpers/action_buttons_helper.rb
@@ -1,0 +1,88 @@
+module ActionButtonsHelper
+  # Per-verb helpers for the show-page breadcrumb action cluster. Each helper
+  # bakes in the established glyph, Bootstrap color, accessible name (for
+  # glyph-only Tier 3), and the link_to-vs-button_to choice. See CLAUDE.md's
+  # "Button Glyphs" section for the policy and full mapping.
+  #
+  # Every helper supports `permission:` and returns nil when denied, so views
+  # can pass `actions: [pdf_button(...), delete_button(...)]` and let the
+  # breadcrumbs helper compact out the nils.
+
+  # --- Tier 3: glyph-only (title required) ---
+
+  def delete_button(resource, confirm: nil)
+    confirm ||= "Are you sure you want to delete this #{resource.class.name.downcase}?"
+    link_to "🗑", resource,
+            class: "btn btn-danger",
+            title: "Delete",
+            "aria-label": "Delete",
+            data: { "turbo-method": "delete", "turbo-confirm": confirm }
+  end
+
+  def pdf_button(path, permission: nil)
+    return nil if permission && !can?(permission)
+    link_to "📄", path,
+            class: "btn btn-success",
+            title: "PDF",
+            "aria-label": "PDF",
+            target: "_blank",
+            data: { turbo: false }
+  end
+
+  def preview_button(path, permission: nil)
+    return nil if permission && !can?(permission)
+    link_to "👁", path,
+            class: "btn btn-info",
+            title: "Preview",
+            "aria-label": "Preview",
+            target: "_blank",
+            data: { turbo: false }
+  end
+
+  # --- Tier 2: glyph + text ---
+
+  def publish_button(path, permission: nil, confirm: nil)
+    return nil if permission && !can?(permission)
+    button_to "🚀 Publish", path,
+              method: :post,
+              class: "btn btn-warning",
+              data: { "turbo-confirm": confirm }.compact
+  end
+
+  def unpublish_button(path, permission: nil, confirm: nil)
+    return nil if permission && !can?(permission)
+    button_to "↩️ Unpublish", path,
+              method: :post,
+              class: "btn btn-outline-secondary",
+              data: { "turbo-confirm": confirm }.compact
+  end
+
+  def convert_to_invoice_button(path, permission: nil, confirm: nil)
+    return nil if permission && !can?(permission)
+    button_to "🚀 Convert to Invoice", path,
+              method: :post,
+              class: "btn btn-info",
+              data: { "turbo-confirm": confirm }.compact
+  end
+
+  def unblock_button(path, permission: nil, confirm: nil)
+    return nil if permission && !can?(permission)
+    button_to "✅ Unblock", path,
+              method: :post,
+              class: "btn btn-success",
+              data: { "turbo-confirm": confirm }.compact
+  end
+
+  def reset_passkeys_button(path, permission: nil, confirm: nil)
+    return nil if permission && !can?(permission)
+    button_to "Reset passkeys", path,
+              method: :post,
+              class: "btn btn-warning",
+              data: { "turbo-confirm": confirm }.compact
+  end
+
+  def audit_log_button(path, permission: nil)
+    return nil if permission && !can?(permission)
+    link_to "📋 Audit log", path, class: "btn btn-secondary"
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -34,8 +34,9 @@ module ApplicationHelper
 
   # Renders the breadcrumb strip that serves as the page header on every
   # index/show/edit/new page. The active (last) crumb is the page identifier;
-  # optional status badges (via the block) sit next to it; an optional action:
-  # button is right-aligned on the same row.
+  # optional status badges (via the block) sit next to it; the right cluster
+  # carries optional secondary actions (`actions:`, an array) followed by the
+  # primary action (`action:`, single) rightmost.
   #
   # Items are either:
   #   - [label, path]  → rendered as a link
@@ -43,11 +44,17 @@ module ApplicationHelper
   # The last item is always rendered as the active (current) crumb, regardless
   # of whether a path was given.
   #
+  # `actions:` accepts an array of pre-built buttons (action_button,
+  # delete_button, button_to forms, etc). nil entries are compacted out, so
+  # views can rely on permission-gated helpers returning nil.
+  #
   #   = breadcrumbs ['Customers', customers_path], @customer.display_name
-  #   = breadcrumbs ['Customers', customers_path], @customer.matchcode, action: action_button('Edit', edit_customer_path(@customer)) do
+  #   = breadcrumbs ['Customers', customers_path], @customer.matchcode,
+  #       actions: [delete_button(@customer)],
+  #       action: action_button('Edit', edit_customer_path(@customer)) do
   #     - unless @customer.active?
   #       %span.badge.bg-secondary Inactive
-  def breadcrumbs(*items, action: nil, &status_block)
+  def breadcrumbs(*items, action: nil, actions: nil, &status_block)
     nav = content_tag :nav, "aria-label": "breadcrumb" do
       content_tag :div, class: "d-flex justify-content-between align-items-center flex-wrap gap-2 border-bottom py-1 mb-2" do
         left = content_tag(:div, class: "d-flex align-items-center flex-wrap gap-2 small") do
@@ -66,7 +73,9 @@ module ApplicationHelper
           end
           ol + (status_block ? capture(&status_block) : "".html_safe)
         end
-        left + (action || "".html_safe)
+        action_cluster_html = Array(actions).compact.map { |a| a }.join.html_safe + (action || "".html_safe)
+        right = action_cluster_html.empty? ? "".html_safe : content_tag(:div, action_cluster_html, class: "d-flex align-items-center flex-wrap gap-2")
+        left + right
       end
     end
     nav + page_header_flash
@@ -118,38 +127,28 @@ module ApplicationHelper
     link_to(text, path, options.merge(class: css_classes))
   end
 
-  # Trashcan (on index) or "Delete" button (on detail pages) for a resource.
+  # Index-context delete link: a small outline trashcan that fits into row
+  # actions. Detail-page delete uses `delete_button(resource)` (defined in
+  # ActionButtonsHelper) — both render the 🗑 glyph, but the index variant is
+  # the small btn-outline-danger sized for table rows.
   # When permission: is given and the current user lacks it, returns nil so
   # views can gate inline without an `- if can?('xxx.edit')` wrap.
   def destroy_link(resource, confirm_text = nil, permission: nil)
     return nil if permission && !can?(permission)
     confirm_text ||= "Are you sure you want to delete this #{resource.class.name.downcase}?"
-
-    if action_name == "index"
-      # Show trashcan icon on index pages (space-saving)
-      list_action_link("🗑", resource, :destroy, {
-        data: {
-          'turbo-method': "delete",
-          'turbo-confirm': confirm_text
-        }
-      })
-    else
-      # Show "Delete" text on detail pages with proper action button styling
-      link_to("Delete", resource, {
-        data: {
-          'turbo-method': "delete",
-          'turbo-confirm': confirm_text
-        },
-        class: "btn btn-danger"
-      })
-    end
+    list_action_link("🗑", resource, :destroy, {
+      data: {
+        'turbo-method': "delete",
+        'turbo-confirm': confirm_text
+      }
+    })
   end
 
   def action_buttons_wrapper(&block)
     content_tag :div, class: "d-flex gap-2 mb-3 mt-3", &block
   end
 
-  def action_button(text, path, type = :primary, permission: nil, target: nil, data: nil)
+  def action_button(text, path, type = :primary, permission: nil, target: nil, data: nil, title: nil)
     return nil if permission && !can?(permission)
     css_class = case type
     when :primary
@@ -168,7 +167,7 @@ module ApplicationHelper
       "btn btn-primary"
     end
 
-    link_to(text, path, class: css_class, target: target, data: data)
+    link_to(text, path, class: css_class, target: target, data: data, title: title, "aria-label": title)
   end
 
   def cancel_button(resource)

--- a/app/views/customers/show.html.haml
+++ b/app/views/customers/show.html.haml
@@ -1,4 +1,8 @@
-= breadcrumbs ['Customers', customers_path], @customer.matchcode, action: action_button('Edit', edit_customer_path(@customer), permission: 'customers.edit') do
+- invoices_action = action_button('Invoices', invoices_path(customer_id: @customer.id, year: 'all'), :info, permission: 'invoices.view', data: { turbo_prefetch: false })
+- delivery_notes_action = action_button('Delivery Notes', delivery_notes_path(customer_id: @customer.id, year: 'all'), :info, permission: 'delivery_notes.view', data: { turbo_prefetch: false })
+- delete_action = delete_button(@customer, confirm: "Are you sure you want to delete customer \"#{@customer.matchcode}\" (#{@customer.name})?") if can?('customers.edit') && !@customer.used_in_invoices?
+- edit_action = action_button('Edit', edit_customer_path(@customer), permission: 'customers.edit')
+= breadcrumbs ['Customers', customers_path], @customer.matchcode, actions: [invoices_action, delivery_notes_action, delete_action], action: edit_action do
   - unless @customer.active?
     %span.badge.bg-secondary Inactive
 
@@ -118,11 +122,3 @@
           Notes
         .card-body
           = simple_format(@customer.notes)
-
-= action_buttons_wrapper do
-  - if can?('invoices.view')
-    = action_button 'Invoices', invoices_path(customer_id: @customer.id, year: 'all'), :info, data: { turbo_prefetch: false }
-  - if can?('delivery_notes.view')
-    = action_button 'Delivery Notes', delivery_notes_path(customer_id: @customer.id, year: 'all'), :info, data: { turbo_prefetch: false }
-  - if can?('customers.edit') && !@customer.used_in_invoices?
-    = button_to 'Delete', @customer, method: :delete, class: 'btn btn-danger', data: { 'turbo-confirm': "Are you sure you want to delete customer \"#{@customer.matchcode}\" (#{@customer.name})?" }

--- a/app/views/delivery_notes/show.html.haml
+++ b/app/views/delivery_notes/show.html.haml
@@ -1,6 +1,12 @@
 - can_edit_dn = can?('delivery_notes.edit')
 - edit_action = action_button('Edit', edit_delivery_note_path(@delivery_note), permission: 'delivery_notes.edit') unless @delivery_note.published?
-= breadcrumbs ['Delivery Notes', delivery_notes_path], (@delivery_note.document_number || "Draft ##{@delivery_note.id}"), action: edit_action do
+- pdf_action = pdf_button(pdf_delivery_note_path(@delivery_note))
+- preview_action = preview_button(preview_delivery_note_path(@delivery_note))
+- convert_action = convert_to_invoice_button(convert_to_invoice_delivery_note_path(@delivery_note), permission: 'delivery_notes.edit', confirm: 'Create an invoice draft from this delivery note?') unless @delivery_note.invoice
+- unpublish_action = unpublish_button(unpublish_delivery_note_path(@delivery_note), permission: 'delivery_notes.edit', confirm: 'Are you sure you want to revert this delivery note to draft status?')
+- delete_action = delete_button(@delivery_note, confirm: "Are you sure you want to delete delivery note \"#{@delivery_note.document_number || "##{@delivery_note.id}"}\"?") if can_edit_dn
+- workflow_actions = @delivery_note.published? ? [pdf_action, convert_action, unpublish_action] : [preview_action, delete_action]
+= breadcrumbs ['Delivery Notes', delivery_notes_path], (@delivery_note.document_number || "Draft ##{@delivery_note.id}"), actions: workflow_actions, action: edit_action do
   - if !@delivery_note.published?
     %span.badge.bg-warning Draft
   - elsif @delivery_note.email_sent_at.present?
@@ -177,18 +183,6 @@
                       %pre.mb-0.font-monospace.text-pre-wrap= line.description
                     - else
                       = simple_format(line.description)
-
-  = action_buttons_wrapper do
-    - if @delivery_note.published?
-      = action_button 'PDF', pdf_delivery_note_path(@delivery_note), :success, target: '_blank', data: { turbo: false }
-      - if can_edit_dn && !@delivery_note.invoice
-        = button_to 'Convert to Invoice', convert_to_invoice_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-info', confirm: 'Create an invoice draft from this delivery note?'
-      - if can_edit_dn
-        = button_to 'Unpublish', unpublish_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-outline-secondary', confirm: 'Are you sure you want to revert this delivery note to draft status?'
-    - else
-      = action_button 'Preview', preview_delivery_note_path(@delivery_note), :info, target: '_blank', data: { turbo: false }
-      - if can_edit_dn
-        = destroy_link(@delivery_note, "Are you sure you want to delete delivery note \"#{@delivery_note.document_number || "##{@delivery_note.id}"}\"?")
 
   - if @delivery_note.published?
     = render 'shared/email_preview_modal', title: "Preview - Delivery Note #{@delivery_note.document_number}"

--- a/app/views/invoices/show.html.haml
+++ b/app/views/invoices/show.html.haml
@@ -1,7 +1,9 @@
 - can_edit_invoice = can?('invoices.edit')
 - edit_action = action_button('Edit', edit_invoice_path(@invoice), permission: 'invoices.edit') unless @invoice.published?
 - problems = @invoice.published? ? [] : @invoice.booking_problems
-= breadcrumbs ['Invoices', invoices_path], (@invoice.document_number || "Draft ##{@invoice.id}"), action: edit_action do
+- pdf_or_preview = @invoice.attachment ? pdf_button(@invoice.attachment) : preview_button(preview_invoice_path(@invoice))
+- delete_action = delete_button(@invoice, confirm: "Are you sure you want to delete invoice \"#{@invoice.document_number || "##{@invoice.id}"}\"?") if !@invoice.published? && can_edit_invoice
+= breadcrumbs ['Invoices', invoices_path], (@invoice.document_number || "Draft ##{@invoice.id}"), actions: [pdf_or_preview, delete_action], action: edit_action do
   - if !@invoice.published?
     %span.badge.bg-warning Draft
   - else
@@ -222,14 +224,6 @@
               %strong Sum Total:
             %td.text-end
               %strong= format_currency(@invoice.sum_total)
-
-  = action_buttons_wrapper do
-    - if @invoice.attachment
-      = action_button 'PDF', @invoice.attachment, :success, target: '_blank', data: { turbo: false }
-    - else
-      = action_button 'Preview', preview_invoice_path(@invoice), :info, target: '_blank', data: { turbo: false }
-    - if !@invoice.published && can_edit_invoice
-      = destroy_link(@invoice, "Are you sure you want to delete invoice \"#{@invoice.document_number || "##{@invoice.id}"}\"?")
 
   - if @invoice.published?
     = render 'shared/email_preview_modal', title: "Preview - Invoice #{@invoice.document_number}"

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,6 +1,9 @@
 - content_for :title, "User #{@user.username}"
 
-= breadcrumbs 'Configuration', ['Users', users_path], @user.username do
+- unblock_action = unblock_button(unblock_user_path(@user), permission: 'users.block', confirm: "Unblock #{@user.username}?") if @user.blocked?
+- reset_action = reset_passkeys_button(reset_passkeys_user_path(@user), permission: 'users.reset_passkeys', confirm: "Delete all of #{@user.username}'s passkeys and email them an invite to register a new one?") if @user.blocked?
+- audit_action = audit_log_button(audit_user_path(@user))
+= breadcrumbs 'Configuration', ['Users', users_path], @user.username, actions: [unblock_action, reset_action, audit_action] do
   - if @user.blocked?
     %span.badge.bg-danger Blocked
   - if @user.id == current_user.id
@@ -146,21 +149,13 @@
                 - if team.builtin?
                   %span.badge.bg-secondary.ms-1 built-in
 
-= action_buttons_wrapper do
-  - if @user.blocked?
-    - if can?('users.block')
-      = button_to 'Unblock', unblock_user_path(@user), method: :post,
-          data: { turbo_confirm: "Unblock #{@user.username}?" },
-          class: 'btn btn-success'
-    - if can?('users.reset_passkeys')
-      = button_to 'Reset passkeys', reset_passkeys_user_path(@user), method: :post,
-          data: { turbo_confirm: "Delete all of #{@user.username}'s passkeys and email them an invite to register a new one?" },
-          class: 'btn btn-warning'
-  - elsif @user.id != current_user.id && can?('users.block')
-    = form_with url: block_user_path(@user), method: :post, local: true, class: 'd-inline-flex' do |f|
-      .input-group.w-fixed-400
-        = f.text_field :reason, class: 'form-control', placeholder: 'Reason (required)', required: true
-        = f.submit 'Block', class: 'btn btn-danger',
-            data: { turbo_confirm: "Block #{@user.username}? All sessions will be terminated." }
-
-  = action_button('View audit log', audit_user_path(@user), :secondary)
+- if !@user.blocked? && @user.id != current_user.id && can?('users.block')
+  .row.mb-3
+    .col-sm-4
+      %strong Block user:
+    .col-sm-8
+      = form_with url: block_user_path(@user), method: :post, local: true do |f|
+        .input-group.w-fixed-400
+          = f.text_field :reason, class: 'form-control', placeholder: 'Reason (required)', required: true
+          = f.submit '🚫 Block', class: 'btn btn-danger',
+              data: { turbo_confirm: "Block #{@user.username}? All sessions will be terminated." }

--- a/docs/superpowers/specs/2026-05-26-show-actions-in-breadcrumb.md
+++ b/docs/superpowers/specs/2026-05-26-show-actions-in-breadcrumb.md
@@ -130,7 +130,6 @@ Established mapping — extend this table, don't invent new glyphs for existing 
 | Publish | `🚀 Publish` | glyph + text | `publish_button` |
 | Unpublish | `↩️ Unpublish` | glyph + text | `unpublish_button` |
 | Convert to Invoice | `🚀 Convert to Invoice` | glyph + text | `convert_to_invoice_button` |
-| Test Booking | `🧪 Test Booking` | glyph + text | `test_booking_button` |
 | Upload PDF | (file-upload form — out of scope) | — | — |
 | Block / Unblock | `🚫 Block` / `✅ Unblock` | glyph + text | `block_button` / `unblock_button` |
 | Audit log | `📋 Audit log` | glyph + text | `audit_log_button` |
@@ -143,19 +142,19 @@ For each show view: delete its `= action_buttons_wrapper do ... end`, build an `
 
 ### `app/views/invoices/show.html.haml`
 
-Today's bottom row: PDF, Preview, Test Booking, Delete. Edit stays as the breadcrumb `action:`.
+After PR #382 lands (this PR is stacked on top of #382), the invoice show bottom row is simpler: **PDF or Preview** (depending on whether the invoice has an attachment) **and Delete** (only when not published). Test Booking is gone — replaced by an inline-validation **Book Invoice** button living inside the **Booking Status** status row (`.col-sm-8.d-flex.align-items-center.gap-2`), which is out of scope per the status-row rule. Edit stays as the breadcrumb `action:`.
 
 ```haml
 - edit_action = action_button('Edit', edit_invoice_path(@invoice), permission: 'invoices.edit') unless @invoice.published?
 - workflow_actions = [
--   pdf_button(pdf_invoice_path(@invoice), permission: 'invoices.read'),
--   preview_button(preview_invoice_path(@invoice), permission: 'invoices.read'),
--   test_booking_button(test_book_invoice_path(@invoice), permission: 'invoices.book'),
--   (delete_button(@invoice) if can?('invoices.delete') && !@invoice.published?),
+-   (@invoice.attachment ? pdf_button(@invoice.attachment) : preview_button(preview_invoice_path(@invoice))),
+-   (delete_button(@invoice, confirm: "Are you sure you want to delete invoice \"#{@invoice.document_number || "##{@invoice.id}"}\"?") if !@invoice.published? && can_edit_invoice),
 - ]
 = breadcrumbs ['Invoices', invoices_path], (@invoice.document_number || "Draft ##{@invoice.id}"), actions: workflow_actions, action: edit_action do
   -# status badges unchanged
 ```
+
+Note: the post-booking green `.alert.alert-success` (Download PDF / Send E-Mail from `params[:booked] == '1'`) is its own body banner introduced by #382 — not part of `action_buttons_wrapper`, not in scope.
 
 ### `app/views/delivery_notes/show.html.haml`
 

--- a/docs/superpowers/specs/2026-05-26-show-actions-in-breadcrumb.md
+++ b/docs/superpowers/specs/2026-05-26-show-actions-in-breadcrumb.md
@@ -1,0 +1,259 @@
+# Show-page actions in the breadcrumb strip
+
+## Context
+
+PR #378 dropped the H1 row on every index/show/edit/new page and folded the page title + a single right-aligned `action:` button + status badges into the breadcrumb strip. That left a separate bottom row (`action_buttons_wrapper`) on show pages still carrying the secondary workflow buttons (PDF, Preview, Test Booking, Publish, Convert to Invoice, Delete, Block/Unblock, Reset passkeys, Audit log, etc.). The two rows of buttons — top-right and bottom — split the user's attention.
+
+This work folds the bottom row into the breadcrumb strip too, so every show page renders a single header row carrying every workflow action. Along the way it also formalises a glyph policy (using emoji as text-shorteners) and introduces per-verb helper methods so the policy can't drift across views.
+
+Out of scope: status-row action buttons (Send E-Mail, Mark Paid, Mark Unpaid). Those stay inline with their status text — their proximity to the status they act on is load-bearing.
+
+## Decisions already made (during brainstorm)
+
+- **Scope**: every button currently rendered through `action_buttons_wrapper` on a show page moves into the breadcrumb strip, including the destructive Delete.
+- **Pre-existing `action:` button keeps its position** (right edge of the strip). New buttons land to its left.
+- **No automatic visual emphasis from the helper.** Callers continue to pick `:primary` / `:info` / `:danger` etc. via `action_button`. The "primary action" concept is expressed in code (which keyword the caller uses) but not in the visual styling — the helper does no fw-bold magic.
+- **Three-tier glyph policy** (see table below). Emoji is a text-shortener, not decoration; tiers are chosen per verb.
+- **Glyph-only buttons require an accessible name** (`title=` and `aria-label=`).
+- **Per-verb helpers** for every entry in the glyph table — so view code reads `pdf_button(path)` not `action_button('📄', path, :success, title: 'PDF', target: '_blank', data: { turbo: false })`. Helpers for status-row verbs (`mark_paid_button`, `mark_unpaid_button`, `send_email_button`) are catalogued in the table for the future migration of those rows, but **not created or wired up in this PR** — the table is the policy, the PR only ships helpers for the show-page bottom row it migrates.
+
+## Helper API changes
+
+### `breadcrumbs` gains `actions:`
+
+```ruby
+def breadcrumbs(*items, action: nil, actions: nil, &status_block)
+```
+
+- `action:` (existing): the single primary action, rightmost in the cluster. Whatever color the caller built it with.
+- `actions:` (new): optional array of additional pre-built buttons. `nil` entries are compacted out, so views can pass `actions: [maybe_a, maybe_b, maybe_c]` and let permission-denied helpers return `nil` naturally.
+- Render order in the right cluster: `actions[0], actions[1], ..., actions[N], action`.
+- All buttons keep `btn-sm` sizing via the existing `nav[aria-label="breadcrumb"] .btn` CSS rule.
+- Backward-compatible: every existing call site continues to work.
+
+### `action_button` gains `title:`
+
+```ruby
+def action_button(text, path, type = :primary, permission: nil, target: nil, data: nil, title: nil)
+```
+
+- When `title:` is given, the helper applies it as both `title=` (hover tooltip) and `aria-label=` (screen-reader name). Required on Tier-3 (glyph-only) buttons.
+- When `title:` is omitted, behaviour is unchanged.
+
+### Per-verb helpers
+
+New module `app/helpers/action_buttons_helper.rb` carrying one helper per entry in the glyph table. Each helper bakes in the glyph, color, accessibility text, and (where applicable) the `link_to` vs `button_to` choice and method/confirm details. Callers pass only path, permission, and any per-call data.
+
+Example sketches:
+
+```ruby
+module ActionButtonsHelper
+  # Glyph-only (Tier 3) — title required.
+  def delete_button(resource, confirm: nil)
+    confirm ||= "Are you sure you want to delete this #{resource.class.name.downcase}?"
+    link_to "🗑", resource,
+      class: "btn btn-danger",
+      title: "Delete", "aria-label": "Delete",
+      data: { 'turbo-method': "delete", 'turbo-confirm': confirm }
+  end
+
+  def pdf_button(path, permission: nil)
+    return nil if permission && !can?(permission)
+    link_to "📄", path,
+      class: "btn btn-success",
+      title: "PDF", "aria-label": "PDF",
+      target: "_blank", data: { turbo: false }
+  end
+
+  def preview_button(path, permission: nil)
+    return nil if permission && !can?(permission)
+    link_to "👁", path,
+      class: "btn btn-info",
+      title: "Preview", "aria-label": "Preview",
+      target: "_blank", data: { turbo: false }
+  end
+
+  # Tier 2 — glyph + text, no title needed.
+  def publish_button(path, permission: nil, confirm: nil)
+    return nil if permission && !can?(permission)
+    button_to "🚀 Publish", path,
+      method: :post, class: "btn btn-warning",
+      data: (confirm ? { 'turbo-confirm': confirm } : {})
+  end
+
+  # ...and similar for every entry in the glyph table.
+end
+```
+
+Two design choices baked in:
+- Helpers carry the **Bootstrap color**. `pdf_button` is `btn-success` because that's the established colour on delivery_notes/show. Changing the colour is a one-line change in the helper, applied everywhere.
+- Helpers handle **permission gating** the same way `action_button` does — return `nil` when denied so `actions:` array compaction takes care of layout.
+
+### `destroy_link` collapses into `delete_button`
+
+`destroy_link(resource, confirm_text)` currently splits behaviour by action: trashcan on `index`, "Delete" text on others. Going forward:
+
+- Detail pages → `delete_button(resource)` (always `🗑` with `title: "Delete"`).
+- Index pages → unchanged behaviour, but renamed or routed through a new index-context helper if it stays divergent.
+
+Simplest path: keep `destroy_link` for index pages (the only remaining caller), unchanged. Detail pages use the new `delete_button`. Each helper does one thing.
+
+## Glyph policy (for CLAUDE.md)
+
+Emoji is a text-shortener, not decoration. Three tiers:
+
+- **Text only** — when the label is already short and universally clear: `Edit`, `+ New`, `Cancel`, `Save`, `Reset passkeys`. Don't prefix with a glyph.
+- **Glyph + text** — for less-familiar workflow actions where the glyph aids scanning but the text is still required: `🚀 Publish`, `🚀 Convert to Invoice`, `🧪 Test Booking`, etc.
+- **Glyph only with `title:`** — for actions whose glyph is universally understood and whose label is fully replaceable: `🗑` Delete, `📄` PDF, `👁` Preview. Always pass `title:` to set both the hover tooltip and the screen-reader `aria-label`.
+
+Label-shortening rule: when a glyph already carries the verb concept and the remaining noun/state is clear, drop the leading verb in the label. So `Mark Paid` → `✅ Paid` (✅ = the verb, "Paid" = the state). Keep `🚀 Publish` etc. full when the verb/object isn't carried by the glyph alone.
+
+Glyph reuse is intentional when the action archetype is the same:
+- 🚀 = "promote forward" (Publish + Convert to Invoice)
+- ✅ = "positive state change" (Paid + Unblock)
+- ↩/↩️ = "revert state" (Unpaid + Unpublish)
+
+Established mapping — extend this table, don't invent new glyphs for existing verbs:
+
+| Verb | Render | Tier | Helper |
+|---|---|---|---|
+| Edit | `Edit` | text-only | (use `action_button`) |
+| + New | `+ New` | text-only | (use `action_button`) |
+| Cancel | `Cancel` | text-only | `cancel_button` (existing) |
+| Reset passkeys | `Reset passkeys` | text-only | `reset_passkeys_button` |
+| Delete | `🗑` (title: "Delete") | glyph-only | `delete_button` |
+| PDF | `📄` (title: "PDF") | glyph-only | `pdf_button` |
+| Preview | `👁` (title: "Preview") | glyph-only | `preview_button` |
+| Mark Paid | `✅ Paid` | glyph + shortened text | `mark_paid_button` |
+| Mark Unpaid | `↩ Unpaid` | glyph + shortened text | `mark_unpaid_button` |
+| Send e-mail | `✉️ Send` | glyph + text | `send_email_button` |
+| Publish | `🚀 Publish` | glyph + text | `publish_button` |
+| Unpublish | `↩️ Unpublish` | glyph + text | `unpublish_button` |
+| Convert to Invoice | `🚀 Convert to Invoice` | glyph + text | `convert_to_invoice_button` |
+| Test Booking | `🧪 Test Booking` | glyph + text | `test_booking_button` |
+| Upload PDF | (file-upload form — out of scope) | — | — |
+| Block / Unblock | `🚫 Block` / `✅ Unblock` | glyph + text | `block_button` / `unblock_button` |
+| Audit log | `📋 Audit log` | glyph + text | `audit_log_button` |
+
+## Per-page migration
+
+For each show view: delete its `= action_buttons_wrapper do ... end`, build an `actions:` array from per-verb helpers, pass it to `breadcrumbs`.
+
+> Path helper names (`pdf_invoice_path`, `test_book_invoice_path`, etc.) and permission keys (`'invoices.read'` etc.) in the examples below are illustrative — the implementation should use whatever the routes file and `Permission` model actually define.
+
+### `app/views/invoices/show.html.haml`
+
+Today's bottom row: PDF, Preview, Test Booking, Delete. Edit stays as the breadcrumb `action:`.
+
+```haml
+- edit_action = action_button('Edit', edit_invoice_path(@invoice), permission: 'invoices.edit') unless @invoice.published?
+- workflow_actions = [
+-   pdf_button(pdf_invoice_path(@invoice), permission: 'invoices.read'),
+-   preview_button(preview_invoice_path(@invoice), permission: 'invoices.read'),
+-   test_booking_button(test_book_invoice_path(@invoice), permission: 'invoices.book'),
+-   (delete_button(@invoice) if can?('invoices.delete') && !@invoice.published?),
+- ]
+= breadcrumbs ['Invoices', invoices_path], (@invoice.document_number || "Draft ##{@invoice.id}"), actions: workflow_actions, action: edit_action do
+  -# status badges unchanged
+```
+
+### `app/views/delivery_notes/show.html.haml`
+
+Today's bottom row branches on `published?`:
+
+- published: PDF, Convert to Invoice (if no invoice exists yet), Unpublish, Delete
+- draft: Preview, Publish, Delete
+
+The Acceptance Document upload form (input-group inside the card) stays where it is — it's a body-section UI, not part of the action_buttons_wrapper, and the recent PR #379 just landed its sizing fix.
+
+```haml
+- edit_action = action_button('Edit', edit_delivery_note_path(@delivery_note), permission: 'delivery_notes.edit') unless @delivery_note.published?
+- workflow_actions = if @delivery_note.published?
+-   [
+-     pdf_button(pdf_delivery_note_path(@delivery_note)),
+-     (convert_to_invoice_button(convert_to_invoice_delivery_note_path(@delivery_note), permission: 'delivery_notes.edit', confirm: 'Create an invoice draft from this delivery note?') unless @delivery_note.invoice),
+-     unpublish_button(unpublish_delivery_note_path(@delivery_note), permission: 'delivery_notes.edit', confirm: 'Are you sure you want to revert this delivery note to draft status?'),
+-     (delete_button(@delivery_note) if can?('delivery_notes.delete')),
+-   ]
+- else
+-   [
+-     preview_button(preview_delivery_note_path(@delivery_note)),
+-     publish_button(publish_delivery_note_path(@delivery_note), permission: 'delivery_notes.edit'),
+-     (delete_button(@delivery_note) if can?('delivery_notes.delete')),
+-   ]
+- end
+= breadcrumbs ['Delivery Notes', delivery_notes_path], (@delivery_note.document_number || "Draft ##{@delivery_note.id}"), actions: workflow_actions, action: edit_action do
+  -# status badges unchanged
+```
+
+### `app/views/customers/show.html.haml`
+
+Today's bottom row: Invoices, Delivery Notes, Delete. Edit stays in `action:`. The "Invoices" and "Delivery Notes" buttons are navigational (jump to filtered list scoped to this customer) and have no clear glyph. Default to text labels for now; revisit later if the row feels crowded.
+
+```haml
+- workflow_actions = [
+-   action_button('Invoices', invoices_path(customer_id: @customer.id), :secondary, permission: 'invoices.read'),
+-   action_button('Delivery Notes', delivery_notes_path(customer_id: @customer.id), :secondary, permission: 'delivery_notes.read'),
+-   (delete_button(@customer) if can?('customers.delete')),
+- ]
+= breadcrumbs ['Customers', customers_path], @customer.matchcode, actions: workflow_actions, action: action_button('Edit', edit_customer_path(@customer), permission: 'customers.edit') do
+  -# Inactive badge unchanged
+```
+
+### `app/views/users/show.html.haml`
+
+Today's bottom row: Block/Unblock, Reset passkeys, Audit log. No `action:` button today (the breadcrumb has only badges). After this PR the breadcrumb gains an `actions:` array.
+
+```haml
+- workflow_actions = [
+-   (@user.blocked? ? unblock_button(unblock_user_path(@user)) : block_button(block_user_path(@user))),
+-   reset_passkeys_button(reset_credentials_user_path(@user)),
+-   audit_log_button(audit_user_path(@user)),
+- ]
+= breadcrumbs 'Configuration', ['Users', users_path], @user.username, actions: workflow_actions do
+  -# Blocked / "This is you" badges unchanged
+```
+
+### Other show pages
+
+- `products/show`, `groups/show`, `teams/show`, `issuer_companies/show`, `sales_tax_*/show`, `jobs_status/show`, `user_invites/show_invite` — no `action_buttons_wrapper` today. No change.
+- `users/audit.html.haml` — no bottom row. No change.
+
+## CSS
+
+No CSS changes needed. The existing `nav[aria-label="breadcrumb"] .btn` rule (btn-sm sizing via Bootstrap CSS variables) already handles a cluster of buttons. The `min-height: 2.5rem` on the row prevents layout jump.
+
+## Tests
+
+- Run the full unit + system test suite. Most existing assertions don't depend on button position; they look for buttons by text (`click_on "Publish"`, `find('button', text: 'Delete')`) which keeps working.
+- One known sensitivity: any test that searches for `🗑` text on detail pages may need an update if it previously found `"Delete"` text. Sweep `test/` after the migration.
+- Add a single helper-method unit test (one example per Tier) to guard the glyph output — e.g. `assert_dom_equal "<a class='btn btn-danger' title='Delete' ...>🗑</a>", delete_button(@customer)`. Belt-and-suspenders against accidental glyph drift in the helpers themselves.
+
+## CLAUDE.md updates
+
+- Add a new section under "Development Preferences" titled **"Button Glyphs (Show-page Actions)"**, containing the full policy + glyph table verbatim from this spec.
+- Extend "UI Helper Methods" with: `breadcrumbs(*items, action:, actions:, &status_block)` (note the new `actions:`); a one-line description of `action_button(...)`'s new `title:` kwarg; and a one-line summary plus pointer for the per-verb helpers ("see Button Glyphs section for the full table").
+- Drop the `destroy_link` index/detail behaviour from the helper inventory (now `destroy_link` is index-only; detail uses `delete_button`).
+
+## Verification
+
+1. `bundle exec rails test`
+2. `bundle exec rails test test/system/`
+3. `pre-commit run --all-files`
+4. Eyeball check on the dev server:
+   - Invoice show in each lifecycle state (draft / booked / paid / overdue / sent) — confirm all expected buttons in the cluster, correct ordering, Edit on the right.
+   - Delivery note show in published vs draft — confirm branch logic produces the right set, the Acceptance Document section is untouched.
+   - Customer show active vs inactive — confirm Inactive badge + Invoices/DNs/Delete + Edit.
+   - User show self / other / blocked — confirm Block/Unblock/Reset/Audit cluster.
+
+## Files touched (anticipated)
+
+- `app/helpers/application_helper.rb` (extend `breadcrumbs` and `action_button`; remove detail-page branch from `destroy_link`)
+- `app/helpers/action_buttons_helper.rb` (new — per-verb helpers)
+- `app/views/invoices/show.html.haml`
+- `app/views/delivery_notes/show.html.haml`
+- `app/views/customers/show.html.haml`
+- `app/views/users/show.html.haml`
+- `CLAUDE.md`
+- `test/helpers/action_buttons_helper_test.rb` (new — tier coverage)
+- Possibly `test/system/*.rb` for any sweeps surfaced during migration

--- a/test/helpers/action_buttons_helper_test.rb
+++ b/test/helpers/action_buttons_helper_test.rb
@@ -1,0 +1,69 @@
+require "test_helper"
+
+class ActionButtonsHelperTest < ActionView::TestCase
+  # Smoke tests that pin the established glyph + Bootstrap color + accessible
+  # name for each helper. Update these when CLAUDE.md's "Button Glyphs" table
+  # changes — they are the executable copy of the policy.
+
+  test "delete_button renders glyph-only with title and aria-label" do
+    customer = Customer.new
+    customer.class.define_singleton_method(:name) { "Customer" }
+    html = delete_button(customer)
+    assert_match(/btn-danger/, html)
+    assert_match(/title="Delete"/, html)
+    assert_match(/aria-label="Delete"/, html)
+    assert_includes html, "🗑"
+    assert_match(/data-turbo-confirm=/, html)
+  end
+
+  test "pdf_button renders glyph-only with title, opens in new tab" do
+    html = pdf_button("/foo.pdf")
+    assert_includes html, "📄"
+    assert_match(/btn-success/, html)
+    assert_match(/title="PDF"/, html)
+    assert_match(/aria-label="PDF"/, html)
+    assert_match(/target="_blank"/, html)
+  end
+
+  test "preview_button renders glyph-only, info color, new tab" do
+    html = preview_button("/preview")
+    assert_includes html, "👁"
+    assert_match(/btn-info/, html)
+    assert_match(/title="Preview"/, html)
+    assert_match(/target="_blank"/, html)
+  end
+
+  test "publish_button renders glyph + text, warning color, POST form" do
+    html = publish_button("/publish")
+    assert_includes html, "🚀 Publish"
+    assert_match(/btn-warning/, html)
+    assert_match(%r{<form[^>]*action="/publish"}, html)
+    assert_match(%r{method="post"}, html)
+  end
+
+  test "convert_to_invoice_button uses the rocket and info color" do
+    html = convert_to_invoice_button("/convert", confirm: "Sure?")
+    assert_includes html, "🚀 Convert to Invoice"
+    assert_match(/btn-info/, html)
+    assert_match(/data-turbo-confirm="Sure\?"/, html)
+  end
+
+  test "unblock_button renders glyph + text, success color" do
+    html = unblock_button("/unblock")
+    assert_includes html, "✅ Unblock"
+    assert_match(/btn-success/, html)
+  end
+
+  test "reset_passkeys_button is text-only despite Tier 2 form rendering" do
+    html = reset_passkeys_button("/reset")
+    assert_includes html, "Reset passkeys"
+    refute_match(/🔄/, html)
+    assert_match(/btn-warning/, html)
+  end
+
+  test "audit_log_button uses clipboard glyph + text" do
+    html = audit_log_button("/audit")
+    assert_includes html, "📋 Audit log"
+    assert_match(/btn-secondary/, html)
+  end
+end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -112,21 +112,19 @@ class ApplicationHelperTest < ActionView::TestCase
 
   test "destroy_link without permission: renders the link" do
     customer = customers(:good_eu)
-    def self.action_name; "show"; end
     html = Nokogiri::HTML.fragment(destroy_link(customer).to_s)
     a = html.at_css("a")
     assert_not_nil a
-    assert_equal "Delete", a.text
+    assert_equal "🗑", a.text
   end
 
   test "destroy_link with permission: returns the link when user has it" do
     Current.user = users(:alice)
     customer = customers(:good_eu)
-    def self.action_name; "show"; end
     html = Nokogiri::HTML.fragment(destroy_link(customer, nil, permission: "customers.edit").to_s)
     a = html.at_css("a")
     assert_not_nil a
-    assert_equal "Delete", a.text
+    assert_equal "🗑", a.text
   ensure
     Current.user = nil
   end
@@ -134,7 +132,6 @@ class ApplicationHelperTest < ActionView::TestCase
   test "destroy_link with permission: returns nil when user lacks it" do
     Current.user = users(:bob)
     customer = customers(:good_eu)
-    def self.action_name; "show"; end
     assert_nil destroy_link(customer, nil, permission: "customers.edit")
   ensure
     Current.user = nil
@@ -143,7 +140,6 @@ class ApplicationHelperTest < ActionView::TestCase
   test "destroy_link with permission: returns nil when no current user" do
     Current.user = nil
     customer = customers(:good_eu)
-    def self.action_name; "show"; end
     assert_nil destroy_link(customer, nil, permission: "customers.edit")
   end
 


### PR DESCRIPTION
> **Stacked on #382** — base branch is `inline-booking-validation`. Merge after #382.

## Summary

- Drop `action_buttons_wrapper` from every show page (invoices, delivery_notes, customers, users); fold the workflow verbs into a new `actions:` array on `breadcrumbs(...)`. The pre-existing right-edge `action:` button keeps its position; new buttons land to its left.
- New `ActionButtonsHelper` module bakes the established glyph, Bootstrap color, accessible name, and link_to-vs-button_to choice into one helper per verb: `delete_button`, `pdf_button`, `preview_button`, `publish_button`, `unpublish_button`, `convert_to_invoice_button`, `unblock_button`, `reset_passkeys_button`, `audit_log_button`.
- `action_button` gains an optional `title:` kwarg that sets both the hover tooltip and the screen-reader `aria-label` — required on Tier-3 glyph-only buttons.
- `destroy_link` is now index-only (always returns the small outline trashcan). Detail pages use `delete_button`.
- `users/show` Block-with-reason form was the only non-button entry in `action_buttons_wrapper`; it moves into a labeled `Block user:` row in the body, matching the Acceptance Document pattern from #379.

## Policy

CLAUDE.md gains a new **Button Glyphs (Show-page Actions)** section establishing a three-tier policy:

- **Text only** — `Edit`, `+ New`, `Cancel`, `Save`, `Reset passkeys`
- **Glyph + text** — `🚀 Publish`, `🚀 Convert to Invoice`, `↩️ Unpublish`, `📥 Upload PDF`, `🚫 Block`, `✅ Unblock`, `📋 Audit log`
- **Glyph only with `title:`** — `🗑` Delete, `📄` PDF, `👁` Preview

Glyph reuse is intentional when archetype matches: 🚀 = promote forward, ✅ = positive state change, ↩/↩️ = revert state. The full verb → glyph → helper table is in CLAUDE.md.

## Brainstorm

Design doc at `docs/superpowers/specs/2026-05-26-show-actions-in-breadcrumb.md`.

## Test plan

- [x] `bundle exec rails test` — 659 runs, 0 failures (includes new `ActionButtonsHelperTest`)
- [x] `bundle exec rails test test/system/` — 65 runs, 0 failures
- [x] `pre-commit run --all-files` — clean
- [ ] Manual eyeball: invoices show (draft / booked / paid / overdue / sent / problems alert), delivery_notes show (draft + published, with and without invoice), customers show (active + inactive, used vs unused), users show (self / other / blocked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)