### PR TITLE
Restore PDF logo top-edge alignment with sender address

### DIFF
--- a/lib/foptemplate/document_base.xsl
+++ b/lib/foptemplate/document_base.xsl
@@ -146,7 +146,10 @@
 
     <!-- implementation detail: logo only -->
     <xsl:template name="impl-company-logo">
-        <fo:block text-align="start" font-size="12pt" xsl:use-attribute-sets="accent-color">
+        <!-- line-height="1" keeps the logo flush with the block top; without it,
+             the enclosing block-container's line-height adds half-leading above
+             the logo line and shifts the logo down relative to the sender address. -->
+        <fo:block text-align="start" font-size="12pt" line-height="1" xsl:use-attribute-sets="accent-color">
             <xsl:choose>
                 <xsl:when test="/document/logo-path">
                     <fo:external-graphic src="{/document/logo-path}"


### PR DESCRIPTION
## Summary
- `e4a6945` added `line-height="120%"` to `company-header-block` (intended for 9pt contact lines), which inherits as 13.2pt into the 12pt logo block above. The extra 0.6pt half-leading shifts the logo down ~2 px vs. the sender address.
- Pin the logo block's own line-height to `1` so it stays flush to its container top; contact-line spacing is preserved (still 13.2pt between lines).

## Verification
- Bbox of real invoice (`pdftotext -bbox`): logo "MY" yMin 49.092 → 48.492; contact `www` yMin 71.013 → 69.813; `voice − www` delta unchanged at 13.20 pt.
- `bundle exec rails test` — 686 runs, 0 failures.
- `pre-commit run --files lib/foptemplate/document_base.xsl` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)