### PR TITLE
Consume ?published=1 after post-publish auto-download fires

### DIFF
--- a/app/javascript/controllers/auto_download_controller.js
+++ b/app/javascript/controllers/auto_download_controller.js
@@ -7,5 +7,12 @@ export default class extends Controller {
     if (this.hasLinkTarget) {
       this.linkTarget.click()
     }
+    // `?published=1` is a one-shot trigger for the post-publish banner; consume it
+    // so reloads (e.g. after send-email) don't re-fire the auto-download.
+    const url = new URL(window.location.href)
+    if (url.searchParams.has("published")) {
+      url.searchParams.delete("published")
+      history.replaceState(history.state, "", url.toString())
+    }
   }
 }

--- a/test/system/email_preview_test.rb
+++ b/test/system/email_preview_test.rb
@@ -60,6 +60,12 @@ class EmailPreviewTest < ApplicationSystemTestCase
     end
   end
 
+  test "post-publish banner strips the published query param so reloads don't re-trigger auto-download" do
+    visit invoice_path(@invoice, published: 1)
+    assert_selector ".alert-success", text: "booked"
+    assert_current_path invoice_path(@invoice), wait: 2
+  end
+
   test "delivery note email preview URLs use correct paths for subdirectory deployment" do
     visit delivery_note_path(@delivery_note)
 


### PR DESCRIPTION
## Summary
- Stops the post-publish banner from re-downloading the PDF on any page reload after the first land
- Most visible trigger: clicking **Send E-Mail** in the banner → modal's `window.location.reload()` re-rendered the banner with `?published=1` still in the URL → auto-download fired again
- `auto_download_controller` now strips `published` via `history.replaceState` after firing the click, making the trigger one-shot; same shared controller covers both invoices and delivery notes

## Test plan
- [x] New system test in `test/system/email_preview_test.rb` asserting the URL drops to canonical after visiting `?published=1`
- [x] Existing `email_preview_test.rb` tests still pass (5 runs, 36 assertions)
- [ ] Manual: publish an invoice → confirm PDF opens once, URL cleans to `/invoices/:id`, then Send E-Mail and confirm no second PDF tab opens
- [ ] Manual: same flow for a delivery note

🤖 Generated with [Claude Code](https://claude.com/claude-code)