### PR TITLE
Customer form: mark Country label as required

### DIFF
--- a/app/views/customers/_form.html.haml
+++ b/app/views/customers/_form.html.haml
@@ -35,7 +35,7 @@
       .col-lg-5
         = f.text_area :address, :class => 'form-control', :rows => 3
     .row.mb-3
-      = f.label :country_iso2, 'Country', required: true, class: 'col-lg-2 col-md-3 col-form-label'
+      = f.label :country_iso2, label: 'Country', required: true, class: 'col-lg-2 col-md-3 col-form-label'
       .col-sm-5
         = f.select :country_iso2, country_options, { prompt: 'Select country...' }, { class: 'form-select', required: true }
     .row.mb-3

--- a/test/controllers/customers_controller_test.rb
+++ b/test/controllers/customers_controller_test.rb
@@ -36,6 +36,8 @@ class CustomersControllerTest < ActionDispatch::IntegrationTest
     assert_select "label.required[for='customer_team_id']"
     assert_select "label.required[for='customer_sales_tax_customer_class_id']"
     assert_select "label.required[for='customer_language_id']"
+    assert_select "label.required[for='customer_country_iso2']"
+    assert_select "select#customer_country_iso2[required]"
   end
 
   test "should create customer" do


### PR DESCRIPTION
The Country label was being rendered without the required asterisk because the label text was passed as a positional argument (`'Country'`) rather than via the `label:` keyword. simple_form's option processing — including the `required:` class — only kicks in for the keyword form.