### PR TITLE
Add structured country_iso2 to issuer + customers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,3 +65,6 @@ gem "webauthn", "~> 3.4"
 
 # Rate-limit unauthenticated endpoints to mitigate brute-force and DoS attacks.
 gem "rack-attack", "~> 6.7"
+
+# ISO 3166 country list and EU/EEA membership data for the country dropdown.
+gem "countries", "~> 7.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,8 @@ GEM
     cose (1.3.1)
       cbor (~> 0.5.9)
       openssl-signature_algorithm (~> 1.0)
+    countries (7.1.1)
+      unaccent (~> 0.3)
     crass (1.0.6)
     cuprite (0.17)
       capybara (~> 3.0)
@@ -396,6 +398,7 @@ GEM
       railties (>= 7.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unaccent (0.4.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
@@ -441,6 +444,7 @@ DEPENDENCIES
   brakeman
   capybara
   config
+  countries (~> 7.0)
   cuprite
   debug
   haml-rails

--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -92,7 +92,7 @@ class CustomersController < ApplicationController
 private
   def customers_params
     params.require(:customer).permit(
-        :matchcode, :name, :address, :vat_id, :supplier_number, :notes, :sales_tax_customer_class_id, :language_id, :payment_terms_days,
+        :matchcode, :name, :address, :country_iso2, :vat_id, :supplier_number, :notes, :sales_tax_customer_class_id, :language_id, :payment_terms_days,
         :invoice_email_auto_to, :invoice_email_auto_subject_template, :invoice_email_auto_enabled, :invoice_email_auto_contact_mode, :active,
         :team_id
     )

--- a/app/controllers/issuer_companies_controller.rb
+++ b/app/controllers/issuer_companies_controller.rb
@@ -66,7 +66,7 @@ class IssuerCompaniesController < ApplicationController
 
   def issuer_company_params
     params.require(:issuer_company).permit(
-      :short_name, :legal_name, :vat_id, :address,
+      :short_name, :legal_name, :vat_id, :address, :country_iso2,
       :bankaccount_bank, :bankaccount_bic, :bankaccount_number,
       :document_contact_line1, :document_contact_line2,
       :document_accent_color,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -170,6 +170,21 @@ module ApplicationHelper
     Rails.application.config.x.app_version
   end
 
+  def country_options
+    @country_options ||= ISO3166::Country.all
+      .map { |c| [ c.iso_short_name, c.alpha2 ] }
+      .sort_by { |name, _| name }
+  end
+
+  def country_name(code)
+    return nil if code.blank?
+    ISO3166::Country.new(code)&.iso_short_name || code
+  end
+
+  def country_unknown?(code)
+    !AddressFormatter.valid_iso2?(code)
+  end
+
   # Stimulus data attributes that wire an element up to the
   # generic-email-preview controller for a given Invoice or DeliveryNote.
   # Relies on the routes following the {action}_{resource}_path convention.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -177,8 +177,7 @@ module ApplicationHelper
   end
 
   def country_name(code)
-    return nil if code.blank?
-    ISO3166::Country.new(code)&.iso_short_name || code
+    AddressFormatter.country_name(code)
   end
 
   def country_unknown?(code)

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -4,6 +4,7 @@ class Customer < ApplicationRecord
 
   validates :name, presence: true
   validates :vat_id, presence: true, if: -> { sales_tax_customer_class&.vat_id_required? }
+  validates :country_iso2, presence: true, inclusion: { in: ISO3166::Country.codes, message: "must be a valid country" }
 
   # Set default language (English) for new customers
   before_validation :set_default_language, on: :create

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -89,6 +89,7 @@ class Invoice < ApplicationRecord
 
     problems << "Customer name is missing." if customer_name.blank?
     problems << "Customer address is missing." if customer_address.blank?
+    problems << "Customer country is missing." unless AddressFormatter.valid_iso2?(customer_country_iso2)
     if customer&.sales_tax_customer_class&.vat_id_required? && customer_vat_id.blank?
       problems << "Customer VAT ID is missing."
     end
@@ -185,6 +186,7 @@ private
     self.customer.reload
     self.customer_name = self.customer.name
     self.customer_address = self.customer.address
+    self.customer_country_iso2 = self.customer.country_iso2
     self.customer_account_number = self.customer.id
     self.customer_supplier_number = self.customer.supplier_number
     self.customer_vat_id = self.customer.vat_id

--- a/app/models/issuer_company.rb
+++ b/app/models/issuer_company.rb
@@ -1,6 +1,7 @@
 class IssuerCompany < ApplicationRecord
   validates :short_name, presence: true
   validates :legal_name, presence: true
+  validates :country_iso2, presence: true, inclusion: { in: ISO3166::Country.codes, message: "must be a valid country" }
   validates :document_accent_color,
             format: { with: /\A#[0-9a-fA-F]{3,8}\z/, message: "must be a hex color like #rrggbb" },
             allow_blank: true

--- a/app/services/address_formatter.rb
+++ b/app/services/address_formatter.rb
@@ -1,0 +1,21 @@
+class AddressFormatter
+  # Sentinel written by the country backfill migrations when no country could
+  # be inferred from existing address text. Not a valid ISO 3166-1 alpha-2
+  # code — `valid_iso2?` rejects it, so the renderer and publish_problems
+  # treat ZZ-rows the same as any other invalid country.
+  UNKNOWN_COUNTRY = "ZZ"
+
+  def self.build(name:, address:, self_country:, other_country:)
+    lines = [ name, address ]
+    lines << country_name(self_country) if self_country != other_country
+    lines.compact.join("\n")
+  end
+
+  def self.valid_iso2?(code)
+    ISO3166::Country.codes.include?(code)
+  end
+
+  def self.country_name(code)
+    ISO3166::Country.new(code)&.iso_short_name
+  end
+end

--- a/app/services/delivery_note_renderer.rb
+++ b/app/services/delivery_note_renderer.rb
@@ -20,8 +20,16 @@ class DeliveryNoteRenderer
         xml_root.tag! "logo-width", @issuer.pdf_logo_width
         xml_root.tag! "logo-height", @issuer.pdf_logo_height
       end
+      issuer_country = @issuer.country_iso2
+      recipient_country = @delivery_note.customer.country_iso2
+
       xml_root.issuer do |xml_issuer|
-        xml_issuer.address @issuer.legal_name + "\n" + @issuer.address
+        xml_issuer.address AddressFormatter.build(
+          name: @issuer.legal_name,
+          address: @issuer.address,
+          self_country: issuer_country,
+          other_country: recipient_country
+        )
         xml_issuer.tag! "short-name", @issuer.short_name
         xml_issuer.tag! "legal-name", @issuer.legal_name
         xml_issuer.tag! "vat-id", @issuer.vat_id
@@ -33,7 +41,12 @@ class DeliveryNoteRenderer
         xml_recipient.tag! "order-no", @delivery_note.cust_order
         xml_recipient.reference @delivery_note.cust_reference
 
-        xml_recipient.address @delivery_note.customer.name + "\n" + @delivery_note.customer.address
+        xml_recipient.address AddressFormatter.build(
+          name: @delivery_note.customer.name,
+          address: @delivery_note.customer.address,
+          self_country: recipient_country,
+          other_country: issuer_country
+        )
         xml_recipient.tag! "account-no", @delivery_note.customer.id
         xml_recipient.tag! "vat-id", @delivery_note.customer.vat_id
         xml_recipient.tag! "supplier-no", @delivery_note.customer.supplier_number if @delivery_note.customer.supplier_number.present?

--- a/app/services/invoice_renderer.rb
+++ b/app/services/invoice_renderer.rb
@@ -21,8 +21,16 @@ class InvoiceRenderer
         xml_root.tag! "logo-width", @issuer.pdf_logo_width
         xml_root.tag! "logo-height", @issuer.pdf_logo_height
       end
+      issuer_country = @issuer.country_iso2
+      recipient_country = @invoice.customer_country_iso2
+
       xml_root.issuer do |xml_issuer|
-        xml_issuer.address @issuer.legal_name + "\n" + @issuer.address
+        xml_issuer.address AddressFormatter.build(
+          name: @issuer.legal_name,
+          address: @issuer.address,
+          self_country: issuer_country,
+          other_country: recipient_country
+        )
         xml_issuer.tag! "short-name", @issuer.short_name
         xml_issuer.tag! "legal-name", @issuer.legal_name
         xml_issuer.tag! "vat-id", @issuer.vat_id
@@ -39,7 +47,12 @@ class InvoiceRenderer
         xml_recipient.tag! "order-no", @invoice.cust_order
         xml_recipient.reference @invoice.cust_reference
 
-        xml_recipient.address @invoice.customer_name + "\n" + @invoice.customer_address
+        xml_recipient.address AddressFormatter.build(
+          name: @invoice.customer_name,
+          address: @invoice.customer_address,
+          self_country: recipient_country,
+          other_country: issuer_country
+        )
         xml_recipient.tag! "account-no", @invoice.customer_account_number
         xml_recipient.tag! "vat-id", @invoice.customer_vat_id
         xml_recipient.tag! "supplier-no", @invoice.customer_supplier_number if @invoice.customer_supplier_number.present?

--- a/app/views/customers/_form.html.haml
+++ b/app/views/customers/_form.html.haml
@@ -35,6 +35,10 @@
       .col-lg-5
         = f.text_area :address, :class => 'form-control', :rows => 3
     .row.mb-3
+      = f.label :country_iso2, 'Country', required: true, class: 'col-lg-2 col-md-3 col-form-label'
+      .col-sm-5
+        = f.select :country_iso2, country_options, { prompt: 'Select country...' }, { class: 'form-select', required: true }
+    .row.mb-3
       = f.label :vat_id, 'VATID', class: 'col-lg-2 col-md-3 col-form-label'
       .col-sm-5
         = f.text_field :vat_id, :class => 'form-control'

--- a/app/views/customers/show.html.haml
+++ b/app/views/customers/show.html.haml
@@ -31,6 +31,15 @@
 
         .row.mb-2
           .col-sm-4
+            %strong Country:
+          .col-sm-8
+            - if country_unknown?(@customer.country_iso2)
+              %span.badge.bg-warning.text-dark Not set
+            - else
+              = country_name(@customer.country_iso2)
+
+        .row.mb-2
+          .col-sm-4
             %strong VAT ID:
           .col-sm-8
             = @customer.vat_id

--- a/app/views/customers/show.html.haml
+++ b/app/views/customers/show.html.haml
@@ -27,7 +27,8 @@
           .col-sm-4
             %strong Address:
           .col-sm-8
-            = simple_format(@customer.address)
+            - @customer.address.split("\n").each do |line|
+              %div= line
 
         .row.mb-2
           .col-sm-4

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -52,6 +52,7 @@
             - @data[:issuer_company].address.split("\n").each do |line|
               - unless line.strip.empty?
                 %div= line.strip
+            %div= AddressFormatter.country_name(@data[:issuer_company].country_iso2)
 
         .mb-2
           %strong VAT ID:

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -50,8 +50,7 @@
           %strong Address:
           %div
             - @data[:issuer_company].address.split("\n").each do |line|
-              - unless line.strip.empty?
-                %div= line.strip
+              %div= line
             %div= AddressFormatter.country_name(@data[:issuer_company].country_iso2)
 
         .mb-2

--- a/app/views/issuer_companies/edit.html.haml
+++ b/app/views/issuer_companies/edit.html.haml
@@ -37,6 +37,10 @@
             = form.label :address, 'Address', class: 'form-label'
             = form.text_area :address, rows: 4, class: 'form-control'
 
+          .mb-3
+            = form.label :country_iso2, 'Country', class: 'form-label'
+            = form.select :country_iso2, country_options, { prompt: 'Select country...' }, { class: 'form-select', required: true }
+
     .col-md-6
       .card
         .card-header

--- a/app/views/issuer_companies/show.html.haml
+++ b/app/views/issuer_companies/show.html.haml
@@ -36,6 +36,15 @@
           .col-sm-8
             = simple_format(@issuer_company.address)
 
+        .row.mb-2
+          .col-sm-4
+            %strong Country:
+          .col-sm-8
+            - if country_unknown?(@issuer_company.country_iso2)
+              %span.badge.bg-warning.text-dark Not set
+            - else
+              = country_name(@issuer_company.country_iso2)
+
   .col-md-6
     .card
       .card-header

--- a/app/views/issuer_companies/show.html.haml
+++ b/app/views/issuer_companies/show.html.haml
@@ -34,7 +34,8 @@
           .col-sm-4
             %strong Address:
           .col-sm-8
-            = simple_format(@issuer_company.address)
+            - @issuer_company.address.split("\n").each do |line|
+              %div= line
 
         .row.mb-2
           .col-sm-4

--- a/app/views/layouts/mailer.html.haml
+++ b/app/views/layouts/mailer.html.haml
@@ -99,5 +99,6 @@
               .company-name= @issuer.legal_name
               - @issuer.address.split("\n").each do |line|
                 .address-line= line
+              .address-line= AddressFormatter.country_name(@issuer.country_iso2)
             - if @issuer.png_logo.present?
               %img.company-logo{src: "data:image/png;base64,#{Base64.encode64(@issuer.png_logo).gsub(/\n/, '')}", alt: @issuer.legal_name}

--- a/app/views/layouts/mailer.text.haml
+++ b/app/views/layouts/mailer.text.haml
@@ -4,3 +4,4 @@
   = @issuer.legal_name
   - @issuer.address.split("\n").each do |line|
     = line
+  = AddressFormatter.country_name(@issuer.country_iso2)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,6 +43,16 @@ en:
   activerecord:
     models:
       delivery_note: "Delivery Note"
+    # country_iso2 is a 2-letter ISO 3166-1 alpha-2 code under the hood. Users
+    # just see "Country" — the column suffix is a schema-level clarification,
+    # not a UI label.
+    attributes:
+      customer:
+        country_iso2: "Country"
+      issuer_company:
+        country_iso2: "Country"
+      invoice:
+        customer_country_iso2: "Customer country"
 
   # Override Rails' default belongs_to required message ("must exist"),
   # which reads as a database/lookup error to end users. Required

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,8 +51,6 @@ en:
         country_iso2: "Country"
       issuer_company:
         country_iso2: "Country"
-      invoice:
-        customer_country_iso2: "Customer country"
 
   # Override Rails' default belongs_to required message ("must exist"),
   # which reads as a database/lookup error to end users. Required

--- a/db/migrate/20260527005332_add_country_iso2_to_issuer_companies_and_customers.rb
+++ b/db/migrate/20260527005332_add_country_iso2_to_issuer_companies_and_customers.rb
@@ -1,0 +1,61 @@
+class AddCountryIso2ToIssuerCompaniesAndCustomers < ActiveRecord::Migration[8.1]
+  UNKNOWN = "ZZ"
+
+  class MigrationIssuerCompany < ActiveRecord::Base
+    self.table_name = "issuer_companies"
+  end
+
+  class MigrationCustomer < ActiveRecord::Base
+    self.table_name = "customers"
+  end
+
+  def up
+    add_column :issuer_companies, :country_iso2, :string, limit: 2,
+      comment: "ISO 3166-1 alpha-2 country code, or 'ZZ' (unknown) for rows that pre-date the structured country column"
+    add_column :customers, :country_iso2, :string, limit: 2,
+      comment: "ISO 3166-1 alpha-2 country code, or 'ZZ' (unknown) for rows that pre-date the structured country column"
+
+    name_lookup = build_name_lookup
+
+    [ MigrationIssuerCompany, MigrationCustomer ].each do |klass|
+      klass.find_each do |row|
+        code, stripped_address = detect_country(row.address, name_lookup)
+        row.update_columns(
+          country_iso2: code || UNKNOWN,
+          address: code ? stripped_address : row.address
+        )
+      end
+    end
+
+    change_column_null :issuer_companies, :country_iso2, false
+    change_column_null :customers, :country_iso2, false
+  end
+
+  def down
+    remove_column :customers, :country_iso2
+    remove_column :issuer_companies, :country_iso2
+  end
+
+  private
+
+  def build_name_lookup
+    require "countries"
+    lookup = {}
+    ISO3166::Country.all.each do |country|
+      names = [ country.iso_short_name, country.common_name, *country.unofficial_names ].compact
+      names.each { |n| lookup[n.downcase.strip] = country.alpha2 }
+    end
+    lookup
+  end
+
+  def detect_country(address, name_lookup)
+    return [ nil, address ] if address.blank?
+    lines = address.split(/\r?\n/)
+    last = lines.last.to_s.strip
+    return [ nil, address ] if last.empty?
+    code = name_lookup[last.downcase]
+    return [ nil, address ] unless code
+    lines.pop
+    [ code, lines.join("\n").rstrip ]
+  end
+end

--- a/db/migrate/20260527005356_add_customer_country_iso2_snapshot_to_invoices.rb
+++ b/db/migrate/20260527005356_add_customer_country_iso2_snapshot_to_invoices.rb
@@ -1,0 +1,56 @@
+class AddCustomerCountryIso2SnapshotToInvoices < ActiveRecord::Migration[8.1]
+  UNKNOWN = "ZZ"
+
+  class MigrationInvoice < ActiveRecord::Base
+    self.table_name = "invoices"
+  end
+
+  class MigrationCustomer < ActiveRecord::Base
+    self.table_name = "customers"
+  end
+
+  def up
+    add_column :invoices, :customer_country_iso2, :string, limit: 2,
+      comment: "Snapshot of customer.country_iso2 at draft time; frozen on publish."
+
+    customer_countries = MigrationCustomer.pluck(:id, :country_iso2).to_h
+    name_lookup = build_name_lookup
+
+    MigrationInvoice.find_each do |invoice|
+      iso2 = customer_countries[invoice.customer_id] || UNKNOWN
+      stripped = strip_country_line(invoice.customer_address, name_lookup)
+      invoice.update_columns(
+        customer_country_iso2: iso2,
+        customer_address: stripped
+      )
+    end
+
+    change_column_null :invoices, :customer_country_iso2, false
+  end
+
+  def down
+    remove_column :invoices, :customer_country_iso2
+  end
+
+  private
+
+  def build_name_lookup
+    require "countries"
+    lookup = {}
+    ISO3166::Country.all.each do |country|
+      names = [ country.iso_short_name, country.common_name, *country.unofficial_names ].compact
+      names.each { |n| lookup[n.downcase.strip] = country.alpha2 }
+    end
+    lookup
+  end
+
+  def strip_country_line(address, name_lookup)
+    return address if address.blank?
+    lines = address.split(/\r?\n/)
+    last = lines.last.to_s.strip
+    return address if last.empty?
+    return address unless name_lookup[last.downcase]
+    lines.pop
+    lines.join("\n").rstrip
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_26_180000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_27_005356) do
   create_table "attachments", force: :cascade do |t|
     t.string "content_type"
     t.datetime "created_at", null: false
@@ -43,6 +43,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_26_180000) do
   create_table "customers", force: :cascade do |t|
     t.boolean "active", default: true, null: false
     t.text "address"
+    t.string "country_iso2", limit: 2, null: false
     t.datetime "created_at", null: false
     t.string "invoice_email_auto_contact_mode", default: "replace_contacts", null: false
     t.boolean "invoice_email_auto_enabled", default: false, null: false
@@ -179,6 +180,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_26_180000) do
     t.string "cust_reference"
     t.text "customer_account_number"
     t.text "customer_address"
+    t.string "customer_country_iso2", limit: 2, null: false
     t.integer "customer_id"
     t.text "customer_name"
     t.text "customer_supplier_number"
@@ -210,6 +212,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_26_180000) do
     t.string "bankaccount_bank"
     t.string "bankaccount_bic"
     t.string "bankaccount_number"
