### PR TITLE
Migrate combined-condition permission wraps; dedupe contacts row

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -145,7 +145,9 @@ module ApplicationHelper
   end
 
   def action_buttons_wrapper(&block)
-    content_tag :div, class: "d-flex gap-2 mb-3 mt-3", &block
+    content = capture(&block)
+    return nil if content.blank?
+    content_tag :div, content, class: "d-flex gap-2 mb-3 mt-3"
   end
 
   def action_button(text, path, type = :primary, permission: nil, target: nil, data: nil, title: nil)

--- a/app/views/customer_contacts/_row.html.haml
+++ b/app/views/customer_contacts/_row.html.haml
@@ -19,10 +19,8 @@
       - else
         %span.text-muted All projects
     .col-md-2.text-end
-      - if can?('customers.edit')
-        = list_action_link "Edit", edit_customer_contact_path(contact), :edit
-        = link_to "🗑", customer_contact_path(contact), class: "btn btn-sm btn-outline-danger py-0",
-                  data: { 'turbo-method': :delete, 'turbo-confirm': "Delete contact \"#{contact.name}\"?" }
+      = list_action_link "Edit", edit_customer_contact_path(contact), :edit, permission: 'customers.edit'
+      = destroy_link contact, "Delete contact \"#{contact.name}\"?", permission: 'customers.edit'
   - if contact.salutation_line.present?
     .row.gx-2
       .col-md-10.offset-md-2.small.text-muted.fst-italic

--- a/app/views/customers/index.html.haml
+++ b/app/views/customers/index.html.haml
@@ -30,5 +30,5 @@
       %td
         = list_action_link('Edit', edit_customer_path(customer), :edit, permission: 'customers.edit')
       %td
-        - if can?('customers.edit') && !customer.used_in_invoices?
-          = destroy_link(customer, "Are you sure you want to delete customer \"#{customer.matchcode}\" (#{customer.name})?")
+        - unless customer.used_in_invoices?
+          = destroy_link(customer, "Are you sure you want to delete customer \"#{customer.matchcode}\" (#{customer.name})?", permission: 'customers.edit')

--- a/app/views/projects/index.html.haml
+++ b/app/views/projects/index.html.haml
@@ -32,5 +32,5 @@
       %td
         = list_action_link('Edit', edit_project_path(project), :edit, permission: 'projects.edit')
       %td
-        - if can?('projects.edit') && project.can_be_deleted?
-          = destroy_link(project, "Are you sure you want to delete project \"#{project.matchcode}\"?")
+        - if project.can_be_deleted?
+          = destroy_link(project, "Are you sure you want to delete project \"#{project.matchcode}\"?", permission: 'projects.edit')

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -19,6 +19,5 @@
             %span.badge.bg-danger Blocked
         %td= l(user.created_at)
 
-- if can?('user_invites.manage')
-  .mt-4
-    = link_to 'View invites', user_invites_path, class: 'btn btn-secondary'
+.mt-4
+  = action_button 'View invites', user_invites_path, :secondary, permission: 'user_invites.manage'

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -19,5 +19,5 @@
             %span.badge.bg-danger Blocked
         %td= l(user.created_at)
 
-.mt-4
+= action_buttons_wrapper do
   = action_button 'View invites', user_invites_path, :secondary, permission: 'user_invites.manage'

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -143,6 +143,18 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_nil destroy_link(customer, nil, permission: "customers.edit")
   end
 
+  test "action_buttons_wrapper wraps non-empty block content in a flex div" do
+    html = Nokogiri::HTML.fragment(action_buttons_wrapper { "<a>Go</a>".html_safe })
+    div = html.at_css("div")
+    assert_not_nil div
+    assert_equal "d-flex gap-2 mb-3 mt-3", div["class"]
+    assert_not_nil div.at_css("a")
+  end
+
+  test "action_buttons_wrapper returns nil when the block is empty" do
+    assert_nil action_buttons_wrapper { "" }
+  end
+
   test "breadcrumbs renders plain-label middle crumbs without a link" do
     html = Nokogiri::HTML.fragment(breadcrumbs("Configuration", [ "Sales Tax", "/sales_tax_rates" ], "Edit"))
     items = html.css("li.breadcrumb-item")


### PR DESCRIPTION
## Summary

- Push `can?` checks inline via the `permission:` keyword on `list_action_link`, `destroy_link`, and `action_button` so views can drop their `- if can?(...)` wrappers.
- Replace the hand-rolled trashcan `link_to` in the customer-contacts row with `destroy_link` (byte-identical output).
- Restructure customers/projects index destroy_link guards to lead with the business gate (`used_in_invoices?`, `can_be_deleted?`) and gate permission inline.
- Swap the users-index "View invites" plain `link_to` for `action_button ..., :secondary, permission: 'user_invites.manage'`.

## Test plan

- [x] `bundle exec rails test` (676 runs, 0 failures, 0 errors)
- [ ] Visual check of `/customers`, `/projects`, `/users`, and a customer contacts row both as a permitted and a non-permitted user