### PR TITLE
Adapt production vhost for HAProxy SNI-passthrough + mod_md

### DIFF
--- a/deploy/apache/abt-vhost.conf.tpl
+++ b/deploy/apache/abt-vhost.conf.tpl
@@ -1,20 +1,37 @@
 # ABT Apache VirtualHost template.
 #
-# Copy to /etc/apache2/sites-available/abt.conf, edit ServerName, SSL paths,
-# and log paths to match the host, then `a2ensite abt && systemctl reload apache2`.
-# The app-owned directives are kept in deploy/apache/abt-app.conf inside the
-# repo so they stay in sync with the application.
+# Copy to /etc/apache2/sites-available/abt.conf, edit ServerName and log
+# paths to match the host, then `a2ensite abt && systemctl reload apache2`.
+# App-owned directives live in deploy/apache/abt-app.conf.
+#
+# Connections arrive via HAProxy using `send-proxy-v2`; mod_remoteip
+# consumes the header to recover the real client IP. Anything that can
+# reach this :443 listener and send a PROXY header can forge that IP —
+# restrict :443 to the HAProxy ingress.
+#
+# mod_md handles ACME via TLS-ALPN-01 over the same :443 listener; HAProxy
+# forwards the ClientHello (ALPN included) verbatim through SNI passthrough.
+# No :80 vhost — HAProxy 301-redirects all HTTP traffic.
+
+MDCertificateAgreement accepted
+MDCAChallenges tls-alpn-01
 
 <VirtualHost *:443>
   ServerName abt.example.com
+  MDomain abt.example.com
 
   ErrorLog  /var/log/apache2/abt_error_ssl.log
   CustomLog /var/log/apache2/abt_access_ssl.log combined
   ServerSignature Off
 
+  # Deliberately no `RemoteIPHeader` — only the PROXY-protocol header on
+  # the TCP connection is trusted, never a client-supplied X-Forwarded-For.
+  RemoteIPProxyProtocol On
+  # Silence AH03507 from HAProxy health checks: trixie's Apache 2.4.67
+  # mod_remoteip rejects PROXY-protocol LOCAL headers (mainline accepts).
+  LogLevel remoteip:crit
+
   SSLEngine on
-  SSLCertificateFile    /etc/apache2/ssl/abt.crt
-  SSLCertificateKeyFile /etc/apache2/ssl/abt.key
 
   Include /srv/abt/deploy/apache/abt-app.conf
 </VirtualHost>

--- a/docs/production-update.md
+++ b/docs/production-update.md
@@ -1,6 +1,6 @@
 # Production Deployment
 
-`bin/production-update` is the automated deployment script for the ABT application in production. Production runs **Puma** behind **Apache 2.4** as a TLS-terminating reverse proxy; both Puma and the Solid Queue jobs worker are supervised as systemd **user** units under the application user. The unit files live in [`deploy/systemd/`](../deploy/systemd/) and the Apache include lives in [`deploy/apache/`](../deploy/apache/).
+`bin/production-update` is the automated deployment script for the ABT application in production. The production target is **Debian 13 (trixie)** running **Puma** behind **Apache 2.4** as a TLS-terminating reverse proxy; both Puma and the Solid Queue jobs worker are supervised as systemd **user** units under the application user. The unit files live in [`deploy/systemd/`](../deploy/systemd/) and the Apache include lives in [`deploy/apache/`](../deploy/apache/).
 
 For a first-time cutover from the previous mod_passenger setup, see [`migrate-passenger-to-puma.md`](./migrate-passenger-to-puma.md).
 
@@ -90,14 +90,30 @@ App-owned directives live in [`deploy/apache/abt-app.conf`](../deploy/apache/abt
 One-time setup on a fresh host:
 
 ```bash
-sudo a2enmod proxy proxy_http headers
+sudo a2enmod proxy proxy_http headers remoteip md
 sudo cp deploy/apache/abt-vhost.conf.tpl /etc/apache2/sites-available/abt.conf
-# edit ServerName, SSL cert paths, log paths in /etc/apache2/sites-available/abt.conf
+# edit ServerName and log paths in /etc/apache2/sites-available/abt.conf
 sudo a2ensite abt
 sudo apache2ctl configtest && sudo systemctl reload apache2
 ```
 
 The `RequestHeader set X-Forwarded-Proto "https"` line in `abt-app.conf` is load-bearing — `config.action_dispatch.trusted_proxies` + `config.force_ssl` in `config/environments/production.rb` depend on it being set (not setifempty). Don't edit either file in isolation.
+
+### HAProxy frontend
+
+The `:443` vhost expects connections to arrive via an HAProxy SNI router using `send-proxy-v2` — `RemoteIPProxyProtocol On` relies on it for the real client IP. Any TCP client that can reach this listener directly can forge the client IP, so make sure `:443` on the Apache host is only reachable from HAProxy (bind Apache to an internal interface and/or restrict at the network layer). HAProxy's `:80` frontend 301-redirects all HTTP traffic to HTTPS and never forwards upstream; Apache has no `:80` vhost.
+
+### TLS certificates (mod_md)
+
+Apache's `mod_md` handles issuance and renewal in-process. Validation uses TLS-ALPN-01 over `:443`, which traverses HAProxy's SNI passthrough cleanly because HAProxy forwards the ClientHello (including the ALPN extension) verbatim upstream.
+
+First-time bootstrap on a fresh host:
+
+1. Make sure DNS for the names in `MDomain` already resolves to the HAProxy public IP and that HAProxy's `services.map` routes the SNI to this host.
+2. Reload Apache. mod_md will reach out to Let's Encrypt on its next wake-up (within minutes) and obtain the cert; until then Apache serves a self-signed placeholder.
+3. Watch `journalctl -u apache2 -f` to confirm issuance.
+
+Renewal happens automatically — mod_md wakes up daily, renews ~30 days before expiry, and triggers a graceful Apache reload. State lives under `/var/lib/apache2/md/`.
 
 ## Solid Queue jobs worker
 


### PR DESCRIPTION
The production Apache vhost template and its docs now assume an HAProxy SNI-passthrough ingress that forwards TLS connections to Apache with `send-proxy-v2`. mod_remoteip consumes the PROXY header on the :443 listener so the real client IP flows through to Puma's X-Forwarded-For chain unchanged.

Certificate issuance moves from certbot to mod_md using TLS-ALPN-01, which works over the same :443 listener because HAProxy forwards the ClientHello (ALPN included) verbatim. The :80 vhost is gone — HAProxy's :80 frontend 301-redirects HTTP traffic itself.

Pin Debian 13 (trixie) as the documented production target, and silence AH03507 noise from HAProxy health checks: trixie's Apache 2.4.67 mod_remoteip rejects PROXY-protocol LOCAL headers that mainline accepts.