+    t.string "country_iso2", limit: 2, null: false
     t.datetime "created_at", null: false
     t.string "currency", default: "EUR", null: false
     t.string "document_accent_color"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -101,8 +101,8 @@ if Rails.env.development?
     issuer.address = <<~ADDRESS.strip
       Businessstraat 123
       1234 AB Amsterdam
-      Netherlands
     ADDRESS
+    issuer.country_iso2 = 'NL'
     issuer.vat_id = 'NL123456789B01'
     issuer.bankaccount_bank = "My Bank B.V."
     issuer.bankaccount_bic = "BICBICBICBIC"
@@ -135,8 +135,8 @@ if Rails.env.development?
     customer.address = <<~ADDRESS.strip
       Ulica Podhalańska 2
       80-322 Gdańsk
-      Poland
     ADDRESS
+    customer.country_iso2 = 'PL'
     customer.vat_id = 'PL0123456789'
     customer.notes = 'Long-term client, monthly invoicing'
     customer.sales_tax_customer_class = eu_class
@@ -153,8 +153,8 @@ if Rails.env.development?
     customer.address = <<~ADDRESS.strip
       Businessstraat 123
       1234 AB Amsterdam
-      Netherlands
     ADDRESS
+    customer.country_iso2 = 'NL'
     customer.vat_id = 'NL123456789B01'
     customer.notes = 'Project-based work'
     customer.sales_tax_customer_class = national_class
