### PR TITLE
Fix published delivery note actions: PDF as primary, preserve number on unpublish

### DIFF
--- a/app/controllers/delivery_notes_controller.rb
+++ b/app/controllers/delivery_notes_controller.rb
@@ -140,7 +140,10 @@ class DeliveryNotesController < ApplicationController
   end
 
   def unpublish
-    @delivery_note.update!(published: false, document_number: nil, date: nil)
+    # document_number and date are intentionally preserved: numbers come from a
+    # gap-free sequence (see require_unnumbered) and the original booking date
+    # is part of the audit trail.
+    @delivery_note.update!(published: false)
     flash[:notice] = "Delivery Note has been reverted to draft status."
 
     respond_to do |format|

--- a/app/views/delivery_notes/show.html.haml
+++ b/app/views/delivery_notes/show.html.haml
@@ -2,11 +2,11 @@
 - can_edit_dn = can?('delivery_notes.edit')
 - edit_action = action_button('Edit', edit_delivery_note_path(@delivery_note), permission: 'delivery_notes.edit') unless @delivery_note.published?
 - pdf_action = pdf_button(pdf_delivery_note_path(@delivery_note))
-- preview_action = preview_button(preview_delivery_note_path(@delivery_note))
+- preview_action = preview_button(preview_delivery_note_path(@delivery_note)) unless @delivery_note.published?
 - unpublish_action = unpublish_button(unpublish_delivery_note_path(@delivery_note), permission: 'delivery_notes.edit', confirm: 'Are you sure you want to revert this delivery note to draft status?')
 - delete_action = delete_button(@delivery_note, confirm: "Are you sure you want to delete delivery note \"#{@delivery_note.display_label}\"?") if can_edit_dn
-- main_action = @delivery_note.published? ? preview_action : edit_action
-- workflow_actions = @delivery_note.published? ? [pdf_action, unpublish_action] : [preview_action, delete_action]
+- main_action = @delivery_note.published? ? pdf_action : edit_action
+- workflow_actions = @delivery_note.published? ? [unpublish_action] : [preview_action, delete_action]
 = breadcrumbs ['Delivery Notes', delivery_notes_path], @delivery_note.display_label, actions: workflow_actions, action: main_action do
   - if !@delivery_note.published?
     %span.badge.bg-warning Draft

--- a/test/controllers/delivery_notes_controller_test.rb
+++ b/test/controllers/delivery_notes_controller_test.rb
@@ -24,6 +24,14 @@ class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "published delivery note show offers PDF action, not the unusable Preview" do
+    note = delivery_notes(:published_delivery_note)
+    get delivery_note_url(note)
+    assert_response :success
+    assert_select "a[href=?]", pdf_delivery_note_path(note)
+    assert_select "a[href=?]", preview_delivery_note_path(note), count: 0
+  end
+
   test "should get new" do
     get new_delivery_note_url
     assert_response :success

--- a/test/controllers/delivery_notes_controller_test.rb
+++ b/test/controllers/delivery_notes_controller_test.rb
@@ -84,10 +84,8 @@ class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
 
   test "should not destroy numbered but unpublished delivery note" do
     note = delivery_notes(:published_delivery_note)
-    # Simulate the "withdrawn but still numbered" state without going through
-    # unpublish (which currently clears document_number).
-    note.update_column(:published, false)
-    assert note.document_number.present?, "fixture should retain its number"
+    post unpublish_delivery_note_url(note)
+    assert note.reload.document_number.present?, "unpublish must preserve the document number"
 
     assert_no_difference("DeliveryNote.count") do
       delete delivery_note_url(note)
@@ -145,15 +143,29 @@ class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
 
   test "should unpublish delivery note" do
     published_note = delivery_notes(:published_delivery_note)
+    original_number = published_note.document_number
+    original_date = published_note.date
 
     post unpublish_delivery_note_url(published_note)
     assert_redirected_to delivery_note_url(published_note)
 
     published_note.reload
     assert_not published_note.published?
-    assert_nil published_note.document_number
-    assert_nil published_note.date
+    assert_equal original_number, published_note.document_number,
+                 "document number must survive unpublish to keep the sequence gap-free"
+    assert_equal original_date, published_note.date
     assert_match "reverted to draft status", flash[:notice]
+
+    # Re-publishing keeps the preserved number but refreshes the date — the
+    # publish event genuinely happened now.
+    travel_to original_date + 2.days do
+      post publish_delivery_note_url(published_note)
+    end
+
+    published_note.reload
+    assert published_note.published?
+    assert_equal original_number, published_note.document_number
+    assert_equal original_date + 2.days, published_note.date
   end
 
   test "should not unpublish draft delivery note" do


### PR DESCRIPTION
## Summary
- **Published DN show: primary action was the broken Preview link.** `DeliveryNotesController#preview` enforces `require_unpublished`, so the primary button on every published delivery note's show page silently redirected with an error. Replace it with the PDF link, drop the unusable preview from published-state entirely. Drafts keep the Preview button as before.
- **Unpublish wiped the document number, defeating the gap-free numbering guard.** `unpublish` was calling `update!(published: false, document_number: nil, date: nil)`, contradicting the file's own `require_unnumbered` comment ("once assigned [numbers] must not vanish, even if the delivery note was later unpublished"). With the number cleared, users could then destroy an unpublished-but-numbered note, opening a gap in the sequence. Preserve both fields on unpublish; `display_label` automatically surfaces the number on show/edit again, and the destroy guard now properly blocks deletion.
- **Re-publish refreshes the date.** On re-publishing a previously published note, `publish!` keeps the preserved number but updates `date` to today — the publish event genuinely happened now. Cosmetic year-prefix vs. date mismatch when re-publish crosses a calendar boundary is accepted as the price of truth; no functional impact (no `DocumentNumber` allocation runs on re-publish, so monotonicity and sequence integrity are untouched).

## Test plan
- [x] `bundle exec rails test` (680 runs, all green)
- [x] `bundle exec rails test test/system/` (58 runs, all green)
- [x] `pre-commit run --all-files`
- New regression test: published DN show exposes PDF link, not Preview (`test/controllers/delivery_notes_controller_test.rb:27`)
- Updated `should unpublish delivery note` now asserts number+date preserved, then re-publishes with `travel_to` and asserts the date refreshes while the number stays
- Updated `should not destroy numbered but unpublished delivery note` now goes through the real unpublish endpoint (no more `update_column` workaround)

🤖 Generated with [Claude Code](https://claude.com/claude-code)