### PR TITLE
Stamp email_sent_at on actual delivery, not at enqueue

### DIFF
--- a/app/controllers/delivery_notes_controller.rb
+++ b/app/controllers/delivery_notes_controller.rb
@@ -297,7 +297,6 @@ class DeliveryNotesController < ApplicationController
       return
     end
     DeliveryNoteMailer.with(delivery_note: @delivery_note).customer_email.deliver_later
-    @delivery_note.update_column(:email_sent_at, Time.current)
     respond_to do |format|
       format.html { redirect_to @delivery_note, notice: "E-Mail queued for sending." }
       format.json { head :ok }
@@ -316,7 +315,6 @@ class DeliveryNotesController < ApplicationController
     delivery_notes = DeliveryNote.visible_to(current_user).where(id: delivery_note_ids, published: true)
     queued_count = 0
     skipped_count = 0
-    now = Time.current
 
     # Partition by [customer_id, resolved-recipient-set]. Two DNs to the same
     # customer with different project-scoped contacts must NOT be combined,
@@ -332,7 +330,6 @@ class DeliveryNotesController < ApplicationController
       else
         DeliveryNoteMailer.with(delivery_notes: dns, recipients: recipients).bulk_customer_email.deliver_later
       end
-      DeliveryNote.where(id: dns.map(&:id)).update_all(email_sent_at: now)
       queued_count += dns.length
     end
 

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -161,7 +161,6 @@ class InvoicesController < ApplicationController
       return
     end
     InvoiceMailer.with(invoice: @invoice).customer_email.deliver_later
-    @invoice.update_column(:email_sent_at, Time.current)
     respond_to do |format|
       format.html { redirect_to @invoice, notice: "E-Mail queued for sending." }
       format.json { head :ok }
@@ -194,12 +193,10 @@ class InvoicesController < ApplicationController
     invoices = Invoice.visible_to(current_user).where(id: invoice_ids, published: true)
     queued_count = 0
     skipped_count = 0
-    now = Time.current
 
     invoices.each do |invoice|
       if invoice.emailable?
         InvoiceMailer.with(invoice: invoice).customer_email.deliver_later
-        invoice.update_column(:email_sent_at, now)
         queued_count += 1
       else
         skipped_count += 1

--- a/config/initializers/mail_delivery_tracker.rb
+++ b/config/initializers/mail_delivery_tracker.rb
@@ -1,0 +1,22 @@
+ActiveSupport::Notifications.subscribe("perform.active_job") do |*args|
+  event = ActiveSupport::Notifications::Event.new(*args)
+  next if event.payload[:exception_object]
+
+  job = event.payload[:job]
+  next unless job.is_a?(ActionMailer::MailDeliveryJob)
+
+  mailer_name, _action, _delivery, opts = job.arguments
+  params = opts.is_a?(Hash) ? (opts[:params] || {}) : {}
+  now = Time.current
+
+  case mailer_name
+  when "InvoiceMailer"
+    params[:invoice]&.update_column(:email_sent_at, now)
+  when "DeliveryNoteMailer"
+    if (dn = params[:delivery_note])
+      dn.update_column(:email_sent_at, now)
+    elsif (dns = params[:delivery_notes])
+      DeliveryNote.where(id: dns.map(&:id)).update_all(email_sent_at: now)
+    end
+  end
+end

--- a/test/controllers/delivery_notes_controller_test.rb
+++ b/test/controllers/delivery_notes_controller_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
   test "should get index" do
     get delivery_notes_url
     assert_response :success
@@ -366,8 +368,10 @@ class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
     note = delivery_notes(:published_delivery_note)
     note.update_column(:email_sent_at, nil)
 
-    post send_email_delivery_note_url(note),
-         headers: { "Accept" => "application/json" }
+    perform_enqueued_jobs do
+      post send_email_delivery_note_url(note),
+           headers: { "Accept" => "application/json" }
+    end
 
     assert_response :success
     assert_not_nil note.reload.email_sent_at
