### PR TITLE
PDF rendering: hide empty Reference/Order No, mark drafts, Austrian SEPA wording

### DIFF
--- a/app/services/delivery_note_renderer.rb
+++ b/app/services/delivery_note_renderer.rb
@@ -40,7 +40,7 @@ class DeliveryNoteRenderer
       end
 
       xml_root.prelude @delivery_note.prelude
-      xml_root.number(draft_aware_number)
+      xml_root.number draft_aware_number
       xml_root.tag! "issue-date", @delivery_note.date || "2999-01-01"
       xml_root.tag! "delivery-timeframe", @delivery_note.delivery_timeframe if @delivery_note.delivery_timeframe.present?
 

--- a/app/services/delivery_note_renderer.rb
+++ b/app/services/delivery_note_renderer.rb
@@ -40,7 +40,7 @@ class DeliveryNoteRenderer
       end
 
       xml_root.prelude @delivery_note.prelude
-      xml_root.number(@delivery_note.document_number || "DRAFT")
+      xml_root.number(draft_aware_number)
       xml_root.tag! "issue-date", @delivery_note.date || "2999-01-01"
       xml_root.tag! "delivery-timeframe", @delivery_note.delivery_timeframe if @delivery_note.delivery_timeframe.present?
 
@@ -79,5 +79,16 @@ class DeliveryNoteRenderer
     FopRenderer.new.render_pdf_with_logo("delivery_note.xsl", logo_data) do |logo_file_path|
       emit_xml(logo_file_path)
     end
+  end
+
+  private
+
+  # Drafts may carry a previously-assigned document number (numbers are
+  # issued from a gap-free sequence and survive unpublish), so check
+  # `published?` rather than the number's presence.
+  def draft_aware_number
+    return @delivery_note.document_number if @delivery_note.published?
+
+    ["DRAFT", @delivery_note.document_number].compact.join(" ")
   end
 end

--- a/app/services/delivery_note_renderer.rb
+++ b/app/services/delivery_note_renderer.rb
@@ -40,7 +40,7 @@ class DeliveryNoteRenderer
       end
 
       xml_root.prelude @delivery_note.prelude
-      xml_root.number @delivery_note.document_number
+      xml_root.number(@delivery_note.document_number || "DRAFT")
       xml_root.tag! "issue-date", @delivery_note.date || "2999-01-01"
       xml_root.tag! "delivery-timeframe", @delivery_note.delivery_timeframe if @delivery_note.delivery_timeframe.present?
 

--- a/app/services/delivery_note_renderer.rb
+++ b/app/services/delivery_note_renderer.rb
@@ -84,11 +84,10 @@ class DeliveryNoteRenderer
   private
 
   # Drafts may carry a previously-assigned document number (numbers are
-  # issued from a gap-free sequence and survive unpublish), so check
-  # `published?` rather than the number's presence.
+  # issued from a gap-free sequence and survive unpublish), but showing
+  # that number on the PDF is confusing — render "DRAFT" alone whenever
+  # the document is not published.
   def draft_aware_number
-    return @delivery_note.document_number if @delivery_note.published?
-
-    ["DRAFT", @delivery_note.document_number].compact.join(" ")
+    @delivery_note.published? ? @delivery_note.document_number : "DRAFT"
   end
 end

--- a/lib/foptemplate/delivery_note.xsl
+++ b/lib/foptemplate/delivery_note.xsl
@@ -131,36 +131,40 @@
                                             </fo:block>
                                         </fo:table-cell>
                                     </fo:table-row>
