### PR TITLE
Dedup ActionButtonsHelper bodies and tests

### DIFF
--- a/app/helpers/action_buttons_helper.rb
+++ b/app/helpers/action_buttons_helper.rb
@@ -7,6 +7,9 @@ module ActionButtonsHelper
   # Every helper supports `permission:` and returns nil when denied, so views
   # can pass `actions: [pdf_button(...), delete_button(...)]` and let the
   # breadcrumbs helper compact out the nils.
+  #
+  # Shared shapes live as private helpers below: `post_button` for the
+  # button_to POST cluster, `glyph_link` for the glyph-only link_to cluster.
 
   # Shared HTML id for the single page-level form on edit/new pages. The
   # breadcrumb's `save_button` and the form element both reference this
@@ -19,73 +22,47 @@ module ActionButtonsHelper
   def delete_button(resource, confirm: nil, permission: nil)
     return nil if permission && !can?(permission)
     confirm ||= "Are you sure you want to delete this #{resource.class.name.downcase}?"
-    link_to "🗑", resource,
-            class: "btn btn-danger",
-            title: "Delete",
-            "aria-label": "Delete",
-            data: { "turbo-method": "delete", "turbo-confirm": confirm }
+    glyph_link "🗑", resource, klass: "btn btn-danger", title: "Delete",
+               data: { "turbo-method": "delete", "turbo-confirm": confirm }
   end
 
   def pdf_button(path, permission: nil)
     return nil if permission && !can?(permission)
-    link_to "📄", path,
-            class: "btn btn-success",
-            title: "PDF",
-            "aria-label": "PDF",
-            target: "_blank",
-            data: { turbo: false }
+    glyph_link "📄", path, klass: "btn btn-success", title: "PDF",
+               target: "_blank", data: { turbo: false }
   end
 
   def preview_button(path, permission: nil)
     return nil if permission && !can?(permission)
-    link_to "👁", path,
-            class: "btn btn-info",
-            title: "Preview",
-            "aria-label": "Preview",
-            target: "_blank",
-            data: { turbo: false }
+    glyph_link "👁", path, klass: "btn btn-info", title: "Preview",
+               target: "_blank", data: { turbo: false }
   end
 
   # --- Tier 2: glyph + text ---
 
   def publish_button(path, permission: nil, confirm: nil)
     return nil if permission && !can?(permission)
-    button_to "🚀 Publish", path,
-              method: :post,
-              class: "btn btn-warning",
-              data: { "turbo-confirm": confirm }.compact
+    post_button "🚀 Publish", path, klass: "btn btn-warning", confirm: confirm
   end
 
   def unpublish_button(path, permission: nil, confirm: nil)
     return nil if permission && !can?(permission)
-    button_to "↩️ Unpublish", path,
-              method: :post,
-              class: "btn btn-outline-secondary",
-              data: { "turbo-confirm": confirm }.compact
+    post_button "↩️ Unpublish", path, klass: "btn btn-outline-secondary", confirm: confirm
   end
 
   def convert_to_invoice_button(path, permission: nil, confirm: nil)
     return nil if permission && !can?(permission)
-    button_to "🚀 Convert to Invoice", path,
-              method: :post,
-              class: "btn btn-info",
-              data: { "turbo-confirm": confirm }.compact
+    post_button "🚀 Convert to Invoice", path, klass: "btn btn-info", confirm: confirm
   end
 
   def unblock_button(path, permission: nil, confirm: nil)
     return nil if permission && !can?(permission)
-    button_to "✅ Unblock", path,
-              method: :post,
-              class: "btn btn-success",
-              data: { "turbo-confirm": confirm }.compact
+    post_button "✅ Unblock", path, klass: "btn btn-success", confirm: confirm
   end
 
   def reset_passkeys_button(path, permission: nil, confirm: nil)
     return nil if permission && !can?(permission)
-    button_to "Reset passkeys", path,
-              method: :post,
-              class: "btn btn-warning",
-              data: { "turbo-confirm": confirm }.compact
+    post_button "Reset passkeys", path, klass: "btn btn-warning", confirm: confirm
   end
 
   def audit_log_button(path, permission: nil)
@@ -110,5 +87,23 @@ module ActionButtonsHelper
   def nav_button(text, path, permission: nil, data: nil)
     return nil if permission && !can?(permission)
     link_to text, path, class: "btn btn-outline-secondary", data: data