@@ -167,8 +167,8 @@ if Rails.env.development?
     customer.address = <<~ADDRESS.strip
       123 Business Ave
       New York, NY 10001
-      United States
     ADDRESS
+    customer.country_iso2 = 'US'
     customer.notes = 'US-based client, quarterly invoicing'
     customer.sales_tax_customer_class = export_class
     customer.language = english
@@ -182,8 +182,8 @@ if Rails.env.development?
     customer.address = <<~ADDRESS.strip
       Hauptstraße 1
       1010 Wien
-      Austria
     ADDRESS
+    customer.country_iso2 = 'AT'
     customer.vat_id = 'ATU99999999'
     customer.notes = 'Engagement ended 2024'
     customer.sales_tax_customer_class = eu_class

--- a/test/controllers/attachments_controller_test.rb
+++ b/test/controllers/attachments_controller_test.rb
@@ -39,6 +39,8 @@ class AttachmentsControllerTest < ActionDispatch::IntegrationTest
       matchcode: "OUT",
       name: "Outside Co.",
       vat_id: "EU141414141",
+
+      country_iso2: "NL",
       sales_tax_customer_class: sales_tax_customer_classes(:eu),
       language: languages(:english),
       team: other_team

--- a/test/controllers/customer_contacts_controller_test.rb
+++ b/test/controllers/customer_contacts_controller_test.rb
@@ -106,6 +106,8 @@ class CustomerContactsControllerTest < ActionDispatch::IntegrationTest
     other_customer = Customer.create!(
       matchcode: "ISO", name: "Iso Co",
       vat_id: "EU131313131",
+
+      country_iso2: "NL",
       sales_tax_customer_class: sales_tax_customer_classes(:eu),
       language: languages(:english),
       team: other_team

--- a/test/controllers/customers_controller_test.rb
+++ b/test/controllers/customers_controller_test.rb
@@ -45,6 +45,7 @@ class CustomersControllerTest < ActionDispatch::IntegrationTest
           matchcode: "TEST123",
           name: "Test Company",
           vat_id: "EU181818181",
+          country_iso2: "NL",
           sales_tax_customer_class_id: @customer.sales_tax_customer_class_id,
           team_id: teams(:default).id
         }
