### PR TITLE
Expand bin/setup, fix FOP test path

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,25 @@ sudo apt-get install libatk1.0-0 libatk-bridge2.0-0 libdrm2 libgtk-3-0 libgbm1 l
 brew install libyaml
 ```
 
-### Ruby Dependencies
-```bash
-bundle install
-```
-
 ### Additional Software
 - Apache FOP 2.10 for PDF generation (run `./script/setup-fop.sh` for automated setup)
 - PostgreSQL (production)
 - Web server
 - Mailgun account for outbound email
 - Solid Queue worker (`bin/jobs`) for `deliver_later` and scheduled jobs (overdue-invoice reports, queue cleanup — see `config/recurring.yml`)
+
+
+Setup
+-----
+
+```bash
+bin/setup
+```
+
+Installs gems, sets up `config/database.yml`, prepares the dev and test databases, verifies the FOP container, and prints a signup invite URL. Idempotent. If FOP isn't built yet, run `script/setup-fop.sh`.
+
+Open the printed invite URL in a browser to register the first user (auto-promoted to Admin). Run tests with `bundle exec rails test`. For PostgreSQL instead of SQLite, see `docs/POSTGRES_DEV.md`.
+
 
 ### Pre-commit Hooks (Optional)
 For automatic whitespace cleanup and code quality checks:

--- a/bin/setup
+++ b/bin/setup
@@ -25,9 +25,19 @@ FileUtils.chdir APP_ROOT do
   puts "\n== Preparing database =="
   system! "bin/rails db:prepare"
 
+  puts "\n== Checking FOP container =="
+  if system("bin/abt-fop-container", "-version", out: File::NULL, err: File::NULL)
+    puts "FOP container OK."
+  else
+    puts "FOP container not available. Run script/setup-fop.sh to build it (needed for PDF rendering)."
+  end
+
   puts "\n== Removing old logs and tempfiles =="
   system! "bin/rails log:clear tmp:clear"
 
   puts "\n== Restarting application server =="
   system! "bin/rails restart"
+
+  puts "\n== Generating signup invite =="
+  system! "bin/rails users:invite"
 end

--- a/script/setup-fop.sh
+++ b/script/setup-fop.sh
@@ -56,7 +56,7 @@ echo "🎉 FOP setup complete!"
 echo ""
 
 echo "🧪 Testing Rails<->FOP integration..."
-if bundle exec rails test test/system/fop_installation_test.rb; then
+if bundle exec rails test test/integration/fop_installation_test.rb; then
   echo "✅ Rails<->FOP integration looks good."
 else
   echo "❌ Rails<->FOP integration needs checking."


### PR DESCRIPTION
## Summary
- `bin/setup` now probes the FOP container (non-fatal — points at `script/setup-fop.sh` if missing) and prints a signup invite URL as the last step, so a fresh checkout reaches a runnable state in one command.
- README replaces the standalone `bundle install` step with a brief Setup section pointing at `bin/setup`. Production-facing "Bootstrapping the first user" section unchanged.
- Fixes `script/setup-fop.sh` exiting with `Rails::TestUnit::InvalidTestError`: the integration test moved from `test/system/` to `test/integration/` in 9ce5d71 (Rails 8 alignment) but the script wasn't updated.

## Test plan
- [ ] `bin/setup` on a fresh checkout completes and prints an invite URL at the end
- [ ] `bin/setup` warns (but doesn't abort) when the FOP container isn't built
- [ ] `script/setup-fop.sh` runs end-to-end and the integration test step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)