### PR TITLE
Align invoice publish naming with delivery notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,8 +53,8 @@ For testing against PostgreSQL (matches production environment):
 - **InvoiceTaxClass** - Applied tax calculations per invoice
 
 ### Invoice Processing Pipeline
-1. **InvoicesController** - Standard CRUD + special actions (preview, book, bulk email)
-2. **InvoiceBooker** - Business logic for "booking" invoices (calculating taxes, assigning document numbers, publishing)
+1. **InvoicesController** - Standard CRUD + special actions (preview, publish, bulk email)
+2. **InvoicePublisher** - Business logic for publishing invoices (calculating taxes, assigning document numbers, attaching PDF). Invoice publishing is irreversible; there is no unpublish action.
 3. **InvoiceRenderer** - PDF generation using Apache FOP with XML/XSL transformation
 4. **Email System** - `DocumentMailer` delivered via `deliver_later` (Solid Queue). Bulk send marks `email_sent_at` for tracking.
 
@@ -80,7 +80,7 @@ For testing against PostgreSQL (matches production environment):
 ### Key Workflow
 1. Create draft invoice with lines
 2. Preview generates temporary PDF without saving
-3. "Book" finalizes invoice (assigns document number, calculates final taxes, publishes)
+3. "Publish" finalizes invoice (assigns document number, calculates final taxes, publishes). The post-publish state is shown as "Booked" — a deliberate accounting-state label.
 4. Published invoices cannot be modified
 5. Email invoices individually or in bulk batches
 
@@ -116,7 +116,7 @@ For testing against PostgreSQL (matches production environment):
 - Open Sans fonts in `lib/foptemplate/open-sans/` for PDF rendering
 
 ## Key Files for Modifications
-- Invoice business logic: `app/controllers/invoice_book_controller.rb`
+- Invoice publish logic: `app/services/invoice_publisher.rb`
 - PDF template: `lib/foptemplate/invoice.xsl`
 - Invoice model: `app/models/invoice.rb`
 - Main invoice controller: `app/controllers/invoices_controller.rb`
@@ -141,7 +141,7 @@ For testing against PostgreSQL (matches production environment):
 ### Status Badges
 - **Show only the deviation from the healthy default.** No badge means "normal."
   - Customer/Project Inactive, User Blocked → badge. Active state → nothing.
-  - Invoice/Delivery Note lifecycle (Draft, Booked, Paid, Overdue, Sent) all get header badges — there's no implicit "good" lifecycle, every state is noteworthy.
+  - Invoice lifecycle (Draft, Booked, Paid, Overdue, Sent) and Delivery Note lifecycle (Draft, Published, Sent) all get header badges — there's no implicit "good" lifecycle, every state is noteworthy. Invoice's finalized state is labelled "Booked" (accounting term) even though the action that gets it there is "Publish"; delivery notes use "Published" for the same state.
 - **Hide superseded badges.** On invoices, the header drops "Booked" once a more specific state (Sent/Paid/Overdue) applies. Sent stacks with Paid/Overdue (email and payment are independent).
 - **In detail grids and list columns, healthy data renders as plain text, not a badge.** Paid (with date), Sent (with timestamp) → plain text. Problem states (Unpaid, Unsent, Overdue, No Recipient) keep their badges.
 - **Hide the status column entirely when a list is filtered to a single state.** On the customers and projects lists, the Status column is only rendered when the filter is "All"; when filtered to Active or Inactive the column would be redundant (every row identical or empty), so the header and cells are omitted.
@@ -186,11 +186,11 @@ For testing against PostgreSQL (matches production environment):
 - To render a `datetime` column as date-only (e.g. `email_sent_at` in compact list rows), call `l(value.to_date)` — `l` on a `Time`/`DateTime` produces the time format.
 
 ### UI Helper Methods