@@ -59,6 +60,7 @@ class CustomersControllerTest < ActionDispatch::IntegrationTest
       matchcode: "UNUSED",
       name: "Unused Customer",
       vat_id: "EU191919191",
+      country_iso2: "NL",
       sales_tax_customer_class: @customer.sales_tax_customer_class,
       team: teams(:default)
     )
@@ -92,6 +94,7 @@ class CustomersControllerTest < ActionDispatch::IntegrationTest
       matchcode: "UNUSED2",
       name: "Another Unused Customer",
       vat_id: "EU202020202",
+      country_iso2: "NL",
       sales_tax_customer_class: @customer.sales_tax_customer_class,
       team: teams(:default)
     )
@@ -108,6 +111,7 @@ class CustomersControllerTest < ActionDispatch::IntegrationTest
       matchcode: "INACTIVE",
       name: "Inactive Customer",
       vat_id: "EU212121212",
+      country_iso2: "NL",
       active: false,
       sales_tax_customer_class: @customer.sales_tax_customer_class,
       team: teams(:default)

--- a/test/controllers/teams_controller_test.rb
+++ b/test/controllers/teams_controller_test.rb
@@ -36,6 +36,8 @@ class TeamsControllerTest < ActionDispatch::IntegrationTest
       matchcode: "IN_USE_TEAM",
       name: "In Use",
       vat_id: "EU151515151",
