### PR TITLE
Small fixes: Add Line placement, empty contacts message, empty invoice edit affordance

### DIFF
--- a/app/controllers/customer_contacts_controller.rb
+++ b/app/controllers/customer_contacts_controller.rb
@@ -29,6 +29,7 @@ class CustomerContactsController < ApplicationController
       respond_to do |format|
         format.turbo_stream do
           render turbo_stream: [
+            turbo_stream.remove("customer_contacts_empty_message"),
             turbo_stream.append("customer_contacts_tbody", partial: "customer_contacts/row", locals: { contact: @contact }),
             turbo_stream.replace("new_customer_contact", partial: "customer_contacts/add_link", locals: { customer: @customer })
           ]
@@ -58,10 +59,17 @@ class CustomerContactsController < ApplicationController
 
   # DELETE /customer_contacts/:id
   def destroy
+    customer = @contact.customer
     @contact.destroy
     respond_to do |format|
-      format.turbo_stream { render turbo_stream: turbo_stream.remove(helpers.dom_id(@contact)) }
-      format.html { redirect_to @contact.customer }
+      format.turbo_stream do
+        streams = [ turbo_stream.remove(helpers.dom_id(@contact)) ]
+        unless customer.customer_contacts.exists?
+          streams << turbo_stream.append("customer_contacts_tbody", partial: "customer_contacts/empty_message")
+        end
+        render turbo_stream: streams
+      end
+      format.html { redirect_to customer }
     end
   end
 

--- a/app/views/customer_contacts/_empty_message.html.haml
+++ b/app/views/customer_contacts/_empty_message.html.haml
@@ -1,0 +1,2 @@
+.text-muted.py-2.small#customer_contacts_empty_message
+  No contacts configured. The customer will not receive any emails unless an Automated Email is configured.

--- a/app/views/customers/_contacts_table.html.haml
+++ b/app/views/customers/_contacts_table.html.haml
@@ -13,7 +13,7 @@
       - if customer.customer_contacts.any?
         = render partial: "customer_contacts/row", collection: customer.customer_contacts.includes(:projects), as: :contact
       - else
-        .text-muted.py-2.small No contacts configured. The customer will not receive any emails unless an Automated Email is configured.
+        = render "customer_contacts/empty_message"
 
     - if can?('customers.edit')
       = render "customer_contacts/add_link", customer: customer

--- a/app/views/invoices/_form.html.haml
+++ b/app/views/invoices/_form.html.haml
@@ -101,6 +101,10 @@
             = f.fields_for :invoice_lines, new_line, child_index: 'NEW_RECORD' do |line_form|
               = render 'invoice_line_fields', f: line_form, line: new_line
 
+          = action_buttons_wrapper do
+            %button.btn.btn-info{type: 'button', data: {action: 'click->invoice-lines#addLine'}}
+              + Add Line
+
           .card.mb-3
             .card-body
               .row
@@ -109,8 +113,3 @@
                 .col-sm-2.text-end
                   %span{data: {invoice_lines_target: 'total'}}
                     = format_currency(0)
-
-          %br
-          = action_buttons_wrapper do
-            %button.btn.btn-info{type: 'button', data: {action: 'click->invoice-lines#addLine'}}
-              + Add Line

--- a/app/views/invoices/show.html.haml
+++ b/app/views/invoices/show.html.haml
@@ -162,6 +162,10 @@
           %th.text-center.col-tax-class Tax Class
           %th.text-end.col-amount Amount
       %tbody
+        - if @invoice.invoice_lines.empty? && !@invoice.published?
+          %tr
+            %td.text-center.py-4{colspan: 5}
+              = action_button 'Edit Lines', edit_invoice_path(@invoice), :info, permission: 'invoices.edit'
         - @invoice.invoice_lines.each do |line|
           - case line.type
           - when 'item'

--- a/test/controllers/invoices_controller_test.rb
+++ b/test/controllers/invoices_controller_test.rb
@@ -176,6 +176,14 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
     assert_select ".badge.bg-success", text: "Booked"
   end
 
+  test "draft invoice without lines renders inline Edit Lines button" do
+    invoice = create_draft_invoice(cust_reference: "EMPTY")
+
+    get invoice_url(invoice)
+    assert_response :success
+    assert_select "table.document-lines-table tbody a", text: "Edit Lines", href: edit_invoice_path(invoice)
+  end
+
   test "draft invoice show renders Publish Status row with Ready badge for a valid draft" do
     invoice = create_invoice_with_item_line(cust_reference: "TEST_DRAFT", quantity: 1.0)
 

--- a/test/system/customer_contacts_test.rb
+++ b/test/system/customer_contacts_test.rb
@@ -105,6 +105,30 @@ class CustomerContactsTest < ApplicationSystemTestCase
     assert_nil CustomerContact.find_by(id: @accounting.id)
   end
 
+  test "empty-state message hides when first contact is added and returns after the last is removed" do
+    empty_customer = customers(:no_email_customer)
+    visit customer_path(empty_customer)
+    assert_selector "#customer_contacts_empty_message"
+
+    click_link "+ Add contact"
+    within("#new_customer_contact") do
+      fill_in "customer_contact[name]", with: "First Contact"
+      fill_in "customer_contact[email]", with: "first@example.com"
+      click_button "Add"
+    end
+
+    new_contact = empty_customer.customer_contacts.find_by(email: "first@example.com")
+    assert_selector "##{ActionView::RecordIdentifier.dom_id(new_contact)}"
+    assert_no_selector "#customer_contacts_empty_message"
+
+    accept_confirm do
+      within("##{ActionView::RecordIdentifier.dom_id(new_contact)}") { click_link "🗑" }
+    end
+
+    assert_no_selector "##{ActionView::RecordIdentifier.dom_id(new_contact)}"
+    assert_selector "#customer_contacts_empty_message"
+  end
+
   test "salutation_line persists from the edit form and renders in the row" do
     visit customer_path(@customer)
     row = "##{ActionView::RecordIdentifier.dom_id(@accounting)}"


### PR DESCRIPTION
## Summary
- Move the invoice form's "+ Add Line" button above the Total Net footer so it sits with the lines it adds to, not behind the total.
- Toggle the "No contacts configured…" warning on the customer page via Turbo Stream so it disappears after the first contact is added and reappears when the last one is removed.
- Render an inline "Edit Lines" button inside the empty document-lines table on a draft invoice's show page so an empty draft is no longer a dead-end view.

## Test plan
- [x] `bundle exec rails test test/system/invoice_lines_test.rb test/system/invoice_edit_test.rb test/system/line_management_test.rb`
- [x] `bundle exec rails test test/system/customer_contacts_test.rb` (incl. new empty-state toggle test)
- [x] `bundle exec rails test test/controllers/invoices_controller_test.rb` (incl. new empty-draft Edit Lines assertion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)