-- `breadcrumbs(*items, action: nil, actions: nil, &status_block)` - Bootstrap breadcrumb strip that serves as the page header on every index/show/edit/new page (every page except the dashboard, `/account/*`, the sign-in / invite-acceptance flow, and the post-book confirmation). Each item is either `[label, path]` (link) or a plain label (non-link). The last item is always the active crumb with `aria-current="page"` (rendered `fw-semibold`), and it is the page identifier — there is no separate H1. The optional block yields inline status badges next to the active crumb. The right cluster carries optional secondary `actions:` (array — `nil` entries are compacted out) followed by the primary `action:` (rightmost). Buttons are built with `action_button(...)` or the per-verb helpers from `ActionButtonsHelper` (see "Button Glyphs" below).
+- `breadcrumbs(*items, action: nil, actions: nil, &status_block)` - Bootstrap breadcrumb strip that serves as the page header on every index/show/edit/new page (every page except the dashboard, `/account/*`, the sign-in / invite-acceptance flow, and the post-publish confirmation). Each item is either `[label, path]` (link) or a plain label (non-link). The last item is always the active crumb with `aria-current="page"` (rendered `fw-semibold`), and it is the page identifier — there is no separate H1. The optional block yields inline status badges next to the active crumb. The right cluster carries optional secondary `actions:` (array — `nil` entries are compacted out) followed by the primary `action:` (rightmost). Buttons are built with `action_button(...)` or the per-verb helpers from `ActionButtonsHelper` (see "Button Glyphs" below).
   - Top-level resources start with the navbar label linked to its index: `['Customers', customers_path]`, `['Projects', projects_path]`, `['Delivery Notes', delivery_notes_path]`, `['Invoices', invoices_path]`.
   - Configuration resources start with a non-link `'Configuration'` crumb (the dropdown has no destination) followed by the resource's navbar label, e.g. `breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], 'Edit'`.
   - On edit pages append `'Edit'` as the active crumb; on new pages append `'New'`. On show pages the resource's identifier (matchcode / document number / name) is the active crumb.
-  - The bottom `action_buttons_wrapper` is gone from show pages — every workflow verb (PDF, Preview, Publish, Convert to Invoice, Delete, etc.) moves into `actions:` on the breadcrumb. Status-row buttons (Send E-Mail, Mark Paid, Mark Unpaid, Book Invoice…) stay inline with their status row. `cancel_button(resource)` on edit/new forms stays — it pairs with Submit, not navigation.
+  - The bottom `action_buttons_wrapper` is gone from show pages — every workflow verb (PDF, Preview, Publish, Convert to Invoice, Delete, etc.) moves into `actions:` on the breadcrumb. Status-row buttons (Send E-Mail, Mark Paid, Mark Unpaid, Publish Invoice…) stay inline with their status row. `cancel_button(resource)` on edit/new forms stays — it pairs with Submit, not navigation.
 - `page_header(title, action: nil, &status_block)` - Page-header row with an H1 title, optional inline status badges via the block, and optional right-aligned action. Only used on pages without breadcrumbs: dashboard (`home/index`), `/account/*`, the sign-in / invite-acceptance / "Invite generated" pages.
 - `action_button(text, path, type = :primary, permission: nil, target: nil, data: nil, title: nil)` - Styled buttons (primary, secondary, success, info, warning, danger). Returns `nil` when `permission:` is given and the current user lacks it. Pass `title:` on glyph-only buttons — the helper applies it as both `title=` (hover tooltip) and `aria-label=` (screen-reader name).
 - `action_buttons_wrapper` - Container for the bottom-of-page workflow action row. Only used by `issuer_companies/edit` and `user_invites/show_invite` now.

--- a/app/controllers/concerns/document_with_lines.rb
+++ b/app/controllers/concerns/document_with_lines.rb
@@ -20,8 +20,8 @@ module DocumentWithLines
 
   # Filter: redirect with a flash if the document doesn't yet have at least
   # one item line. Without this, the renderer hands FOP a table with no
-  # body and FOP aborts; this is also the business rule for booking /
-  # publishing a meaningful document.
+  # body and FOP aborts; this is also the business rule for publishing
+  # a meaningful document.
   #
   # Relies on PublishableDocument for the record lookup and human label,
   # and on the model including HasLineItems for `has_items?`.

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -11,10 +11,10 @@ class InvoicesController < ApplicationController
   before_action -> { require_permission!("invoices.view") }, only: %i[index show preview preview_email preview_email_raw]
   before_action -> { require_permission!("invoices.edit") }, only: %i[
     new create edit update destroy
-    book send_email mark_paid mark_unpaid bulk_send_emails
+    publish send_email mark_paid mark_unpaid bulk_send_emails
   ]
 
-  before_action :set_invoice, only: %i[show edit update destroy book preview preview_email preview_email_raw send_email mark_paid mark_unpaid]
+  before_action :set_invoice, only: %i[show edit update destroy publish preview preview_email preview_email_raw send_email mark_paid mark_unpaid]
 
   # Permit the inline <style> blocks and embedded data: images that the
   # mailer layout produces. Scoped strictly to the iframe response so the
@@ -34,11 +34,11 @@ class InvoicesController < ApplicationController
   # spec tells browsers to ignore 'unsafe-inline' — which would re-block the
   # mailer's inline <style> tags. Strip the nonce list for this action.
   before_action(only: :preview_email_raw) { request.content_security_policy_nonce_directives = [] }
-  before_action :require_unpublished, only: %i[edit update destroy preview book]
+  before_action :require_unpublished, only: %i[edit update destroy preview publish]
   before_action :require_published, only: %i[send_email mark_paid mark_unpaid]
   # preview_email reads from a pre-rendered @invoice.attachment, so it never
