### PR TITLE
Style sales tax show pages

### DIFF
--- a/app/views/sales_tax_customer_classes/show.html.haml
+++ b/app/views/sales_tax_customer_classes/show.html.haml
@@ -1,11 +1,51 @@
 = breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], ['Customer Tax Classes', sales_tax_customer_classes_path], @sales_tax_customer_class.name, action: action_button('Edit', edit_sales_tax_customer_class_path(@sales_tax_customer_class), permission: 'sales_tax.edit')
 
-%p
-  %b Name:
-  = @sales_tax_customer_class.name
-%p
-  %b Invoice note:
-  = @sales_tax_customer_class.invoice_note
-%p
-  %b VAT ID required:
-  = @sales_tax_customer_class.vat_id_required? ? 'Yes' : 'No'
+.row
+  .col-md-8
+    .card
+      .card-header
+        Customer Tax Class
+      .card-body
+        .row.mb-2
+          .col-sm-3
+            %strong Name:
+          .col-sm-9
+            = @sales_tax_customer_class.name
+
+        .row.mb-2
+          .col-sm-3
+            %strong Invoice note:
+          .col-sm-9
+            - if @sales_tax_customer_class.invoice_note.present?
+              = simple_format(@sales_tax_customer_class.invoice_note)
+            - else
+              %em None
+
+        .row.mb-2
+          .col-sm-3
+            %strong VAT ID required:
+          .col-sm-9
+            = @sales_tax_customer_class.vat_id_required? ? 'Yes' : 'No'
+
+- if @sales_tax_customer_class.sales_tax_rates.any?
+  .row.mt-4
+    .col-md-8
+      .card
+        .card-header
+          Tax Rates
+        .card-body
+          %table.table.table-striped.table-sm.mb-0
+            %tr
+              %th Product class
+              %th Rate
+            - @sales_tax_customer_class.sales_tax_rates.includes(:sales_tax_product_class).each do |rate|
+              %tr
+                %td= link_to rate.sales_tax_product_class.name, rate.sales_tax_product_class
+                %td
+                  = link_to sales_tax_rate_path(rate) do
+                    = rate.rate
+                    \%
+
+= action_buttons_wrapper do
+  - if can?('sales_tax.edit')
+    = destroy_link(@sales_tax_customer_class, "Are you sure you want to delete customer class \"#{@sales_tax_customer_class.name}\"?")

--- a/app/views/sales_tax_product_classes/show.html.haml
+++ b/app/views/sales_tax_product_classes/show.html.haml
@@ -2,9 +2,43 @@
   - if @sales_tax_product_class.is_default?
     %span.badge.bg-success Default
 
-%p
-  %b Name:
-  = @sales_tax_product_class.name
-%p
-  %b Indicator code:
-  = @sales_tax_product_class.indicator_code
+.row
+  .col-md-8
+    .card
+      .card-header
+        Product Tax Class
+      .card-body
+        .row.mb-2
+          .col-sm-3
+            %strong Name:
+          .col-sm-9
+            = @sales_tax_product_class.name
+
+        .row.mb-2
+          .col-sm-3
+            %strong Indicator code:
+          .col-sm-9
+            = @sales_tax_product_class.indicator_code
+
+- if @sales_tax_product_class.sales_tax_rates.any?
+  .row.mt-4
+    .col-md-8
+      .card
+        .card-header
+          Tax Rates
+        .card-body
+          %table.table.table-striped.table-sm.mb-0
+            %tr
+              %th Customer class
+              %th Rate
+            - @sales_tax_product_class.sales_tax_rates.includes(:sales_tax_customer_class).each do |rate|
+              %tr
+                %td= link_to rate.sales_tax_customer_class.name, rate.sales_tax_customer_class
+                %td
+                  = link_to sales_tax_rate_path(rate) do
+                    = rate.rate
+                    \%
+
+= action_buttons_wrapper do
+  - if can?('sales_tax.edit')
+    = destroy_link(@sales_tax_product_class, "Are you sure you want to delete product class \"#{@sales_tax_product_class.name}\"?")

--- a/app/views/sales_tax_rates/show.html.haml
+++ b/app/views/sales_tax_rates/show.html.haml
@@ -1,11 +1,32 @@
 = breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], "#{@sales_tax_rate.sales_tax_customer_class&.name} / #{@sales_tax_rate.sales_tax_product_class&.name}", action: action_button('Edit', edit_sales_tax_rate_path(@sales_tax_rate), permission: 'sales_tax.edit')
 
-%p
-  %b Sales tax customer class:
-  = @sales_tax_rate.sales_tax_customer_class_id
-%p
-  %b Sales tax product class:
-  = @sales_tax_rate.sales_tax_product_class_id
-%p
-  %b Rate:
-  = @sales_tax_rate.rate
+.row
+  .col-md-8
+    .card
+      .card-header
+        Tax Rate
+      .card-body
+        .row.mb-2
+          .col-sm-3
+            %strong Customer class:
+          .col-sm-9
+            - if @sales_tax_rate.sales_tax_customer_class
+              = link_to @sales_tax_rate.sales_tax_customer_class.name, @sales_tax_rate.sales_tax_customer_class
+
+        .row.mb-2
+          .col-sm-3
+            %strong Product class:
+          .col-sm-9
+            - if @sales_tax_rate.sales_tax_product_class
+              = link_to @sales_tax_rate.sales_tax_product_class.name, @sales_tax_rate.sales_tax_product_class
+
+        .row.mb-2
+          .col-sm-3
+            %strong Rate:
+          .col-sm-9
+            = @sales_tax_rate.rate
+            \%
+
+= action_buttons_wrapper do
+  - if can?('sales_tax.edit')
+    = destroy_link(@sales_tax_rate, "Are you sure you want to delete tax rate for \"#{@sales_tax_rate.sales_tax_customer_class&.name}\" / \"#{@sales_tax_rate.sales_tax_product_class&.name}\"?")


### PR DESCRIPTION
## Summary
- Replace scaffold-style `%p/%b` listings on the sales tax customer class, product class, and rate show pages with the card + `.row > .col-sm-3/.col-sm-9` pattern used by the customers, products, and issuer companies show pages.
- Customer/product class show pages list their associated tax rates in a small linked table when any exist; the rate show page links to the referenced customer and product classes.
- Bottom action row uses `action_buttons_wrapper` + `destroy_link`, gated on the `sales_tax.edit` permission; Edit stays in the breadcrumb action slot.

## Test plan
- [x] `bundle exec rails test` (645 runs, 0 failures)
- [ ] Manual: visit `/sales_tax_customer_classes/:id`, `/sales_tax_product_classes/:id`, `/sales_tax_rates/:id` and confirm cards render and links navigate
- [ ] Manual: confirm Edit button only shows for users with `sales_tax.edit`, same for Delete

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>