+  end
+
+  private
+
+  # Tier-2 shape: POST form button with a Bootstrap class and an optional
+  # turbo-confirm prompt.
+  def post_button(label, path, klass:, confirm: nil)
+    button_to label, path,
+              method: :post,
+              class: klass,
+              data: { "turbo-confirm": confirm }.compact
+  end
+
+  # Tier-3 shape: glyph-only link with a Bootstrap class and an accessible
+  # name. The `title:` becomes both the hover tooltip and the screen-reader
+  # `aria-label`. Extra `link_opts` (e.g. `target:`, `data:`) pass through.
+  def glyph_link(glyph, path, klass:, title:, **link_opts)
+    link_to glyph, path, link_opts.merge(class: klass, title: title, "aria-label": title)
   end
 end

--- a/app/helpers/action_buttons_helper.rb
+++ b/app/helpers/action_buttons_helper.rb
@@ -20,49 +20,44 @@ module ActionButtonsHelper
   # --- Tier 3: glyph-only (title required) ---
 
   def delete_button(resource, confirm: nil, permission: nil)
-    return nil if permission && !can?(permission)
     confirm ||= "Are you sure you want to delete this #{resource.class.name.downcase}?"
     glyph_link "🗑", resource, klass: "btn btn-danger", title: "Delete",
+               permission: permission,
                data: { "turbo-method": "delete", "turbo-confirm": confirm }
   end
 
   def pdf_button(path, permission: nil)
-    return nil if permission && !can?(permission)
     glyph_link "📄", path, klass: "btn btn-success", title: "PDF",
+               permission: permission,
                target: "_blank", data: { turbo: false }
   end
 
   def preview_button(path, permission: nil)
-    return nil if permission && !can?(permission)
     glyph_link "👁", path, klass: "btn btn-info", title: "Preview",
+               permission: permission,
                target: "_blank", data: { turbo: false }
   end
 
   # --- Tier 2: glyph + text ---
 
   def publish_button(path, permission: nil, confirm: nil)
-    return nil if permission && !can?(permission)
-    post_button "🚀 Publish", path, klass: "btn btn-warning", confirm: confirm
+    post_button "🚀 Publish", path, klass: "btn btn-warning", permission: permission, confirm: confirm
   end
 
   def unpublish_button(path, permission: nil, confirm: nil)
-    return nil if permission && !can?(permission)
-    post_button "↩️ Unpublish", path, klass: "btn btn-outline-secondary", confirm: confirm
+    post_button "↩️ Unpublish", path, klass: "btn btn-outline-secondary", permission: permission, confirm: confirm
   end
 
   def convert_to_invoice_button(path, permission: nil, confirm: nil)
-    return nil if permission && !can?(permission)
-    post_button "🚀 Convert to Invoice", path, klass: "btn btn-info", confirm: confirm
+    post_button "🚀 Convert to Invoice", path, klass: "btn btn-info", permission: permission, confirm: confirm
   end
 
   def unblock_button(path, permission: nil, confirm: nil)
-    return nil if permission && !can?(permission)
-    post_button "✅ Unblock", path, klass: "btn btn-success", confirm: confirm
+    post_button "✅ Unblock", path, klass: "btn btn-success", permission: permission, confirm: confirm
   end
 
   def reset_passkeys_button(path, permission: nil, confirm: nil)
-    return nil if permission && !can?(permission)
-    post_button "Reset passkeys", path, klass: "btn btn-warning", confirm: confirm
+    post_button "Reset passkeys", path, klass: "btn btn-warning", permission: permission, confirm: confirm
   end
 
   def audit_log_button(path, permission: nil)
@@ -92,8 +87,10 @@ module ActionButtonsHelper
   private
 
   # Tier-2 shape: POST form button with a Bootstrap class and an optional
-  # turbo-confirm prompt.
-  def post_button(label, path, klass:, confirm: nil)
+  # turbo-confirm prompt. Returns nil when `permission:` is set and the
+  # current user lacks it.
+  def post_button(label, path, klass:, permission: nil, confirm: nil)
+    return nil if permission && !can?(permission)
     button_to label, path,
               method: :post,
               class: klass,
