### PR TITLE
Add bin/journal helper and tag puma/jobs syslog identifiers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This is "ABT", a Rails 8 application for invoice and delivery-note management. B
 
 ## Repository Layout
 
-- All repo-local executables live in `bin/` — Bundler binstubs plus custom scripts (`abt-fop`, `abt-fop-container`, `jobs`, `postgres-dev`, `production-update`, `setup`, `setup-fop`).
+- All repo-local executables live in `bin/` — Bundler binstubs plus custom scripts (`abt-fop`, `abt-fop-container`, `jobs`, `journal`, `postgres-dev`, `production-update`, `setup`, `setup-fop`).
 - Long-form documentation lives in `docs/` and uses lowercase kebab-case filenames (`postgres-dev.md`, `production-update.md`).
 - Do not reintroduce a `script/` directory.
 

--- a/bin/journal
+++ b/bin/journal
@@ -1,0 +1,47 @@
+#!/bin/bash
+# View journalctl logs for the ABT systemd user units.
+#
+# Designed to be invoked via `sudo bin/journal <unit> [args...]` on the
+# production host. We can't use `journalctl --user-unit` as the abt user
+# because per-user journal files aren't accessible without
+# systemd-journal/adm group membership; running as root and filtering on
+# the journal fields directly avoids that requirement.
+
+set -euo pipefail
+
+usage() {
+    cat >&2 <<EOF
+Usage: $(basename "$0") {puma|jobs} [journalctl args...]
+
+View journalctl logs for the ABT systemd user units. Run via sudo (root
+can read all journals; the abt user typically cannot without being in
+the systemd-journal group).
+
+Examples:
+  sudo $(basename "$0") puma -f
+  sudo $(basename "$0") jobs --since "1 hour ago"
+  sudo $(basename "$0") puma -n 200 --no-pager
+EOF
+    exit 1
+}
+
+if [[ $# -lt 1 ]]; then
+    usage
+fi
+
+case "$1" in
+    puma) unit=abt-puma.service ;;
+    jobs) unit=abt-jobs.service ;;
+    -h|--help) usage ;;
+    *) echo "Unknown unit: $1 (expected 'puma' or 'jobs')" >&2; usage ;;
+esac
+shift
+
+abt_uid=$(id -u abt 2>/dev/null) || {
+    echo "User 'abt' does not exist on this host." >&2
+    exit 1
+}
+
+# _SYSTEMD_USER_UNIT + _UID filters to messages from the abt user's
+# systemd --user instance, regardless of which user is invoking journalctl.
+exec journalctl _SYSTEMD_USER_UNIT="$unit" _UID="$abt_uid" "$@"

--- a/deploy/systemd/abt-jobs.service
+++ b/deploy/systemd/abt-jobs.service
@@ -8,6 +8,7 @@ WorkingDirectory=%h
 Environment=RAILS_ENV=production
 Environment=FOP_EXTRA_JAR_PATH=/srv/fop-extra-jars
 ExecStart=/usr/bin/bundle exec %h/bin/jobs
+SyslogIdentifier=abt-jobs
 TimeoutStopSec=30
 Restart=always
 RestartSec=5

--- a/deploy/systemd/abt-puma.service
+++ b/deploy/systemd/abt-puma.service
@@ -8,6 +8,7 @@ WorkingDirectory=%h
 Environment=RAILS_ENV=production
 Environment=FOP_EXTRA_JAR_PATH=/srv/fop-extra-jars
 ExecStart=/usr/bin/bundle exec puma -C %h/config/puma.rb
+SyslogIdentifier=abt-puma
 ExecReload=/bin/kill -SIGUSR2 $MAINPID
 # SIGUSR2 hot-restart spawns a new process tree that systemd is unaware of;
 # KillMode=mixed sends the stop signal to only the main PID and lets Puma


### PR DESCRIPTION
## Summary

- Add `bin/journal` — wraps `journalctl _SYSTEMD_USER_UNIT=… _UID=…` so operators can read puma/jobs logs with `sudo bin/journal puma -f` (or `jobs`) without remembering field matchers.
- Set `SyslogIdentifier=abt-puma` / `abt-jobs` on the two systemd user units so journal lines no longer show up as `bundle[...]:`.

## Test plan

- [ ] On the production host, deploy and run `sudo bin/journal puma -n 20 --no-pager` — entries appear and are now labeled `abt-puma`.
- [ ] `sudo bin/journal jobs --since "1 hour ago" --no-pager` — same, labeled `abt-jobs`.
- [ ] `bin/journal --help` and `bin/journal bogus` print usage and exit non-zero.
- [ ] After `bin/production-update` (or manual `systemctl --user daemon-reload && systemctl --user restart abt-puma.service abt-jobs.service`), new log lines use the new identifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)