### PR TITLE
Migrate remaining indexes to permission: arg on link helpers

### DIFF
--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -24,10 +24,9 @@
       %td= group.permission_count
       %td= group.bypass_team_scoping? ? 'Yes' : 'No'
       %td
-        - if can?('groups.manage')
-          = list_action_link('Edit', edit_group_path(group), :edit)
+        = list_action_link('Edit', edit_group_path(group), :edit, permission: 'groups.manage')
       %td
-        - if can?('groups.manage') && !group.builtin?
-          = destroy_link(group, "Are you sure you want to delete group \"#{group.name}\"?")
-        - elsif group.builtin?
+        - if group.builtin?
           %span.text-muted —
+        - else
+          = destroy_link(group, "Are you sure you want to delete group \"#{group.name}\"?", permission: 'groups.manage')

--- a/app/views/sales_tax_rates/index.html.haml
+++ b/app/views/sales_tax_rates/index.html.haml
@@ -16,11 +16,9 @@
         = sales_tax_rate.rate
         \%
       %td
-        - if can?('sales_tax.edit')
-          = list_action_link('Edit', edit_sales_tax_rate_path(sales_tax_rate), :edit)
+        = list_action_link('Edit', edit_sales_tax_rate_path(sales_tax_rate), :edit, permission: 'sales_tax.edit')
       %td
-        - if can?('sales_tax.edit')
-          = destroy_link(sales_tax_rate, "Are you sure you want to delete tax rate for \"#{sales_tax_rate.sales_tax_customer_class&.name}\" / \"#{sales_tax_rate.sales_tax_product_class&.name}\"?")
+        = destroy_link(sales_tax_rate, "Are you sure you want to delete tax rate for \"#{sales_tax_rate.sales_tax_customer_class&.name}\" / \"#{sales_tax_rate.sales_tax_product_class&.name}\"?", permission: 'sales_tax.edit')
 
 - if @sales_tax_rates.empty?
   %p

--- a/app/views/teams/index.html.haml
+++ b/app/views/teams/index.html.haml
@@ -24,10 +24,9 @@
       %td= team.customer_count
       %td= team.project_count
       %td
-        - if can?('teams.manage')
-          = list_action_link('Edit', edit_team_path(team), :edit)
+        = list_action_link('Edit', edit_team_path(team), :edit, permission: 'teams.manage')
       %td
-        - if can?('teams.manage') && !team.builtin?
-          = destroy_link(team, "Are you sure you want to delete team \"#{team.name}\"?")
-        - elsif team.builtin?
+        - if team.builtin?
           %span.text-muted —
+        - else
+          = destroy_link(team, "Are you sure you want to delete team \"#{team.name}\"?", permission: 'teams.manage')


### PR DESCRIPTION
## Summary

- `sales_tax_rates/index`: drop the two `if can?('sales_tax.edit')` wraps around Edit / destroy in favor of inline `permission:` args on `list_action_link` / `destroy_link`.
- `groups/index`, `teams/index`: drop the Edit wrap. Restructure the combined `if can?('xxx.manage') && !builtin?` + `elsif builtin?` block for destroy so the `builtin?` branch leads (renders the `—`) and `destroy_link` gates inline via `permission:`. Semantics unchanged across all permitted × builtin combinations.
- `users/index` has no `list_action_link` / `destroy_link` calls remaining (the redundant View column was dropped in #391), so nothing to migrate there.

Finishes the cleanup PR #392 deferred — the four files were skipped at the time to avoid conflicts with the concurrent #390 / #391.

## Test plan

- [x] `bundle exec rails test` — 675 runs, 2530 assertions, 0 failures.
- [ ] Manual: as a user lacking `sales_tax.edit`, the sales tax rates index renders no Edit / 🗑 per row.
- [ ] Manual: as a user lacking `groups.manage`, the groups index renders no Edit; non-builtin rows have an empty destroy cell; builtin rows still show `—`.
- [ ] Manual: same as groups for teams with `teams.manage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)