@@ -103,7 +100,9 @@ module ActionButtonsHelper
   # Tier-3 shape: glyph-only link with a Bootstrap class and an accessible
   # name. The `title:` becomes both the hover tooltip and the screen-reader
   # `aria-label`. Extra `link_opts` (e.g. `target:`, `data:`) pass through.
-  def glyph_link(glyph, path, klass:, title:, **link_opts)
+  # Returns nil when `permission:` is set and the current user lacks it.
+  def glyph_link(glyph, path, klass:, title:, permission: nil, **link_opts)
+    return nil if permission && !can?(permission)
     link_to glyph, path, link_opts.merge(class: klass, title: title, "aria-label": title)
   end
 end

--- a/test/helpers/action_buttons_helper_test.rb
+++ b/test/helpers/action_buttons_helper_test.rb
@@ -6,86 +6,64 @@ class ActionButtonsHelperTest < ActionView::TestCase
   # Smoke tests that pin the established glyph + Bootstrap color + accessible
   # name for each helper. Update these when CLAUDE.md's "Button Glyphs" table
   # changes — they are the executable copy of the policy.
+  #
+  # The permission: mechanic is shared via `return nil if permission && !can?(...)`
+  # in every helper, so it gets one set of dedicated cases against delete_button
+  # rather than being re-tested per verb.
+
+  # --- Tier 3 (glyph-only) ---
 
   test "delete_button renders glyph-only with title and aria-label" do
     customer = Customer.new
     customer.class.define_singleton_method(:name) { "Customer" }
     html = delete_button(customer)
-    assert_match(/btn-danger/, html)
-    assert_match(/title="Delete"/, html)
-    assert_match(/aria-label="Delete"/, html)
-    assert_includes html, "🗑"
+    assert_glyph_link html, glyph: "🗑", klass: "btn-danger", title: "Delete"
     assert_match(/data-turbo-confirm=/, html)
-  end
-
-  test "delete_button with permission: returns the link when user has it" do
-    Current.user = users(:alice)
-    customer = customers(:good_eu)
-    html = delete_button(customer, permission: "customers.edit")
-    assert_match(/btn-danger/, html)
-    assert_includes html, "🗑"
-  ensure
-    Current.user = nil
-  end
-
-  test "delete_button with permission: returns nil when user lacks it" do
-    Current.user = users(:bob)
-    customer = customers(:good_eu)
-    assert_nil delete_button(customer, permission: "customers.edit")
-  ensure
-    Current.user = nil
-  end
-
-  test "delete_button with permission: returns nil when no current user" do
-    Current.user = nil
-    customer = customers(:good_eu)
-    assert_nil delete_button(customer, permission: "customers.edit")
   end
 
   test "pdf_button renders glyph-only with title, opens in new tab" do
     html = pdf_button("/foo.pdf")
-    assert_includes html, "📄"
-    assert_match(/btn-success/, html)
-    assert_match(/title="PDF"/, html)
-    assert_match(/aria-label="PDF"/, html)
+    assert_glyph_link html, glyph: "📄", klass: "btn-success", title: "PDF"
     assert_match(/target="_blank"/, html)
   end
 
   test "preview_button renders glyph-only, info color, new tab" do
     html = preview_button("/preview")
-    assert_includes html, "👁"
-    assert_match(/btn-info/, html)
-    assert_match(/title="Preview"/, html)
+    assert_glyph_link html, glyph: "👁", klass: "btn-info", title: "Preview"
     assert_match(/target="_blank"/, html)
   end
 
+  # --- Tier 2 (glyph + text, POST form) ---
+
   test "publish_button renders glyph + text, warning color, POST form" do
     html = publish_button("/publish")
-    assert_includes html, "🚀 Publish"
-    assert_match(/btn-warning/, html)
+    assert_post_button html, label: "🚀 Publish", klass: "btn-warning"
     assert_match(%r{<form[^>]*action="/publish"}, html)
-    assert_match(%r{method="post"}, html)
   end
 
   test "convert_to_invoice_button uses the rocket and info color" do
     html = convert_to_invoice_button("/convert", confirm: "Sure?")
-    assert_includes html, "🚀 Convert to Invoice"
-    assert_match(/btn-info/, html)
+    assert_post_button html, label: "🚀 Convert to Invoice", klass: "btn-info"
     assert_match(/data-turbo-confirm="Sure\?"/, html)
   end
 
   test "unblock_button renders glyph + text, success color" do
     html = unblock_button("/unblock")
