### PR TITLE
ci: harden GitHub Actions workflows (zizmor audit)

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Approve PR
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             await github.rest.pulls.createReview({

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,6 +1,7 @@
 name: Auto Approve
-permissions:
-  pull-requests: write
+
+# Deny-all by default; the job below grants only what it needs.
+permissions: {}
 
 on:
   issue_comment:
@@ -8,6 +9,9 @@ on:
 
 jobs:
   auto-approve:
+    name: Approve PR
+    permissions:
+      pull-requests: write
     if: |
       github.event.issue.pull_request &&
       github.event.comment.body == '/approve' &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
@@ -87,6 +89,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
@@ -102,6 +106,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Set up Node.js
       uses: actions/setup-node@v6
@@ -121,6 +127,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,12 @@ jobs:
           - 5432:5432
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
 
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
       with:
         bundler-cache: true
 
@@ -88,12 +88,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
 
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
       with:
         bundler-cache: true
 
@@ -105,12 +105,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
 
     - name: Set up Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: '22'
         cache: 'npm'
@@ -126,14 +126,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
 
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
       with:
         bundler-cache: true
 
     - name: Run pre-commit hooks
-      uses: pre-commit/action@v3.0.1
+      uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
 
     steps:
     - name: Get Dependabot metadata

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,17 +1,20 @@
 name: Dependabot Auto-Merge
 
+# Deny-all by default; the job below grants only what it needs.
+permissions: {}
+
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
-permissions:
-  contents: write
-  pull-requests: write
-  checks: read
-
 jobs:
   dependabot:
+    name: Auto-merge Dependabot PRs
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      checks: read
     if: github.event.pull_request.user.login == 'dependabot[bot]'
 
     steps:

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - name: Get Dependabot metadata
       id: metadata
-      uses: dependabot/fetch-metadata@v3
+      uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
       with:
         github-token: "${{ secrets.GITHUB_TOKEN }}"
 


### PR DESCRIPTION
Addresses findings from a `zizmor` audit of `.github/workflows/`.

## Changes

**artipacked (low)** — set `persist-credentials: false` on all four `actions/checkout` steps in `ci.yml`, so the `GITHUB_TOKEN` is not left in `.git/config` and cannot leak via uploaded artifacts.

**bot-conditions (high)** — `dependabot.yml` now gates the auto-merge job on `github.event.pull_request.user.login` instead of the spoofable `github.actor` context.

**unpinned-uses (high)** — pinned all six actions to full commit SHAs with version comments so Dependabot's `github-actions` updater keeps bumping the SHA while preserving the readable tag:

| Action | SHA | Tag |
|---|---|---|
| actions/checkout | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` | v6.0.2 |
| ruby/setup-ruby | `afeafc3d1ab54a631816aba4c914a0081c12ff2f` | v1.310.0 |
| actions/setup-node | `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` | v6.4.0 |
| pre-commit/action | `2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd` | v3.0.1 |
| actions/github-script | `3a2844b7e9c422d3c10d287c895573f7108da1b3` | v9.0.0 |
| dependabot/fetch-metadata | `25dd0e34f4fe68f24cc83900b1fe3fe149efef98` | v3.1.0 |

**excessive-permissions (high) + anonymous-definition (info)** — `auto-approve.yml` and `dependabot.yml` now use a top-level deny-all (`permissions: {}`) and grant the specific scopes at the job level. Both jobs got explicit `name:` keys.

## Result

`zizmor` (default persona) reports **no findings**. Remaining auditor-persona items were intentionally left out of scope: `concurrency-limits` (3), `undocumented-permissions` (2), `unpinned-images` for the `postgres:17` test service (1).

https://claude.ai/code/session_01Jx2yfjtvwxpiY17Kzk3JDj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jx2yfjtvwxpiY17Kzk3JDj)_