### PR TITLE
Add permission: keyword to list_action_link and destroy_link

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -99,7 +99,11 @@ module ApplicationHelper
     render("layouts/messages")
   end
 
-  def list_action_link(text, path, type = :default, options = {})
+  # Compact in-row action link (Edit / View / Delete...). When permission: is
+  # given and the current user lacks it, returns nil so views can drop their
+  # explicit `- if can?('xxx.edit')` wraps and gate inline.
+  def list_action_link(text, path, type = :default, options = {}, permission: nil)
+    return nil if permission && !can?(permission)
     css_classes = case type
     when :show
       "btn btn-sm btn-outline-primary py-0"
@@ -114,7 +118,11 @@ module ApplicationHelper
     link_to(text, path, options.merge(class: css_classes))
   end
 
-  def destroy_link(resource, confirm_text = nil)
+  # Trashcan (on index) or "Delete" button (on detail pages) for a resource.
+  # When permission: is given and the current user lacks it, returns nil so
+  # views can gate inline without an `- if can?('xxx.edit')` wrap.
+  def destroy_link(resource, confirm_text = nil, permission: nil)
+    return nil if permission && !can?(permission)
     confirm_text ||= "Are you sure you want to delete this #{resource.class.name.downcase}?"
 
     if action_name == "index"

--- a/app/views/customers/index.html.haml
+++ b/app/views/customers/index.html.haml
@@ -28,8 +28,7 @@
       %td= customer.name
       %td= customer.team&.name
       %td
-        - if can?('customers.edit')
-          = list_action_link('Edit', edit_customer_path(customer), :edit)
+        = list_action_link('Edit', edit_customer_path(customer), :edit, permission: 'customers.edit')
       %td
         - if can?('customers.edit') && !customer.used_in_invoices?
           = destroy_link(customer, "Are you sure you want to delete customer \"#{customer.matchcode}\" (#{customer.name})?")

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -14,8 +14,6 @@
       %td= format_currency(product.rate)
       %td= product.sales_tax_product_class && product.sales_tax_product_class.name
       %td
-        - if can?('products.edit')
-          = list_action_link('Edit', edit_product_path(product), :edit)
+        = list_action_link('Edit', edit_product_path(product), :edit, permission: 'products.edit')
       %td
-        - if can?('products.edit')
-          = destroy_link(product, "Are you sure you want to delete product \"#{product.title}\"?")
+        = destroy_link(product, "Are you sure you want to delete product \"#{product.title}\"?", permission: 'products.edit')

--- a/app/views/projects/index.html.haml
+++ b/app/views/projects/index.html.haml
@@ -30,8 +30,7 @@
       %td= project.bill_to_customer.try(:matchcode)
       %td= project.team&.name
       %td
-        - if can?('projects.edit')
-          = list_action_link('Edit', edit_project_path(project), :edit)
+        = list_action_link('Edit', edit_project_path(project), :edit, permission: 'projects.edit')
       %td
         - if can?('projects.edit') && project.can_be_deleted?
           = destroy_link(project, "Are you sure you want to delete project \"#{project.matchcode}\"?")

--- a/app/views/sales_tax_customer_classes/index.html.haml
+++ b/app/views/sales_tax_customer_classes/index.html.haml
@@ -12,8 +12,6 @@
       %td= sales_tax_customer_class.name
       %td= sales_tax_customer_class.invoice_note
       %td
-        - if can?('sales_tax.edit')
-          = list_action_link('Edit', edit_sales_tax_customer_class_path(sales_tax_customer_class), :edit)
+        = list_action_link('Edit', edit_sales_tax_customer_class_path(sales_tax_customer_class), :edit, permission: 'sales_tax.edit')
       %td
-        - if can?('sales_tax.edit')
-          = destroy_link(sales_tax_customer_class, "Are you sure you want to delete customer class \"#{sales_tax_customer_class.name}\"?")
+        = destroy_link(sales_tax_customer_class, "Are you sure you want to delete customer class \"#{sales_tax_customer_class.name}\"?", permission: 'sales_tax.edit')

--- a/app/views/sales_tax_product_classes/index.html.haml
+++ b/app/views/sales_tax_product_classes/index.html.haml
@@ -16,8 +16,6 @@
         - if sales_tax_product_class.is_default?
           %span.badge.bg-success Default
       %td
