### PR TITLE
Rebalance breadcrumb action colors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,7 +197,7 @@ For testing against PostgreSQL (matches production environment):
 - `destroy_link(resource, confirm_text)` - Compact `🗑` outline link for the **Actions** column on index pages. On detail pages use `delete_button(resource)` instead.
 - `list_action_link(text, path, type)` - Compact buttons for in-table row actions.
 - Per-verb helpers in `ActionButtonsHelper` (`delete_button`, `pdf_button`, `preview_button`, `publish_button`, `unpublish_button`, `convert_to_invoice_button`, `unblock_button`, `reset_passkeys_button`, `audit_log_button`) — see "Button Glyphs" below for the full mapping and policy.
-- `nav_button(text, path, permission: nil, data: nil)` (in `ActionButtonsHelper`) — cross-resource navigation in the breadcrumb action cluster (e.g. customer show → its Invoices/Delivery Notes; sales-tax rates → Customer/Product Classes). Bakes in `:info` so the color convention is centralized. Don't reach for `action_button(..., :info)` for cross-resource navigation — use `nav_button` instead.
+- `nav_button(text, path, permission: nil, data: nil)` (in `ActionButtonsHelper`) — cross-resource navigation in the breadcrumb action cluster (e.g. customer show → its Invoices/Delivery Notes; sales-tax rates → Customer/Product Classes). Renders `btn-outline-secondary` so nav reads as quiet/link-ish and yields visual prominence to the page's primary action. Don't reach for filled variants for cross-resource navigation — use `nav_button` instead.
 
 ### Button Glyphs (Show-page Actions)
 

--- a/app/helpers/action_buttons_helper.rb
+++ b/app/helpers/action_buttons_helper.rb
@@ -89,10 +89,11 @@ module ActionButtonsHelper
 
   # Cross-resource navigation in the breadcrumb action cluster: jumping to a
   # related list/page (e.g. from a customer to its Invoices, or from Sales Tax
-  # rates to Customer/Product Classes). Bakes in `:info` so the convention is
-  # not re-decided per caller.
+  # rates to Customer/Product Classes). Uses `btn-outline-secondary` so nav
+  # reads as quiet/link-ish and yields visual prominence to the page's primary
+  # action (`+ New` / `Edit`, which are filled `btn-primary`).
   def nav_button(text, path, permission: nil, data: nil)
     return nil if permission && !can?(permission)
-    link_to text, path, class: "btn btn-info", data: data
+    link_to text, path, class: "btn btn-outline-secondary", data: data
   end
 end

--- a/app/views/account/credentials/index.html.haml
+++ b/app/views/account/credentials/index.html.haml
@@ -1,6 +1,6 @@
 - content_for :title, 'My passkeys'
 
-= page_header('My passkeys', action: action_button('+ New', new_account_credential_path, :info))
+= page_header('My passkeys', action: action_button('+ New', new_account_credential_path))
 
 %table.table.table-striped.table-sm
   %thead

--- a/app/views/customers/index.html.haml
+++ b/app/views/customers/index.html.haml
@@ -1,4 +1,4 @@
-= breadcrumbs 'Customers', action: action_button('+ New', new_customer_path, :info, permission: 'customers.edit')
+= breadcrumbs 'Customers', action: action_button('+ New', new_customer_path, permission: 'customers.edit')
 
 .mb-3
   .btn-toolbar.mb-3{:role=>"toolbar", "aria-label"=>"List toolbar"}

--- a/app/views/delivery_notes/index.html.haml
+++ b/app/views/delivery_notes/index.html.haml
@@ -1,4 +1,4 @@
-= breadcrumbs 'Delivery Notes', action: action_button('+ New', new_delivery_note_path, :info, permission: 'delivery_notes.edit')
+= breadcrumbs 'Delivery Notes', action: action_button('+ New', new_delivery_note_path, permission: 'delivery_notes.edit')
 
 
 .bulk-select-container{data: { controller: 'bulk-select' }}

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -1,4 +1,4 @@
-= breadcrumbs 'Configuration', 'Groups', action: action_button('+ New', new_group_path, :info, permission: 'groups.manage')
+= breadcrumbs 'Configuration', 'Groups', action: action_button('+ New', new_group_path, permission: 'groups.manage')
 
 %p.text-muted
   Groups bundle system-level permissions. A user inherits all permissions of every group they belong to.

--- a/app/views/invoices/index.html.haml
+++ b/app/views/invoices/index.html.haml
@@ -1,4 +1,4 @@
-= breadcrumbs 'Invoices', action: action_button('+ New', new_invoice_path, :info, permission: 'invoices.edit')
+= breadcrumbs 'Invoices', action: action_button('+ New', new_invoice_path, permission: 'invoices.edit')
 
 
 .bulk-select-container{data: { controller: 'bulk-select' }}

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -1,4 +1,4 @@
-= breadcrumbs 'Configuration', 'Product Catalog', action: action_button('+ New', new_product_path, :info, permission: 'products.edit')
+= breadcrumbs 'Configuration', 'Product Catalog', action: action_button('+ New', new_product_path, permission: 'products.edit')
 
 %table.table.table-striped.table-sm
   %tr

--- a/app/views/projects/index.html.haml
+++ b/app/views/projects/index.html.haml
@@ -1,4 +1,4 @@
-= breadcrumbs 'Projects', action: action_button('+ New', new_project_path, :info, permission: 'projects.edit')
+= breadcrumbs 'Projects', action: action_button('+ New', new_project_path, permission: 'projects.edit')
 
 .mb-3
   .btn-toolbar.mb-3{:role=>"toolbar", "aria-label"=>"List toolbar"}

