### PR TITLE
Render the email preview modal once per show page

### DIFF
--- a/app/views/delivery_notes/show.html.haml
+++ b/app/views/delivery_notes/show.html.haml
@@ -8,183 +8,187 @@
   - else
     %span.badge.bg-success Booked
 
-- if params[:published] == '1' && @delivery_note.published?
-  .alert.alert-success.mb-3{data: {controller: 'auto-download'}}
-    %h4.alert-heading.mb-2= "Delivery Note #{@delivery_note.document_number} published."
-    %p.mb-3 Download the PDF and send it to your customer.
-    .d-flex.gap-2{data: email_preview_data(@delivery_note)}
-      = link_to 'Download PDF', pdf_delivery_note_path(@delivery_note), class: 'btn btn-success', target: '_blank', data: { turbo: false, 'auto-download-target': 'link' }
-      - if @delivery_note.emailable?
-        %button.btn.btn-outline-success{data: {action: 'click->generic-email-preview#open'}} Send E-Mail
-      = render 'shared/email_preview_modal', title: "Preview - Delivery Note #{@delivery_note.document_number}" if @delivery_note.emailable?
+-# Single generic-email-preview controller scope so the modal can be rendered
+-# once at the bottom and serve every trigger site on the page.
+%div{data: (@delivery_note.published? ? email_preview_data(@delivery_note) : {})}
+  - if params[:published] == '1' && @delivery_note.published?
+    .alert.alert-success.mb-3{data: {controller: 'auto-download'}}
+      %h4.alert-heading.mb-2= "Delivery Note #{@delivery_note.document_number} published."
+      %p.mb-3 Download the PDF and send it to your customer.
+      .d-flex.gap-2
+        = link_to 'Download PDF', pdf_delivery_note_path(@delivery_note), class: 'btn btn-success', target: '_blank', data: { turbo: false, 'auto-download-target': 'link' }
+        - if @delivery_note.emailable?
+          %button.btn.btn-outline-success{data: {action: 'click->generic-email-preview#open'}} Send E-Mail
 
-.row.mb-2
-  .col-md-6
-    .document-details
-      - if @delivery_note.date
+  .row.mb-2
+    .col-md-6
+      .document-details
+        - if @delivery_note.date
+          .row.mb-2
+            .col-sm-4
+              %strong Date:
+            .col-sm-8
+              = l(@delivery_note.date)
         .row.mb-2
           .col-sm-4
-            %strong Date:
+            %strong Customer:
           .col-sm-8
