### PR TITLE
Drop tests that duplicate shared-concern coverage

### DIFF
--- a/test/controllers/concerns/publishable_document_test.rb
+++ b/test/controllers/concerns/publishable_document_test.rb
@@ -38,6 +38,13 @@ class PublishableDocumentTest < ActionDispatch::IntegrationTest
     assert_match "Published invoices can not be modified", flash[:error]
   end
 
+  test "require_unpublished blocks publish on a published invoice" do
+    invoice = invoices(:published_invoice)
+    post publish_invoice_url(invoice)
+    assert_redirected_to invoice_url(invoice)
+    assert_match "Published invoices can not be modified", flash[:error]
+  end
+
   test "require_published blocks send_email on a draft invoice" do
     invoice = invoices(:draft_invoice)
     post send_email_invoice_url(invoice)

--- a/test/controllers/invoices_controller_test.rb
+++ b/test/controllers/invoices_controller_test.rb
@@ -385,45 +385,6 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
     assert_equal 0.0, tax_class.value, "Tax value should be 0.0"
   end
 
-  test "should not edit published invoice" do
-    invoice = invoices(:published_invoice)
-    get edit_invoice_url(invoice)
-    assert_redirected_to invoice_url(invoice)
-    assert_match "Published invoices can not be modified", flash[:error]
-  end
-
-  test "should not update published invoice" do
-    invoice = invoices(:published_invoice)
-    original_ref = invoice.cust_reference
-
-    patch invoice_url(invoice), params: { invoice: { cust_reference: "HACKED" } }
-
-    assert_redirected_to invoice_url(invoice)
-    assert_match "Published invoices can not be modified", flash[:error]
-    assert_equal original_ref, invoice.reload.cust_reference
-  end
-
-  test "should not destroy published invoice" do
-    invoice = invoices(:published_invoice)
-    assert_no_difference("Invoice.count") do
-      delete invoice_url(invoice)
-    end
-    assert_redirected_to invoice_url(invoice)
-    assert_match "Published invoices can not be modified", flash[:error]
-  end
-
-  test "should not preview published invoice" do
-    invoice = invoices(:published_invoice)
-    get preview_invoice_url(invoice)
-    assert_redirected_to invoice_url(invoice)
-    assert_match "Published invoices can not be modified", flash[:error]
-  end
-
-  test "should not POST publish on published invoice" do
-    invoice = invoices(:published_invoice)
-
-    post publish_invoice_url(invoice)
-    assert_redirected_to invoice_url(invoice)
-    assert_match "Published invoices can not be modified", flash[:error]
-  end
+  # Published-invoice guards (edit/update/destroy/preview/publish) live in
+  # test/controllers/concerns/publishable_document_test.rb.
 end

--- a/test/models/delivery_note_line_test.rb
+++ b/test/models/delivery_note_line_test.rb
@@ -1,24 +1,8 @@
 require "test_helper"
 
+# LineItem concern (title/type/inheritance_column/is_item?/TYPE_OPTIONS) is
+# covered by InvoiceLineTest. Only DN-specific quantity validation lives here.
 class DeliveryNoteLineTest < ActiveSupport::TestCase
-  test "should require title" do
-    line = DeliveryNoteLine.new
-    assert_not line.valid?
-    assert_includes line.errors[:title], "can't be blank"
-  end
-
-  test "should require type" do
-    line = DeliveryNoteLine.new(title: "Test")
-    assert_not line.valid?
-    assert_includes line.errors[:type], "can't be blank"
-  end
-
-  test "should validate type is in TYPE_OPTIONS" do
-    line = DeliveryNoteLine.new(title: "Test", type: "invalid_type")
-    assert_not line.valid?
-    assert_includes line.errors[:type], "is not included in the list"
-  end
-
   test "should require quantity for item type" do
     line = DeliveryNoteLine.new(title: "Test", type: "item", delivery_note: delivery_notes(:published_delivery_note))
     assert_not line.valid?
@@ -28,20 +12,5 @@ class DeliveryNoteLineTest < ActiveSupport::TestCase
   test "should not require quantity for non-item types" do
     line = DeliveryNoteLine.new(title: "Test", type: "text", delivery_note: delivery_notes(:published_delivery_note))
     assert line.valid?
