### PR TITLE
Install pre-commit hooks from bin/setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,21 +46,19 @@ Open the printed invite URL in a browser to register the first user (auto-promot
 
 
 ### Pre-commit Hooks (Optional)
-For automatic whitespace cleanup and code quality checks:
+Install `pre-commit` to enable the hooks defined in `.pre-commit-config.yaml`:
 ```bash
-# Install pre-commit
 # Debian/Ubuntu:
 sudo apt install pre-commit
 # macOS with Homebrew:
 brew install pre-commit
 # or with pip:
 pip install pre-commit
+```
 
-# Install the hooks (run from repository root)
+`bin/setup` runs `pre-commit install` automatically when the `pre-commit` binary is on `PATH`. To install hooks without rerunning setup:
+```bash
 pre-commit install
-
-# Optional: run on all existing files
-pre-commit run --all-files
 ```
 
 

--- a/bin/setup
+++ b/bin/setup
@@ -32,6 +32,13 @@ FileUtils.chdir APP_ROOT do
     puts "FOP container not available. Run script/setup-fop.sh to build it (needed for PDF rendering)."
   end
 
+  puts "\n== Installing pre-commit hooks =="
+  if system("pre-commit", "--version", out: File::NULL, err: File::NULL)
+    system "pre-commit", "install"
+  else
+    puts "pre-commit not installed. See README.md for instructions."
+  end
+
   puts "\n== Removing old logs and tempfiles =="
   system! "bin/rails log:clear tmp:clear"
 


### PR DESCRIPTION
## Summary
- `bin/setup` now detects `pre-commit` and runs `pre-commit install` when present; prints a README pointer when not. Mirrors the existing FOP container check.
- README's "Pre-commit Hooks (Optional)" section reworded to point at `.pre-commit-config.yaml` for the hook list and to mention the new auto-install in `bin/setup`.

## Test plan
- [x] `ruby -c bin/setup` clean
- [x] `pre-commit run --all-files` clean
- [x] Dry-run of new block exercises both branches (binary present → `pre-commit install` runs; binary absent → hint printed)
- [ ] First-time `bin/setup` on a fresh clone installs the hook without manual intervention when `pre-commit` is on PATH

🤖 Generated with [Claude Code](https://claude.com/claude-code)