### PR TITLE
Inline page title and accent style in application layout

### DIFF
--- a/app/assets/stylesheets/utilities.css.scss
+++ b/app/assets/stylesheets/utilities.css.scss
@@ -22,9 +22,9 @@
 .w-fixed-250 { width: 250px; }
 
 // --- Issuer accent theme helpers ---
-// The --issuer-accent-color variable is injected once by the application
-// layout via ApplicationHelper#issuer_accent_color_style, so these helpers
-// work on every page.
+// The --issuer-accent-color variable is injected once at the top of the
+// application layout (app/views/layouts/application.html.haml) so these
+// helpers work on every page.
 
 .text-issuer-accent {
   color: var(--issuer-accent-color) !important;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,15 +9,6 @@ module ApplicationHelper
     @current_currency ||= IssuerCompany.get_the_issuer!&.currency || "EUR"
   end
 
-  def page_title
-    issuer = IssuerCompany.get_the_issuer!
-    if issuer&.short_name.present?
-      "ABT: #{issuer.short_name}"
-    else
-      "ABT"
-    end
-  end
-
   def format_currency(amount)
     return "" if amount.nil?
     case current_currency
@@ -187,18 +178,5 @@ module ApplicationHelper
       "generic-email-preview-raw-preview-url-value" => send("preview_email_raw_#{prefix}_path", resource),
       "generic-email-preview-send-url-value" => send("send_email_#{prefix}_path", resource)
     }
-  end
-
-  # Emits a <style> tag in the layout head that sets the --issuer-accent-color
-  # CSS variable from the active IssuerCompany's document_accent_color. Returns
-  # nil (so the layout renders nothing) when no issuer or no accent color is
-  # configured. document_accent_color is validated against a hex pattern on
-  # the model; tag.style HTML-escapes the body as defense-in-depth so any
-  # bypass of that validation can't break out of the <style> context.
-  def issuer_accent_color_style
-    color = IssuerCompany.get_the_issuer!&.document_accent_color
-    return unless color.present?
-    tag.style ":root { --issuer-accent-color: #{color}; }",
-              nonce: content_security_policy_nonce
   end
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,13 +1,18 @@
 !!!
 %html
   %head
-    %title= content_for?(:title) ? yield(:title) : page_title
+    - issuer = IssuerCompany.get_the_issuer!
+    - default_title = issuer&.short_name.present? ? "ABT: #{issuer.short_name}" : "ABT"
+    %title= content_for?(:title) ? yield(:title) : default_title
     %meta{name: "robots", content: "noindex, nofollow"}
     = csrf_meta_tags
     = csp_meta_tag
     = favicon_link_tag 'favicon.svg', type: 'image/svg+xml'
     = stylesheet_link_tag    "application", :media => "all"
-    = issuer_accent_color_style
+    - if issuer&.document_accent_color.present?
+      -# document_accent_color is hex-validated on the model; tag.style HTML-escapes
+      -# the body as defense-in-depth against any bypass of that validation.
+      = tag.style ":root { --issuer-accent-color: #{issuer.document_accent_color}; }", nonce: content_security_policy_nonce
     = javascript_importmap_tags
     = javascript_tag nonce: true do
       :plain


### PR DESCRIPTION
## Summary
- `ApplicationHelper#page_title` and `#issuer_accent_color_style` each had a single caller (the layout) and each issued its own `IssuerCompany.get_the_issuer!` query.
- Read the active issuer once at the top of `app/views/layouts/application.html.haml`, inline both computations there, and delete the two helpers.
- Drops three identical `SELECT ... FROM issuer_companies` per page render to two. `current_currency` keeps its existing per-view-instance `@current_currency` ivar; collapsing to a single query was not worth a new `Current.issuer` accessor.

Fixes #368.

## Test plan
- [x] `bundle exec rails test test/integration/page_title_test.rb` — existing integration tests for the dynamic title still pass.
- [x] `bundle exec rails test` — full suite green (673 runs, 2529 assertions, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)