### PR TITLE
Widen PDF contact-line box to fit Inter

### DIFF
--- a/lib/foptemplate/document_base.xsl
+++ b/lib/foptemplate/document_base.xsl
@@ -163,7 +163,7 @@
 
     <!-- Component: company logo/name block with contact lines (typically on first page) -->
     <xsl:template name="company-header-block">
-        <fo:block-container height="1cm" width="6cm" top="0cm" left="0cm" position="absolute" line-height="120%">
+        <fo:block-container height="1cm" width="8cm" top="0cm" left="0cm" position="absolute" line-height="120%">
             <xsl:call-template name="impl-company-logo"/>
 
             <fo:block text-align="start" font-size="9pt" xsl:use-attribute-sets="accent-color">


### PR DESCRIPTION
## Summary

- The page-sequence font switched from OpenSans to Inter in e4a6945 (2025-08-10), but the 6cm `company-header-block` container was sized against OpenSans Light metrics. At 9pt, Inter ExtraLight glyphs are wider, so contact-line1 strings that previously fit started wrapping to a second line and spilling out of the 1cm container.
- Widens the contact box to 8cm, matching the document-type header and info-box table immediately below it (right column origin `8.75cm`, ~8.5cm usable to the right margin, so the new width leaves headroom).

## Test plan

- [ ] Render a recent published invoice (one where contact-line1 was wrapping in production) and confirm it now fits on a single line.
- [ ] Verify the wider box does not visually collide with the recipient envelope window on the left or the document-type header below.
- [ ] `bundle exec rails test test/services/invoice_renderer_test.rb test/services/delivery_note_renderer_test.rb` (passes locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)