@@ -412,9 +416,13 @@ class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
     note1 = create_published_delivery_note(customer: customer, document_number: "DN-2025-002", cust_reference: "BULK-TEST-1")
     note2 = create_published_delivery_note(customer: customer, document_number: "DN-2025-003", cust_reference: "BULK-TEST-2")
 
-    post bulk_send_emails_delivery_notes_url, params: { delivery_note_ids: [ note1.id, note2.id ] }
+    perform_enqueued_jobs do
+      post bulk_send_emails_delivery_notes_url, params: { delivery_note_ids: [ note1.id, note2.id ] }
+    end
     assert_redirected_to delivery_notes_url
     assert_match "2 emails queued for sending", flash[:notice]
+    assert_not_nil note1.reload.email_sent_at
+    assert_not_nil note2.reload.email_sent_at
   end
 
   test "should send individual emails when delivery notes are for different customers" do

--- a/test/controllers/invoices_controller_email_test.rb
+++ b/test/controllers/invoices_controller_email_test.rb
@@ -117,7 +117,27 @@ class InvoicesControllerEmailTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :success
-    assert_not_nil invoice.reload.email_sent_at
+  end
+
+  class RaisingInterceptor
+    def self.delivering_email(_mail)
+      raise StandardError, "simulated delivery failure"
+    end
+  end
+
+  test "send_email does not stamp email_sent_at when delivery fails" do
+    invoice = invoices(:published_invoice)
+    invoice.update_column(:email_sent_at, nil)
+
+    ActionMailer::Base.register_interceptor(RaisingInterceptor)
+    begin
+      post send_email_invoice_path(invoice)
+      assert_raises(StandardError) { perform_enqueued_jobs }
+    ensure
+      ActionMailer::Base.unregister_interceptor(RaisingInterceptor)
+    end
+
+    assert_nil invoice.reload.email_sent_at
   end
 
   test "send_email returns an error status for JSON when no recipient is configured" do


### PR DESCRIPTION
## Summary
- Move the `email_sent_at` write out of the controllers (where it stamped at `deliver_later` enqueue time) into a `perform.active_job` notification subscriber that fires only when `MailDeliveryJob` for `InvoiceMailer` / `DeliveryNoteMailer` completes without raising.
- Restores the pre-098b0f1 semantic: the column records actual delivery. A permanently failed send leaves the document with `email_sent_at: nil` so the "Unsent" filter re-surfaces it for retry.
- Fixes #345.

## Trade-offs (explicitly accepted in plan)
- Pending window: between click and queue drain, the status row reads "Unsent" again. The flash "E-Mail queued for sending." is the in-the-moment confirmation. This matches pre-098b0f1 behavior.
- Mailgun post-acceptance bounces are still invisible (would need webhook tracking; out of scope).

## Follow-up issues worth filing (from parallel review)
1. Double-send guard — a user who re-clicks "Send E-Mail" before the queue drains can enqueue a duplicate. Same as pre-098b0f1; a Stimulus disable-after-click would fix it.
2. Bulk-send redirect drops the `filter: 'unsent'` query param, landing the user on the *All* tab.
3. "Unsent" badge now spans three cases (never queued / in-flight / permanently failed) — a tooltip or distinct "Queued" state could disambiguate.
4. `JobsStatusController` could decode failed `MailDeliveryJob` arguments and link back to the affected invoice/DN.

## Test plan
- [x] `bundle exec rails test` — 722 runs, 0 failures
- [x] `pre-commit run --all-files` — clean
- [x] New failure-path test: raising ActionMailer interceptor + assert `email_sent_at` stays nil
- [x] Existing comprehensive success-path test covers the subscriber's single-document path
- [x] Extended existing multi-DN-same-customer bulk test to assert both DNs get stamped (covers the subscriber's `params[:delivery_notes]` array branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)