-            = l(@delivery_note.date)
-      .row.mb-2
-        .col-sm-4
-          %strong Customer:
-        .col-sm-8
-          = link_to @delivery_note.customer.name, @delivery_note.customer
-      - if @delivery_note.project_id.present?
-        .row.mb-2
-          .col-sm-4
-            %strong Project:
-          .col-sm-8
-            - if @delivery_note.project
-              = link_to @delivery_note.project.display_name, @delivery_note.project
-            - else
-              %em (Project ##{@delivery_note.project_id} - not found)
-      - if @delivery_note.cust_order.present?
-        .row.mb-2
-          .col-sm-4
-            %strong Order No:
-          .col-sm-8
-            = @delivery_note.cust_order
-      - if @delivery_note.cust_reference.present?
-        .row.mb-2
-          .col-sm-4
-            %strong Reference:
-          .col-sm-8
-            = @delivery_note.cust_reference
+            = link_to @delivery_note.customer.name, @delivery_note.customer
+        - if @delivery_note.project_id.present?
+          .row.mb-2
+            .col-sm-4
+              %strong Project:
+            .col-sm-8
+              - if @delivery_note.project
+                = link_to @delivery_note.project.display_name, @delivery_note.project
+              - else
+                %em (Project ##{@delivery_note.project_id} - not found)
+        - if @delivery_note.cust_order.present?
+          .row.mb-2
+            .col-sm-4
+              %strong Order No:
+            .col-sm-8
+              = @delivery_note.cust_order
+        - if @delivery_note.cust_reference.present?
+          .row.mb-2
+            .col-sm-4
+              %strong Reference:
+            .col-sm-8
+              = @delivery_note.cust_reference
 
-  .col-md-6
-    .document-details
-      - if @delivery_note.delivery_timeframe.present?
-        .row.mb-2
-          .col-sm-4
-            %strong Delivery Period:
-          .col-sm-8
-            = @delivery_note.delivery_timeframe
-      - unless @delivery_note.published?
-        .row.mb-2
-          .col-sm-4
-            %strong Publish Status:
-          .col-sm-8.d-flex.align-items-center.gap-2
-            - if @delivery_note.has_items?
-              %span.badge.bg-success Ready
-            - else
-              %span.badge.bg-warning No item lines
-            - if can_edit_dn
+    .col-md-6
+      .document-details
+        - if @delivery_note.delivery_timeframe.present?
+          .row.mb-2
+            .col-sm-4
+              %strong Delivery Period:
+            .col-sm-8
+              = @delivery_note.delivery_timeframe
+        - unless @delivery_note.published?
+          .row.mb-2
+            .col-sm-4
+              %strong Publish Status:
+            .col-sm-8.d-flex.align-items-center.gap-2
               - if @delivery_note.has_items?
-                = button_to 'Publish…', publish_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-sm btn-info', form: { class: 'button_to ms-auto' }
+                %span.badge.bg-success Ready
               - else
-                %span.ms-auto
-                  %button.btn.btn-sm.btn-info{disabled: true} Publish…
-      - if @delivery_note.published?
-        .row.mb-2
-          .col-sm-4
-            %strong Email Status:
-          .col-sm-8.d-flex.align-items-center.gap-2{data: email_preview_data(@delivery_note)}
-            - if @delivery_note.email_sent_at
-              Sent #{l(@delivery_note.email_sent_at)}
-            - elsif @delivery_note.emailable?
-              %span.badge.bg-warning Unsent
-            - else
-              %span.badge.bg-secondary No Recipient
-            - if can_edit_dn
-              - if @delivery_note.emailable?
-                %button.btn.btn-sm.btn-warning.ms-auto{data: {action: 'click->generic-email-preview#open'}}
-                  Send E-Mail
+                %span.badge.bg-warning No item lines
+              - if can_edit_dn
+                - if @delivery_note.has_items?
+                  = button_to 'Publish…', publish_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-sm btn-info', form: { class: 'button_to ms-auto' }
+                - else
+                  %span.ms-auto
+                    %button.btn.btn-sm.btn-info{disabled: true} Publish…
+        - if @delivery_note.published?
+          .row.mb-2
+            .col-sm-4
+              %strong Email Status:
+            .col-sm-8.d-flex.align-items-center.gap-2
+              - if @delivery_note.email_sent_at
+                Sent #{l(@delivery_note.email_sent_at)}
+              - elsif @delivery_note.emailable?
+                %span.badge.bg-warning Unsent
               - else
-                %span.ms-auto{data: {'bs-toggle': 'tooltip'}, title: 'No contact is configured to receive this delivery note. Add a contact on the customer with "Delivery Notes" enabled.'}
-                  %button.btn.btn-sm.btn-warning{disabled: true}
+                %span.badge.bg-secondary No Recipient
+              - if can_edit_dn
+                - if @delivery_note.emailable?
+                  %button.btn.btn-sm.btn-warning.ms-auto{data: {action: 'click->generic-email-preview#open'}}
                     Send E-Mail
-            = render 'shared/email_preview_modal', title: "Preview - Delivery Note #{@delivery_note.document_number}"
-      - if @delivery_note.invoice
-        .row.mb-2
-          .col-sm-4
-            %strong Invoice:
-          .col-sm-8
-            = link_to "Invoice #{@delivery_note.invoice.document_number || "##{@delivery_note.invoice.id}"}", @delivery_note.invoice
-            - if @delivery_note.invoice.published?
-              %span.badge.bg-success.ms-2 Booked
-            - else
-              %span.badge.bg-warning.ms-2 Draft
+                - else
+                  %span.ms-auto{data: {'bs-toggle': 'tooltip'}, title: 'No contact is configured to receive this delivery note. Add a contact on the customer with "Delivery Notes" enabled.'}
+                    %button.btn.btn-sm.btn-warning{disabled: true}
+                      Send E-Mail
+        - if @delivery_note.invoice
+          .row.mb-2
+            .col-sm-4
+              %strong Invoice:
+            .col-sm-8
+              = link_to "Invoice #{@delivery_note.invoice.document_number || "##{@delivery_note.invoice.id}"}", @delivery_note.invoice
+              - if @delivery_note.invoice.published?
+                %span.badge.bg-success.ms-2 Booked
+              - else
+                %span.badge.bg-warning.ms-2 Draft
 
 
-- if @delivery_note.published?
-  .mb-4
-    .card
-      .card-header.d-flex.justify-content-between.align-items-center
-        %h5.mb-0 Acceptance Document
-      .card-body
-        - if @delivery_note.acceptance_attachment
-          .mb-3
-            .d-flex.align-items-center
-              %i.fas.fa-file-pdf.text-danger.me-2
-              = link_to @delivery_note.acceptance_attachment.filename, @delivery_note.acceptance_attachment, class: 'me-auto', target: '_blank'
-              %small.text-muted.ms-2
-                = "Uploaded #{l(@delivery_note.acceptance_attachment.created_at)}"
-          .d-flex.gap-2.align-items-center
+  - if @delivery_note.published?
+    .mb-4
+      .card
+        .card-header.d-flex.justify-content-between.align-items-center
+          %h5.mb-0 Acceptance Document
+        .card-body
+          - if @delivery_note.acceptance_attachment
+            .mb-3
+              .d-flex.align-items-center
+                %i.fas.fa-file-pdf.text-danger.me-2
+                = link_to @delivery_note.acceptance_attachment.filename, @delivery_note.acceptance_attachment, class: 'me-auto', target: '_blank'
+                %small.text-muted.ms-2
+                  = "Uploaded #{l(@delivery_note.acceptance_attachment.created_at)}"
+            .d-flex.gap-2.align-items-center
+              = form_with url: upload_acceptance_delivery_note_path(@delivery_note), method: :post, multipart: true, local: true, data: { controller: 'file-upload-validation' } do |form|
+                .input-group.w-fixed-400
+                  = form.file_field :acceptance_pdf, accept: 'application/pdf', class: 'form-control', data: { file_upload_validation_target: 'fileInput' }
+                  = form.submit 'Replace', class: 'btn btn-warning', data: { file_upload_validation_target: 'submitButton' }
+              = button_to 'Delete', delete_acceptance_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-outline-danger', confirm: 'Are you sure you want to delete the acceptance document?'
+          - else
             = form_with url: upload_acceptance_delivery_note_path(@delivery_note), method: :post, multipart: true, local: true, data: { controller: 'file-upload-validation' } do |form|
               .input-group.w-fixed-400
                 = form.file_field :acceptance_pdf, accept: 'application/pdf', class: 'form-control', data: { file_upload_validation_target: 'fileInput' }
-                = form.submit 'Replace', class: 'btn btn-warning', data: { file_upload_validation_target: 'submitButton' }
-            = button_to 'Delete', delete_acceptance_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-outline-danger', confirm: 'Are you sure you want to delete the acceptance document?'
-        - else
-          = form_with url: upload_acceptance_delivery_note_path(@delivery_note), method: :post, multipart: true, local: true, data: { controller: 'file-upload-validation' } do |form|
-            .input-group.w-fixed-400
-              = form.file_field :acceptance_pdf, accept: 'application/pdf', class: 'form-control', data: { file_upload_validation_target: 'fileInput' }
-              = form.submit 'Upload PDF', class: 'btn btn-primary', data: { file_upload_validation_target: 'submitButton' }
-          %small.text-muted.d-block.mt-2
-            Upload the signed acceptance document (PDF only)
+                = form.submit 'Upload PDF', class: 'btn btn-primary', data: { file_upload_validation_target: 'submitButton' }
+            %small.text-muted.d-block.mt-2
+              Upload the signed acceptance document (PDF only)
 
-- if @delivery_note.prelude.present?
-  .mb-4
-    .card
-      .card-body
-        = simple_format(@delivery_note.prelude)
+  - if @delivery_note.prelude.present?
+    .mb-4
+      .card
+        .card-body
+          = simple_format(@delivery_note.prelude)
 
-.document-lines.mb-2
-  %table.table.table-bordered.document-lines-table
-    %thead
-      %tr
-        %th.text-end.col-quantity Quantity
-        %th Description
-    %tbody
-      - @delivery_note.delivery_note_lines.each do |line|
-        - case line.type
-        - when 'item'
-          %tr
-            %td.text-end
-              = number_with_precision(line.quantity, precision: 2, strip_insignificant_zeros: true)
-            %td
-              %strong= line.title
-              - if line.description.present?
-                %br
-                %small.text-muted= simple_format(line.description, {}, wrapper_tag: 'span')
-              =#line.delivery_time
-        - when 'subheading'
-          %tr
-            %td.fw-bold.table-secondary.document-section-row{colspan: 5}
-              = line.title
-        - when 'text', 'plain'
-          %tr
-            %td.document-text-row{colspan: 5}
-              - if line.title.present?
-                %div= line.title
-              - if line.description.present?
-                %div.text-muted.document-line-comment
-                  - if line.type == 'plain'
-                    %pre.mb-0.font-monospace.text-pre-wrap= line.description
-                  - else
-                    = simple_format(line.description)
+  .document-lines.mb-2
+    %table.table.table-bordered.document-lines-table
+      %thead
+        %tr
+          %th.text-end.col-quantity Quantity
+          %th Description
+      %tbody
+        - @delivery_note.delivery_note_lines.each do |line|
+          - case line.type
+          - when 'item'
+            %tr
+              %td.text-end
+                = number_with_precision(line.quantity, precision: 2, strip_insignificant_zeros: true)
+              %td
+                %strong= line.title
+                - if line.description.present?
+                  %br
+                  %small.text-muted= simple_format(line.description, {}, wrapper_tag: 'span')
+                =#line.delivery_time
+          - when 'subheading'
+            %tr
+              %td.fw-bold.table-secondary.document-section-row{colspan: 5}
+                = line.title
+          - when 'text', 'plain'
+            %tr
+              %td.document-text-row{colspan: 5}
+                - if line.title.present?
+                  %div= line.title
+                - if line.description.present?
+                  %div.text-muted.document-line-comment
+                    - if line.type == 'plain'
+                      %pre.mb-0.font-monospace.text-pre-wrap= line.description
+                    - else
+                      = simple_format(line.description)
 
-= action_buttons_wrapper do
+  = action_buttons_wrapper do
+    - if @delivery_note.published?
+      = action_button 'PDF', pdf_delivery_note_path(@delivery_note), :success, target: '_blank', data: { turbo: false }
+      - if can_edit_dn && !@delivery_note.invoice
+        = button_to 'Convert to Invoice', convert_to_invoice_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-info', confirm: 'Create an invoice draft from this delivery note?'
+      - if can_edit_dn
+        = button_to 'Unpublish', unpublish_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-outline-secondary', confirm: 'Are you sure you want to revert this delivery note to draft status?'
+    - else
+      = action_button 'Preview', preview_delivery_note_path(@delivery_note), :info, target: '_blank', data: { turbo: false }
+      - if can_edit_dn
+        = destroy_link(@delivery_note, "Are you sure you want to delete delivery note \"#{@delivery_note.document_number || "##{@delivery_note.id}"}\"?")
+
   - if @delivery_note.published?
-    = action_button 'PDF', pdf_delivery_note_path(@delivery_note), :success, target: '_blank', data: { turbo: false }
-    - if can_edit_dn && !@delivery_note.invoice
-      = button_to 'Convert to Invoice', convert_to_invoice_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-info', confirm: 'Create an invoice draft from this delivery note?'
-    - if can_edit_dn
-      = button_to 'Unpublish', unpublish_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-outline-secondary', confirm: 'Are you sure you want to revert this delivery note to draft status?'
-  - else
-    = action_button 'Preview', preview_delivery_note_path(@delivery_note), :info, target: '_blank', data: { turbo: false }
-    - if can_edit_dn
-      = destroy_link(@delivery_note, "Are you sure you want to delete delivery note \"#{@delivery_note.document_number || "##{@delivery_note.id}"}\"?")
+    = render 'shared/email_preview_modal', title: "Preview - Delivery Note #{@delivery_note.document_number}"

--- a/app/views/invoices/show.html.haml
+++ b/app/views/invoices/show.html.haml
@@ -17,215 +17,219 @@
     - if sent
       %span.badge.bg-success Sent
 
-- if params[:booked] == '1' && @invoice.published? && @invoice.attachment
-  .alert.alert-success.mb-3{data: {controller: 'auto-download'}}
-    %h4.alert-heading.mb-2= "Invoice #{@invoice.document_number} booked."
-    %p.mb-3 Download the PDF and send it to your customer.
-    .d-flex.gap-2{data: email_preview_data(@invoice)}
-      = link_to 'Download PDF', @invoice.attachment, class: 'btn btn-success', target: '_blank', data: { turbo: false, 'auto-download-target': 'link' }
-      - if @invoice.emailable?
-        %button.btn.btn-outline-success{data: {action: 'click->generic-email-preview#open'}} Send E-Mail
-      = render 'shared/email_preview_modal', title: "Preview - Invoice #{@invoice.document_number}" if @invoice.emailable?
+-# Single generic-email-preview controller scope so the modal can be rendered
+-# once at the bottom and serve every trigger site on the page.
+%div{data: (@invoice.published? ? email_preview_data(@invoice) : {})}
+  - if params[:booked] == '1' && @invoice.published? && @invoice.attachment
+    .alert.alert-success.mb-3{data: {controller: 'auto-download'}}
+      %h4.alert-heading.mb-2= "Invoice #{@invoice.document_number} booked."
+      %p.mb-3 Download the PDF and send it to your customer.
+      .d-flex.gap-2
+        = link_to 'Download PDF', @invoice.attachment, class: 'btn btn-success', target: '_blank', data: { turbo: false, 'auto-download-target': 'link' }
+        - if @invoice.emailable?
+          %button.btn.btn-outline-success{data: {action: 'click->generic-email-preview#open'}} Send E-Mail
 
-.row.mb-2
-  .col-md-6
-    .document-details
-      - if @invoice.date
+  .row.mb-2
+    .col-md-6
+      .document-details
+        - if @invoice.date
+          .row.mb-2
+            .col-sm-4
+              %strong Date:
+            .col-sm-8
+              = l(@invoice.date)
         .row.mb-2
           .col-sm-4
-            %strong Date:
+            %strong Customer:
           .col-sm-8
-            = l(@invoice.date)
-      .row.mb-2
-        .col-sm-4
-          %strong Customer:
-        .col-sm-8
-          = link_to(@invoice.customer_name || @invoice.customer.name, @invoice.customer)
-      - if @invoice.project_id.present?
-        .row.mb-2
-          .col-sm-4
-            %strong Project:
-          .col-sm-8
-            - if @invoice.project
-              = link_to @invoice.project.display_name, @invoice.project
-            - else
-              %em (Project ##{@invoice.project_id} - not found)
-      - if @invoice.cust_order.present?
-        .row.mb-2
-          .col-sm-4
-            %strong Order No:
-          .col-sm-8
-            = @invoice.cust_order
-      - if @invoice.cust_reference.present?
-        .row.mb-2
-          .col-sm-4
-            %strong Reference:
-          .col-sm-8
-            = @invoice.cust_reference
+            = link_to(@invoice.customer_name || @invoice.customer.name, @invoice.customer)
+        - if @invoice.project_id.present?
+          .row.mb-2
+            .col-sm-4
+              %strong Project:
+            .col-sm-8
+              - if @invoice.project
+                = link_to @invoice.project.display_name, @invoice.project
+              - else
+                %em (Project ##{@invoice.project_id} - not found)
+        - if @invoice.cust_order.present?
+          .row.mb-2
+            .col-sm-4
+              %strong Order No:
+            .col-sm-8
+              = @invoice.cust_order
+        - if @invoice.cust_reference.present?
+          .row.mb-2
+            .col-sm-4
+              %strong Reference:
+            .col-sm-8
+              = @invoice.cust_reference
 
-  .col-md-6
-    .document-details
-      - if @invoice.due_date
-        .row.mb-2
-          .col-sm-4
-            %strong Due Date:
-          .col-sm-8
-            = l(@invoice.due_date)
-            %span.text-muted.ms-2 (#{@invoice.payment_terms_days} days net)
-      - else
-        .row.mb-2
-          .col-sm-4
-            %strong Payment Terms:
-          .col-sm-8
-            = @invoice.payment_terms_days
-            days net
+    .col-md-6
+      .document-details
+        - if @invoice.due_date
+          .row.mb-2
+            .col-sm-4
+              %strong Due Date:
+            .col-sm-8
+              = l(@invoice.due_date)
+              %span.text-muted.ms-2 (#{@invoice.payment_terms_days} days net)
+        - else
+          .row.mb-2
+            .col-sm-4
+              %strong Payment Terms:
+            .col-sm-8
+              = @invoice.payment_terms_days
+              days net
 
-      - unless @invoice.published?
-        .row.mb-2
-          .col-sm-4
-            %strong Booking Status:
-          .col-sm-8.d-flex.align-items-center.gap-2
-            - if problems.any?
-              %span.badge.bg-warning= pluralize(problems.size, 'problem')
-            - else
-              %span.badge.bg-success Ready
-            - if can_edit_invoice
+        - unless @invoice.published?
+          .row.mb-2
+            .col-sm-4
+              %strong Booking Status:
+            .col-sm-8.d-flex.align-items-center.gap-2
               - if problems.any?
-                %span.ms-auto{title: problems.join("\n")}
-                  %button.btn.btn-sm.btn-info{disabled: true} Book Invoice…
+                %span.badge.bg-warning= pluralize(problems.size, 'problem')
               - else
-                = button_to 'Book Invoice…', book_invoice_path(@invoice), method: :post, class: 'btn btn-sm btn-info', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Book invoice and assign a document number? This cannot be undone.' }
+                %span.badge.bg-success Ready
+              - if can_edit_invoice
+                - if problems.any?
+                  %span.ms-auto{title: problems.join("\n")}
+                    %button.btn.btn-sm.btn-info{disabled: true} Book Invoice…
+                - else
+                  = button_to 'Book Invoice…', book_invoice_path(@invoice), method: :post, class: 'btn btn-sm btn-info', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Book invoice and assign a document number? This cannot be undone.' }
 
-      - if @invoice.published?
-        .row.mb-2
-          .col-sm-4
-            %strong Email Status:
-          .col-sm-8.d-flex.align-items-center.gap-2{data: email_preview_data(@invoice)}
-            - if @invoice.email_sent_at
-              Sent #{l(@invoice.email_sent_at)}
-            - elsif @invoice.emailable?
-              %span.badge.bg-warning Unsent
-            - else
-              %span.badge.bg-secondary No Recipient
-            - if can_edit_invoice && @invoice.attachment
-              - if @invoice.emailable?
-                %button.btn.btn-sm.btn-warning.ms-auto{data: {action: 'click->generic-email-preview#open'}}
-                  Send E-Mail
+        - if @invoice.published?
+          .row.mb-2
+            .col-sm-4
+              %strong Email Status:
+            .col-sm-8.d-flex.align-items-center.gap-2
+              - if @invoice.email_sent_at
+                Sent #{l(@invoice.email_sent_at)}
+              - elsif @invoice.emailable?
+                %span.badge.bg-warning Unsent
               - else
-                %span.ms-auto{data: {'bs-toggle': 'tooltip'}, title: 'No contact is configured to receive this invoice. Add a contact on the customer, or enable Automated E-Mail.'}
-                  %button.btn.btn-sm.btn-warning{disabled: true}
+                %span.badge.bg-secondary No Recipient
+              - if can_edit_invoice && @invoice.attachment
+                - if @invoice.emailable?
+                  %button.btn.btn-sm.btn-warning.ms-auto{data: {action: 'click->generic-email-preview#open'}}
                     Send E-Mail
-            = render 'shared/email_preview_modal', title: "Preview - Invoice #{@invoice.document_number}"
+                - else
+                  %span.ms-auto{data: {'bs-toggle': 'tooltip'}, title: 'No contact is configured to receive this invoice. Add a contact on the customer, or enable Automated E-Mail.'}
+                    %button.btn.btn-sm.btn-warning{disabled: true}
+                      Send E-Mail
 
-        .row.mb-2
-          .col-sm-4
-            %strong Payment Status:
-          .col-sm-8.d-flex.align-items-center.gap-2{data: {controller: 'modal'}}
-            - if @invoice.paid?
-              Paid #{l(@invoice.paid_at.to_date)}
-            - elsif @invoice.overdue?
-              %span.badge.bg-danger Overdue
-            - else
-              %span.badge.bg-warning Unpaid
-            - if can_edit_invoice
+          .row.mb-2
+            .col-sm-4
+              %strong Payment Status:
+            .col-sm-8.d-flex.align-items-center.gap-2{data: {controller: 'modal'}}
               - if @invoice.paid?
-                -# button_to wraps the button in a form; the form is the flex
-                -# child, so ms-auto must go on the form to push it right.
-                = button_to 'Mark Unpaid', mark_unpaid_invoice_path(@invoice), method: :post, class: 'btn btn-sm btn-outline-secondary', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Mark this invoice as unpaid?' }
+                Paid #{l(@invoice.paid_at.to_date)}
+              - elsif @invoice.overdue?
+                %span.badge.bg-danger Overdue
               - else
-                %button.btn.btn-sm.btn-success.ms-auto{data: {action: 'click->modal#open'}}
-                  Mark Paid…
-                = render 'shared/mark_paid_modal', invoice: @invoice
+                %span.badge.bg-warning Unpaid
+              - if can_edit_invoice
+                - if @invoice.paid?
+                  -# button_to wraps the button in a form; the form is the flex
+                  -# child, so ms-auto must go on the form to push it right.
+                  = button_to 'Mark Unpaid', mark_unpaid_invoice_path(@invoice), method: :post, class: 'btn btn-sm btn-outline-secondary', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Mark this invoice as unpaid?' }
+                - else
+                  %button.btn.btn-sm.btn-success.ms-auto{data: {action: 'click->modal#open'}}
+                    Mark Paid…
+                  = render 'shared/mark_paid_modal', invoice: @invoice
 
-      - if @invoice.delivery_note
-        .row.mb-2
-          .col-sm-4
-            %strong Source:
-          .col-sm-8
-            = link_to "Delivery Note #{@invoice.delivery_note.document_number || "##{@invoice.delivery_note.id}"}", @invoice.delivery_note
+        - if @invoice.delivery_note
+          .row.mb-2
+            .col-sm-4
+              %strong Source:
+            .col-sm-8
+              = link_to "Delivery Note #{@invoice.delivery_note.document_number || "##{@invoice.delivery_note.id}"}", @invoice.delivery_note
 
-- if @invoice.prelude.present?
-  .mb-4
-    .card
-      .card-body
-        = simple_format(@invoice.prelude)
+  - if @invoice.prelude.present?
+    .mb-4
+      .card
+        .card-body
+          = simple_format(@invoice.prelude)
 
-- if !@invoice.published? && problems.any?
-  .alert.alert-warning.mb-3
-    %strong This invoice cannot be booked yet:
-    %ul.mb-0
-      - problems.each do |p|
-        %li= p
+  - if !@invoice.published? && problems.any?
+    .alert.alert-warning.mb-3
+      %strong This invoice cannot be booked yet:
+      %ul.mb-0
+        - problems.each do |p|
+          %li= p
 
-.document-lines.mb-2
-  %table.table.table-bordered.document-lines-table
-    %thead
-      %tr
-        %th.col-description Description
-        %th.text-end.col-quantity Quantity
-        %th.text-end.col-rate Rate
-        %th.text-center.col-tax-class Tax Class
-        %th.text-end.col-amount Amount
-    %tbody
-      - @invoice.invoice_lines.each do |line|
-        - case line.type
-        - when 'item'
-          %tr
-            %td
-              %strong= line.title
-              - if line.description.present?
-                %br
-                %small.text-muted= simple_format(line.description, {}, wrapper_tag: 'span')
-            %td.text-end
-              = number_with_precision(line.quantity, precision: 2, strip_insignificant_zeros: true)
-            %td.text-end
-              = format_currency(line.rate)
-            %td.text-center
-              %small= line.sales_tax_product_class&.name
-            %td.text-end
-              %strong= format_currency(line.amount || (line.quantity * line.rate))
-        - when 'subheading'
-          %tr
-            %td.fw-bold.table-secondary.document-section-row{colspan: 5}
-              = line.title
-        - when 'text', 'plain'
-          %tr
-            %td.document-text-row{colspan: 5}
-              - if line.title.present?
-                %div= line.title
-              - if line.description.present?
-                %div.text-muted.document-line-comment
-                  - if line.type == 'plain'
-                    %pre.mb-0.font-monospace.text-pre-wrap= line.description
-                  - else
-                    = simple_format(line.description)
-
-.row.justify-content-end
-  .col-md-4
-    %table.table.table-sm
-      %tbody
+  .document-lines.mb-2
+    %table.table.table-bordered.document-lines-table
+      %thead
         %tr
-          %td.text-end
-            %strong Sum Net:
-          %td.text-end
-            %strong= format_currency(@invoice.sum_net)
-        - if @invoice.invoice_tax_classes.any?
-          - @invoice.invoice_tax_classes.each do |tax_class|
+          %th.col-description Description
+          %th.text-end.col-quantity Quantity
+          %th.text-end.col-rate Rate
+          %th.text-center.col-tax-class Tax Class
+          %th.text-end.col-amount Amount
+      %tbody
+        - @invoice.invoice_lines.each do |line|
+          - case line.type
+          - when 'item'
             %tr
+              %td
+                %strong= line.title
+                - if line.description.present?
+                  %br
+                  %small.text-muted= simple_format(line.description, {}, wrapper_tag: 'span')
               %td.text-end
-                Tax (#{tax_class.rate}%):
+                = number_with_precision(line.quantity, precision: 2, strip_insignificant_zeros: true)
               %td.text-end
-                = format_currency(tax_class.value)
-        %tr.table-dark
-          %td.text-end
-            %strong Sum Total:
-          %td.text-end
-            %strong= format_currency(@invoice.sum_total)
+                = format_currency(line.rate)
+              %td.text-center
+                %small= line.sales_tax_product_class&.name
+              %td.text-end
+                %strong= format_currency(line.amount || (line.quantity * line.rate))
+          - when 'subheading'
+            %tr
+              %td.fw-bold.table-secondary.document-section-row{colspan: 5}
+                = line.title
+          - when 'text', 'plain'
+            %tr
+              %td.document-text-row{colspan: 5}
+                - if line.title.present?
+                  %div= line.title
+                - if line.description.present?
+                  %div.text-muted.document-line-comment
+                    - if line.type == 'plain'
+                      %pre.mb-0.font-monospace.text-pre-wrap= line.description
+                    - else
+                      = simple_format(line.description)
 
-= action_buttons_wrapper do
-  - if @invoice.attachment
-    = action_button 'PDF', @invoice.attachment, :success, target: '_blank', data: { turbo: false }
-  - else
-    = action_button 'Preview', preview_invoice_path(@invoice), :info, target: '_blank', data: { turbo: false }
-  - if !@invoice.published && can_edit_invoice
-    = destroy_link(@invoice, "Are you sure you want to delete invoice \"#{@invoice.document_number || "##{@invoice.id}"}\"?")
+  .row.justify-content-end
+    .col-md-4
+      %table.table.table-sm
+        %tbody
+          %tr
+            %td.text-end
+              %strong Sum Net:
+            %td.text-end
+              %strong= format_currency(@invoice.sum_net)
+          - if @invoice.invoice_tax_classes.any?
+            - @invoice.invoice_tax_classes.each do |tax_class|
+              %tr
+                %td.text-end
+                  Tax (#{tax_class.rate}%):
+                %td.text-end
+                  = format_currency(tax_class.value)
+          %tr.table-dark
+            %td.text-end
+              %strong Sum Total:
+            %td.text-end
+              %strong= format_currency(@invoice.sum_total)
+
+  = action_buttons_wrapper do
+    - if @invoice.attachment
+      = action_button 'PDF', @invoice.attachment, :success, target: '_blank', data: { turbo: false }
+    - else
+      = action_button 'Preview', preview_invoice_path(@invoice), :info, target: '_blank', data: { turbo: false }
+    - if !@invoice.published && can_edit_invoice
+      = destroy_link(@invoice, "Are you sure you want to delete invoice \"#{@invoice.document_number || "##{@invoice.id}"}\"?")
+
+  - if @invoice.published?
+    = render 'shared/email_preview_modal', title: "Preview - Invoice #{@invoice.document_number}"


### PR DESCRIPTION
## Summary

(Originally planned as stacked on #389; that landed before this branch went up, so it targets master directly. The motivating duplication came from #389's post-publish banner being added alongside the existing Email Status row.)

The invoice and delivery-note show pages each had two trigger sites for the \`generic-email-preview\` modal — the post-success banner and the Email Status row — and each site rendered its own \`data-controller=\"generic-email-preview\"\` scope plus its own copy of \`_email_preview_modal\`. When both sites rendered (published with the banner showing), the modal subtree was duplicated in the DOM.

Hoist the controller scope to a single wrapper around the show body. Render the modal exactly once at the bottom of the wrapper. Every trigger button keeps its \`data-action=\"click->generic-email-preview#open\"\` and now resolves to the single modal target. Draft views get an empty wrapper (no \`data-controller\` attached) since they have no email triggers.

## Diff shape

Most of the diff is indentation — every line below the new wrapper shifted right by two spaces. Real semantic changes:

- One wrapper \`%div{data: ...}\` added per file.
- One \`= render 'shared/email_preview_modal', ...\` added at the bottom of each wrapper.
- The two per-site \`{data: email_preview_data(...)}\` attributes and two per-site modal renders removed per file.

## Test plan

- [x] \`bundle exec rails test\` — 659 runs, 0 failures
- [ ] Manual: on a booked invoice, the post-booking banner's Send E-Mail opens the modal; after reload (no \`?booked=1\`) the Email Status row's Send E-Mail still opens it. Same drill for delivery notes after publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)