### PR TITLE
Extract code style guide to docs/code-style.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,160 +124,31 @@ For testing against PostgreSQL (matches production environment):
 - Auth flows: `app/controllers/sessions_controller.rb`, `invites_controller.rb`, `account/`, `users_controller.rb`
 - UI helpers: `app/helpers/application_helper.rb`
 
-## Development Preferences
+## Code Style
 
-### Template Language
-- Use HAML (`.html.haml`) for all view templates
+See [`docs/code-style.md`](docs/code-style.md) for the canonical style reference (HAML, Bootstrap, Stimulus, tests, status badges, action button glyphs, formatting, comments, commit messages). Read it before writing code.
 
-### UI Framework
-- Bootstrap 5 for responsive design and components
-- Turbo for SPA-like interactions without JavaScript complexity
-- Stimulus controllers for interactive components (bulk-select, email-preview)
-- European-style date/time formatting throughout
-- Strict Content Security Policy — no inline styles in views. Put styling in CSS/SCSS files and apply via classes. Inline `style="..."` attributes are only allowed in email templates (rendered HTML email, not subject to the app CSP).
-- Bootstrap's JavaScript is NOT bundled — only its CSS. JS-driven components (modals, popovers, dropdowns, collapses, JS tooltips) require a custom Stimulus controller; `data-bs-toggle` / `data-bs-target` attributes do nothing on their own.
-- Established pattern: manually toggle `d-none`/`show` classes from a Stimulus controller (see `app/javascript/controllers/generic_email_preview_controller.js` and `app/javascript/controllers/modal_controller.js`).
+UI helpers live in `app/helpers/application_helper.rb` (page chrome: `breadcrumbs`, `page_header`, `action_button`, `destroy_link`, `list_action_link`, `action_buttons_wrapper`) and `app/helpers/action_buttons_helper.rb` (per-verb wrappers: `delete_button`, `pdf_button`, `preview_button`, `publish_button`, `unpublish_button`, `unblock_button`, `reset_passkeys_button`, `audit_log_button`, `save_button`, `nav_button`). Read the source for signatures.
 
-### Status Badges
-- **Show only the deviation from the healthy default.** No badge means "normal."
-  - Customer/Project Inactive, User Blocked → badge. Active state → nothing.
-  - Invoice lifecycle (Draft, Booked, Paid, Overdue, Sent) and Delivery Note lifecycle (Draft, Published, Sent) all get header badges — there's no implicit "good" lifecycle, every state is noteworthy. Invoice's finalized state is labelled "Booked" (accounting term) even though the action that gets it there is "Publish"; delivery notes use "Published" for the same state.
-- **Hide superseded badges.** On invoices, the header drops "Booked" once a more specific state (Sent/Paid/Overdue) applies. Sent stacks with Paid/Overdue (email and payment are independent).
-- **In detail grids and list columns, healthy data renders as plain text, not a badge.** Paid (with date), Sent (with timestamp) → plain text. Problem states (Unpaid, Unsent, Overdue, No Recipient) keep their badges.
-- **Hide the status column entirely when a list is filtered to a single state.** On the customers and projects lists, the Status column is only rendered when the filter is "All"; when filtered to Active or Inactive the column would be redundant (every row identical or empty), so the header and cells are omitted.
-- Header badges sit inline with the active breadcrumb crumb (via the `breadcrumbs(...)` status block) at the default badge size — no `fs-` modifier needed.
+## Claude Operational Notes
 
-### Status-row Action Buttons
-- On document show pages, "act on this status" controls (Send E-Mail, Mark Paid…, Mark Unpaid) sit inline at the right edge of their status row's `col-sm-8`, separating the status text/badge on the left from the action on the right. The row container is `.col-sm-8.d-flex.align-items-center.gap-2`.
-- `ms-auto` must go on the actual flex child:
-  - Direct `%button` → put `ms-auto` on the button.
-  - Disabled-tooltip variant (a `%span` wrapping a disabled `%button`) → put `ms-auto` on the wrapping `%span`.
-  - `button_to` → the generated `<form class="button_to">` is the flex child, so `ms-auto` on the inner button has no effect. Pass it on the form instead: `button_to ..., form: { class: 'button_to ms-auto' }` (keep the `button_to` class — `bootstrap_and_overrides.css.scss` styles it).
-
-## Development Best Practices
+### Communication
+- Direct, technical language. No buzzwords ("leverage", "stakeholders", "going forward", "let's").
+- Concise. Imperative mood ("Run the test", not "We should run the test").
 
 ### Running rails
