### PR TITLE
Align groups/teams index edit/destroy with reference pattern

### DIFF
--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -23,9 +23,11 @@
       %td= group.member_count
       %td= group.permission_count
       %td= group.bypass_team_scoping? ? 'Yes' : 'No'
-      %td= list_action_link('Edit', edit_group_path(group), :edit)
       %td
-        - if group.builtin?
+        - if can?('groups.manage')
+          = list_action_link('Edit', edit_group_path(group), :edit)
+      %td
+        - if can?('groups.manage') && !group.builtin?
+          = destroy_link(group, "Are you sure you want to delete group \"#{group.name}\"?")
+        - elsif group.builtin?
           %span.text-muted —
-        - else
-          = destroy_link(group, "Delete group \"#{group.name}\"?")

--- a/app/views/teams/index.html.haml
+++ b/app/views/teams/index.html.haml
@@ -23,9 +23,11 @@
       %td= team.member_count
       %td= team.customer_count
       %td= team.project_count
-      %td= list_action_link('Edit', edit_team_path(team), :edit)
       %td
-        - if team.builtin?
+        - if can?('teams.manage')
+          = list_action_link('Edit', edit_team_path(team), :edit)
+      %td
+        - if can?('teams.manage') && !team.builtin?
+          = destroy_link(team, "Are you sure you want to delete team \"#{team.name}\"?")
+        - elsif team.builtin?
           %span.text-muted —
-        - else
-          = destroy_link(team, "Delete team \"#{team.name}\"?")


### PR DESCRIPTION
## Summary
- Gate per-row Edit and destroy_link on groups/index and teams/index with `can?('groups.manage')` / `can?('teams.manage')`, matching the customers/projects/products/sales_tax convention.
- Expand the destroy confirm copy from `Delete X "..."?` to `Are you sure you want to delete X "..."?`, the wording used on every other index page in the app.

Permission keys exist already (`groups.manage`, `teams.manage`); no new keys or actions are introduced. The check is functionally redundant today because both controllers wrap every action with `require_permission!`, but adding it brings these two pages in line with the rest of Configuration so the surface pattern is uniform.

Audited but unchanged:
- `products/index`, `sales_tax_rates/index`, `sales_tax_customer_classes/index`, `sales_tax_product_classes/index` — already match the reference pattern.
- `users/index` — no edit/destroy column by design (block/reset live on the user show page).
- `jobs_status/show`, `issuer_companies/show` — not list pages, no per-row actions.

## Test plan
- [x] `bundle exec rails test test/controllers/` (241 runs, 0 failures)
- [ ] Visual check: as a user with `groups.manage`, group/team edit + delete buttons still render; built-in groups/teams still show `—` instead of a delete button.

Generated with [Claude Code](https://claude.com/claude-code)