-                                    <fo:table-row line-height="130%">
-                                        <fo:table-cell>
-                                            <fo:block font-family="{$font-name-display}" xsl:use-attribute-sets="accent-color">
-                                                <xsl:choose>
-                                                    <xsl:when test="/document/language = 'de'">Ihr Zeichen:</xsl:when>
-                                                    <xsl:otherwise>Your Reference:</xsl:otherwise>
-                                                </xsl:choose>
-                                            </fo:block>
-                                        </fo:table-cell>
-                                        <fo:table-cell>
-                                            <fo:block>
-                                                <xsl:value-of select="/document/recipient/reference" />
-                                            </fo:block>
-                                        </fo:table-cell>
-                                    </fo:table-row>
-                                    <fo:table-row line-height="130%">
-                                        <fo:table-cell>
-                                            <fo:block font-family="{$font-name-display}" xsl:use-attribute-sets="accent-color">
-                                                <xsl:choose>
-                                                    <xsl:when test="/document/language = 'de'">Ihr Auftrag:</xsl:when>
-                                                    <xsl:otherwise>Your Order No:</xsl:otherwise>
-                                                </xsl:choose>
-                                            </fo:block>
-                                        </fo:table-cell>
-                                        <fo:table-cell>
-                                            <fo:block>
-                                                <xsl:value-of select="/document/recipient/order-no" />
-                                            </fo:block>
-                                        </fo:table-cell>
-                                    </fo:table-row>
+                                    <xsl:if test="normalize-space(/document/recipient/reference) != ''">
+                                        <fo:table-row line-height="130%">
+                                            <fo:table-cell>
+                                                <fo:block font-family="{$font-name-display}" xsl:use-attribute-sets="accent-color">
+                                                    <xsl:choose>
+                                                        <xsl:when test="/document/language = 'de'">Ihr Zeichen:</xsl:when>
+                                                        <xsl:otherwise>Your Reference:</xsl:otherwise>
+                                                    </xsl:choose>
+                                                </fo:block>
+                                            </fo:table-cell>
+                                            <fo:table-cell>
+                                                <fo:block>
+                                                    <xsl:value-of select="/document/recipient/reference" />
+                                                </fo:block>
+                                            </fo:table-cell>
+                                        </fo:table-row>
+                                    </xsl:if>
+                                    <xsl:if test="normalize-space(/document/recipient/order-no) != ''">
+                                        <fo:table-row line-height="130%">
+                                            <fo:table-cell>
+                                                <fo:block font-family="{$font-name-display}" xsl:use-attribute-sets="accent-color">
+                                                    <xsl:choose>
+                                                        <xsl:when test="/document/language = 'de'">Ihr Auftrag:</xsl:when>
+                                                        <xsl:otherwise>Your Order No:</xsl:otherwise>
+                                                    </xsl:choose>
+                                                </fo:block>
+                                            </fo:table-cell>
+                                            <fo:table-cell>
+                                                <fo:block>
+                                                    <xsl:value-of select="/document/recipient/order-no" />
+                                                </fo:block>
+                                            </fo:table-cell>
+                                        </fo:table-row>
+                                    </xsl:if>
                                     <xsl:if test="/document/recipient/supplier-no">
                                         <fo:table-row line-height="130%">
                                             <fo:table-cell>

--- a/lib/foptemplate/invoice.xsl
+++ b/lib/foptemplate/invoice.xsl
@@ -517,7 +517,7 @@
                             </fo:block-container>
                             <fo:block>
                                 <xsl:choose>
-                                    <xsl:when test="/document/language = 'de'">Bei Überweisungen von außerhalb des SEPA-Raums stellen Sie bitte sicher, dass der vollständige Betrag auf unserem Konto ankommt.</xsl:when>
+                                    <xsl:when test="/document/language = 'de'">Bei Überweisungen von außerhalb des SEPA-Raums stellen Sie bitte sicher, dass der vollständige Betrag auf unserem Konto einlangt.</xsl:when>
                                     <xsl:otherwise>For transfers from outside the SEPA region, please ensure the full amount reaches our account.</xsl:otherwise>
                                 </xsl:choose>
                             </fo:block>

--- a/lib/foptemplate/invoice.xsl
+++ b/lib/foptemplate/invoice.xsl
@@ -177,36 +177,40 @@
                                             </fo:block>
                                         </fo:table-cell>
                                     </fo:table-row>