-  # invokes FOP. The guard belongs on the actions that actually book/render.
-  before_action :require_item_line, only: %i[book preview]
+  # invokes FOP. The guard belongs on the actions that actually publish/render.
+  before_action :require_item_line, only: %i[publish preview]
 
   # GET /invoices
   def index
@@ -110,26 +110,26 @@ class InvoicesController < ApplicationController
     redirect_to invoices_url
   end
 
-  def book
-    booker = InvoiceBooker.new @invoice, IssuerCompany.get_the_issuer!
-    if booker.publish!
-      redirect_to invoice_path(@invoice, booked: 1)
+  def publish
+    publisher = InvoicePublisher.new @invoice, IssuerCompany.get_the_issuer!
+    if publisher.publish!
+      redirect_to invoice_path(@invoice, published: 1)
     else
-      flash[:error] = "Booking failed: #{@invoice.booking_problems.join('; ')}"
+      flash[:error] = "Publishing failed: #{@invoice.publish_problems.join('; ')}"
       redirect_to @invoice
     end
   end
 
   def preview
     issuer = IssuerCompany.get_the_issuer!
-    booker = InvoiceBooker.new @invoice, issuer
+    publisher = InvoicePublisher.new @invoice, issuer
     problems = nil
     pdf = nil
 
     ActiveRecord::Base.transaction(requires_new: true) do
       @invoice.document_number = "DRAFT"
-      booker.prepare!
-      problems = @invoice.booking_problems
+      publisher.prepare!
+      problems = @invoice.publish_problems
       pdf = InvoiceRenderer.new(@invoice, issuer).render if problems.empty?
       raise ActiveRecord::Rollback, "preview only"
     end

--- a/app/models/concerns/has_line_items.rb
+++ b/app/models/concerns/has_line_items.rb
@@ -13,7 +13,7 @@ module HasLineItems
   end
 
   # At least one line of type 'item' (as opposed to text / subheading /
-  # plain). Required for booking taxes / totals and for the document to
+  # plain). Required for publishing taxes / totals and for the document to
   # carry meaningful content.
   def has_items?
     public_send(self.class.line_items_association).any?(&:is_item?)

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -95,7 +95,7 @@ class Invoice < ApplicationRecord
     self.published? && !self.paid? && self.due_date.present? && self.due_date < Date.current
   end
 
-  def booking_problems
+  def publish_problems
     problems = []
     return problems if published?
 

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -13,7 +13,7 @@ module Permission
     Entry.new(key: "projects.view",       label: "View projects",           category: "Operations"),
     Entry.new(key: "projects.edit",       label: "Create / edit projects",  category: "Operations"),
     Entry.new(key: "invoices.view",       label: "View invoices",           category: "Operations"),
-    Entry.new(key: "invoices.edit",       label: "Create / book / send invoices", category: "Operations"),
+    Entry.new(key: "invoices.edit",       label: "Create / publish / send invoices", category: "Operations"),
     Entry.new(key: "delivery_notes.view", label: "View delivery notes",     category: "Operations"),
     Entry.new(key: "delivery_notes.edit", label: "Create / publish / send delivery notes", category: "Operations"),
 

--- a/app/services/invoice_publisher.rb
+++ b/app/services/invoice_publisher.rb
@@ -1,4 +1,4 @@
-class InvoiceBooker
+class InvoicePublisher
   attr_reader :log
 
   def initialize(invoice, issuer)
@@ -17,8 +17,8 @@ class InvoiceBooker
     @invoice.due_date = @invoice.date + @invoice.payment_terms_days.days
   end
 
-  # Performs the irreversible booking. Returns true on success, false otherwise.
-  # On failure, problems are accessible via @invoice.booking_problems.
+  # Performs the irreversible publish. Returns true on success, false otherwise.
+  # On failure, problems are accessible via @invoice.publish_problems.
   def publish!
     if @invoice.published?
       @log << "E: already published"
@@ -27,7 +27,7 @@ class InvoiceBooker
 
     prepare!
 
-    problems = @invoice.booking_problems
+    problems = @invoice.publish_problems
     if problems.any?
       problems.each { |p| @log << "E: #{p}" }
       return false

--- a/app/views/delivery_notes/show.html.haml
+++ b/app/views/delivery_notes/show.html.haml
@@ -12,7 +12,7 @@
   - elsif @delivery_note.email_sent_at.present?
     %span.badge.bg-success Sent
   - else
-    %span.badge.bg-success Booked
+    %span.badge.bg-success Published
 
 -# Single generic-email-preview controller scope so the modal can be rendered
 -# once at the bottom and serve every trigger site on the page.

--- a/app/views/invoices/_form.html.haml
+++ b/app/views/invoices/_form.html.haml
@@ -70,7 +70,7 @@
         .col-sm-4
           .mb-3
             %label.form-label Date