-    assert_includes html, "✅ Unblock"
-    assert_match(/btn-success/, html)
+    assert_post_button html, label: "✅ Unblock", klass: "btn-success"
   end
 
   test "reset_passkeys_button is text-only despite Tier 2 form rendering" do
     html = reset_passkeys_button("/reset")
-    assert_includes html, "Reset passkeys"
+    assert_post_button html, label: "Reset passkeys", klass: "btn-warning"
     refute_match(/🔄/, html)
-    assert_match(/btn-warning/, html)
   end
+
+  test "unpublish_button renders glyph + text, outline-secondary color" do
+    html = unpublish_button("/unpublish")
+    assert_post_button html, label: "↩️ Unpublish", klass: "btn-outline-secondary"
+  end
+
+  # --- Tier 1 (plain link) ---
 
   test "audit_log_button uses clipboard glyph + text" do
     html = audit_log_button("/audit")
@@ -100,6 +78,8 @@ class ActionButtonsHelperTest < ActionView::TestCase
     assert_match(%r{href="/invoices"}, html)
   end
 
+  # --- save_button (form-submit shape) ---
+
   test "save_button renders a submit button bound to the shared form id" do
     html = save_button
     assert_match(/<button[^>]*type="submit"/, html)
@@ -113,10 +93,48 @@ class ActionButtonsHelperTest < ActionView::TestCase
     assert_includes html, "Update Issuer Company"
   end
 
-  test "save_button with permission: returns nil when user lacks it" do
+  # --- Permission gate (shared across every helper; tested once via delete_button) ---
+
+  test "permission: returns the button when current user has it" do
+    Current.user = users(:alice)
+    html = delete_button(customers(:good_eu), permission: "customers.edit")
+    assert_match(/btn-danger/, html)
+    assert_includes html, "🗑"
+  ensure
+    Current.user = nil
+  end
+
+  test "permission: returns nil when current user lacks it" do
+    Current.user = users(:bob)
+    assert_nil delete_button(customers(:good_eu), permission: "customers.edit")
+  ensure
+    Current.user = nil
+  end
+
+  test "permission: returns nil when there is no current user" do
+    Current.user = nil
+    assert_nil delete_button(customers(:good_eu), permission: "customers.edit")
+  end
+
+  test "permission: gate also covers save_button (button_tag shape)" do
     Current.user = users(:bob)
     assert_nil save_button(permission: "customers.edit")
   ensure
     Current.user = nil
+  end
+
+  private
+
+  def assert_glyph_link(html, glyph:, klass:, title:)
+    assert_includes html, glyph
+    assert_match(/#{Regexp.escape(klass)}/, html)
+    assert_match(/title="#{Regexp.escape(title)}"/, html)
+    assert_match(/aria-label="#{Regexp.escape(title)}"/, html)
+  end
+
+  def assert_post_button(html, label:, klass:)
+    assert_includes html, label
+    assert_match(/#{Regexp.escape(klass)}/, html)
+    assert_match(%r{<form[^>]*method="post"}, html)
   end
 end


### PR DESCRIPTION
## Summary

- Extract two private helpers — `post_button` for the Tier-2 button_to cluster (5 helpers: publish, unpublish, convert_to_invoice, unblock, reset_passkeys) and `glyph_link` for the Tier-3 link_to cluster (3 helpers: delete, pdf, preview). Each public method becomes a one-liner over the shared shape.
- `audit_log_button`, `nav_button`, and `save_button` stay bespoke — their shapes don't fit either cluster.
- Dedup the smoke tests via `assert_glyph_link` / `assert_post_button` and consolidate the four `permission:` test cases into a single shared-mechanic block (with one extra case covering `save_button`, which uses `button_tag` instead of the shared `post_button` path).
- Adds the missing `unpublish_button` smoke test that the original file overlooked.

No metaprogramming, no behavior change. Helper file goes from 11 near-identical bodies to 11 one-liners + 2 private shapes.

## Test plan

- [x] `bundle exec rails test` — 692 / 2581 / 0
- [x] `bundle exec rails test test/system/` (headless) — 64 / 279 / 0
- [x] `bundle exec rails test test/helpers/action_buttons_helper_test.rb` — 16 / 93 / 0 (was 15 / 79 before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)