### PR TITLE
Restore PDF contact lines to 9pt

### DIFF
--- a/lib/foptemplate/document_base.xsl
+++ b/lib/foptemplate/document_base.xsl
@@ -186,10 +186,9 @@
                 <xsl:with-param name="padding-before" select="$logo-sender-alignment-padding" />
             </xsl:call-template>
 
-            <!-- 8pt contact lines inherit the page-sequence's 12pt line-height
-                 (4pt of leading between www / voice lines), which is enough
-                 breathing room for two short lines under the logo. -->
-            <fo:block text-align="start" font-size="8pt" xsl:use-attribute-sets="accent-color">
+            <!-- 9pt contact lines inherit the page-sequence's 12pt line-height
+                 (3pt of leading between www / voice lines). -->
+            <fo:block text-align="start" font-size="9pt" xsl:use-attribute-sets="accent-color">
                 <fo:block white-space-collapse="false">
                     <xsl:value-of select="abt:strip-space(/document/issuer/contact-line1)" />
                 </fo:block>


### PR DESCRIPTION
## Summary
- Revert the contact-lines font size from 8pt back to 9pt; the 8pt from #435 read too small under the logo.
- Logo↔sender-address alignment (`padding-before="$logo-sender-alignment-padding"` on the logo block) is untouched — contact lines are a sibling block below the logo and don't feed into that alignment.

## Test plan
- [x] `bundle exec rails test test/services/invoice_renderer_test.rb` — XSL→FOP→PDF pipeline still renders.
- [x] Visually inspected a rendered sample invoice header: logo top still aligns with sender-address top; the three contact lines (www / email / voice) are visibly larger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)