### PR TITLE
Document how to silence Passenger phone-home log lines

### DIFF
--- a/apache2.conf.tpl
+++ b/apache2.conf.tpl
@@ -1,3 +1,10 @@
+# To silence Phusion's phone-home checks (anonymous telemetry logs
+# spurious "End time can not be before or equal to begin time" notices;
+# the security update checker logs a "no update found" line every 24h),
+# set these in the global Apache server context (not inside a VirtualHost):
+#   PassengerDisableAnonymousTelemetry on
+#   PassengerDisableSecurityUpdateCheck on
+
 <VirtualHost *:443>
   ServerName abt
 


### PR DESCRIPTION
## Summary
- Top-of-template comment with the two Apache directives that silence Phusion's telemetry collector and security update checker.
- No runtime change — the directives are recipes for the operator to apply in the production Apache config; the template itself only contains a VirtualHost so it can't host server-context directives directly.

## Test plan
- [x] No code paths changed; nothing to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)