### PR TITLE
Gate Configuration index buttons; drop redundant Users View column

### DIFF
--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -1,4 +1,4 @@
-= breadcrumbs 'Configuration', 'Groups', action: action_button('+ New', new_group_path, :info)
+= breadcrumbs 'Configuration', 'Groups', action: action_button('+ New', new_group_path, :info, permission: 'groups.manage')
 
 %p.text-muted
   Groups bundle system-level permissions. A user inherits all permissions of every group they belong to.

--- a/app/views/teams/index.html.haml
+++ b/app/views/teams/index.html.haml
@@ -1,4 +1,4 @@
-= breadcrumbs 'Configuration', 'Teams', action: action_button('+ New', new_team_path, :info)
+= breadcrumbs 'Configuration', 'Teams', action: action_button('+ New', new_team_path, :info, permission: 'teams.manage')
 
 %p.text-muted
   Teams control which customers and projects a user can see. Every customer and project belongs to exactly one team.

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,6 +1,6 @@
 - content_for :title, 'Users'
 
-= breadcrumbs 'Configuration', 'Users', action: action_button('+ Invite user', new_user_invite_path, :info)
+= breadcrumbs 'Configuration', 'Users', action: action_button('+ Invite user', new_user_invite_path, :info, permission: 'user_invites.manage')
 
 %table.table.table-striped.table-sm
   %thead
@@ -9,7 +9,6 @@
       %th Full name
       %th Status
       %th Created
-      %th
   %tbody
     - @users.each do |user|
       %tr
@@ -19,7 +18,7 @@
           - if user.blocked?
             %span.badge.bg-danger Blocked
         %td= l(user.created_at)
-        %td= list_action_link('View', user_path(user), :show)
 
-.mt-4
-  = link_to 'View invites', user_invites_path, class: 'btn btn-secondary'
+- if can?('user_invites.manage')
+  .mt-4
+    = link_to 'View invites', user_invites_path, class: 'btn btn-secondary'


### PR DESCRIPTION
## Summary
- `groups/index` and `teams/index`: add `permission:` arg to the `+ New` `action_button` so it hides for users without `groups.manage` / `teams.manage` (matches products / sales_tax_rates convention; controllers require these keys via `before_action`).
- `users/index`: gate `+ Invite user` and the `View invites` link with `user_invites.manage` — the key `UserInvitesController` enforces.
- `users/index`: drop the redundant `View` action column; the username column already links to `user_path(user)`.

## Test plan
- [x] `bundle exec rails test` (656 runs, 0 failures)
- [x] `bundle exec rails test test/controllers/groups_controller_test.rb test/controllers/teams_controller_test.rb test/controllers/users_controller_test.rb test/controllers/user_invites_controller_test.rb test/integration/permissions_enforcement_test.rb`
- [x] `pre-commit run --all-files`

Generated with [Claude Code](https://claude.com/claude-code)