### PR TITLE
Link bill-to customer on project show page

### DIFF
--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -25,7 +25,7 @@
             %strong Bill to Customer:
           .col-sm-9
             - if @project.bill_to_customer
-              = @project.bill_to_customer.name
+              = link_to @project.bill_to_customer.name, @project.bill_to_customer
               %small.text-muted (#{@project.bill_to_customer.matchcode})
             - else
               %span.text-muted No customer (reusable project)


### PR DESCRIPTION
## Summary
- Wrap the bill-to customer name on `projects/show` in `link_to` so it navigates to the customer, matching the pattern used on invoice/delivery-note show pages.

## Test plan
- [ ] Open a project with a bill-to customer; click the name and verify it lands on the customer page.
- [ ] Open a reusable project (no bill-to customer); verify the "No customer (reusable project)" placeholder still renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)