### PR TITLE
Render flash below page header instead of above

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -48,7 +48,7 @@ module ApplicationHelper
   #     - unless @customer.active?
   #       %span.badge.bg-secondary Inactive
   def breadcrumbs(*items, action: nil, &status_block)
-    content_tag :nav, "aria-label": "breadcrumb" do
+    nav = content_tag :nav, "aria-label": "breadcrumb" do
       content_tag :div, class: "d-flex justify-content-between align-items-center flex-wrap gap-2 border-bottom py-1 mb-2" do
         left = content_tag(:div, class: "d-flex align-items-center flex-wrap gap-2 small") do
           ol = content_tag :ol, class: "breadcrumb mb-0" do
@@ -69,6 +69,7 @@ module ApplicationHelper
         left + (action || "".html_safe)
       end
     end
+    nav + page_header_flash
   end
 
   # Renders the page header row: title (left), optional inline status badges
@@ -78,7 +79,7 @@ module ApplicationHelper
   #   nil-when-denied result), or nil for no action area.
   # status_block: yields zero or more inline badges next to the title.
   def page_header(title, action: nil, &status_block)
-    content_tag :div, class: "d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2" do
+    header_row = content_tag :div, class: "d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2" do
       title_area = content_tag(:div, class: "d-flex align-items-center flex-wrap gap-2") do
         header = content_tag(:h1, title, class: "mb-0")
         status = status_block ? capture(&status_block) : "".html_safe
@@ -86,6 +87,16 @@ module ApplicationHelper
       end
       title_area + (action || "".html_safe)
     end
+    header_row + page_header_flash
+  end
+
+  # Renders flash messages inline (just below the page header / breadcrumb)
+  # and sets a sentinel so the layout suppresses its top-of-content fallback.
+  # Keeps the page identifier anchored at the top so flash never pushes it
+  # down between visits.
+  def page_header_flash
+    content_for(:flash_rendered_inline, true)
+    render("layouts/messages")
   end
 
   def list_action_link(text, path, type = :default, options = {})

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -31,8 +31,10 @@
     %main#main{:role => "main", :class => "flex-grow-1"}
       .container
         .content
-          = render 'layouts/messages'
-          = content_for?(:content) ? yield(:content) : yield
+          - body = capture { content_for?(:content) ? yield(:content) : yield }
+          - unless content_for?(:flash_rendered_inline)
+            = render 'layouts/messages'
+          = body
     %footer.footer.mt-auto
       .container
         %p.mb-0.text-center

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -58,6 +58,28 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_equal "Acme", last.text.strip
   end
 
+  test "breadcrumbs sets the flash_rendered_inline sentinel" do
+    breadcrumbs([ "Customers", "/customers" ], "Acme")
+    assert content_for?(:flash_rendered_inline)
+  end
+
+  test "breadcrumbs emits flash messages inline below the breadcrumb" do
+    flash[:notice] = "Saved!"
+    html = Nokogiri::HTML.fragment(breadcrumbs([ "Customers", "/customers" ], "Acme"))
+    alert = html.at_css(".alert.alert-success")
+    assert_not_nil alert, "expected flash alert to be rendered inline by breadcrumbs"
+    assert_includes alert.text, "Saved!"
+  end
+
+  test "page_header sets the flash_rendered_inline sentinel and emits flash inline" do
+    flash[:alert] = "Nope"
+    html = Nokogiri::HTML.fragment(page_header("Dashboard"))
+    assert content_for?(:flash_rendered_inline)
+    alert = html.at_css(".alert.alert-danger")
+    assert_not_nil alert
+    assert_includes alert.text, "Nope"
+  end
+
   test "breadcrumbs renders plain-label middle crumbs without a link" do
     html = Nokogiri::HTML.fragment(breadcrumbs("Configuration", [ "Sales Tax", "/sales_tax_rates" ], "Edit"))
     items = html.css("li.breadcrumb-item")


### PR DESCRIPTION
## Summary
- Flash messages now render inline immediately below the breadcrumb / page header instead of above them, so the page identifier no longer shifts down by an alert's height between visits.
- `breadcrumbs` and `page_header` embed `layouts/messages` into their output and set a `content_for(:flash_rendered_inline)` sentinel; the layout only renders the top-of-content flash partial when that sentinel is unset (covers views without a header).

## Test plan
- [x] `bundle exec rails test` (648 runs, 0 failures)
- [x] `bundle exec rails test test/system/` (65 runs, 0 failures)
- [x] New helper tests cover the sentinel and inline flash rendering for both helpers
- [ ] Manually trigger a flash (create/update a record) and confirm the breadcrumb stays put and the alert appears just below it; reload and confirm the breadcrumb sits at the same vertical position

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>