### PR TITLE
Token-in-URL log leakage + dead delivery_notes#publish GET route

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -48,8 +48,7 @@ class Rack::Attack
   # COSE parsing, attestation). Strict per-/64 budget.
   throttle("webauthn-verify/ip", limit: 10, period: 1.minute) do |req|
     next nil unless req.post?
-    if req.path == "/session/verify" ||
-       req.path.match?(%r{\A/invites/[^/]+/verify\z})
+    if req.path == "/session/verify" || req.path == "/invites/verify"
       ip_key(req)
     end
   end
@@ -58,7 +57,7 @@ class Rack::Attack
   throttle("auth-post/ip", limit: 30, period: 1.minute) do |req|
     next nil unless req.post?
     if req.path.match?(%r{\A/session/(options|verify)\z}) ||
-       req.path.match?(%r{\A/invites/[^/]+/(options|verify)\z})
+       req.path.match?(%r{\A/invites/(options|verify)\z})
       ip_key(req)
     end
   end
@@ -72,8 +71,8 @@ class Rack::Attack
   # Tokenized GETs.
   throttle("token-fetch/ip", limit: 60, period: 1.minute) do |req|
     next nil unless req.get?
-    if req.path.match?(%r{\A/invites/[^/]+\z}) ||
-       req.path.match?(%r{\A/account/email_confirmations/[^/]+\z})
+    if req.path == "/invites" ||
+       req.path == "/account/email_confirmations"
       ip_key(req)
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,7 +81,6 @@ Rails.application.routes.draw do
       get "preview"
       get "preview_email"
       get "preview_email_raw"
-      get "publish"
       post "publish"
       post "send_email"
       get "pdf"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ Rails.application.routes.draw do
       end
     end
     resources :emails, only: [ :index, :create, :destroy ]
-    resources :email_confirmations, only: [ :show ], param: :token
+    get "email_confirmations", to: "email_confirmations#show", as: :email_confirmation
     resource :block, only: [ :create ]
     resources :audit_events, only: [ :index ]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,12 +6,9 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :invites, only: [ :show ], param: :token do
-    member do
-      post :options
-      post :verify
-    end
-  end
+  get "invites", to: "invites#show", as: :invite
+  post "invites/options", to: "invites#options", as: :options_invite
+  post "invites/verify", to: "invites#verify", as: :verify_invite
 
   namespace :account do
     resource :profile, only: [ :show ]

--- a/test/controllers/user_invites_controller_test.rb
+++ b/test/controllers/user_invites_controller_test.rb
@@ -14,6 +14,6 @@ class UserInvitesControllerTest < ActionDispatch::IntegrationTest
       post user_invites_path
     end
     assert_response :success
-    assert_select "code", /\/invites\//
+    assert_select "code", /\/invites\?token=/
   end
 end

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -18,7 +18,7 @@ class UserMailerTest < ActionMailer::TestCase
   test "email_confirmation includes confirmation URL" do
     email = users(:alice).emails.create!(address: "new@example.com")
     email.generate_confirmation_token!
-    url = "http://example.com/account/email_confirmations/sometoken"
+    url = "http://example.com/account/email_confirmations?token=sometoken"
 
     mail = UserMailer.email_confirmation(email, url)
     assert_equal [ "new@example.com" ], mail.to

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -48,7 +48,7 @@ class UserMailerTest < ActionMailer::TestCase
   end
 
   test "passkey_reset_invite includes the invite URL" do
-    url = "http://example.com/invites/abc123"
+    url = "http://example.com/invites?token=abc123"
     mail = UserMailer.passkey_reset_invite(users(:alice), url, "alice@example.com")
     assert_match url, body_text(mail)
   end

--- a/test/services/absolute_url_test.rb
+++ b/test/services/absolute_url_test.rb
@@ -22,7 +22,7 @@ class AbsoluteUrlTest < ActiveSupport::TestCase
 
     url = AbsoluteUrl.invite("tok-123")
 
