### PR TITLE
Move convert-to-invoice into Invoice row; promote Preview as primary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,14 +190,14 @@ For testing against PostgreSQL (matches production environment):
   - Top-level resources start with the navbar label linked to its index: `['Customers', customers_path]`, `['Projects', projects_path]`, `['Delivery Notes', delivery_notes_path]`, `['Invoices', invoices_path]`.
   - Configuration resources start with a non-link `'Configuration'` crumb (the dropdown has no destination) followed by the resource's navbar label, e.g. `breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], 'Edit'`.
   - On edit pages append `'Edit'` as the active crumb; on new pages append `'New'`. On show pages the resource's identifier (matchcode / document number / name) is the active crumb.
-  - The bottom `action_buttons_wrapper` is gone from show pages — every workflow verb (PDF, Preview, Publish, Convert to Invoice, Delete, etc.) moves into `actions:` on the breadcrumb. Status-row buttons (Send E-Mail, Mark Paid, Mark Unpaid, Publish Invoice…) stay inline with their status row.
+  - The bottom `action_buttons_wrapper` is gone from show pages — every workflow verb (PDF, Preview, Publish, Delete, etc.) moves into `actions:` on the breadcrumb. Status-row buttons (Send E-Mail, Mark Paid, Mark Unpaid, Publish Invoice…, Create invoice from delivery note) stay inline with their status row.
   - Edit/new pages put `Save` in the breadcrumb's primary `action:` slot via `save_button` (see `ActionButtonsHelper`). There is no Cancel button — the breadcrumb's parent crumb is the way back without saving.
 - `page_header(title, action: nil, &status_block)` - Page-header row with an H1 title, optional inline status badges via the block, and optional right-aligned action. Only used on pages without breadcrumbs: dashboard (`home/index`), `/account/*`, the sign-in / invite-acceptance / "Invite generated" pages.
 - `action_button(text, path, type = :primary, permission: nil, target: nil, data: nil, title: nil)` - Styled buttons (primary, secondary, success, info, warning, danger). Returns `nil` when `permission:` is given and the current user lacks it. Pass `title:` on glyph-only buttons — the helper applies it as both `title=` (hover tooltip) and `aria-label=` (screen-reader name).
 - `action_buttons_wrapper` - Container for an inline action row. Skips emitting the wrapper when its block produces no content (so permission-gated children that all return `nil` don't leave an empty row). Remaining callsites: `invoices/_form` and `delivery_notes/_form` for the in-form `+ Add Line` button below the lines table, and a handful of show pages (`sales_tax_rates/show`, `sales_tax_customer_classes/show`, `sales_tax_product_classes/show`, `user_invites/show_invite`) pending follow-up migration.
 - `destroy_link(resource, confirm_text)` - Compact `🗑` outline link for the **Actions** column on index pages. On detail pages use `delete_button(resource)` instead.
 - `list_action_link(text, path, type)` - Compact buttons for in-table row actions.
-- Per-verb helpers in `ActionButtonsHelper` (`delete_button`, `pdf_button`, `preview_button`, `publish_button`, `unpublish_button`, `convert_to_invoice_button`, `unblock_button`, `reset_passkeys_button`, `audit_log_button`, `save_button`) — see "Button Glyphs" below for the full mapping and policy.
+- Per-verb helpers in `ActionButtonsHelper` (`delete_button`, `pdf_button`, `preview_button`, `publish_button`, `unpublish_button`, `unblock_button`, `reset_passkeys_button`, `audit_log_button`, `save_button`) — see "Button Glyphs" below for the full mapping and policy.
 - `save_button(label: "Save", permission: nil)` (in `ActionButtonsHelper`) — the primary submit button on every edit/new page, lives in the breadcrumb's `action:` slot. Submits the page's main form via the HTML5 `form="page-form"` attribute, so the form partial must set `html: { id: ActionButtonsHelper::PAGE_FORM_ID }` (or `id: ActionButtonsHelper::PAGE_FORM_ID` for `form_with`). Each edit/new page has exactly one page-level form; override locally if a future template needs a second.
 - `nav_button(text, path, permission: nil, data: nil)` (in `ActionButtonsHelper`) — cross-resource navigation in the breadcrumb action cluster (e.g. customer show → its Invoices/Delivery Notes; sales-tax rates → Customer/Product Classes). Renders `btn-outline-secondary` so nav reads as quiet/link-ish and yields visual prominence to the page's primary action. Don't reach for filled variants for cross-resource navigation — use `nav_button` instead.
 
@@ -206,13 +206,13 @@ For testing against PostgreSQL (matches production environment):
 Glyphs on action buttons are space-savers, not decoration. Three tiers:
 
 - **Text only** when the label is already short and universally clear: `Edit`, `+ New`, `Save`, `Reset passkeys`. Don't prefix with a glyph.
-- **Glyph + text** for less-familiar workflow actions where the glyph aids scanning but the text is still required: `🚀 Publish`, `🚀 Convert to Invoice`, etc.
+- **Glyph + text** for less-familiar workflow actions where the glyph aids scanning but the text is still required: `🚀 Publish`, `📥 Upload PDF`, etc.
 - **Glyph only with `title:`** for actions whose glyph is universally understood and whose label is fully replaceable: `🗑` Delete, `📄` PDF, `👁` Preview. Always pass `title:` to set both the hover tooltip and the screen-reader `aria-label`.
 
 Label-shortening rule: when a glyph already carries the verb concept and the remaining noun/state is clear, drop the leading verb in the label. So `Mark Paid` → `✅ Paid` (✅ = the verb, "Paid" = the state). Keep `🚀 Publish`, `📥 Upload PDF` full when the verb/object isn't carried by the glyph alone.
 
 Glyph reuse is intentional when the action archetype is the same:
-- 🚀 = "promote forward" (Publish + Convert to Invoice)
+- 🚀 = "promote forward" (Publish + Create invoice from delivery note)
 - ✅ = "positive state change" (Paid + Unblock)
 - ↩ / ↩️ = "revert state" (Unpaid + Unpublish) — Unicode-distinct but visually similar; they never coexist on the same page
 
@@ -232,7 +232,7 @@ Established mapping — extend this table; don't invent new glyphs for existing 
 | Send e-mail | `✉️ Send` | glyph + text | (status-row, inline) |
 | Publish | `🚀 Publish` | glyph + text | `publish_button` |
 | Unpublish | `↩️ Unpublish` | glyph + text | `unpublish_button` |
-| Convert to Invoice | `🚀 Convert to Invoice` | glyph + text | `convert_to_invoice_button` |
+| Convert to Invoice | `🚀 Create…` | glyph + text | (status-row, inline) |
 | Upload PDF | `📥 Upload PDF` | glyph + text | (form, inline) |
 | Block | `🚫 Block` | glyph + text | (form-with-reason, inline) |
 | Unblock | `✅ Unblock` | glyph + text | `unblock_button` |

--- a/app/helpers/action_buttons_helper.rb
+++ b/app/helpers/action_buttons_helper.rb
@@ -48,10 +48,6 @@ module ActionButtonsHelper
     post_button "↩️ Unpublish", path, klass: "btn btn-outline-secondary", permission: permission, confirm: confirm
   end
 
-  def convert_to_invoice_button(path, permission: nil, confirm: nil)
-    post_button "🚀 Convert to Invoice", path, klass: "btn btn-info", permission: permission, confirm: confirm
-  end
-
   def unblock_button(path, permission: nil, confirm: nil)
     post_button "✅ Unblock", path, klass: "btn btn-success", permission: permission, confirm: confirm
   end

--- a/app/views/delivery_notes/show.html.haml
+++ b/app/views/delivery_notes/show.html.haml
@@ -2,11 +2,11 @@
 - edit_action = action_button('Edit', edit_delivery_note_path(@delivery_note), permission: 'delivery_notes.edit') unless @delivery_note.published?
 - pdf_action = pdf_button(pdf_delivery_note_path(@delivery_note))
 - preview_action = preview_button(preview_delivery_note_path(@delivery_note))
-- convert_action = convert_to_invoice_button(convert_to_invoice_delivery_note_path(@delivery_note), permission: 'delivery_notes.edit', confirm: 'Create an invoice draft from this delivery note?') unless @delivery_note.invoice
 - unpublish_action = unpublish_button(unpublish_delivery_note_path(@delivery_note), permission: 'delivery_notes.edit', confirm: 'Are you sure you want to revert this delivery note to draft status?')
 - delete_action = delete_button(@delivery_note, confirm: "Are you sure you want to delete delivery note \"#{@delivery_note.document_number || "##{@delivery_note.id}"}\"?") if can_edit_dn
-- workflow_actions = @delivery_note.published? ? [pdf_action, convert_action, unpublish_action] : [preview_action, delete_action]
-= breadcrumbs ['Delivery Notes', delivery_notes_path], (@delivery_note.document_number || "Draft ##{@delivery_note.id}"), actions: workflow_actions, action: edit_action do
+- main_action = @delivery_note.published? ? preview_action : edit_action
+- workflow_actions = @delivery_note.published? ? [pdf_action, unpublish_action] : [preview_action, delete_action]
+= breadcrumbs ['Delivery Notes', delivery_notes_path], (@delivery_note.document_number || "Draft ##{@delivery_note.id}"), actions: workflow_actions, action: main_action do
   - if !@delivery_note.published?
     %span.badge.bg-warning Draft
   - elsif @delivery_note.email_sent_at.present?
@@ -104,16 +104,21 @@
                   %span.ms-auto{data: {'bs-toggle': 'tooltip'}, title: 'No contact is configured to receive this delivery note. Add a contact on the customer with "Delivery Notes" enabled.'}
                     %button.btn.btn-sm.btn-warning{disabled: true}
                       Send E-Mail
-        - if @delivery_note.invoice
+        - if @delivery_note.published?
           .row.mb-2
             .col-sm-4
               %strong Invoice:
-            .col-sm-8
-              = link_to "Invoice #{@delivery_note.invoice.document_number || "##{@delivery_note.invoice.id}"}", @delivery_note.invoice
-              - if @delivery_note.invoice.published?
-                %span.badge.bg-success.ms-2 Booked
+            .col-sm-8.d-flex.align-items-center.gap-2
+              - if @delivery_note.invoice
+                = link_to "Invoice #{@delivery_note.invoice.document_number || "##{@delivery_note.invoice.id}"}", @delivery_note.invoice
+                - if @delivery_note.invoice.published?
+                  %span.badge.bg-success Booked
+                - else
+                  %span.badge.bg-warning Draft
               - else
-                %span.badge.bg-warning.ms-2 Draft
+                Not invoiced
+                - if can_edit_dn
+                  = button_to '🚀 Create…', convert_to_invoice_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-sm btn-info', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Create an invoice draft from this delivery note?' }
 
 
   - if @delivery_note.published?

--- a/test/controllers/delivery_notes_controller_test.rb
+++ b/test/controllers/delivery_notes_controller_test.rb
@@ -127,6 +127,18 @@ class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
     assert_select ".alert-success .alert-heading", count: 0
   end
 
+  test "show renders Invoice row with create button when published delivery note has no invoice yet" do
+    note = delivery_notes(:published_delivery_note)
+    assert_nil note.invoice, "fixture should not yet be invoiced"
+
+    get delivery_note_url(note)
+    assert_response :success
+    assert_select "strong", text: "Invoice:"
+    assert_select "form[action=?]", convert_to_invoice_delivery_note_path(note) do
+      assert_select "button"
+    end
+  end
+
   test "should unpublish delivery note" do
     published_note = delivery_notes(:published_delivery_note)
 

--- a/test/controllers/delivery_notes_controller_test.rb
+++ b/test/controllers/delivery_notes_controller_test.rb
@@ -12,8 +12,16 @@ class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
   # the same shared dropdown partial.
 
   test "should show delivery note" do
-    get delivery_note_url(delivery_notes(:published_delivery_note))
+    note = delivery_notes(:published_delivery_note)
+    assert_nil note.invoice, "fixture should not yet be invoiced"
+
+    get delivery_note_url(note)
     assert_response :success
+    # Invoice row renders with the convert button when published but not yet invoiced
+    assert_select "strong", text: "Invoice:"
+    assert_select "form[action=?]", convert_to_invoice_delivery_note_path(note) do
+      assert_select "button"
+    end
   end
 
   test "should get new" do
@@ -125,18 +133,6 @@ class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
     get delivery_note_url(delivery_notes(:published_delivery_note))
     assert_response :success
     assert_select ".alert-success .alert-heading", count: 0
-  end
-
-  test "show renders Invoice row with create button when published delivery note has no invoice yet" do
-    note = delivery_notes(:published_delivery_note)
-    assert_nil note.invoice, "fixture should not yet be invoiced"
-
-    get delivery_note_url(note)
-    assert_response :success
-    assert_select "strong", text: "Invoice:"
-    assert_select "form[action=?]", convert_to_invoice_delivery_note_path(note) do
-      assert_select "button"
-    end
   end
 
   test "should unpublish delivery note" do

--- a/test/helpers/action_buttons_helper_test.rb
+++ b/test/helpers/action_buttons_helper_test.rb
@@ -41,12 +41,6 @@ class ActionButtonsHelperTest < ActionView::TestCase
     assert_match(%r{<form[^>]*action="/publish"}, html)
   end
 
-  test "convert_to_invoice_button uses the rocket and info color" do
-    html = convert_to_invoice_button("/convert", confirm: "Sure?")
-    assert_post_button html, label: "🚀 Convert to Invoice", klass: "btn-info"
-    assert_match(/data-turbo-confirm="Sure\?"/, html)
-  end
-
   test "unblock_button renders glyph + text, success color" do
     html = unblock_button("/unblock")
     assert_post_button html, label: "✅ Unblock", klass: "btn-success"


### PR DESCRIPTION
## Summary
Reorganize the show page for published delivery notes.

- **Invoice row** always renders when published — link + status badge when invoiced, **Not invoiced** + a small `🚀 Create…` button when not. Previously the row was hidden until an invoice existed, so the action was discoverable only via the breadcrumb cluster.
- **Action cluster** when published: Preview is now the primary; PDF and Unpublish stay as secondary; convert-to-invoice leaves the cluster entirely. Draft state is unchanged.
- The `convert_to_invoice_button` helper had no remaining callers and is removed along with its test. The new status-row button uses the `btn-sm` / `form: { class: 'button_to ms-auto' }` pattern that the Publish… button already established.
- CLAUDE.md (Button Glyphs / UI Helper Methods) updated to reflect the new placement.

## Test plan
- [x] New controller test asserting the Invoice row renders with the convert form when the published delivery note has no invoice yet
- [x] Existing delivery-note controller tests still pass (5 system, 50 controller, 213 assertions)
- [x] Existing `ActionButtonsHelper` tests still pass (post-#409 deduped shape)
- [ ] Manual: open a published delivery note with no invoice → confirm Invoice row shows "Not invoiced" + 🚀 Create… button; click → land on draft invoice
- [ ] Manual: open a published delivery note that already has an invoice → row shows link + Booked/Draft badge, no Create button
- [ ] Manual: confirm Preview (👁) is now the primary action; PDF (📄) and Unpublish (↩️) are secondary
- [ ] Manual: draft delivery note unchanged (Edit primary; Preview + Delete secondary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)