### PR TITLE
Combine account/emails Add input and button

### DIFF
--- a/app/views/account/emails/index.html.haml
+++ b/app/views/account/emails/index.html.haml
@@ -29,11 +29,9 @@
 
 %h2 Add new email
 = form_with url: account_emails_path, method: :post, scope: :user_email, local: true do |f|
-  .row.g-2
-    .col-md-6
-      = f.email_field :address, class: 'form-control', placeholder: 'new@example.com', required: true
-    .col-md-2
-      = f.submit 'Add', class: 'btn btn-primary'
+  .input-group.w-fixed-400
+    = f.email_field :address, class: 'form-control', placeholder: 'new@example.com', required: true
+    = f.submit 'Add', class: 'btn btn-primary'
   .form-text You'll receive a confirmation link at this address.
 
 .mt-4


### PR DESCRIPTION
## Summary
- Switch the "Add new email" form on `/account/emails` from the split `.row.g-2` / `.col-md-6` / `.col-md-2` layout to the established `.input-group.w-fixed-400` pattern used on `users/show` and `delivery_notes/show`, so the input and submit render visually combined.

## Test plan
- [ ] Visit `/account/emails`; verify the address field and Add button sit attached at ~400px wide.
- [ ] Submit a new address; confirmation flow still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)