### PR TITLE
Form labels: drop redundant required:/label: where auto-derivation matches

### DIFF
--- a/app/views/customers/_form.html.haml
+++ b/app/views/customers/_form.html.haml
@@ -20,7 +20,7 @@
           = f.label :active, class: 'form-check-label'
 
     .row.mb-3
-      = f.label :team_id, label: 'Team', required: true, class: 'col-lg-2 col-md-3 col-form-label'
+      = f.label :team_id, required: true, class: 'col-lg-2 col-md-3 col-form-label'
       .col-sm-5
         = f.collection_select :team_id, available_teams, :id, :name, { prompt: 'Select team...' }, {:class => 'form-select', :required => true}
         - if available_teams.empty?
@@ -35,7 +35,7 @@
       .col-lg-5
         = f.text_area :address, :class => 'form-control', :rows => 3
     .row.mb-3
-      = f.label :country_iso2, label: 'Country', required: true, class: 'col-lg-2 col-md-3 col-form-label'
+      = f.label :country_iso2, class: 'col-lg-2 col-md-3 col-form-label'
       .col-sm-5
         = f.select :country_iso2, country_options, { prompt: 'Select country...' }, { class: 'form-select', required: true }
     .row.mb-3
@@ -52,7 +52,7 @@
       .col-sm-5
         = f.collection_select :sales_tax_customer_class_id, SalesTaxCustomerClass.all, :id, :name, { prompt: 'Select tax class...' }, {:class => 'form-select', :required => true}
     .row.mb-3
-      = f.label :language_id, required: true, class: 'col-lg-2 col-md-3 col-form-label', label: "Language"
+      = f.label :language_id, required: true, class: 'col-lg-2 col-md-3 col-form-label'
       .col-sm-5
         = f.collection_select :language_id, Language.all, :id, :title, { prompt: 'Select language...' }, {:class => 'form-select', :required => true}
     %hr

--- a/app/views/products/_form.html.haml
+++ b/app/views/products/_form.html.haml
@@ -11,7 +11,7 @@
 
   .form-inputs
     .row.mb-3
-      = f.label :title, required: true, class: 'col-lg-2 col-md-3 col-form-label'
+      = f.label :title, class: 'col-lg-2 col-md-3 col-form-label'
       .col-sm-3
         = f.text_field :title, {:class => 'form-control', :required => true}
     .row.mb-3
@@ -19,7 +19,7 @@
       .col-sm-9
         = f.text_area :description, {:class => 'form-control', :rows => 4}
     .row.mb-3
-      = f.label :rate, required: true, class: 'col-lg-2 col-md-3 col-form-label'
+      = f.label :rate, class: 'col-lg-2 col-md-3 col-form-label'
       .col-sm-3
         = f.number_field :rate, {:class => 'form-control', :required => true}
     .row.mb-3

--- a/app/views/projects/_form.html.haml
+++ b/app/views/projects/_form.html.haml
@@ -31,7 +31,7 @@
           = f.collection_select :bill_to_customer_id, @customer_options, :id, :name, { prompt: 'Select customer...', include_blank: 'No customer (reusable project)' }, {:class => 'form-select', "data-project-team-target" => "customer", "data-customer-team-map" => @customer_options.to_h { |c| [c.id, { team_id: c.team_id, team_name: c.team&.name }] }.to_json}
 
       .row.mb-3{"data-project-team-target" => "teamRow"}
-        = f.label :team_id, label: 'Team', required: true, class: 'col-lg-2 col-md-3 col-form-label'
+        = f.label :team_id, required: true, class: 'col-lg-2 col-md-3 col-form-label'
         .col-sm-5
           = f.collection_select :team_id, available_teams, :id, :name, { prompt: 'Select team...' }, {:class => 'form-select', :required => true, "data-project-team-target" => "teamSelect"}
           - if @project.bill_to_customer_id.present? && selected_customer_team


### PR DESCRIPTION
## Summary
Follow-up to #450. simple_form auto-derives both the `required` CSS class (from the model's presence validators) and the label text (from `humanize` / locale), so the explicit options were redundant in a handful of places.

**Dropped** (6 lines total):
- `customers/_form.html.haml`: `:team_id` (drop `label: 'Team'` — humanize matches), `:country_iso2` (drop both — directly validated + locale provides "Country"), `:language_id` (drop `label: "Language"`)
- `products/_form.html.haml`: `:title`, `:rate` (drop `required: true` — directly validated)
- `projects/_form.html.haml`: `:team_id` (drop `label: 'Team'`)

**Kept (load-bearing)**: `required: true` on belongs_to FK labels (`:team_id`, `:language_id`, `:sales_tax_*_id`). simple_form's auto-detection runs against the association name (`:team`), not the FK column (`:team_id`), so the explicit option is what gets the asterisk to render. Empirically verified — removing it broke the existing `label.required[for='project_team_id']` assertion.

**Kept (humanize is wrong / differs)**: explicit `label:` text for `:vat_id` ("Vat" → "VATID"), `:supplier_number`, `:sales_tax_*_id` (humanize: "Sales tax customer class", UI: "Sales Tax Class"), `:invoice_email_auto_*`, `:payment_terms_days`.

## Test plan
- [x] `bundle exec rails test` (759 runs green; controller tests for customers/products/projects already assert `label.required[for=...]` for these fields)
- [x] `pre-commit run --all-files`
- [ ] Manual smoke: load `/customers/new`, `/products/new`, `/projects/new` and confirm the required-field asterisks still render

🤖 Generated with [Claude Code](https://claude.com/claude-code)