+
+      country_iso2: "NL",
       sales_tax_customer_class: sales_tax_customer_classes(:eu),
       language: languages(:english),
       team: teams(:acme)

--- a/test/fixtures/customers.yml
+++ b/test/fixtures/customers.yml
@@ -4,7 +4,7 @@ good_eu:
   address: |
     Lulzstreet 3/2/1
     LH234234 Shiphol
-    European Union
+  country_iso2: BE
   vat_id: EU99999999
   notes: MyText
   sales_tax_customer_class: eu
@@ -18,7 +18,7 @@ good_national:
   address: |
     Lulzstreet 3/2/1
     LH234234 Heathrow
-    NATIONAL COUNTRY
+  country_iso2: NL
   vat_id: NAT9999999
   notes:
   sales_tax_customer_class: national
@@ -32,7 +32,7 @@ auto_email_customer:
   address: |
     456 Auto Street
     12345 Email City
-    EMAIL COUNTRY
+  country_iso2: NL
   vat_id: AUTO123456
   invoice_email_auto_enabled: true
   invoice_email_auto_to: billing@autoemail.com
@@ -49,7 +49,7 @@ no_email_customer:
   address: |
     789 Silent Street
     99999 Quiet Town
-    NO EMAIL COUNTRY
+  country_iso2: DE
   vat_id: NOEMAIL789
   sales_tax_customer_class: eu
   language: english

--- a/test/fixtures/invoices.yml
+++ b/test/fixtures/invoices.yml
@@ -1,5 +1,6 @@
 published_invoice:
   customer: good_eu
+  customer_country_iso2: BE
   project: one
   attachment: invoice_pdf
   document_number: "INV-2024-001"
@@ -15,6 +16,7 @@ published_invoice:
 
 auto_email_invoice:
   customer: auto_email_customer
+  customer_country_iso2: NL
   project: two
   attachment: auto_email_pdf
   document_number: "INV-2024-002"
@@ -30,6 +32,7 @@ auto_email_invoice:
 
 no_email_invoice:
   customer: no_email_customer
+  customer_country_iso2: DE
   project: one
   attachment: invoice_pdf
   document_number: "INV-2024-003"
@@ -44,6 +47,7 @@ no_email_invoice:
 
 draft_invoice:
   customer: good_national
+  customer_country_iso2: NL
   project: two
   document_number: null
   published: false
@@ -55,6 +59,7 @@ draft_invoice:
 
 license_invoice:
   customer: good_national
+  customer_country_iso2: NL
   project: one
   document_number: null
   published: false