-    assert_equal "https://example.test/abt/invites/tok-123", url
+    assert_equal "https://example.test/abt/invites?token=tok-123", url
   end
 
   test "invite URL omits sub-path when script_name is blank" do
@@ -32,7 +32,7 @@ class AbsoluteUrlTest < ActiveSupport::TestCase
 
     url = AbsoluteUrl.invite("tok-123")
 
-    assert_equal "https://example.test/invites/tok-123", url
+    assert_equal "https://example.test/invites?token=tok-123", url
   end
 
   test "account_email_confirmation URL includes script_name from Settings" do

--- a/test/services/absolute_url_test.rb
+++ b/test/services/absolute_url_test.rb
@@ -42,6 +42,6 @@ class AbsoluteUrlTest < ActiveSupport::TestCase
 
     url = AbsoluteUrl.account_email_confirmation("tok-xyz")
 
-    assert_equal "https://example.test/abt/account/email_confirmations/tok-xyz", url
+    assert_equal "https://example.test/abt/account/email_confirmations?token=tok-xyz", url
   end
 end

--- a/test/system/user_invites_test.rb
+++ b/test/system/user_invites_test.rb
@@ -8,6 +8,6 @@ class UserInvitesTest < ApplicationSystemTestCase
     click_button "+ Invite user"
 
     assert_selector "h1", text: "Invite generated"
-    assert_selector "code", text: %r{/invites/}
+    assert_selector "code", text: %r{/invites\?token=}
   end
 end


### PR DESCRIPTION
## Summary
- Move invite and email-confirmation tokens off the URL path and into a `?token=` query param so Rails request logs redact them via the existing `filter_parameters += [:password, :token]` entry. Rails logs now show `?token=[FILTERED]`.
- Drop the unused `get "publish"` route from `delivery_notes` (publish is only ever invoked via POST), matching the `invoices` resource and removing a side-effecting GET endpoint.

Routes change shape (all helper names preserved via explicit `as:`):

| Helper | Before | After |
|---|---|---|
| `invite_path` | `/invites/:token` | `/invites?token=…` |
| `options_invite_path` | `/invites/:token/options` | `/invites/options?token=…` |
| `verify_invite_path` | `/invites/:token/verify` | `/invites/verify?token=…` |
| `account_email_confirmation_path` | `/account/email_confirmations/:token` | `/account/email_confirmations?token=…` |

`config/initializers/rack_attack.rb` path matchers updated to the new shapes; throttle keys and limits unchanged.

## Scope and known limitations
- This addresses **Rails-side logging only**. The production Apache vhost (`deploy/apache/abt-vhost.conf.tpl`) uses the `combined` LogFormat, which prints `%r` — the full request line including the query string. So `abt_access_ssl.log` still records the token until a follow-up scrubs it there (`mod_log_config` doesn't honor `filter_parameters`).
- Existing in-flight invite / email-confirmation links point at the old path and will 404 after merge. Acceptable: tokens are single-use and short-lived (invites 24h).
- Browser-history / address-bar exposure of the token is unchanged — moving from path to query string doesn't help here.
- Referer-leak risk reviewed and ruled out: strict CSP (`default-src 'self'`), local Open-Sans, no third-party resources on the invite landing page or the email-confirmation redirect path.

## Test plan
- [x] `bundle exec rails test test/controllers test/integration test/services test/mailers test/models` — 669 runs, 0 failures
- [x] `bundle exec rails test test/system/user_invites_test.rb` — invite-generation system test passes against new URL shape
- [ ] Verify in dev: open an issued invite link with the new query-string shape and complete signup
- [ ] Verify in dev: trigger an email-confirmation send and click the link
- [ ] Confirm Rails log shows `?token=[FILTERED]` for a real request

🤖 Generated with [Claude Code](https://claude.com/claude-code)