### PR TITLE
Email To/Cc: display names + harden dedup (closes #344)

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -5,9 +5,11 @@ class Customer < ApplicationRecord
   validates :name, presence: true
   validates :vat_id, presence: true, if: -> { sales_tax_customer_class&.vat_id_required? }
   validates :country_iso2, presence: true, inclusion: { in: ISO3166::Country.codes, message: "must be a valid country" }
+  validates :invoice_email_auto_to, format: { with: URI::MailTo::EMAIL_REGEXP, allow_blank: true }
 
   # Set default language (English) for new customers
   before_validation :set_default_language, on: :create
+  before_validation :normalize_invoice_email_auto_to
 
   belongs_to :sales_tax_customer_class
   belongs_to :language
@@ -91,6 +93,10 @@ class Customer < ApplicationRecord
 
   def set_default_language
     self.language ||= Language.find_by(iso_code: "en")
+  end
+
+  def normalize_invoice_email_auto_to
+    self.invoice_email_auto_to = invoice_email_auto_to.to_s.strip if invoice_email_auto_to
   end
 
   def check_if_used

--- a/app/models/customer_contact.rb
+++ b/app/models/customer_contact.rb
@@ -2,6 +2,8 @@ class CustomerContact < ApplicationRecord
   belongs_to :customer
   has_and_belongs_to_many :projects, join_table: :customer_contact_projects
 
+  before_validation :normalize_email_and_name
+
   validates :name,  presence: true
   validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }
   validate :customer_must_be_visible_to_current_user, if: :will_save_change_to_customer_id?
@@ -16,7 +18,20 @@ class CustomerContact < ApplicationRecord
     projects.empty? || projects.include?(project)
   end
 
+  def to_email_address
+    addr = Mail::Address.new
+    addr.address = email.to_s
+    # Collapse CR/LF so a malicious contact name can't inject headers.
+    addr.display_name = name.to_s.gsub(/[\r\n]+/, " ")
+    addr.format
+  end
+
   private
+
+  def normalize_email_and_name
+    self.email = email.to_s.strip if email
+    self.name  = name.to_s.strip  if name
+  end
 
   def projects_belong_to_customer_or_unassigned
     bad = projects.reject { |p| p.bill_to_customer_id.nil? || p.bill_to_customer_id == customer_id }

--- a/app/models/delivery_note.rb
+++ b/app/models/delivery_note.rb
@@ -21,7 +21,7 @@ class DeliveryNote < ApplicationRecord
   }
 
   def email_recipients
-    customer.contacts_for_delivery_note(self).map(&:email)
+    customer.contacts_for_delivery_note(self).map(&:to_email_address)
   end
 
   # The contact whose salutation_line should personalize this delivery note's

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -32,17 +32,20 @@ class Invoice < ApplicationRecord
   scope :unpaid, -> { where(paid_at: nil) }
 
   # Recipients for a real outbound send. Honors invoice_email_auto_contact_mode
-  # when the customer's auto-email feature is on. Returns an array of email
-  # strings; callers compose them into mail.to / mail.cc.
+  # when the customer's auto-email feature is on. Returns RFC 5322 mailbox
+  # strings (`"Name" <addr>`) for contacts, bare address for the auto-To.
   def email_recipients
-    return customer.contacts_for_invoice(self).map(&:email) unless customer.invoice_email_auto_enabled?
+    return customer.contacts_for_invoice(self).map(&:to_email_address) unless customer.invoice_email_auto_enabled?
     [ customer.invoice_email_auto_to ].compact_blank
   end
 
   def email_cc_recipients
     return [] unless customer.invoice_email_auto_enabled? && customer.cc_contacts?
-    auto_to = customer.invoice_email_auto_to.to_s.downcase.strip
-    customer.contacts_for_invoice(self).map(&:email).reject { |e| e.to_s.downcase.strip == auto_to }
+    auto_to = customer.invoice_email_auto_to.to_s.downcase
+    customer.contacts_for_invoice(self)
+      .uniq    { |c| c.email.to_s.downcase }
+      .reject  { |c| c.email.to_s.downcase == auto_to }
+      .map(&:to_email_address)
   end
 
   # The contact whose salutation_line should personalize this invoice's email,

--- a/app/views/customers/_form.html.haml
+++ b/app/views/customers/_form.html.haml
@@ -63,7 +63,7 @@
           = f.input_field :invoice_email_auto_enabled, as: :boolean, class: 'form-check-input'
           = f.label :invoice_email_auto_enabled, class: 'form-check-label', label: 'On'
       .col-lg-4
