### PR TITLE
Prefill customer on "+ New" from customer-filtered lists

### DIFF
--- a/app/controllers/delivery_notes_controller.rb
+++ b/app/controllers/delivery_notes_controller.rb
@@ -71,7 +71,7 @@ class DeliveryNotesController < ApplicationController
 
   # GET /delivery_notes/new
   def new
-    @delivery_note = DeliveryNote.new
+    @delivery_note = DeliveryNote.new(customer_id: params[:customer_id].presence)
     set_form_options
   end
 

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -74,7 +74,7 @@ class InvoicesController < ApplicationController
 
   # GET /invoices/new
   def new
-    @invoice = Invoice.new
+    @invoice = Invoice.new(customer_id: params[:customer_id].presence)
     set_form_options
   end
 

--- a/app/views/delivery_notes/index.html.haml
+++ b/app/views/delivery_notes/index.html.haml
@@ -1,4 +1,4 @@
-= breadcrumbs 'Delivery Notes', action: action_button('+ New', new_delivery_note_path, permission: 'delivery_notes.edit')
+= breadcrumbs 'Delivery Notes', action: action_button('+ New', new_delivery_note_path(customer_id: @selected_customer_id), permission: 'delivery_notes.edit')
 
 
 .bulk-select-container{data: { controller: 'bulk-select' }}

--- a/app/views/invoices/index.html.haml
+++ b/app/views/invoices/index.html.haml
@@ -1,4 +1,4 @@
-= breadcrumbs 'Invoices', action: action_button('+ New', new_invoice_path, permission: 'invoices.edit')
+= breadcrumbs 'Invoices', action: action_button('+ New', new_invoice_path(customer_id: @selected_customer_id), permission: 'invoices.edit')
 
 
 .bulk-select-container{data: { controller: 'bulk-select' }}

--- a/test/controllers/invoices_controller_test.rb
+++ b/test/controllers/invoices_controller_test.rb
@@ -113,6 +113,13 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "new prefills customer when customer_id param is given" do
+    customer = customers(:good_eu)
+    get new_invoice_url(customer_id: customer.id)
+    assert_response :success
+    assert_select "input#invoice_customer_id[value=?]", customer.id.to_s
+  end
+
   test "should create invoice" do
     assert_difference("Invoice.count") do
       post invoices_url, params: {


### PR DESCRIPTION
## Summary
- When the invoices or delivery-notes list is filtered to a single customer, the breadcrumb **+ New** button now carries `customer_id` through to the new form, so the customer dropdown is preselected.
- Index views pass `customer_id: @selected_customer_id` to `new_invoice_path` / `new_delivery_note_path` (URL helpers drop the param when nil, so the unfiltered case is unchanged).
- `InvoicesController#new` / `DeliveryNotesController#new` build the record with `customer_id: params[:customer_id].presence`.
- The new-form customer dropdown already renders a prefilled customer correctly via `@invoice.customer_id` / `@delivery_note.customer_id`; no form changes.

## Test plan
- [x] `bundle exec rails test test/controllers/invoices_controller_test.rb` (new regression test asserting the hidden `invoice_customer_id` input is prefilled)
- [x] `bundle exec rails test test/controllers/delivery_notes_controller_test.rb` (no regressions)
- [ ] Manual: visit `/invoices`, filter to a customer, click **+ New** → dropdown shows that customer
- [ ] Manual: visit `/invoices` unfiltered, click **+ New** → dropdown shows "Select customer..."
- [ ] Manual: same two checks for `/delivery_notes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)