-- Always use `bundle exec rails` to run `rails`
+- Always `bundle exec rails ...`. Bare `rails test` skips migrations.
 
-### Testing Guidelines
-- Write simple unit tests when implementing new features
-- Test database auto-migrates via `ActiveRecord::Migration.maintain_test_schema!` in test_helper.rb
-- **NEVER use `assigns()` in tests** - use `assert_select` or other response testing methods instead
-- **Run UI tests headless by default before declaring frontend/UI tasks complete** when making frontend/UI changes
-- **NEVER use `sleep` in system tests** - use Capybara's waiting methods instead (`assert_selector`, `assert_text`, `assert_no_text` with `wait:` option)
+### Verifying UI work
+- Run system tests headless before declaring frontend tasks done: `bundle exec rails test test/system/`.
+- After Stimulus changes, run `npm run lint` (catches event-listener leaks).
 
-### UI Testing Commands
-- Run all system tests: `bundle exec rails test test/system/`
-- Run specific system test file: `bundle exec rails test test/system/filename_test.rb`
-- Run specific test method: `bundle exec rails test test/system/filename_test.rb -n test_method_name`
-- System tests use Cuprite (headless Chrome) driver configured in ApplicationSystemTestCase
-- Screenshots saved to `tmp/capybara/` on test failures for debugging
+### System administration
+- NEVER run `sudo`. If a system package is needed, explain what's needed and ask the user to install.
 
-### Multi-Region Compatibility
-- This app supports multiple regions - NEVER hardcode currency symbols like $ or USD
-- Use IssuerCompany.currency field for currency configuration (defaults to EUR)
-- Currency formatting handled by ApplicationHelper#format_currency
-- Date/datetime formatting: use Rails' `l(date)` / `l(time)` in views (or `I18n.l(...)` in controllers/models). Defaults are configured in `config/locales/en.yml` under `date.formats.default` (`%d.%m.%Y`) and `time.formats.default` (`%d.%m.%Y %H:%M`).
+### Git
+- NEVER check in screenshots or temporary image files.
+- Always run `pre-commit run --all-files` before committing.
 