-        = f.text_field :invoice_email_auto_to, {:class => 'form-control', :placeholder => 'To:'}
+        = f.email_field :invoice_email_auto_to, {:class => 'form-control', :placeholder => 'To:'}
       .col-lg-4
         = f.text_field :invoice_email_auto_subject_template, {:class => 'form-control', :placeholder => 'Subject: XXXX $CUST_REF$ $CUST_ORDER$'}
     .row.mb-3

--- a/test/mailers/invoice_mailer_test.rb
+++ b/test/mailers/invoice_mailer_test.rb
@@ -57,17 +57,69 @@ class InvoiceMailerTest < ActionMailer::TestCase
     assert mail.cc.blank?, "expected mail.cc to be blank, got #{mail.cc.inspect}"
   end
 
-  test "customer_email with auto + cc_contacts deduplicates a contact whose email matches the auto address case-insensitively" do
+  test "customer_email strips surrounding whitespace from auto_to before emitting To header" do
     customer = customers(:auto_email_customer)
-    customer.customer_contacts.create!(name: "Shouty", email: customer.invoice_email_auto_to.upcase, receives_invoice_emails: true)
+    customer.update!(invoice_email_auto_to: "  billing@autoemail.com  ")
     invoice = invoices(:auto_email_invoice)
 
     mail = InvoiceMailer.with(invoice: invoice).customer_email
 
     assert_equal [ "billing@autoemail.com" ], mail.to
-    # backup@autoemail.com (from the auto_email_contact fixture) survives;
-    # the BILLING@AUTOEMAIL.COM contact was dropped from CC.
     assert_equal [ "backup@autoemail.com" ], mail.cc
+  end
+
+  test "customer_email deduplicates two contacts that share the same email" do
+    customer = customers(:auto_email_customer)
+    customer.customer_contacts.create!(name: "Backup Dup", email: "backup@autoemail.com", receives_invoice_emails: true)
+    invoice = invoices(:auto_email_invoice)
+
+    mail = InvoiceMailer.with(invoice: invoice).customer_email
+
+    assert_equal [ "billing@autoemail.com" ], mail.to
+    assert_equal [ "backup@autoemail.com" ], mail.cc
+  end
+
+  test "customer_email drops every contact whose email case-insensitively matches the auto_to" do
+    customer = customers(:auto_email_customer)
+    customer.customer_contacts.create!(name: "Variant One", email: "BILLING@autoemail.com", receives_invoice_emails: true)
+    customer.customer_contacts.create!(name: "Variant Two", email: "Billing@AUTOEMAIL.com", receives_invoice_emails: true)
+    invoice = invoices(:auto_email_invoice)
+
+    mail = InvoiceMailer.with(invoice: invoice).customer_email
+
+    assert_equal [ "billing@autoemail.com" ], mail.to
+    assert_equal [ "backup@autoemail.com" ], mail.cc
+  end
+
+  test "customer_email To header carries each contact's display name" do
+    invoice = invoices(:published_invoice)
+    mail = InvoiceMailer.with(invoice: invoice).customer_email
+
+    assert_equal [ "GOOD Accounting", "PROJ001 Lead" ].sort, mail[:to].display_names.sort
+  end
+
+  test "customer_email Cc header carries the contact display name" do
+    invoice = invoices(:auto_email_invoice)
+    mail = InvoiceMailer.with(invoice: invoice).customer_email
+
+    assert_equal [ "Auto Email Backup" ], mail[:cc].display_names
+  end
+
+  test "customer_email auto_to is emitted as a bare address with no display name" do
+    invoice = invoices(:auto_email_invoice)
+    mail = InvoiceMailer.with(invoice: invoice).customer_email
+
+    assert_equal [ nil ], mail[:to].display_names
+  end
+
+  test "customer_email strips CRLF from contact display names to prevent header injection" do
+    customer_contacts(:good_eu_accounting).update!(name: "Bad\r\nBcc: attacker@example.com")
+    invoice = invoices(:published_invoice)
+
+    mail = InvoiceMailer.with(invoice: invoice).customer_email
+
+    assert_no_match(/[\r\n]/, mail[:to].display_names.compact.join)
+    assert_equal [ "bcc@example.com" ], mail.bcc, "no extra Bcc injected"
   end
 
   test "customer_email with auto + cc_contacts but no matching contact omits cc" do

