### PR TITLE
Fix Jobs Status next-run column; keep finished jobs for 7 days

### DIFF
--- a/app/controllers/jobs_status_controller.rb
+++ b/app/controllers/jobs_status_controller.rb
@@ -19,10 +19,6 @@ class JobsStatusController < ApplicationController
     }
 
     @recurring_tasks = SolidQueue::RecurringTask.order(:key).to_a
-    @next_recurring_runs = SolidQueue::RecurringExecution
-                             .where(task_key: @recurring_tasks.map(&:key))
-                             .group(:task_key)
-                             .minimum(:run_at)
 
     @failed_jobs = SolidQueue::FailedExecution
                      .includes(:job)

--- a/app/views/jobs_status/show.html.haml
+++ b/app/views/jobs_status/show.html.haml
@@ -105,12 +105,7 @@
                   - elsif task.command.present?
                     %code= task.command
                 %td= task.queue_name || 'default'
-                %td
-                  - next_run = @next_recurring_runs[task.key]
-                  - if next_run
-                    = l(next_run)
-                  - else
-                    %span.text-muted —
+                %td= l(task.next_time)
 
 .card.mb-4
   .card-header

--- a/config/initializers/solid_queue.rb
+++ b/config/initializers/solid_queue.rb
@@ -1,0 +1,1 @@
+SolidQueue.clear_finished_jobs_after = 7.days

--- a/test/controllers/jobs_status_controller_test.rb
+++ b/test/controllers/jobs_status_controller_test.rb
@@ -7,7 +7,6 @@ class JobsStatusControllerTest < ActionDispatch::IntegrationTest
     SolidQueue::ScheduledExecution.delete_all
     SolidQueue::ClaimedExecution.delete_all
     SolidQueue::BlockedExecution.delete_all
-    SolidQueue::RecurringExecution.delete_all
     SolidQueue::Job.delete_all
     SolidQueue::RecurringTask.delete_all
     SolidQueue::Process.delete_all
@@ -58,6 +57,19 @@ class JobsStatusControllerTest < ActionDispatch::IntegrationTest
     assert_select "code", text: "my_command_task"
     assert_select "td", text: "OverdueInvoicesReportJob"
     assert_select "code", text: "SolidQueue::Job.clear_finished_in_batches"
+  end
+
+  test "shows next run time computed from a recurring task's schedule" do
+    travel_to Time.zone.local(2026, 5, 27, 12, 0, 0) do
+      task = SolidQueue::RecurringTask.create!(
+        key: "daily_task", schedule: "every day at 13:00",
+        command: "puts 1", static: true
+      )
+
+      get jobs_status_path
+      assert_response :success
+      assert_select "td", text: I18n.l(task.next_time)
+    end
   end
 
   test "lists recently failed jobs with error class and message" do


### PR DESCRIPTION
## Summary

- The recurring tasks **Next run** column on `/jobs_status` queried `SolidQueue::RecurringExecution` (records of *past* enqueues) and took `.minimum(:run_at)` — the oldest surviving row. Because the schema cascades `recurring_executions` deletion when finished `solid_queue_jobs` are cleaned up, the displayed time drifted to roughly `clear_finished_jobs_after` ago, and tasks that hadn't fired in that window showed `—`. Replaced with `RecurringTask#next_time` (Fugit-parsed schedule), which is the actual next future occurrence.
- Bumped `SolidQueue.clear_finished_jobs_after` from the 1-day default to 7 days so finished-job history sticks around for a week. Note: the **Finished** counter on the dashboard and the `solid_queue_jobs` table will grow proportionally.

## Test plan

- [x] `bundle exec rails test test/controllers/jobs_status_controller_test.rb`
- [ ] Visually verify on a deployed environment that every recurring task shows a future `Next run` timestamp instead of `—` or a stale past time