-### Formatting Standards
-- ALWAYS use European date formats: DD.MM.YYYY for dates, DD.MM.YYYY HH:MM for datetimes
-- Use DD.MM for short dates when year is implied
-- NEVER use American MM/DD/YYYY or MM-DD formats
-- To render a `datetime` column as date-only (e.g. `email_sent_at` in compact list rows), call `l(value.to_date)` — `l` on a `Time`/`DateTime` produces the time format.
-
-### UI Helper Methods
-- Page titles use Rails' standard `- content_for :title, "..."` placed as the first line of the view (no "ABT:" prefix — that is the layout's fallback when no title is set). `breadcrumbs(...)` and `page_header(...)` auto-call `content_for :title` from their primary label when one hasn't been set yet, so most views can rely on the auto-derive. Set it explicitly when the breadcrumb's active crumb is too generic for a browser tab — concretely: every edit page (active crumb is `'Edit'`), every new page (`'New'`), and the invoice/delivery-note show pages (the bare `display_label` reads as just a number; use `display_name` for the prefixed "Invoice 20240017" / "Delivery Note 20240301" form). Edit pages use the SAME `content_for :title` line as their show-page counterpart — the tab title identifies which resource you're on; the page itself tells you you're in edit mode.
-- `breadcrumbs(*items, action: nil, actions: nil, &status_block)` - Bootstrap breadcrumb strip that serves as the page header on every index/show/edit/new page (every page except the dashboard, `/account/*`, the sign-in / invite-acceptance flow, and the post-publish confirmation). Each item is either `[label, path]` (link) or a plain label (non-link). The last item is always the active crumb with `aria-current="page"` (rendered `fw-semibold`), and it is the page identifier — there is no separate H1. Auto-calls `content_for :title` with the active crumb's label unless one has already been set. The optional block yields inline status badges next to the active crumb. The right cluster carries optional secondary `actions:` (array — `nil` entries are compacted out) followed by the primary `action:` (rightmost). Buttons are built with `action_button(...)` or the per-verb helpers from `ActionButtonsHelper` (see "Button Glyphs" below).
-  - Top-level resources start with the navbar label linked to its index: `['Customers', customers_path]`, `['Projects', projects_path]`, `['Delivery Notes', delivery_notes_path]`, `['Invoices', invoices_path]`.
-  - Configuration resources start with a non-link `'Configuration'` crumb (the dropdown has no destination) followed by the resource's navbar label, e.g. `breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], 'Edit'`.
-  - On edit pages append `'Edit'` as the active crumb; on new pages append `'New'`. On show pages the resource's identifier (matchcode / document number / name) is the active crumb.
-  - The bottom `action_buttons_wrapper` is gone from show pages — every workflow verb (PDF, Preview, Publish, Delete, etc.) moves into `actions:` on the breadcrumb. Status-row buttons (Send E-Mail, Mark Paid, Mark Unpaid, Publish Invoice…, Create invoice from delivery note) stay inline with their status row.
-  - Edit/new pages put `Save` in the breadcrumb's primary `action:` slot via `save_button` (see `ActionButtonsHelper`). There is no Cancel button — the breadcrumb's parent crumb is the way back without saving.
-- `page_header(title, action: nil, &status_block)` - Page-header row with an H1 title, optional inline status badges via the block, and optional right-aligned action. Auto-calls `content_for :title, title` unless a title has already been set. Only used on pages without breadcrumbs: dashboard (`home/index`), `/account/*`, the sign-in / invite-acceptance / "Invite generated" pages.
-- `action_button(text, path, type = :primary, permission: nil, target: nil, data: nil, title: nil)` - Styled buttons (primary, secondary, success, info, warning, danger). Returns `nil` when `permission:` is given and the current user lacks it. Pass `title:` on glyph-only buttons — the helper applies it as both `title=` (hover tooltip) and `aria-label=` (screen-reader name).
-- `action_buttons_wrapper` - Container for an inline action row. Skips emitting the wrapper when its block produces no content (so permission-gated children that all return `nil` don't leave an empty row). Remaining callsites: `invoices/_form` and `delivery_notes/_form` for the in-form `+ Add Line` button below the lines table, and `user_invites/show_invite` pending follow-up migration.
-- `destroy_link(resource, confirm_text)` - Compact `🗑` outline link for the **Actions** column on index pages. On detail pages use `delete_button(resource)` instead.
-- `list_action_link(text, path, type)` - Compact buttons for in-table row actions.
-- Per-verb helpers in `ActionButtonsHelper` (`delete_button`, `pdf_button`, `preview_button`, `publish_button`, `unpublish_button`, `unblock_button`, `reset_passkeys_button`, `audit_log_button`, `save_button`) — see "Button Glyphs" below for the full mapping and policy.
-- `save_button(label: "Save", permission: nil)` (in `ActionButtonsHelper`) — the primary submit button on every edit/new page, lives in the breadcrumb's `action:` slot. Submits the page's main form via the HTML5 `form="page-form"` attribute, so the form partial must set `html: { id: ActionButtonsHelper::PAGE_FORM_ID }` (or `id: ActionButtonsHelper::PAGE_FORM_ID` for `form_with`). Each edit/new page has exactly one page-level form; override locally if a future template needs a second.
-- `nav_button(text, path, permission: nil, data: nil)` (in `ActionButtonsHelper`) — cross-resource navigation in the breadcrumb action cluster (e.g. customer show → its Invoices/Delivery Notes; sales-tax rates → Customer/Product Classes). Renders `btn-outline-secondary` so nav reads as quiet/link-ish and yields visual prominence to the page's primary action. Don't reach for filled variants for cross-resource navigation — use `nav_button` instead.
-
-### Button Glyphs (Show-page Actions)
-
-Glyphs on action buttons are space-savers, not decoration. Three tiers:
-
-- **Text only** when the label is already short and universally clear: `Edit`, `+ New`, `Save`, `Reset passkeys`. Don't prefix with a glyph.
-- **Glyph + text** for less-familiar workflow actions where the glyph aids scanning but the text is still required: `🚀 Publish`, `📥 Upload PDF`, etc.
-- **Glyph only with `title:`** for actions whose glyph is universally understood and whose label is fully replaceable: `🗑` Delete, `📄` PDF, `👁` Preview. Always pass `title:` to set both the hover tooltip and the screen-reader `aria-label`.
-
-Label-shortening rule: when a glyph already carries the verb concept and the remaining noun/state is clear, drop the leading verb in the label. So `Mark Paid` → `✅ Paid` (✅ = the verb, "Paid" = the state). Keep `🚀 Publish`, `📥 Upload PDF` full when the verb/object isn't carried by the glyph alone.
-
-Glyph reuse is intentional when the action archetype is the same:
-- 🚀 = "promote forward" (Publish + Create invoice from delivery note)
-- ✅ = "positive state change" (Paid + Unblock)
-- ↩ / ↩️ = "revert state" (Unpaid + Unpublish) — Unicode-distinct but visually similar; they never coexist on the same page
-
-Established mapping — extend this table; don't invent new glyphs for existing verbs:
-
-| Verb | Render | Tier | Helper |
-|---|---|---|---|
-| Edit | `Edit` | text-only | `action_button` |
-| + New | `+ New` | text-only | `action_button` |
-| Save | `Save` | text-only | `save_button` |
-| Reset passkeys | `Reset passkeys` | text-only | `reset_passkeys_button` |
-| Delete | `🗑` (title "Delete") | glyph-only | `delete_button` |
-| PDF | `📄` (title "PDF") | glyph-only | `pdf_button` |
-| Preview | `👁` (title "Preview") | glyph-only | `preview_button` |
-| Mark Paid | `✅ Paid` | glyph + shortened text | (status-row, inline) |
-| Mark Unpaid | `↩ Unpaid` | glyph + shortened text | (status-row, inline) |
-| Send e-mail | `✉️ Send` | glyph + text | (status-row, inline) |
-| Publish | `🚀 Publish` | glyph + text | `publish_button` |
-| Unpublish | `↩️ Unpublish` | glyph + text | `unpublish_button` |
-| Convert to Invoice | `🚀 Create…` | glyph + text | (status-row, inline) |
-| Upload PDF | `📥 Upload PDF` | glyph + text | (form, inline) |
-| Block | `🚫 Block` | glyph + text | (form-with-reason, inline) |
-| Unblock | `✅ Unblock` | glyph + text | `unblock_button` |
-| Audit log | `📋 Audit log` | glyph + text | `audit_log_button` |
-
-### JavaScript/Stimulus Controllers
-- **ALWAYS implement `disconnect()` method** in Stimulus controllers that add event listeners
-- Store bound function references (e.g., `this.boundHandler = this.method.bind(this)`) for proper cleanup
-- Remove event listeners in `disconnect()` using the same bound reference used in `addEventListener`
-- When re-attaching listeners to dynamically created elements, remove existing listeners first to prevent duplicates
-- Document event listeners are particularly important to clean up to prevent memory leaks
-- **Run `npm run lint` after writing Stimulus controllers** to check for event listener memory leaks
-- **NEVER use relative imports** like `import Controller from "./other_controller"` - use importmap paths like `import Controller from "controllers/other_controller"` to ensure proper resolution in production
-- **NEVER hardcode absolute URL paths** in JavaScript - use Rails URL helpers passed via data attributes to ensure proper subdirectory deployment compatibility
-
-### Communication Style
-- Use direct, technical language in all communications
-- Avoid management/business buzzwords and corporate speak
-- Be concise and specific rather than verbose or promotional
-- Focus on technical implementation details rather than high-level benefits
-- Use imperative mood for instructions (e.g. "Run the test" not "We should run the test")
-- Avoid phrases like "let's", "we need to", "going forward", "best practices", "leverage", "stakeholders"
-- Be factual and precise rather than enthusiastic or salesy
-
-### Code Quality
-- Follow DRY when refactoring or fixing bugs, but don't overdo it
-- Prefer clarity and maintainability over excessive abstraction
-
-### Git Commit Message Style
-- Use concise, direct subject lines (e.g. "Auto-resize textareas")
-- Brief functional description in body (one sentence explaining main functionality)
-- Key implementation details as short, factual bullet points
-- Include practical context when relevant (demo content, examples)
-- Maintain Claude Code attribution footer
-- Avoid verbose technical explanations or excessive detail in commit messages
-
-### System Administration
-- **NEVER run `sudo` commands**
-- If system packages need to be installed, explain what is needed and ask the user to install them
-
-### Git and Version Control
-- **NEVER check in screenshots or temporary image files**
-- Use `.gitignore` to exclude temporary files and screenshots from commits
-
-### Development Commands
-- **ALWAYS run `pre-commit run --all-files` before committing** to ensure code formatting and linting
-- **Use `pkill -f puma` to kill running `rails server`** when needed to stop development server
+### Development server
+- `pkill -f puma` to stop a running `rails server`.

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -1,0 +1,102 @@
+# Code Style
+
+The canonical style reference for this repo. Project structure, architecture, models, and tooling commands live in `CLAUDE.md`.
+
+## Tests
+- One scenario per `test "..." do` block — minimal setup, focused assertions, no leading comment (the name is the explanation).
+- Use `assert_select` and response assertions. Never `assigns()`.
+- Skip pixel-position / `getBoundingClientRect` system tests for CSS class tweaks.
+- A shared one-line fix across `Invoice`/`DeliveryNote` gets its regression test in one place, not both.
+- When adding or refactoring code, delete now-redundant nearby tests in the same change.
+- System tests wait with Capybara matchers (`assert_selector`, `assert_text`) — never `sleep`.
+
+## Stimulus / JavaScript
+- ES modules; `import Controller from "controllers/..."` — importmap paths, never relative.
+- Bind handlers once in `connect()` (`this.boundX = this.x.bind(this)`); remove the same reference in `disconnect()`. Re-attaching to dynamic elements? Remove existing listeners first to prevent duplicates.
+- Bootstrap modals / dropdowns / collapses / popovers need a Stimulus controller — toggle `d-none`/`show` manually. Bootstrap JS isn't bundled; `data-bs-toggle` does nothing on its own.
+- Never hardcode URL paths in JS — pass them in via data attributes from Rails URL helpers.
+
+## Views (HAML + Bootstrap 5)
+- HAML for every template (`.html.haml`). No `.erb`.
+- No inline `style="..."` — strict CSP. Put rules in `app/assets/stylesheets/*.scss`, apply by class. Mail templates are the only exception.
+- Non-dashboard / non-account pages use `breadcrumbs(...)` as the page header — no separate `<h1>`. Edit/new pages put the primary submit in `action:` via `save_button`. No Cancel button — the parent crumb is the way back.
+- Page titles: rely on `breadcrumbs` / `page_header` auto-deriving `content_for :title` from the active crumb. Override with an explicit `- content_for :title, "..."` only when the crumb is too generic for a browser tab (Edit/New pages; invoice/delivery-note show pages where the bare number isn't a useful label — use `display_name` for the prefixed form).
+
+## Status badges
+- Show only deviation from the healthy default. Active/normal renders no badge in headers and as plain text in tables.
+- Lifecycle states (Draft, Booked, Published, Sent, Paid, Overdue) all get header badges — no state is implicitly "good".
+- Hide superseded badges: Invoice header drops "Booked" once Sent/Paid/Overdue applies. Sent stacks with Paid/Overdue (email and payment are independent).
+- Hide a list's Status column when filtered to a single state (column would be redundant).
+- Empty optional fields render nothing — no blank labels in detail grids or PDFs.
+
+## Status-row action buttons (show pages)
+- "Act on this status" controls (Send E-Mail, Mark Paid…, Mark Unpaid, Convert to Invoice) sit at the right edge of their status row's `.col-sm-8.d-flex.align-items-center.gap-2`.
+- `ms-auto` goes on the actual flex child:
+  - Plain `%button` → on the button itself.
+  - Disabled-tooltip variant (`%span` wrapping a disabled `%button`) → on the wrapping `%span`.
+  - `button_to` → on the generated `<form>`: `button_to ..., form: { class: 'button_to ms-auto' }`. Keep `button_to` — `bootstrap_and_overrides.css.scss` styles it.
+
+## Action button glyphs
+Three tiers:
+- **Text only** when the label is short and universally clear (`Edit`, `+ New`, `Save`, `Reset passkeys`) — no glyph prefix.
+- **Glyph + text** for less-familiar workflow actions (`🚀 Publish`, `📥 Upload PDF`, `🚫 Block`).
+- **Glyph only** for universally-understood verbs. Always pass `title:` (sets tooltip + `aria-label`): `🗑` Delete, `📄` PDF, `👁` Preview.
+
+When the glyph carries the verb, drop the leading verb from the label: `Mark Paid` → `✅ Paid`, `Mark Unpaid` → `↩ Unpaid`. Keep verb+object when the glyph alone isn't enough.
+
+Reuse glyphs for the same archetype — don't invent new ones:
+- 🚀 promote forward (Publish, Create invoice from delivery note)
+- ✅ positive state change (Paid, Unblock)
+- ↩ / ↩️ revert state (Unpaid, Unpublish) — Unicode-distinct but visually similar; never coexist on the same page
+
+Established mapping — extend it, don't invent new glyphs for existing verbs:
+
+| Verb | Render | Helper |
+|---|---|---|
+| Edit | `Edit` | `action_button` |
+| + New | `+ New` | `action_button` |
+| Save | `Save` | `save_button` |
+| Reset passkeys | `Reset passkeys` | `reset_passkeys_button` |
+| Delete | `🗑` | `delete_button` |
+| PDF | `📄` | `pdf_button` |
+| Preview | `👁` | `preview_button` |
+| Mark Paid | `✅ Paid` | (status-row, inline) |
+| Mark Unpaid | `↩ Unpaid` | (status-row, inline) |
+| Send e-mail | `✉️ Send` | (status-row, inline) |
+| Publish | `🚀 Publish` | `publish_button` |
+| Unpublish | `↩️ Unpublish` | `unpublish_button` |
+| Convert to Invoice | `🚀 Create…` | (status-row, inline) |
+| Upload PDF | `📥 Upload PDF` | (form, inline) |
+| Block | `🚫 Block` | (form-with-reason, inline) |
+| Unblock | `✅ Unblock` | `unblock_button` |
+| Audit log | `📋 Audit log` | `audit_log_button` |
+
+For cross-resource navigation in a breadcrumb action cluster, use `nav_button` (outline-secondary). Don't reach for filled variants for nav.
+
+## Controllers
+- Permission gates: `before_action -> { require_permission!("scope.verb") }, only: [...]`.
+- Read through tenant scopes (`Model.visible_to(current_user)`).
+- On validation failure: `render :new`/`:edit, status: :unprocessable_content`. On success: `redirect_to`, optionally with `notice:`.
+- Production absolute URLs go through `AbsoluteUrl`. Don't set `default_url_options`.
+
+## Errors & UX
+- Never `window.location.reload()` / meta-refresh / JS redirect when the server rejects a form/XHR (CSRF, session, auth). Surface the server's `error` field; the user clicks Reload.
+- CSRF rescue lives in `ApplicationController#handle_invalid_authenticity_token` — don't replace it with a redirect.
+
+## Formatting
+- Dates: `DD.MM.YYYY` via `l(date)`; datetimes `DD.MM.YYYY HH:MM` via `l(time)`. Use `l(value.to_date)` to render a datetime as date-only. `DD.MM` (short) when the year is implied. Never American formats.
+- Currency: never hardcode `$` / `€` / `EUR`. Use `format_currency(amount)`; symbol comes from `IssuerCompany.currency`.
+
+## Layout judgment
+- Don't call a multi-column card layout imbalanced by card count — judge by realistic per-column rendered height. List-bound cards (sessions, audit events, line items) grow with data and naturally fill a column.
+
+## Comments
+- Default to none. Add a one-liner only when the *why* isn't obvious from the code (workaround, invariant, hidden constraint).
+- Don't reference the current PR/task in comments — that belongs in the PR description.
+
+## Code quality
+- DRY when refactoring or fixing, but don't overdo it. Prefer clarity and maintainability over excessive abstraction.
+
+## Commit messages
+- Subject: concise, direct (e.g. "Auto-resize textareas").
+- Body: one functional sentence, plus short factual bullets if needed. No verbose explanations.


### PR DESCRIPTION
## Summary
- Move HAML/Bootstrap/Stimulus/test/badge/action-button/formatting conventions out of `CLAUDE.md` into a standalone `docs/code-style.md` (102 lines, self-contained).
- Trim `CLAUDE.md` by ~130 lines: keep project structure, architecture, dependencies, and Claude-only tooling directives (`bundle exec rails`, `pre-commit`, `npm run lint`, no `sudo`, no screenshots, `pkill puma`), plus a one-line pointer to the new doc.
- Tooling commands stay Claude-only — `docs/code-style.md` is style for humans and doesn't dictate how to run tools.

## Test plan
- [ ] `CLAUDE.md` still reads cleanly with the style sections replaced by the pointer.
- [ ] `docs/code-style.md` is a complete style reference on its own (no broken references back to `CLAUDE.md`).
- [ ] Action-button glyph table renders correctly on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)