--- a/app/views/sales_tax_customer_classes/index.html.haml
+++ b/app/views/sales_tax_customer_classes/index.html.haml
@@ -1,4 +1,4 @@
-= breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], 'Customer Tax Classes', action: action_button('+ New', new_sales_tax_customer_class_path, :info, permission: 'sales_tax.edit')
+= breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], 'Customer Tax Classes', action: action_button('+ New', new_sales_tax_customer_class_path, permission: 'sales_tax.edit')
 
 %table.table.table-striped.table-sm
   %tr

--- a/app/views/sales_tax_product_classes/index.html.haml
+++ b/app/views/sales_tax_product_classes/index.html.haml
@@ -1,4 +1,4 @@
-= breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], 'Product Tax Classes', action: action_button('+ New', new_sales_tax_product_class_path, :info, permission: 'sales_tax.edit')
+= breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], 'Product Tax Classes', action: action_button('+ New', new_sales_tax_product_class_path, permission: 'sales_tax.edit')
 
 %table.table.table-striped.table-sm
   %tr

--- a/app/views/sales_tax_rates/index.html.haml
+++ b/app/views/sales_tax_rates/index.html.haml
@@ -1,6 +1,6 @@
 - customer_classes_action = nav_button('Customer Classes', sales_tax_customer_classes_path)
 - product_classes_action = nav_button('Product Classes', sales_tax_product_classes_path)
-= breadcrumbs 'Configuration', 'Sales Tax', actions: [customer_classes_action, product_classes_action], action: action_button('+ New', new_sales_tax_rate_path, :info, permission: 'sales_tax.edit')
+= breadcrumbs 'Configuration', 'Sales Tax', actions: [customer_classes_action, product_classes_action], action: action_button('+ New', new_sales_tax_rate_path, permission: 'sales_tax.edit')
 
 %table.table.table-striped.table-sm
   %tr

--- a/app/views/teams/index.html.haml
+++ b/app/views/teams/index.html.haml
@@ -1,4 +1,4 @@
-= breadcrumbs 'Configuration', 'Teams', action: action_button('+ New', new_team_path, :info, permission: 'teams.manage')
+= breadcrumbs 'Configuration', 'Teams', action: action_button('+ New', new_team_path, permission: 'teams.manage')
 
 %p.text-muted
   Teams control which customers and projects a user can see. Every customer and project belongs to exactly one team.

--- a/app/views/user_invites/index.html.haml
+++ b/app/views/user_invites/index.html.haml
@@ -1,6 +1,6 @@
 - content_for :title, 'Invites'
 
-= breadcrumbs 'Configuration', ['Users', users_path], 'Invites', action: action_button('+ New', new_user_invite_path, :info)
+= breadcrumbs 'Configuration', ['Users', users_path], 'Invites', action: action_button('+ New', new_user_invite_path)
 
 %table.table.table-striped.table-sm
   %thead

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,6 +1,6 @@
 - content_for :title, 'Users'
 
-= breadcrumbs 'Configuration', 'Users', action: action_button('+ Invite user', new_user_invite_path, :info, permission: 'user_invites.manage')
+= breadcrumbs 'Configuration', 'Users', action: action_button('+ Invite user', new_user_invite_path, permission: 'user_invites.manage')
 
 %table.table.table-striped.table-sm
   %thead

--- a/test/helpers/action_buttons_helper_test.rb
+++ b/test/helpers/action_buttons_helper_test.rb
@@ -93,10 +93,10 @@ class ActionButtonsHelperTest < ActionView::TestCase
     assert_match(/btn-secondary/, html)
   end
 
-  test "nav_button renders the given label with info color" do
+  test "nav_button renders the given label with outline-secondary style" do
     html = nav_button("Invoices", "/invoices")
     assert_includes html, "Invoices"
-    assert_match(/btn-info/, html)
+    assert_match(/btn-outline-secondary/, html)
     assert_match(%r{href="/invoices"}, html)
   end
 end


### PR DESCRIPTION
## Summary
After #397 the breadcrumb action cluster had three different archetypes — create-new, cross-resource navigation, and workflow promotion — all rendering as `btn-info`. Most visibly on `/sales_tax_rates`, that produced three cyan buttons in a row that looked indistinguishable.

This PR establishes one rule: **the page's primary action is `btn-primary`** — covering both `+ New` / `+ Invite` on index pages and `Edit` on show pages. `nav_button` drops to `btn-outline-secondary` so cross-resource nav reads as quiet/link-ish and yields visual prominence to the primary CTA.

End state per archetype:

| Archetype | Was | Becomes |
|---|---|---|
| `+ New` / `+ Invite` (index pages) | `btn-info` | `btn-primary` |
| `Edit` (show pages) | `btn-primary` | unchanged |
| `nav_button` (cross-resource nav) | `btn-info` | `btn-outline-secondary` |
| Everything else (PDF, Preview, Publish, Convert, Delete, Audit log, …) | — | unchanged |

Cyan disappears from the breadcrumb action cluster; `convert_to_invoice_button` and `preview_button` keep `:info` but never co-render with `nav_button`.

## Test plan
- [x] `bundle exec rails test test/helpers/action_buttons_helper_test.rb`
- [x] `bundle exec rails test test/controllers/customers_controller_test.rb`
- [x] `pre-commit run --all-files`
- [ ] Visual check `/sales_tax_rates`: two gray-outline buttons (Customer/Product Classes) + one solid blue `+ New`.
- [ ] Visual check `/customers/<id>`: Invoices / Delivery Notes are gray-outline; Delete red; Edit solid blue.
- [ ] Visual check any other index (`/customers`, `/invoices`, …): `+ New` is now solid blue, not cyan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)