--- a/test/fixtures/issuer_companies.yml
+++ b/test/fixtures/issuer_companies.yml
@@ -8,7 +8,7 @@ one:
   address: |
     Randostraat 3
     1324 Somewhere
-    The Netherlands
+  country_iso2: NL
   bankaccount_bank: My Bank B.V.
   bankaccount_bic: BICBICBICBIC
   bankaccount_number: NL91ABNA0417164300

--- a/test/integration/invoice_language_test.rb
+++ b/test/integration/invoice_language_test.rb
@@ -14,6 +14,8 @@ class InvoiceLanguageTest < ActionDispatch::IntegrationTest
       matchcode: "ENG",
       address: "123 English Street\nLondon, UK",
       vat_id: "EN123456789",
+
+      country_iso2: "NL",
       sales_tax_customer_class: sales_tax_customer_classes(:national),
       language: languages(:english),
       team: teams(:default)
@@ -47,6 +49,8 @@ class InvoiceLanguageTest < ActionDispatch::IntegrationTest
       matchcode: "DEU",
       address: "Musterstraße 123\n12345 Berlin, Deutschland",
       vat_id: "DE987654321",
+
+      country_iso2: "NL",
       sales_tax_customer_class: sales_tax_customer_classes(:national),
       language: languages(:german),
       team: teams(:default)