-        - if can?('sales_tax.edit')
-          = list_action_link('Edit', edit_sales_tax_product_class_path(sales_tax_product_class), :edit)
+        = list_action_link('Edit', edit_sales_tax_product_class_path(sales_tax_product_class), :edit, permission: 'sales_tax.edit')
       %td
-        - if can?('sales_tax.edit')
-          = destroy_link(sales_tax_product_class, "Are you sure you want to delete product class \"#{sales_tax_product_class.name}\"?")
+        = destroy_link(sales_tax_product_class, "Are you sure you want to delete product class \"#{sales_tax_product_class.name}\"?", permission: 'sales_tax.edit')

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -80,6 +80,73 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_includes alert.text, "Nope"
   end
 
+  test "list_action_link without permission: renders the link" do
+    html = Nokogiri::HTML.fragment(list_action_link("Edit", "/customers/1/edit", :edit))
+    a = html.at_css("a")
+    assert_not_nil a
+    assert_equal "Edit", a.text
+    assert_equal "/customers/1/edit", a["href"]
+  end
+
+  test "list_action_link with permission: returns the link when user has it" do
+    Current.user = users(:alice)
+    html = Nokogiri::HTML.fragment(list_action_link("Edit", "/customers/1/edit", :edit, permission: "customers.edit").to_s)
+    a = html.at_css("a")
+    assert_not_nil a
+    assert_equal "Edit", a.text
+  ensure
+    Current.user = nil
+  end
+
+  test "list_action_link with permission: returns nil when user lacks it" do
+    Current.user = users(:bob)
+    assert_nil list_action_link("Edit", "/customers/1/edit", :edit, permission: "customers.edit")
+  ensure
+    Current.user = nil
+  end
+
+  test "list_action_link with permission: returns nil when no current user" do
+    Current.user = nil
+    assert_nil list_action_link("Edit", "/customers/1/edit", :edit, permission: "customers.edit")
+  end
+
+  test "destroy_link without permission: renders the link" do
+    customer = customers(:good_eu)
+    def self.action_name; "show"; end
+    html = Nokogiri::HTML.fragment(destroy_link(customer).to_s)
+    a = html.at_css("a")
+    assert_not_nil a
+    assert_equal "Delete", a.text
+  end
+
+  test "destroy_link with permission: returns the link when user has it" do
+    Current.user = users(:alice)
+    customer = customers(:good_eu)
+    def self.action_name; "show"; end
+    html = Nokogiri::HTML.fragment(destroy_link(customer, nil, permission: "customers.edit").to_s)
+    a = html.at_css("a")
+    assert_not_nil a
+    assert_equal "Delete", a.text
+  ensure
+    Current.user = nil
+  end
+
+  test "destroy_link with permission: returns nil when user lacks it" do
+    Current.user = users(:bob)
+    customer = customers(:good_eu)
+    def self.action_name; "show"; end
+    assert_nil destroy_link(customer, nil, permission: "customers.edit")
+  ensure
+    Current.user = nil
+  end
+
+  test "destroy_link with permission: returns nil when no current user" do
+    Current.user = nil
+    customer = customers(:good_eu)
+    def self.action_name; "show"; end
+    assert_nil destroy_link(customer, nil, permission: "customers.edit")
+  end
+
   test "breadcrumbs renders plain-label middle crumbs without a link" do
     html = Nokogiri::HTML.fragment(breadcrumbs("Configuration", [ "Sales Tax", "/sales_tax_rates" ], "Edit"))
     items = html.css("li.breadcrumb-item")


### PR DESCRIPTION
## Summary

- Mirrors `action_button`'s `permission:` keyword on `list_action_link` and `destroy_link`: when given and `can?(permission)` is false, the helper returns `nil` so the link disappears.
- Migrates simple `- if can?('xxx.edit')` wraps in 5 index views to use the new inline gate. Combined-condition wraps (e.g. `can? && resource.can_be_deleted?`) and the 4 files owned by concurrent PRs are left untouched.
- Adds unit tests covering both helpers with permission granted, denied, and no current user.

## Test plan

- [x] `bundle exec rails test test/helpers/application_helper_test.rb` (18 runs, 0 failures)
- [x] `bundle exec rails test` (664 runs, 0 failures)
- [x] `pre-commit run --all-files`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>