### PR TITLE
Inline Edit Lines button on empty draft delivery note

### DIFF
--- a/app/views/delivery_notes/show.html.haml
+++ b/app/views/delivery_notes/show.html.haml
@@ -145,6 +145,10 @@
           %th.text-end.col-quantity Quantity
           %th Description
       %tbody
+        - if @delivery_note.delivery_note_lines.empty? && !@delivery_note.published?
+          %tr
+            %td.text-center.py-4{colspan: 2}
+              = action_button 'Edit Lines', edit_delivery_note_path(@delivery_note), :info, permission: 'delivery_notes.edit'
         - @delivery_note.delivery_note_lines.each do |line|
           - case line.type
           - when 'item'


### PR DESCRIPTION
## Summary
- Mirror of the invoice show-page affordance from #439 for draft delivery notes with no lines: render an inline "Edit Lines" button in the empty document-lines table body, between the column header and the (absent) sums area.

## Test plan
- [x] `bundle exec rails test test/controllers/delivery_notes_controller_test.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)