### PR TITLE
Fix missing-rate inline form on sales tax rates index

### DIFF
--- a/app/views/sales_tax_rates/index.html.haml
+++ b/app/views/sales_tax_rates/index.html.haml
@@ -57,14 +57,13 @@
           %td
             = missing_rate[:product].name
           %td{:colspan => 3}
-            %form{:method=>:post, :action=>url_for(:action=>"create", :controller => "sales_tax_rates"), :class=>"form-horizontal"}
-              %input{:type => :hidden, :name => "authencity_token", :value => form_authenticity_token}
-              %input{:type => :hidden, :name => "sales_tax_rate[sales_tax_customer_class_id]", :value => missing_rate[:customer].id}
-              %input{:type => :hidden, :name => "sales_tax_rate[sales_tax_product_class_id]", :value => missing_rate[:product].id}
-              %input{:type => :number, :name => "sales_tax_rate[rate]", :class => "numeric float"}
-              \% &nbsp;
-              %button{:type => :submit, :class => "btn"}
-                Create
+            = form_with model: SalesTaxRate.new(sales_tax_customer_class_id: missing_rate[:customer].id, sales_tax_product_class_id: missing_rate[:product].id), local: true, class: 'd-flex align-items-center gap-2' do |f|
+              = f.hidden_field :sales_tax_customer_class_id
+              = f.hidden_field :sales_tax_product_class_id
+              .input-group.w-auto
+                = f.number_field :rate, class: 'form-control', step: 0.01, required: true
+                %span.input-group-text %
+              = f.submit 'Create', class: 'btn btn-primary'
 = action_buttons_wrapper do
   = action_button 'Customer Classes', sales_tax_customer_classes_path, :secondary
   = action_button 'Product Classes', sales_tax_product_classes_path, :secondary


### PR DESCRIPTION
## Summary
- The per-row inline "create missing rate" form on `/sales_tax_rates` was a hand-rolled `%form` whose CSRF hidden input was misspelled `authencity_token`. With `protect_from_forgery with: :exception` active in `ApplicationController` (and no skip on the controller), submitting it triggered `InvalidAuthenticityToken` and the rate was never created.
- Replaced with `form_with(model: SalesTaxRate.new(...), local: true)` so the CSRF token, action URL, and field naming come from Rails. Switched to `f.hidden_field` / `f.number_field` / `f.submit`.
- Picked up project styling: `btn btn-primary` on the submit, Bootstrap `input-group` around the percent input matching the main new-rate form.

## Test plan
- [x] `bundle exec rails test` — 656 runs, 0 failures, 0 errors
- [ ] Manual: create a sales tax product class and customer class with no matching rate, load `/sales_tax_rates`, submit the inline "Create" form, verify the rate is created and redirects with the success flash

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>