-            .form-control-plaintext (set at booking)
+            .form-control-plaintext (set at publishing)
 
       .row
         .col-sm-4

--- a/app/views/invoices/show.html.haml
+++ b/app/views/invoices/show.html.haml
@@ -1,6 +1,6 @@
 - can_edit_invoice = can?('invoices.edit')
 - edit_action = action_button('Edit', edit_invoice_path(@invoice), permission: 'invoices.edit') unless @invoice.published?
-- problems = @invoice.published? ? [] : @invoice.booking_problems
+- problems = @invoice.published? ? [] : @invoice.publish_problems
 - pdf_or_preview = @invoice.attachment ? pdf_button(@invoice.attachment) : preview_button(preview_invoice_path(@invoice))
 - delete_action = delete_button(@invoice, confirm: "Are you sure you want to delete invoice \"#{@invoice.document_number || "##{@invoice.id}"}\"?") if !@invoice.published? && can_edit_invoice
 = breadcrumbs ['Invoices', invoices_path], (@invoice.document_number || "Draft ##{@invoice.id}"), actions: [pdf_or_preview, delete_action], action: edit_action do
@@ -22,7 +22,7 @@
 -# Single generic-email-preview controller scope so the modal can be rendered
 -# once at the bottom and serve every trigger site on the page.
 %div{data: (@invoice.published? ? email_preview_data(@invoice) : {})}
-  - if params[:booked] == '1' && @invoice.published? && @invoice.attachment
+  - if params[:published] == '1' && @invoice.published? && @invoice.attachment
     .alert.alert-success.mb-3{data: {controller: 'auto-download'}}
       %h4.alert-heading.mb-2= "Invoice #{@invoice.document_number} booked."
       %p.mb-3 Download the PDF and send it to your customer.
@@ -87,7 +87,7 @@
         - unless @invoice.published?
           .row.mb-2
             .col-sm-4
-              %strong Booking Status:
+              %strong Publish Status:
             .col-sm-8.d-flex.align-items-center.gap-2
               - if problems.any?
                 %span.badge.bg-warning= pluralize(problems.size, 'problem')
@@ -96,9 +96,9 @@
               - if can_edit_invoice
                 - if problems.any?
                   %span.ms-auto{title: problems.join("\n")}
-                    %button.btn.btn-sm.btn-info{disabled: true} Book Invoice…
+                    %button.btn.btn-sm.btn-info{disabled: true} Publish Invoice…
                 - else
-                  = button_to 'Book Invoice…', book_invoice_path(@invoice), method: :post, class: 'btn btn-sm btn-info', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Book invoice and assign a document number? This cannot be undone.' }
+                  = button_to 'Publish Invoice…', publish_invoice_path(@invoice), method: :post, class: 'btn btn-sm btn-info', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Publish invoice and assign a document number? This cannot be undone.' }
 
         - if @invoice.published?
           .row.mb-2
@@ -155,7 +155,7 @@
 
   - if !@invoice.published? && problems.any?
     .alert.alert-warning.mb-3
-      %strong This invoice cannot be booked yet:
+      %strong This invoice cannot be published yet:
       %ul.mb-0
         - problems.each do |p|
           %li= p

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,7 +60,7 @@ Rails.application.routes.draw do
       get "preview"
       get "preview_email"
       get "preview_email_raw"
-      post "book"
+      post "publish"
       post "send_email"
       post "mark_paid"
       post "mark_unpaid"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -523,7 +523,7 @@ if Rails.env.development?
     complex_invoice.save!
   end
 
-  # Booked invoice for 2025
+  # Published invoice for 2025
   unless Invoice.exists?(document_number: '20250001')
     current_year_invoice = Invoice.create!(
       customer: good_company,
@@ -568,7 +568,7 @@ if Rails.env.development?
       position: 3
     )
 
-    # Properly initialize the invoice by running the booking process
+    # Properly initialize the invoice by running the publish process
     current_year_invoice.save! # Trigger before_save callbacks
     current_year_invoice.due_date = Date.new(2025, 2, 14)
 
@@ -585,7 +585,7 @@ if Rails.env.development?
     current_year_invoice.save!
   end
 
-  # Booked invoice for last year (2024)
+  # Published invoice for last year (2024)
   unless Invoice.exists?(document_number: '20240145')
     last_year_invoice = Invoice.create!(
       customer: local_company,

--- a/test/controllers/invoices_controller_paid_test.rb
+++ b/test/controllers/invoices_controller_paid_test.rb
@@ -72,7 +72,7 @@ class InvoicesControllerPaidTest < ActionDispatch::IntegrationTest
     assert_equal "Draft invoices can not be used for this action.", flash[:error]
   end
 
-  test "show page exposes unpaid status with mark paid form for booked invoice" do
+  test "show page exposes unpaid status with mark paid form for published invoice" do
     invoice = invoices(:published_invoice)
     invoice.update!(paid_at: nil)
 

--- a/test/controllers/invoices_controller_test.rb
+++ b/test/controllers/invoices_controller_test.rb
@@ -118,7 +118,7 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
       # date is nil for draft invoices
     )
 
-    # Create a booked invoice from previous year
+    # Create a published invoice from previous year
     Invoice.create!(
       customer: customers(:good_eu),
       project: projects(:test_project),
@@ -183,7 +183,7 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "should show booked invoice with tax classes" do
+  test "should show published invoice with tax classes" do
     invoice = Invoice.create!(
       customer: customers(:good_eu),
       project: projects(:test_project),
@@ -218,7 +218,7 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
     assert_select ".badge.bg-success", text: "Booked"
   end
 
-  test "draft invoice show renders Booking Status row with Ready badge for a valid draft" do
+  test "draft invoice show renders Publish Status row with Ready badge for a valid draft" do
     invoice = Invoice.create!(
       customer: customers(:good_eu),
       project: projects(:test_project),
@@ -237,10 +237,10 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select ".badge.bg-warning", text: "Draft"
     assert_select ".badge.bg-success", text: "Ready"
-    assert_select "form.button_to button", text: /Book Invoice/
+    assert_select "form.button_to button", text: /Publish Invoice/
   end
 
-  test "draft invoice show renders problems alert and disabled Book button when invoice has missing data" do
+  test "draft invoice show renders problems alert and disabled Publish button when invoice has missing data" do
     invoice = Invoice.create!(
       customer: customers(:good_eu),
       project: projects(:test_project),
@@ -259,7 +259,7 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
     get invoice_url(invoice)
     assert_response :success
     assert_select ".alert-warning li", text: /Broken Line.*rate/
-    assert_select "button[disabled]", text: /Book Invoice/
+    assert_select "button[disabled]", text: /Publish Invoice/
   end
 
   test "should get edit" do
@@ -361,11 +361,11 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_content
   end
 
-  test "book action publishes a valid draft and redirects to show with booked=1" do
+  test "publish action publishes a valid draft and redirects to show with published=1" do
     invoice = Invoice.create!(
       customer: customers(:good_eu),
       project: projects(:test_project),
-      cust_reference: "BOOK_OK"
+      cust_reference: "PUBLISH_OK"
     )
     invoice.invoice_lines.create!(
       type: "item",
@@ -376,20 +376,20 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
       position: 1
     )
 
-    post book_invoice_url(invoice)
+    post publish_invoice_url(invoice)
 
-    assert_redirected_to invoice_path(invoice, booked: 1)
+    assert_redirected_to invoice_path(invoice, published: 1)
     invoice.reload
     assert invoice.published?
     assert invoice.document_number.present?
     assert invoice.attachment.present?
   end
 
-  test "book action redirects with flash[:error] when invoice has booking problems" do
+  test "publish action redirects with flash[:error] when invoice has publish problems" do
     invoice = Invoice.create!(
       customer: customers(:good_eu),
       project: projects(:test_project),
-      cust_reference: "BOOK_FAIL"
+      cust_reference: "PUBLISH_FAIL"
     )
     line = invoice.invoice_lines.create!(
       type: "item",
@@ -401,10 +401,10 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
     )
     line.update_columns(rate: nil)
 
-    post book_invoice_url(invoice)
+    post publish_invoice_url(invoice)
 
     assert_redirected_to invoice_url(invoice)
-    assert_match(/Booking failed/, flash[:error])
+    assert_match(/Publishing failed/, flash[:error])
     assert_not invoice.reload.published?
     assert_nil invoice.document_number
   end
@@ -427,7 +427,7 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
       position: 1
     )
 
-    # Run test booking first time to create tax classes
+    # Run an update to create tax classes
     patch invoice_url(invoice), params: { invoice: { cust_reference: "NEW_REF" } }
     invoice.reload
 
@@ -438,7 +438,7 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
     # Modify the invoice to trigger recalculation
     invoice.invoice_lines.first.update!(quantity: 3.0)
 
-    # Run test booking again - should reuse existing tax class
+    # Run update again - should reuse existing tax class
     patch invoice_url(invoice), params: { invoice: { cust_reference: "NEW_REF2" } }
     invoice.reload
 
@@ -529,16 +529,16 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
     assert_match "Published invoices can not be modified", flash[:error]
   end
 
-  test "should not POST book on published invoice" do
+  test "should not POST publish on published invoice" do
     invoice = invoices(:published_invoice)
-    # require_item_line fires before require_unpublished in the book POST,
+    # require_item_line fires before require_unpublished in the publish POST,
     # so a line is needed to reach the publish guard.
     invoice.invoice_lines.create!(
       type: "item", title: "x", rate: 1.0, quantity: 1.0,
       sales_tax_product_class: sales_tax_product_classes(:standard), position: 1
     )
 
-    post book_invoice_url(invoice)
+    post publish_invoice_url(invoice)
     assert_redirected_to invoice_url(invoice)
     assert_match "Published invoices can not be modified", flash[:error]
   end

--- a/test/integration/invoice_language_test.rb
+++ b/test/integration/invoice_language_test.rb
@@ -117,7 +117,7 @@ class InvoiceLanguageTest < ActionDispatch::IntegrationTest
   def test_pdf_generation_for_export_customer_without_vat_id
     # Customers in tax classes that don't require a VAT ID (export / non-EU /
     # B2C) must be able to render an invoice PDF. Regression test for the
-    # invoice_booker check that previously rejected any blank customer_vat_id.
+    # invoice_publisher check that previously rejected any blank customer_vat_id.
     export_customer = Customer.create!(
       name: "USA Corporation Inc.",
       matchcode: "USACORP_TEST",

--- a/test/integration/pdf_generation_test.rb
+++ b/test/integration/pdf_generation_test.rb
@@ -34,14 +34,14 @@ class PdfGenerationTest < ActionDispatch::IntegrationTest
     assert_valid_pdf_response
   end
 
-  def test_invoice_booking_creates_attachment
-    # Book the invoice (this should create PDF attachment)
-    post book_invoice_path(@invoice)
+  def test_invoice_publishing_creates_attachment
+    # Publish the invoice (this should create PDF attachment)
+    post publish_invoice_path(@invoice)
 
-    assert_redirected_to invoice_path(@invoice, booked: 1)
+    assert_redirected_to invoice_path(@invoice, published: 1)
 
     @invoice.reload
-    assert @invoice.published?, "Invoice should be published after booking"
+    assert @invoice.published?, "Invoice should be published after publishing"
 
     # Check if PDF attachment was created
     assert @invoice.attachment.present?
@@ -54,7 +54,7 @@ class PdfGenerationTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     # While we can't easily parse PDF content in tests, we can verify
-    # that the invoice was processed through the booking controller
+    # that the invoice was processed through the publish controller
     # by checking that invoice_lines have calculated amounts
     @invoice.reload
     assert @invoice.invoice_lines.any? { |line| line.amount.present? if line.type == "item" }
@@ -72,20 +72,20 @@ class PdfGenerationTest < ActionDispatch::IntegrationTest
     assert_match(/no item lines/i, flash[:error])
   end
 
-  def test_booking_an_empty_invoice_is_blocked
+  def test_publishing_an_empty_invoice_is_blocked
     empty = Invoice.create!(
       customer: @customer,
       project: @project
     )
 
-    post book_invoice_path(empty)
+    post publish_invoice_path(empty)
 
     assert_redirected_to invoice_path(empty)
     assert_match(/no item lines/i, flash[:error])
     assert_not empty.reload.published?
   end
 
-  def test_booking_an_invoice_with_only_non_item_lines_is_blocked
+  def test_publishing_an_invoice_with_only_non_item_lines_is_blocked
     inv = Invoice.create!(
       customer: @customer,
       project: @project
@@ -93,7 +93,7 @@ class PdfGenerationTest < ActionDispatch::IntegrationTest
     inv.invoice_lines.create!(type: "text", title: "Note", description: "no items here", position: 1)
     inv.invoice_lines.create!(type: "subheading", title: "Section", position: 2)
 
-    post book_invoice_path(inv)
+    post publish_invoice_path(inv)
 
     assert_redirected_to invoice_path(inv)
     assert_match(/no item lines/i, flash[:error])

--- a/test/models/invoice_test.rb
+++ b/test/models/invoice_test.rb
@@ -103,74 +103,74 @@ class InvoiceTest < ActiveSupport::TestCase
     assert_equal 1234.56, invoice.sum_total
   end
 
-  test "booking_problems is empty for a complete draft" do
+  test "publish_problems is empty for a complete draft" do
     invoice = license_invoice_with_tax_config
-    assert_empty invoice.booking_problems
+    assert_empty invoice.publish_problems
   end
 
-  test "booking_problems reports a missing rate using the line title" do
+  test "publish_problems reports a missing rate using the line title" do
     invoice = license_invoice_with_tax_config
     line = invoice.invoice_lines.find_by(type: "item")
     line.update_columns(rate: nil)
 
-    problems = invoice.reload.booking_problems
+    problems = invoice.reload.publish_problems
     assert(problems.any? { |p| p.include?(line.title) && p.include?("rate") })
   end
 
-  test "booking_problems reports a missing quantity using the line title" do
+  test "publish_problems reports a missing quantity using the line title" do
     invoice = license_invoice_with_tax_config
     line = invoice.invoice_lines.find_by(type: "item")
     line.update_columns(quantity: nil)
 
-    problems = invoice.reload.booking_problems
+    problems = invoice.reload.publish_problems
     assert(problems.any? { |p| p.include?(line.title) && p.include?("quantity") })
   end
 
-  test "booking_problems reports a missing tax config using the line title" do
+  test "publish_problems reports a missing tax config using the line title" do
     invoice = license_invoice_with_tax_config
     line = invoice.invoice_lines.find_by(type: "item")
     line.update_columns(sales_tax_product_class_id: 999_999)
 
-    problems = invoice.reload.booking_problems
+    problems = invoice.reload.publish_problems
     assert(problems.any? { |p| p.include?(line.title) && p.include?("tax configuration") })
   end
 
-  test "booking_problems reports a missing customer name" do
+  test "publish_problems reports a missing customer name" do
     invoice = license_invoice_with_tax_config
     invoice.update_columns(customer_name: nil)
-    assert_includes invoice.booking_problems, "Customer name is missing."
+    assert_includes invoice.publish_problems, "Customer name is missing."
   end
 
-  test "booking_problems reports a missing customer address" do
+  test "publish_problems reports a missing customer address" do
     invoice = license_invoice_with_tax_config
     invoice.update_columns(customer_address: nil)
-    assert_includes invoice.booking_problems, "Customer address is missing."
+    assert_includes invoice.publish_problems, "Customer address is missing."
   end
 
-  test "booking_problems reports a missing VAT ID when the customer class requires one" do
+  test "publish_problems reports a missing VAT ID when the customer class requires one" do
     invoice = license_invoice_with_tax_config # uses good_national (vat_id_required)
     invoice.update_columns(customer_vat_id: nil)
-    assert_includes invoice.booking_problems, "Customer VAT ID is missing."
+    assert_includes invoice.publish_problems, "Customer VAT ID is missing."
   end
 
-  test "booking_problems does not require a VAT ID for an export customer class" do
+  test "publish_problems does not require a VAT ID for an export customer class" do
     invoice = license_invoice_with_tax_config
     invoice.customer.update_columns(sales_tax_customer_class_id: sales_tax_customer_classes(:restoftheworld).id)
     invoice.update_columns(customer_vat_id: nil)
     invoice.reload
-    assert_not_includes invoice.booking_problems, "Customer VAT ID is missing."
+    assert_not_includes invoice.publish_problems, "Customer VAT ID is missing."
   end
 
-  test "booking_problems reports a draft with no item lines" do
+  test "publish_problems reports a draft with no item lines" do
     invoice = license_invoice_with_tax_config
     invoice.invoice_lines.where(type: "item").destroy_all
-    assert_includes invoice.reload.booking_problems, "Invoice has no item lines."
+    assert_includes invoice.reload.publish_problems, "Invoice has no item lines."
   end
 
-  test "booking_problems is empty for a published invoice regardless of data" do
+  test "publish_problems is empty for a published invoice regardless of data" do
     invoice = invoices(:published_invoice)
     assert invoice.published?
-    assert_empty invoice.booking_problems
+    assert_empty invoice.publish_problems
   end
 
   test "in_year returns invoices whose date falls in the given year" do

--- a/test/services/invoice_publisher_test.rb
+++ b/test/services/invoice_publisher_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class InvoiceBookerTest < ActiveSupport::TestCase
+class InvoicePublisherTest < ActiveSupport::TestCase
   test "should use customer payment terms for due date calculation" do
     # Use existing customer and update payment terms
     customer = customers(:good_eu)
@@ -65,7 +65,7 @@ class InvoiceBookerTest < ActiveSupport::TestCase
     )
     invoice.invoice_lines.create!(type: "item", title: "X", quantity: 1.0, rate: 100.0, position: 1)
 
-    # Lock in the snapshot the same way a booked invoice does
+    # Lock in the snapshot the same way a published invoice does
     invoice.update!(published: true)
 
     assert_equal 30, invoice.payment_terms_days
@@ -83,10 +83,10 @@ class InvoiceBookerTest < ActiveSupport::TestCase
 
     invoice = Invoice.create!(customer: customer, project: projects(:test_project), cust_reference: "NOVATID-EU")
 
-    booker = InvoiceBooker.new(invoice, issuer_companies(:one))
-    booker.prepare!
+    publisher = InvoicePublisher.new(invoice, issuer_companies(:one))
+    publisher.prepare!
 
-    assert_includes invoice.booking_problems, "Customer VAT ID is missing."
+    assert_includes invoice.publish_problems, "Customer VAT ID is missing."
   end
 
   test "prepare! does not flag vat_id for export customers" do
@@ -98,10 +98,10 @@ class InvoiceBookerTest < ActiveSupport::TestCase
 
     invoice = Invoice.create!(customer: customer, project: projects(:test_project), cust_reference: "NOVATID-EXPORT")
 
-    booker = InvoiceBooker.new(invoice, issuer_companies(:one))
-    booker.prepare!
+    publisher = InvoicePublisher.new(invoice, issuer_companies(:one))
+    publisher.prepare!
 
-    assert_not_includes invoice.booking_problems, "Customer VAT ID is missing."
+    assert_not_includes invoice.publish_problems, "Customer VAT ID is missing."
   end
 
   test "prepare! derives due_date from the invoice's persisted payment_terms_days" do
@@ -117,8 +117,8 @@ class InvoiceBookerTest < ActiveSupport::TestCase
 
     assert_equal 21, invoice.payment_terms_days
 
-    booker = InvoiceBooker.new(invoice, issuer_companies(:one))
-    booker.prepare!
+    publisher = InvoicePublisher.new(invoice, issuer_companies(:one))
+    publisher.prepare!
 
     assert_equal Date.new(2024, 6, 22), invoice.due_date
   end
@@ -137,8 +137,8 @@ class InvoiceBookerTest < ActiveSupport::TestCase
       sales_tax_product_class: sales_tax_product_classes(:standard)
     )
 
-    booker = InvoiceBooker.new(invoice.reload, issuer_companies(:one))
-    assert_not booker.publish!
+    publisher = InvoicePublisher.new(invoice.reload, issuer_companies(:one))
+    assert_not publisher.publish!
 
     invoice.reload
     assert_not invoice.published?
@@ -149,8 +149,8 @@ class InvoiceBookerTest < ActiveSupport::TestCase
     invoice = invoices(:published_invoice)
     assert invoice.published?
 
-    booker = InvoiceBooker.new(invoice, issuer_companies(:one))
-    assert_not booker.publish!
-    assert_includes booker.log, "E: already published"
+    publisher = InvoicePublisher.new(invoice, issuer_companies(:one))
+    assert_not publisher.publish!
+    assert_includes publisher.log, "E: already published"
   end
 end

--- a/test/unit/invoice_tax_calculator_test.rb
+++ b/test/unit/invoice_tax_calculator_test.rb
@@ -92,10 +92,10 @@ class InvoiceTaxCalculationTest < ActiveSupport::TestCase
       position: 1
     )
 
-    problems = @invoice.booking_problems
+    problems = @invoice.publish_problems
 
     assert(problems.any? { |p| p.include?("Product") && p.include?("tax configuration") },
-           "Expected booking_problems to flag missing tax config, got: #{problems.inspect}")
+           "Expected publish_problems to flag missing tax config, got: #{problems.inspect}")
   end
 
   test "has_items? returns true when invoice has item lines" do
@@ -203,7 +203,7 @@ class InvoiceTaxCalculationTest < ActiveSupport::TestCase
       position: 4
     )
 
-    assert_empty @invoice.booking_problems
+    assert_empty @invoice.publish_problems
     assert @invoice.has_items?, "Invoice should have items"
   end
 end


### PR DESCRIPTION
## Summary

- Rename invoice "book/booking/booker" action vocabulary to "publish" so invoices and delivery notes use the same verb for the draft → finalized action. Service `InvoiceBooker` → `InvoicePublisher`; controller action `book` → `publish`; route `POST /invoices/:id/publish`; model `Invoice#booking_problems` → `Invoice#publish_problems`; redirect param `booked=1` → `published=1`; flash `Booking failed` → `Publishing failed`; permission label "Create / book / send invoices" → "Create / publish / send invoices".
- The "Booked" status badge on a published invoice stays — that's the resulting accounting state, not the action. The post-publish banner "Invoice <number> booked." also stays. DeliveryNote's matching badge changes from "Booked" to "Published" since DN has no accounting connotation. The embedded related-invoice badge on the DN show page stays "Booked" (refers to an invoice).
- Asymmetry preserved: invoices still have no `unpublish` action; delivery notes still do.
- CLAUDE.md, seed comments, and the `DocumentWithLines`/`HasLineItems` concern docstrings refreshed to match.

## Test plan

- [x] `bundle exec rails test` (680 runs, 2545 assertions, 0 failures)
- [x] `bundle exec rails routes` confirms `publish_invoice_path` (POST /invoices/:id/publish); no `book_invoice_path`
- [x] `pre-commit run --all-files` clean
- [ ] Manual smoke: draft invoice show page shows "Publish Status:" row, "Publish Invoice…" button with confirm copy "Publish invoice and assign a document number? This cannot be undone."
- [ ] Manual smoke: after publishing, banner reads "Invoice <number> booked." and header badge reads "Booked"
- [ ] Manual smoke: published-but-unsent delivery note header badge reads "Published"; the related-invoice badge on the same page still reads "Booked"

🤖 Generated with [Claude Code](https://claude.com/claude-code)