@@ -78,6 +82,8 @@ class InvoiceLanguageTest < ActionDispatch::IntegrationTest
     english_customer = Customer.create!(
       name: "English Customer", matchcode: "ENG1", address: "English Address",
       vat_id: "EN111111111",
+
+      country_iso2: "NL",
       sales_tax_customer_class: sales_tax_customer_classes(:national),
       language: languages(:english),
       team: teams(:default)
@@ -86,6 +92,8 @@ class InvoiceLanguageTest < ActionDispatch::IntegrationTest
     german_customer = Customer.create!(
       name: "German Customer", matchcode: "GER1", address: "German Address",
       vat_id: "DE222222222",
+
+      country_iso2: "NL",
       sales_tax_customer_class: sales_tax_customer_classes(:national),
       language: languages(:german),
       team: teams(:default)
@@ -121,7 +129,8 @@ class InvoiceLanguageTest < ActionDispatch::IntegrationTest
     export_customer = Customer.create!(
       name: "USA Corporation Inc.",
       matchcode: "USACORP_TEST",
-      address: "123 Business Ave\nNew York, NY 10001\nUnited States",
+      address: "123 Business Ave\nNew York, NY 10001",
+      country_iso2: "US",
       sales_tax_customer_class: sales_tax_customer_classes(:restoftheworld),
       language: languages(:english),
       team: teams(:default)
@@ -146,6 +155,8 @@ class InvoiceLanguageTest < ActionDispatch::IntegrationTest
       matchcode: "TEST",
       address: "Test Address",
       vat_id: "EN111111111",
+
+      country_iso2: "NL",
       sales_tax_customer_class: sales_tax_customer_classes(:national),
       team: teams(:default)
     )

--- a/test/models/customer_contact_test.rb
+++ b/test/models/customer_contact_test.rb
@@ -73,6 +73,8 @@ class CustomerContactTest < ActiveSupport::TestCase
     other_customer = Customer.create!(
       matchcode: "OTH", name: "Other",
       vat_id: "EU101010101",
+
+      country_iso2: "NL",
       sales_tax_customer_class: sales_tax_customer_classes(:eu),
       language: languages(:english),
       team: other_team
@@ -101,6 +103,8 @@ class CustomerContactTest < ActiveSupport::TestCase
     other_customer = Customer.create!(
       matchcode: "VOTH", name: "Visibility Other",
       vat_id: "EU121212121",
+
+      country_iso2: "NL",
       sales_tax_customer_class: sales_tax_customer_classes(:eu),
       language: languages(:english),
       team: other_team

--- a/test/models/customer_team_scoping_test.rb
+++ b/test/models/customer_team_scoping_test.rb
@@ -11,6 +11,8 @@ class CustomerTeamScopingTest < ActiveSupport::TestCase
       matchcode: "ACME_ONLY",
       name: "Acme Only",
       vat_id: "EU111111111",
+
+      country_iso2: "NL",
       sales_tax_customer_class: sales_tax_customer_classes(:eu),
       language: languages(:english),
       team: teams(:acme)
@@ -32,6 +34,8 @@ class CustomerTeamScopingTest < ActiveSupport::TestCase
         matchcode: "AS_BOB",
         name: "Bob Customer",
         vat_id: "EU222222222",
+
+        country_iso2: "NL",
         sales_tax_customer_class: sales_tax_customer_classes(:eu),
         language: languages(:english),
         team: teams(:acme)
@@ -46,6 +50,8 @@ class CustomerTeamScopingTest < ActiveSupport::TestCase
         matchcode: "BAD_BOB",
         name: "Bob Bad",
         vat_id: "EU333333333",
+
+        country_iso2: "NL",
         sales_tax_customer_class: sales_tax_customer_classes(:eu),
         language: languages(:english),
         team: other_team
@@ -64,6 +70,8 @@ class CustomerTeamScopingTest < ActiveSupport::TestCase
         matchcode: "AS_ALICE",
         name: "Alice Customer",
         vat_id: "EU444444444",
+
+        country_iso2: "NL",
         sales_tax_customer_class: sales_tax_customer_classes(:eu),
         language: languages(:english),
         team: other_team
@@ -80,6 +88,8 @@ class CustomerTeamScopingTest < ActiveSupport::TestCase
       matchcode: "SYS",
       name: "System Customer",
       vat_id: "EU555555555",
+
+      country_iso2: "NL",
       sales_tax_customer_class: sales_tax_customer_classes(:eu),
       language: languages(:english),
       team: other_team

--- a/test/models/customer_test.rb
+++ b/test/models/customer_test.rb
@@ -6,6 +6,7 @@ class CustomerTest < ActiveSupport::TestCase
       matchcode: "TEST",
       name: "Test Customer",
       vat_id: "EU000000000",
+      country_iso2: "NL",
       sales_tax_customer_class: sales_tax_customer_classes(:eu),
       language: languages(:english),
       team: teams(:default),
@@ -42,6 +43,19 @@ class CustomerTest < ActiveSupport::TestCase
     customer = build_customer(name: nil)
     assert_not customer.valid?
     assert_includes customer.errors[:name], "can't be blank"
+  end
+
+  test "requires country_iso2" do
+    customer = build_customer(country_iso2: nil)
+    assert_not customer.valid?
+    assert_includes customer.errors[:country_iso2], "can't be blank"
+  end
+
+  test "rejects ZZ sentinel and other non-ISO country codes" do
+    [ "ZZ", "XX", "GERMANY", "" ].each do |bad|
+      customer = build_customer(country_iso2: bad)
+      assert_not customer.valid?, "expected #{bad.inspect} to be invalid"
+    end
   end
 
   test "requires vat_id when its sales_tax_customer_class requires one" do

--- a/test/models/invoice_test.rb
+++ b/test/models/invoice_test.rb
@@ -69,13 +69,14 @@ class InvoiceTest < ActiveSupport::TestCase
 
   test "update_customer copies customer fields to the draft invoice on save" do
     invoice = invoices(:draft_invoice)
-    invoice.customer.update!(supplier_number: "SUP-001")
+    invoice.customer.update!(supplier_number: "SUP-001", country_iso2: "AT")
     invoice.save!
     assert_equal invoice.customer.name, invoice.customer_name
     assert_equal invoice.customer.address, invoice.customer_address
     assert_equal invoice.customer.id, invoice.customer_account_number.to_i
     assert_equal invoice.customer.vat_id, invoice.customer_vat_id
     assert_equal "SUP-001", invoice.customer_supplier_number
+    assert_equal "AT", invoice.customer_country_iso2
     assert_equal invoice.customer.payment_terms_days, invoice.payment_terms_days
     assert_equal invoice.customer.sales_tax_customer_class.invoice_note, invoice.tax_note
   end
@@ -147,6 +148,12 @@ class InvoiceTest < ActiveSupport::TestCase
     assert_includes invoice.publish_problems, "Customer address is missing."
   end
 
+  test "publish_problems reports an unknown customer country" do
+    invoice = license_invoice_with_tax_config
+    invoice.update_columns(customer_country_iso2: AddressFormatter::UNKNOWN_COUNTRY)
+    assert_includes invoice.publish_problems, "Customer country is missing."
+  end
+
   test "publish_problems reports a missing VAT ID when the customer class requires one" do
     invoice = license_invoice_with_tax_config # uses good_national (vat_id_required)
     invoice.update_columns(customer_vat_id: nil)
@@ -182,6 +189,7 @@ class InvoiceTest < ActiveSupport::TestCase
       matchcode: "ACME_YEAR_LEAK",
       name: "Acme Year Leak",
       vat_id: "EU161616161",
+      country_iso2: "AT",
       sales_tax_customer_class: sales_tax_customer_classes(:eu),
       language: languages(:english),
       team: acme

--- a/test/models/issuer_company_test.rb
+++ b/test/models/issuer_company_test.rb
@@ -15,21 +15,21 @@ class IssuerCompanyTest < ActiveSupport::TestCase
 
   test "document_accent_color accepts hex colors of 3, 4, 6, and 8 hex digits" do
     [ "#abc", "#ABCD", "#aabbcc", "#AABBCCDD" ].each do |color|
-      company = IssuerCompany.new(short_name: "X", legal_name: "Y", document_accent_color: color)
+      company = IssuerCompany.new(short_name: "X", legal_name: "Y", country_iso2: "NL", document_accent_color: color)
       assert company.valid?, "expected color=#{color} to be valid"
     end
   end
 
   test "document_accent_color rejects non-hex values" do
     [ "red", "#xyz", "3366cc", "#12" ].each do |color|
-      company = IssuerCompany.new(short_name: "X", legal_name: "Y", document_accent_color: color)
+      company = IssuerCompany.new(short_name: "X", legal_name: "Y", country_iso2: "NL", document_accent_color: color)
       assert_not company.valid?, "expected color=#{color} to be invalid"
       assert_includes company.errors[:document_accent_color], "must be a hex color like #rrggbb"
     end
   end
 
   test "document_accent_color is optional" do
-    company = IssuerCompany.new(short_name: "X", legal_name: "Y", document_accent_color: nil)
+    company = IssuerCompany.new(short_name: "X", legal_name: "Y", country_iso2: "NL", document_accent_color: nil)
     assert company.valid?
     company.document_accent_color = ""
     assert company.valid?

--- a/test/models/project_team_scoping_test.rb
+++ b/test/models/project_team_scoping_test.rb
@@ -6,6 +6,8 @@ class ProjectTeamScopingTest < ActiveSupport::TestCase
       matchcode: "ACME_CUST",
       name: "Acme Co.",
       vat_id: "EU666666666",
+
+      country_iso2: "NL",
       sales_tax_customer_class: sales_tax_customer_classes(:eu),
       language: languages(:english),
       team: teams(:acme)
@@ -41,6 +43,8 @@ class ProjectTeamScopingTest < ActiveSupport::TestCase
       matchcode: "ACME_CUST2",
       name: "Acme 2",
       vat_id: "EU777777777",
+
+      country_iso2: "NL",
       sales_tax_customer_class: sales_tax_customer_classes(:eu),
       language: languages(:english),
       team: teams(:acme)

--- a/test/models/sales_tax_customer_class_test.rb
+++ b/test/models/sales_tax_customer_class_test.rb
@@ -25,7 +25,8 @@ class SalesTaxCustomerClassTest < ActiveSupport::TestCase
       sales_tax_customer_class: klass,
       language: languages(:english),
       team: teams(:default),
-      vat_id: "EU171717171"
+      vat_id: "EU171717171",
+      country_iso2: "NL"
     )
     assert_raises(ActiveRecord::DeleteRestrictionError) { klass.destroy }
   end

--- a/test/models/scoped_through_customer_test.rb
+++ b/test/models/scoped_through_customer_test.rb
@@ -14,6 +14,8 @@ class ScopedThroughCustomerTest < ActiveSupport::TestCase
       matchcode: "OTHER",
       name: "Other Co",
       vat_id: "EU888888888",
+
+      country_iso2: "NL",
       sales_tax_customer_class: sales_tax_customer_classes(:eu),
       language: languages(:english),
       team: @other_team

--- a/test/models/team_test.rb
+++ b/test/models/team_test.rb
@@ -26,6 +26,8 @@ class TeamTest < ActiveSupport::TestCase
       matchcode: "INUSE",
       name: "In Use Co.",
       vat_id: "EU999999999",
+
+      country_iso2: "NL",
       sales_tax_customer_class: sales_tax_customer_classes(:eu),
       language: languages(:english),
       team: team

--- a/test/services/invoice_publisher_test.rb
+++ b/test/services/invoice_publisher_test.rb
@@ -33,6 +33,8 @@ class InvoicePublisherTest < ActiveSupport::TestCase
       name: "Default Customer",
       address: "789 Default St",
       vat_id: "VAT456",
+
+      country_iso2: "NL",
       sales_tax_customer_class: sales_tax_customer_classes(:eu)
     )
 

--- a/test/services/invoice_renderer_test.rb
+++ b/test/services/invoice_renderer_test.rb
@@ -29,4 +29,24 @@ class InvoiceRendererTest < ActiveSupport::TestCase
     pdf = InvoiceRenderer.new(@invoice, @issuer).render
     assert pdf.start_with?("%PDF"), "expected a PDF (got #{pdf[0, 16].inspect})"
   end
+
+  test "omits country line on both sender and recipient when they share a country" do
+    @invoice.update_columns(customer_country_iso2: @issuer.country_iso2)
+    xml = InvoiceRenderer.new(@invoice, @issuer).emit_xml(nil)
+    assert_no_match %r{<address>[^<]*Netherlands}, xml
+  end
+
+  test "includes country line on sender and recipient when they differ" do
+    @issuer.update!(country_iso2: "AT")
+    @invoice.update_columns(customer_country_iso2: "DE")
+    xml = InvoiceRenderer.new(@invoice, @issuer).emit_xml(nil)
+    assert_match %r{<issuer>.*<address>[^<]*Austria}m, xml
+    assert_match %r{<recipient>.*<address>[^<]*Germany}m, xml
+  end
+
+  test "omits country line when one side is the unknown sentinel" do
+    @invoice.update_columns(customer_country_iso2: AddressFormatter::UNKNOWN_COUNTRY)
+    xml = InvoiceRenderer.new(@invoice, @issuer).emit_xml(nil)
+    assert_no_match %r{<recipient>.*Unknown}m, xml
+  end
 end


### PR DESCRIPTION
## Summary

- Adds an ISO 3166-1 alpha-2 `country_iso2` column on `issuer_companies` and `customers`, plus a `customer_country_iso2` snapshot on `invoices` (matches the existing `customer_*` snapshot pattern). Country list + EU/EEA flags come from the `countries` gem so nothing in this repo needs hand-maintenance — `bundle update countries` is the refresh path.
- Migration is best-effort: matches the last line of existing freeform `address` text against ISO names + the gem's `unofficial_names` (covers German aliases like "Österreich"/"Deutschland" and common variants like "USA"/"The Netherlands"), strips the matched line from `address` and from the `invoices.customer_address` snapshot, and falls back to `ZZ` for anything it can't identify. Model `inclusion: { in: ISO3166::Country.codes }` rejects `ZZ`, so the next admin edit of any `ZZ` row forces a real country to be picked.
- PDF renderers (invoice + delivery note) drop the country line from both sender and recipient when the two share a country, so domestic documents render unchanged. `AddressFormatter.country_name` returns nil for unknown codes, so the renderer's `lines.compact` suppresses the sentinel without an extra guard.

## Test plan

- [x] `bundle exec rails test` — 685 runs, 0 failures.
- [ ] Migrate prod-shaped data and confirm best-effort detection lands the expected ISO codes (and lands `ZZ` for whatever it can't parse). Manually fix the `ZZ` rows via the customer/issuer edit forms.
- [ ] Preview an invoice with a same-country customer → no country line on either address block.
- [ ] Preview an invoice with a cross-border customer → "Country" appears at the end of both sender and recipient address blocks; tiny "Returns to:" postal footer follows the same rule.
- [ ] Edit a customer (and the issuer) → dropdown is alphabetized, marked required, and rejects empty submit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)