### PR TITLE
Move Sales Tax nav buttons into the breadcrumb

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,7 @@ For testing against PostgreSQL (matches production environment):
 - `destroy_link(resource, confirm_text)` - Compact `🗑` outline link for the **Actions** column on index pages. On detail pages use `delete_button(resource)` instead.
 - `list_action_link(text, path, type)` - Compact buttons for in-table row actions.
 - Per-verb helpers in `ActionButtonsHelper` (`delete_button`, `pdf_button`, `preview_button`, `publish_button`, `unpublish_button`, `convert_to_invoice_button`, `unblock_button`, `reset_passkeys_button`, `audit_log_button`) — see "Button Glyphs" below for the full mapping and policy.
+- `nav_button(text, path, permission: nil, data: nil)` (in `ActionButtonsHelper`) — cross-resource navigation in the breadcrumb action cluster (e.g. customer show → its Invoices/Delivery Notes; sales-tax rates → Customer/Product Classes). Bakes in `:info` so the color convention is centralized. Don't reach for `action_button(..., :info)` for cross-resource navigation — use `nav_button` instead.
 
 ### Button Glyphs (Show-page Actions)
 

--- a/app/helpers/action_buttons_helper.rb
+++ b/app/helpers/action_buttons_helper.rb
@@ -85,4 +85,13 @@ module ActionButtonsHelper
     return nil if permission && !can?(permission)
     link_to "📋 Audit log", path, class: "btn btn-secondary"
   end
+
+  # Cross-resource navigation in the breadcrumb action cluster: jumping to a
+  # related list/page (e.g. from a customer to its Invoices, or from Sales Tax
+  # rates to Customer/Product Classes). Bakes in `:info` so the convention is
+  # not re-decided per caller.
+  def nav_button(text, path, permission: nil, data: nil)
+    return nil if permission && !can?(permission)
+    link_to text, path, class: "btn btn-info", data: data
+  end
 end

--- a/app/views/customers/show.html.haml
+++ b/app/views/customers/show.html.haml
@@ -1,5 +1,5 @@
-- invoices_action = action_button('Invoices', invoices_path(customer_id: @customer.id, year: 'all'), :info, permission: 'invoices.view', data: { turbo_prefetch: false })
-- delivery_notes_action = action_button('Delivery Notes', delivery_notes_path(customer_id: @customer.id, year: 'all'), :info, permission: 'delivery_notes.view', data: { turbo_prefetch: false })
+- invoices_action = nav_button('Invoices', invoices_path(customer_id: @customer.id, year: 'all'), permission: 'invoices.view', data: { turbo_prefetch: false })
+- delivery_notes_action = nav_button('Delivery Notes', delivery_notes_path(customer_id: @customer.id, year: 'all'), permission: 'delivery_notes.view', data: { turbo_prefetch: false })
 - delete_action = delete_button(@customer, confirm: "Are you sure you want to delete customer \"#{@customer.matchcode}\" (#{@customer.name})?") if can?('customers.edit') && !@customer.used_in_invoices?
 - edit_action = action_button('Edit', edit_customer_path(@customer), permission: 'customers.edit')
 = breadcrumbs ['Customers', customers_path], @customer.matchcode, actions: [invoices_action, delivery_notes_action, delete_action], action: edit_action do

--- a/app/views/sales_tax_rates/index.html.haml
+++ b/app/views/sales_tax_rates/index.html.haml
@@ -1,4 +1,6 @@
-= breadcrumbs 'Configuration', 'Sales Tax', action: action_button('+ New', new_sales_tax_rate_path, :info, permission: 'sales_tax.edit')
+- customer_classes_action = nav_button('Customer Classes', sales_tax_customer_classes_path)
+- product_classes_action = nav_button('Product Classes', sales_tax_product_classes_path)
+= breadcrumbs 'Configuration', 'Sales Tax', actions: [customer_classes_action, product_classes_action], action: action_button('+ New', new_sales_tax_rate_path, :info, permission: 'sales_tax.edit')
 
 %table.table.table-striped.table-sm
   %tr
@@ -62,6 +64,3 @@
                 = f.number_field :rate, class: 'form-control', step: 0.01, required: true
                 %span.input-group-text %
               = f.submit 'Create', class: 'btn btn-primary'
-= action_buttons_wrapper do
-  = action_button 'Customer Classes', sales_tax_customer_classes_path, :secondary
-  = action_button 'Product Classes', sales_tax_product_classes_path, :secondary

--- a/test/helpers/action_buttons_helper_test.rb
+++ b/test/helpers/action_buttons_helper_test.rb
@@ -66,4 +66,11 @@ class ActionButtonsHelperTest < ActionView::TestCase
     assert_includes html, "📋 Audit log"
     assert_match(/btn-secondary/, html)
   end
+
+  test "nav_button renders the given label with info color" do
+    html = nav_button("Invoices", "/invoices")
+    assert_includes html, "Invoices"
+    assert_match(/btn-info/, html)
+    assert_match(%r{href="/invoices"}, html)
+  end
 end


### PR DESCRIPTION
## Summary
- Sales Tax rates index: move `Customer Classes` / `Product Classes` from the bottom `action_buttons_wrapper` into the breadcrumb action cluster, matching every other index/show page.
- Add `nav_button(text, path, permission:, data:)` in `ActionButtonsHelper` for cross-resource navigation in the breadcrumb cluster — bakes in `:info`, so the convention isn't re-decided per caller.
- Route `customers/show`'s existing Invoices / Delivery Notes buttons through `nav_button` too, and document it in CLAUDE.md alongside the other action-cluster helpers.

## Test plan
- [x] `bundle exec rails test test/helpers/action_buttons_helper_test.rb`
- [x] `bundle exec rails test test/controllers/customers_controller_test.rb`
- [x] `pre-commit run --all-files`
- [ ] Visual check on `/sales_tax_rates` — both buttons now sit top-right next to `+ New`, all `:info` blue.
- [ ] Visual check on a customer show page — Invoices / Delivery Notes still render unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)