-                                    <fo:table-row line-height="130%">
-                                        <fo:table-cell>
-                                            <fo:block font-family="{$font-name-display}" xsl:use-attribute-sets="accent-color">
-                                                <xsl:choose>
-                                                    <xsl:when test="/document/language = 'de'">Ihr Zeichen:</xsl:when>
-                                                    <xsl:otherwise>Your Reference:</xsl:otherwise>
-                                                </xsl:choose>
-                                            </fo:block>
-                                        </fo:table-cell>
-                                        <fo:table-cell>
-                                            <fo:block>
-                                                <xsl:value-of select="/document/recipient/reference" />
-                                            </fo:block>
-                                        </fo:table-cell>
-                                    </fo:table-row>
-                                    <fo:table-row line-height="130%">
-                                        <fo:table-cell>
-                                            <fo:block font-family="{$font-name-display}" xsl:use-attribute-sets="accent-color">
-                                                <xsl:choose>
-                                                    <xsl:when test="/document/language = 'de'">Ihr Auftrag:</xsl:when>
-                                                    <xsl:otherwise>Your Order No:</xsl:otherwise>
-                                                </xsl:choose>
-                                            </fo:block>
-                                        </fo:table-cell>
-                                        <fo:table-cell>
-                                            <fo:block>
-                                                <xsl:value-of select="/document/recipient/order-no" />
-                                            </fo:block>
-                                        </fo:table-cell>
-                                    </fo:table-row>
+                                    <xsl:if test="normalize-space(/document/recipient/reference) != ''">
+                                        <fo:table-row line-height="130%">
+                                            <fo:table-cell>
+                                                <fo:block font-family="{$font-name-display}" xsl:use-attribute-sets="accent-color">
+                                                    <xsl:choose>
+                                                        <xsl:when test="/document/language = 'de'">Ihr Zeichen:</xsl:when>
+                                                        <xsl:otherwise>Your Reference:</xsl:otherwise>
+                                                    </xsl:choose>
+                                                </fo:block>
+                                            </fo:table-cell>
+                                            <fo:table-cell>
+                                                <fo:block>
+                                                    <xsl:value-of select="/document/recipient/reference" />
+                                                </fo:block>
+                                            </fo:table-cell>
+                                        </fo:table-row>
+                                    </xsl:if>
+                                    <xsl:if test="normalize-space(/document/recipient/order-no) != ''">
+                                        <fo:table-row line-height="130%">
+                                            <fo:table-cell>
+                                                <fo:block font-family="{$font-name-display}" xsl:use-attribute-sets="accent-color">
+                                                    <xsl:choose>
+                                                        <xsl:when test="/document/language = 'de'">Ihr Auftrag:</xsl:when>
+                                                        <xsl:otherwise>Your Order No:</xsl:otherwise>
+                                                    </xsl:choose>
+                                                </fo:block>
+                                            </fo:table-cell>
+                                            <fo:table-cell>
+                                                <fo:block>
+                                                    <xsl:value-of select="/document/recipient/order-no" />
+                                                </fo:block>
+                                            </fo:table-cell>
+                                        </fo:table-row>
+                                    </xsl:if>
                                     <xsl:if test="normalize-space(/document/recipient/vat-id) != ''">
                                         <fo:table-row line-height="130%">
                                             <fo:table-cell>


### PR DESCRIPTION
## Summary
- Skip the "Your Reference" / "Your Order No" rows in invoice and delivery-note PDFs when the fields are empty (same `normalize-space(...) != ''` pattern already used for VAT ID).
- Render `DRAFT` in place of the document number on delivery-note PDFs whenever the document is not published. Keys off `published?`, not `document_number.nil?`, because numbers come from a gap-free sequence and can survive unpublish (see `require_unnumbered`).
- Replace `ankommt` with `einlangt` in the German SEPA payment note — Austrian business-German register, matching the rest of the document.

## Test plan
- [ ] Preview a draft delivery note with no document number → PDF shows `DRAFT` in the number slot.
- [ ] Preview a delivery note that was published then unpublished → PDF still shows `DRAFT` (not the old number).
- [ ] Published delivery note PDF → unchanged, shows its document number.
- [ ] Invoice and delivery-note PDFs with empty `cust_reference` / `cust_order` → no "Your Reference" / "Your Order No" row.
- [ ] Same documents with values present → both rows still render.
- [ ] German-language invoice PDF shows the new `einlangt` wording in the SEPA note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)