### PR TITLE
Add permission: arg to delete_button helper

### DIFF
--- a/app/helpers/action_buttons_helper.rb
+++ b/app/helpers/action_buttons_helper.rb
@@ -10,7 +10,8 @@ module ActionButtonsHelper
 
   # --- Tier 3: glyph-only (title required) ---
 
-  def delete_button(resource, confirm: nil)
+  def delete_button(resource, confirm: nil, permission: nil)
+    return nil if permission && !can?(permission)
     confirm ||= "Are you sure you want to delete this #{resource.class.name.downcase}?"
     link_to "🗑", resource,
             class: "btn btn-danger",

--- a/app/views/customers/show.html.haml
+++ b/app/views/customers/show.html.haml
@@ -1,6 +1,6 @@
 - invoices_action = nav_button('Invoices', invoices_path(customer_id: @customer.id, year: 'all'), permission: 'invoices.view', data: { turbo_prefetch: false })
 - delivery_notes_action = nav_button('Delivery Notes', delivery_notes_path(customer_id: @customer.id, year: 'all'), permission: 'delivery_notes.view', data: { turbo_prefetch: false })
-- delete_action = delete_button(@customer, confirm: "Are you sure you want to delete customer \"#{@customer.matchcode}\" (#{@customer.name})?") if can?('customers.edit') && !@customer.used_in_invoices?
+- delete_action = delete_button(@customer, confirm: "Are you sure you want to delete customer \"#{@customer.matchcode}\" (#{@customer.name})?", permission: 'customers.edit') unless @customer.used_in_invoices?
 - edit_action = action_button('Edit', edit_customer_path(@customer), permission: 'customers.edit')
 = breadcrumbs ['Customers', customers_path], @customer.matchcode, actions: [invoices_action, delivery_notes_action, delete_action], action: edit_action do
   - unless @customer.active?

--- a/test/helpers/action_buttons_helper_test.rb
+++ b/test/helpers/action_buttons_helper_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class ActionButtonsHelperTest < ActionView::TestCase
+  helper ApplicationHelper
+
   # Smoke tests that pin the established glyph + Bootstrap color + accessible
   # name for each helper. Update these when CLAUDE.md's "Button Glyphs" table
   # changes — they are the executable copy of the policy.
@@ -14,6 +16,30 @@ class ActionButtonsHelperTest < ActionView::TestCase
     assert_match(/aria-label="Delete"/, html)
     assert_includes html, "🗑"
     assert_match(/data-turbo-confirm=/, html)
+  end
+
+  test "delete_button with permission: returns the link when user has it" do
+    Current.user = users(:alice)
+    customer = customers(:good_eu)
+    html = delete_button(customer, permission: "customers.edit")
+    assert_match(/btn-danger/, html)
+    assert_includes html, "🗑"
+  ensure
+    Current.user = nil
+  end
+
+  test "delete_button with permission: returns nil when user lacks it" do
+    Current.user = users(:bob)
+    customer = customers(:good_eu)
+    assert_nil delete_button(customer, permission: "customers.edit")
+  ensure
+    Current.user = nil
+  end
+
+  test "delete_button with permission: returns nil when no current user" do
+    Current.user = nil
+    customer = customers(:good_eu)
+    assert_nil delete_button(customer, permission: "customers.edit")
   end
 
   test "pdf_button renders glyph-only with title, opens in new tab" do


### PR DESCRIPTION
## Summary
- `delete_button` was the only helper in `ActionButtonsHelper` without a `permission:` kwarg, contradicting the module's own docstring.
- Migrates the sole pre-existing call site (`customers/show.html.haml`) to use the new kwarg; the `used_in_invoices?` business gate stays as a trailing `unless`.
- Adds the three permission-branch tests (`has`, `lacks`, `no current user`) that sibling helpers (e.g. `destroy_link`) already carry.

## Test plan
- [x] `bundle exec rails test` — 679 runs, 0 failures, 0 errors.
- [x] Visual: confirm trashcan button still appears on `/customers/:id` for users with `customers.edit` (and only when not used in invoices).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>