### PR TITLE
Don't set date on draft delivery note in seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -668,7 +668,6 @@ if Rails.env.development?
       cust_reference: 'PO-2025-001',
       cust_order: 'ORDER-WEB-2025',
       prelude: 'Delivery of completed web application components for Q1 2025 project',
-      date: 1.week.ago.to_date,
       delivery_start_date: 2.weeks.ago.to_date,
       delivery_end_date: 1.week.ago.to_date,
       published: false


### PR DESCRIPTION
## Summary
- The first sample delivery note is seeded with `published: false` but had `date: 1.week.ago.to_date`.
- In the model, `date` represents the publication date — `DeliveryNote#publish!` assigns `Date.today` — so drafts should leave it unset (matches the pure-draft invoice seeds).
- The other two delivery notes that set `date` are immediately published via `update!(published: true, …)`, so they're consistent and untouched.

## Test plan
- [ ] `bundle exec rails db:reset` in development and confirm the first delivery note shows up as a draft with no date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)