-  end
-
-  test "is_item? returns true for item type" do
-    line = delivery_note_lines(:item_line)
-    assert line.is_item?
-  end
-
-  test "is_item? returns false for non-item types" do
-    line = delivery_note_lines(:text_line)
-    assert_not line.is_item?
-  end
-
-  test "TYPE_OPTIONS contains valid types" do
-    expected_types = %w[text item subheading plain]
-    assert_equal expected_types.sort, DeliveryNoteLine::TYPE_OPTIONS.values.sort
   end
 end

--- a/test/models/invoice_test.rb
+++ b/test/models/invoice_test.rb
@@ -173,33 +173,9 @@ class InvoiceTest < ActiveSupport::TestCase
     assert_empty invoice.publish_problems
   end
 
-  test "in_year returns invoices whose date falls in the given year" do
-    year = Date.current.year
-    assert_includes Invoice.in_year(year), invoices(:published_invoice)
-
-    other_year = year - 5
-    assert_not_includes Invoice.in_year(other_year), invoices(:published_invoice)
-  end
-
-  test "in_year with include_drafts: true includes invoices with a null date" do
-    invoices(:draft_invoice).update_columns(date: nil)
-    year = Date.current.year
-    assert_not_includes Invoice.in_year(year), invoices(:draft_invoice)
-    assert_includes Invoice.in_year(year, include_drafts: true), invoices(:draft_invoice)
-  end
-
-  test "available_years returns distinct years with a non-null date, newest first" do
-    invoices(:draft_invoice).update_columns(date: Date.new(2020, 6, 1))
-    invoices(:license_invoice).update_columns(date: Date.new(2022, 4, 1))
-    invoices(:no_email_invoice).update_columns(date: nil)
-
-    years = Invoice.available_years
-    assert_equal years, years.uniq.sort.reverse
-    assert_includes years, 2020
-    assert_includes years, 2022
-    assert_not_includes years, nil
-  end
-
+  # in_year / available_years (YearFilterable concern) are covered by
+  # test/models/concerns/year_filterable_test.rb. The cross-team test below
+  # remains — it exercises visible_to interaction, not the concern itself.
   test "available_years honors the surrounding scope (no cross-team year leak)" do
     acme = teams(:acme)
     acme_customer = Customer.create!(

--- a/test/models/scoped_through_customer_test.rb
+++ b/test/models/scoped_through_customer_test.rb
@@ -59,32 +59,4 @@ class ScopedThroughCustomerTest < ActiveSupport::TestCase
     invoice = Invoice.new(customer: @other_customer, project: @other_project)
     assert invoice.valid?, invoice.errors.full_messages.inspect
   end
-
-  test "DeliveryNote.new rejects customer_id from a team Current.user can't see" do
-    Current.set(user: users(:bob)) do
-      dn = DeliveryNote.new(customer_id: @other_customer.id,
-                            delivery_start_date: Date.current)
-      refute dn.valid?
-      assert_includes dn.errors[:customer_id], "must be a customer you can access"
-    end
-  end
-
-  test "DeliveryNote.new rejects project_id from a team Current.user can't see" do
-    Current.set(user: users(:bob)) do
-      dn = DeliveryNote.new(customer: customers(:good_eu),
-                            project_id: @other_project.id,
-                            delivery_start_date: Date.current)
-      refute dn.valid?
-      assert_includes dn.errors[:project_id], "must be a project you can access"
-    end
-  end
-
-  test "DeliveryNote.new accepts customer_id from a team Current.user can see" do
-    Current.set(user: users(:bob)) do
-      dn = DeliveryNote.new(customer: customers(:good_eu),
-                            project: projects(:one),
-                            delivery_start_date: Date.current)
-      assert dn.valid?, dn.errors.full_messages.inspect
-    end
-  end
 end

--- a/test/system/line_management_test.rb
+++ b/test/system/line_management_test.rb
@@ -1,9 +1,12 @@
 require "application_system_test_case"
 
+# Line add/remove/reorder/type-visibility live in BaseLinesController and are
+# exercised through the Invoice routes here. DeliveryNote wires the same JS
+# the same way; we trust that and don't mirror these cases under DN.
+# DN-specific assertions (no [rate] input) live in delivery_note_lines_test.rb.
 class LineManagementTest < ApplicationSystemTestCase
   setup do
     @invoice = invoices(:draft_invoice)
-    @delivery_note = delivery_notes(:draft_delivery_note)
 
     # Add test lines to work with
     @invoice.invoice_lines.create!(
@@ -12,13 +15,6 @@ class LineManagementTest < ApplicationSystemTestCase
     )
     @invoice.invoice_lines.create!(
       type: "text", title: "Second Text", position: 2, amount: 0
-    )
-
-    @delivery_note.delivery_note_lines.create!(
-      type: "item", title: "First Delivery", position: 1, quantity: 5
-    )
-    @delivery_note.delivery_note_lines.create!(
-      type: "text", title: "Second Note", position: 2
     )
   end
 
@@ -32,19 +28,6 @@ class LineManagementTest < ApplicationSystemTestCase
     end
 
     # Persisted line should be hidden, not removed
-    assert_not first_line.visible?
-    destroy_field = first_line.find('input[name*="[_destroy]"]', visible: false)
-    assert_equal "1", destroy_field.value
-  end
-
-  test "removing persisted delivery note lines marks them for destruction" do
-    visit edit_delivery_note_path(@delivery_note)
-
-    first_line = first("[data-line-index]")
-    within first_line do
-      click_button "🗑"
-    end
-
     assert_not first_line.visible?
     destroy_field = first_line.find('input[name*="[_destroy]"]', visible: false)
     assert_equal "1", destroy_field.value
@@ -68,21 +51,6 @@ class LineManagementTest < ApplicationSystemTestCase
     assert_selector "[data-line-index]", count: initial_count
   end
 
-  test "removing new delivery note lines removes them from DOM" do
-    visit edit_delivery_note_path(@delivery_note)
-
-    initial_count = all("[data-line-index]").count
-    click_button "Add Line"
-    assert_selector "[data-line-index]", count: initial_count + 1
-
-    new_line = all("[data-line-index]").last
-    within new_line do
-      click_button "🗑"
-    end
-
-    assert_selector "[data-line-index]", count: initial_count
-  end
-
   # Test line reordering
   test "moving invoice lines up reorders them correctly" do
     visit edit_invoice_path(@invoice)
@@ -95,8 +63,6 @@ class LineManagementTest < ApplicationSystemTestCase
     within lines[1] do
       click_button "▲"
     end
-
-    sleep 0.1
 
     updated_lines = all("[data-line-index]")
     new_first_title = updated_lines[0].find('input[name*="[title]"]').value
@@ -122,29 +88,6 @@ class LineManagementTest < ApplicationSystemTestCase
       click_button "▼"
     end
 
-    sleep 0.1
-
-    updated_lines = all("[data-line-index]")
-    new_first_title = updated_lines[0].find('input[name*="[title]"]').value
-    new_second_title = updated_lines[1].find('input[name*="[title]"]').value
-
-    assert_equal second_title, new_first_title
-    assert_equal first_title, new_second_title
-  end
-
-  test "moving delivery note lines up reorders them correctly" do
-    visit edit_delivery_note_path(@delivery_note)
-
-    lines = all("[data-line-index]")
-    first_title = lines[0].find('input[name*="[title]"]').value
-    second_title = lines[1].find('input[name*="[title]"]').value
-
-    within lines[1] do
-      click_button "▲"
-    end
-
-    sleep 0.1
-
     updated_lines = all("[data-line-index]")
     new_first_title = updated_lines[0].find('input[name*="[title]"]').value
     new_second_title = updated_lines[1].find('input[name*="[title]"]').value
@@ -168,8 +111,6 @@ class LineManagementTest < ApplicationSystemTestCase
       click_button "▲"
     end
 
-    sleep 0.1
-
     # Check that field names have been reindexed correctly
     updated_lines = all("[data-line-index]")
     new_first = updated_lines[0].find('input[name*="[title]"]')[:name]
@@ -178,25 +119,6 @@ class LineManagementTest < ApplicationSystemTestCase
     # Field names should have changed (indicating reindexing occurred)
     assert_not_equal original_first, new_first
     assert_not_equal original_second, new_second
-  end
-
-  test "form field names are reindexed after reordering delivery note lines" do
-    visit edit_delivery_note_path(@delivery_note)
-
-    lines = all("[data-line-index]")
-    original_first = lines[0].find('input[name*="[title]"]')[:name]
-
-    within lines[1] do
-      click_button "▲"
-    end
-
-    sleep 0.1
-
-    updated_lines = all("[data-line-index]")
-    new_first = updated_lines[0].find('input[name*="[title]"]')[:name]
-
-    # Field name should have changed
-    assert_not_equal original_first, new_first
   end
 
   # Test line type field visibility
@@ -226,34 +148,6 @@ class LineManagementTest < ApplicationSystemTestCase
     end
   end
 
-  test "delivery note line field visibility changes with type selection" do
-    visit edit_delivery_note_path(@delivery_note)
-
-    click_button "Add Line"
-    new_line = all("[data-line-index]").last
-
-    within new_line do
-      type_select = find('select[name*="[type]"]')
-
-      # Test item type (default) - no rate field for delivery notes
-      assert_equal "item", type_select.value
-      assert_selector 'div[data-line-type-target="itemOnly"]', visible: true
-      assert_selector '[data-line-type-target="notSubheading"]', visible: true
-      assert_selector 'input[name*="[quantity]"]'
-      assert_no_selector 'input[name*="[rate]"]'  # Delivery notes don't have rates
-
-      # Test subheading type
-      select "Subheading", from: type_select[:name]
-      assert_selector 'div[data-line-type-target="itemOnly"]', visible: false
-      assert_selector '[data-line-type-target="notSubheading"]', visible: false
-
-      # Test text type
-      select "Text", from: type_select[:name]
-      assert_selector 'div[data-line-type-target="itemOnly"]', visible: false
-      assert_selector '[data-line-type-target="notSubheading"]', visible: true
-    end
-  end
-
   # Test total calculation for invoices (delivery notes don't have totals)
   test "invoice total updates when modifying line values" do
     visit edit_invoice_path(@invoice)
@@ -270,18 +164,14 @@ class LineManagementTest < ApplicationSystemTestCase
       find('input[name*="[rate]"]').native.send_keys(:tab)
     end
 
-    sleep 0.1
-
-    updated_total = total_element.text
-    assert_not_equal initial_total, updated_total
-
-    line_total = new_line.find("[data-line-total]").text
-    assert_equal "€60.00", line_total  # 3 × 20.00
+    # Capybara auto-waits on assert_selector with :text — wait for the line
+    # total to update before reading the running total.
+    assert_selector "[data-line-total]", text: "€60.00"
+    assert_not_equal initial_total, total_element.text
   end
 
   # Test removing the last line
-  test "can remove the last line from invoice and delivery note" do
-    # Test with invoice: Add one line, then remove it
+  test "can remove the last invoice line" do
     visit edit_invoice_path(@invoice)
 
     # Remove existing lines to get down to single line scenario
@@ -300,26 +190,6 @@ class LineManagementTest < ApplicationSystemTestCase
     end
 
     # Persisted line should be hidden but marked for destruction
-    hidden_line = first("[data-line-index]", visible: false)
-    destroy_field = hidden_line.find('input[name*="[_destroy]"]', visible: false)
-    assert_equal "1", destroy_field.value
-
-    # Test with delivery note: similar scenario
-    visit edit_delivery_note_path(@delivery_note)
-
-    # Remove all but one line
-    all("[data-line-index]")[1..-1].each do |line|
-      within line do
-        click_button "🗑"
-      end
-    end
-
-    # Remove the last line - should work now
-    within first("[data-line-index]") do
-      click_button "🗑"
-    end
-
-    # Should be marked for destruction
     hidden_line = first("[data-line-index]", visible: false)
     destroy_field = hidden_line.find('input[name*="[_destroy]"]', visible: false)
     assert_equal "1", destroy_field.value


### PR DESCRIPTION
## Summary
- Drop Invoice/DeliveryNote-side tests that mirror the canonical concern coverage (LineItem, PublishableDocument, YearFilterable, ScopedThroughCustomer).
- Net: 6 files changed, 23 insertions, 268 deletions.
- One previously-untested case (`require_unpublished` on `publish`) moved into `publishable_document_test.rb` before the duplicate was dropped.
- Removed `sleep 0.1` calls from the rewritten `line_management_test.rb` per the no-sleep policy.

## Test plan
- [x] `bundle exec rails test` — 673 runs, 2529 assertions, 0 failures
- [x] `bundle exec rails test test/system/` — 60 runs, 264 assertions, 0 failures
- [x] `pre-commit run --all-files` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)