### PR TITLE
Deduplicate and realign CI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       run: |
         echo "$PWD/bin" >> $GITHUB_PATH
         cp config/database.yml.sample config/database.yml
-        ./bin/abt-fop-container -version || echo "FOP version check failed"
+        ./bin/abt-fop-container -version
 
     - name: Setup database
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,6 @@ jobs:
     name: Rails tests
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        ruby-version: ['3.3']
-
     services:
       postgres:
         image: postgres:17
@@ -36,10 +32,10 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
-    - name: Set up Ruby ${{ matrix.ruby-version }}
+    - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: ${{ matrix.ruby-version }}
+        ruby-version: '3.3'
         bundler-cache: true
 
     - name: Build FOP Docker container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,21 +115,6 @@ jobs:
     - name: Check Stimulus controllers for event listener leaks
       run: npm run lint
 
-  fop-container:
-    name: FOP Container Test
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v6
-
-    - name: Build FOP Docker container
-      run: |
-        podman build -f Dockerfile.fop -t abt-fop .
-
-    - name: Test FOP is available
-      run: |
-        podman run --rm abt-fop fop -version
-
   pre-commit:
     name: Pre-commit Hooks
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: '18'
+        node-version: '22'
         cache: 'npm'
 
     - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,13 +127,5 @@ jobs:
       with:
         bundler-cache: true
 
-    - name: Set up Python
-      uses: actions/setup-python@v6
-      with:
-        python-version: '3.x'
-
-    - name: Install pre-commit
-      run: pip install pre-commit
-
     - name: Run pre-commit hooks
-      run: pre-commit run --all-files
+      uses: pre-commit/action@v3.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.3'
         bundler-cache: true
 
     - name: Build FOP Docker container
@@ -92,7 +91,6 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.3'
         bundler-cache: true
 
     - name: Run Brakeman
@@ -142,7 +140,6 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.3'
         bundler-cache: true
 
     - name: Set up Python


### PR DESCRIPTION
## Summary
- Drop the single-value Ruby matrix and let `.tool-versions` drive `ruby/setup-ruby@v1` across rails-test, brakeman, and pre-commit.
- Delete the standalone `fop-container` job — `rails-test` already builds and exercises the same image (and via `bin/abt-fop-container`, also covers the wrapper script).
- Fail rails-test fast when the FOP version probe errors (dropped `|| echo`).
- Bump CI Node from 18 (EOL April 2025) to 22.
- Replace the manual `setup-python` + `pip install pre-commit` trio with `pre-commit/action@v3.0.1`, which caches hook envs. Ruby setup stays in that job because the local `rubocop` hook is `language: system`.

## Test plan
- [ ] All CI jobs run and pass on this branch
- [ ] `Set up Ruby` step in all three Ruby jobs picks up Ruby 3.3.8 from `.tool-versions`
- [ ] `pre-commit` job successfully runs `bin/rubocop` via `pre-commit/action`
- [ ] FOP version probe in `rails-test` runs and exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)