### PR TITLE
Mirror invoice post-booking banner on delivery notes#publish

### DIFF
--- a/app/controllers/delivery_notes_controller.rb
+++ b/app/controllers/delivery_notes_controller.rb
@@ -110,16 +110,11 @@ class DeliveryNotesController < ApplicationController
   end
 
   def publish
-    begin
-      @delivery_note.publish!
-      flash[:notice] = "Delivery Note #{@delivery_note.document_number} has been published."
-    rescue StandardError => e
-      flash[:error] = "Failed to publish delivery note: #{e.message}"
-    end
-
-    respond_to do |format|
-      format.html { redirect_to @delivery_note }
-    end
+    @delivery_note.publish!
+    redirect_to delivery_note_path(@delivery_note, published: 1)
+  rescue StandardError => e
+    flash[:error] = "Failed to publish delivery note: #{e.message}"
+    redirect_to @delivery_note
   end
 
   def preview

--- a/app/views/delivery_notes/show.html.haml
+++ b/app/views/delivery_notes/show.html.haml
@@ -8,6 +8,16 @@
   - else
     %span.badge.bg-success Booked
 
+- if params[:published] == '1' && @delivery_note.published?
+  .alert.alert-success.mb-3{data: {controller: 'auto-download'}}
+    %h4.alert-heading.mb-2= "Delivery Note #{@delivery_note.document_number} published."
+    %p.mb-3 Download the PDF and send it to your customer.
+    .d-flex.gap-2{data: email_preview_data(@delivery_note)}
+      = link_to 'Download PDF', pdf_delivery_note_path(@delivery_note), class: 'btn btn-success', target: '_blank', data: { turbo: false, 'auto-download-target': 'link' }
+      - if @delivery_note.emailable?
+        %button.btn.btn-outline-success{data: {action: 'click->generic-email-preview#open'}} Send E-Mail
+      = render 'shared/email_preview_modal', title: "Preview - Delivery Note #{@delivery_note.document_number}" if @delivery_note.emailable?
+
 .row.mb-2
   .col-md-6
     .document-details

--- a/test/controllers/delivery_notes_controller_test.rb
+++ b/test/controllers/delivery_notes_controller_test.rb
@@ -222,6 +222,34 @@ class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
     assert_match "Draft delivery notes can not be used for this action", flash[:error]
   end
 
+  test "publish action redirects to show with published=1 on success" do
+    note = delivery_notes(:draft_delivery_note)
+    note.delivery_note_lines.create!(
+      type: "item", title: "x", quantity: 1.0, position: 1
+    )
+
+    post publish_delivery_note_url(note)
+    assert_redirected_to delivery_note_path(note, published: 1)
+    assert_not flash[:notice].present?, "success path should not flash; the banner replaces it"
+
+    note.reload
+    assert note.published?
+    assert note.document_number.present?
+  end
+
+  test "show renders post-publish banner when arriving with ?published=1" do
+    get delivery_note_url(delivery_notes(:published_delivery_note), published: 1)
+    assert_response :success
+    assert_select ".alert-success .alert-heading", text: /published/
+    assert_select ".alert-success a", text: "Download PDF"
+  end
+
+  test "show does not render post-publish banner without ?published=1" do
+    get delivery_note_url(delivery_notes(:published_delivery_note))
+    assert_response :success
+    assert_select ".alert-success .alert-heading", count: 0
+  end
+
   test "should unpublish delivery note" do
     published_note = delivery_notes(:published_delivery_note)
 


### PR DESCRIPTION
## Summary

Mirror the post-booking banner from PR #382 onto delivery notes:

- `DeliveryNotesController#publish` redirects to show with `?published=1` on success and drops the `flash[:notice]` — the banner replaces it. Failure path still flashes since it falls back to the plain show.
- `app/views/delivery_notes/show.html.haml` renders a green success banner near the top when `params[:published] == '1'` with a **Download PDF** call-to-action and (when emailable) a **Send E-Mail** button. The existing `auto_download` Stimulus controller from #382 is reused — it clicks the PDF link on connect so the download starts automatically; the visible button is the fallback if the browser blocks the auto-click.

Closes the asymmetry called out in the memory follow-up from #382 ([[invoices_delivery_notes_alignment]]).

## Test plan

- [x] `bundle exec rails test` — 659 runs, 0 failures
- [x] New controller tests cover publish-success redirect target, banner render when `?published=1`, and banner absence on plain show
- [ ] Manual: publish a draft delivery note in a browser, confirm banner + PDF tab opens / button is one click away if blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)