--- a/test/models/customer_contact_test.rb
+++ b/test/models/customer_contact_test.rb
@@ -25,6 +25,37 @@ class CustomerContactTest < ActiveSupport::TestCase
     assert_includes contact.errors[:email], "is invalid"
   end
 
+  test "strips surrounding whitespace from email before validation" do
+    contact = CustomerContact.create!(customer: customers(:good_eu), name: "X", email: "  x@example.com  ")
+    assert_equal "x@example.com", contact.reload.email
+  end
+
+  test "strips surrounding whitespace from name before validation" do
+    contact = CustomerContact.create!(customer: customers(:good_eu), name: "  X  ", email: "x@example.com")
+    assert_equal "X", contact.reload.name
+  end
+
+  test "whitespace-only email is rejected because strip makes it blank" do
+    contact = CustomerContact.new(customer: customers(:good_eu), name: "X", email: "   ")
+    assert_not contact.valid?
+    assert_includes contact.errors[:email], "can't be blank"
+  end
+
+  test "to_email_address formats as RFC 5322 mailbox with display name" do
+    contact = CustomerContact.new(name: "John Doe", email: "john@example.com")
+    assert_equal "John Doe <john@example.com>", contact.to_email_address
+  end
+
+  test "to_email_address quotes display names that contain special characters" do
+    contact = CustomerContact.new(name: "Doe, John", email: "john@example.com")
+    assert_equal '"Doe, John" <john@example.com>', contact.to_email_address
+  end
+
+  test "to_email_address strips CR/LF from the display name to prevent header injection" do
+    contact = CustomerContact.new(name: "Bad\r\nBcc: attacker@example.com", email: "ok@example.com")
+    assert_no_match(/[\r\n]/, contact.to_email_address)
+  end
+
   test "applies_to_project? returns true for any project when no projects assigned" do
     contact = customer_contacts(:good_eu_accounting)
     assert_empty contact.projects

--- a/test/models/customer_test.rb
+++ b/test/models/customer_test.rb
@@ -262,4 +262,24 @@ class CustomerTest < ActiveSupport::TestCase
     customer.update!(vat_id: "BE0987654321")
     assert_nil customer.current_vat_verification
   end
+
+  test "strips surrounding whitespace from invoice_email_auto_to before save" do
+    customer = customers(:auto_email_customer)
+    customer.update!(invoice_email_auto_to: "  billing@autoemail.com  ")
+    assert_equal "billing@autoemail.com", customer.reload.invoice_email_auto_to
+  end
+
+  test "rejects an invoice_email_auto_to that is not a valid email" do
+    customer = build_customer(invoice_email_auto_to: "not-an-email")
+    assert_not customer.valid?
+    assert_includes customer.errors[:invoice_email_auto_to], "is invalid"
+  end
+
+  test "allows blank invoice_email_auto_to" do
+    customer = build_customer(invoice_email_auto_to: nil)
+    assert customer.valid?, customer.errors.full_messages.inspect
+
+    customer = build_customer(invoice_email_auto_to: "")
+    assert customer.valid?, customer.errors.full_messages.inspect
+  end
 end


### PR DESCRIPTION
## Summary
- Recipients now see `"Contact Name" <addr>` in `To`/`Cc` for invoice and delivery-note mail (new `CustomerContact#to_email_address` via `Mail::Address`, CRLF-safe).
- Closes #344: `Invoice#email_cc_recipients` now `.uniq`s the contact list — covers duplicate contacts AND case-different duplicates of the auto-To in one pass.
- Save-time normalization: `CustomerContact` and `Customer` strip whitespace from email fields before validation; `Customer` validates `invoice_email_auto_to` format when present.
- Customer admin form uses `email_field` for `invoice_email_auto_to` so browsers reject malformed input client-side.

The auto-To address is intentionally emitted as a bare address (no display name) — it's a single string field with no associated person.

## Test plan
- [x] `bundle exec rails test` (full suite green, 761 runs)
- [x] `bundle exec rails test test/system/` (61 runs green)
- [x] `pre-commit run --all-files`
- [ ] Manually verify in admin UI: editing a customer with a malformed `invoice_email_auto_to` is rejected client-side by the browser
- [ ] Manually verify an outbound invoice email renders `"Name" <addr>` in `To`/`Cc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)