### PR TITLE
Security hardening: spawn FOP without a shell + require master key in production

### DIFF
--- a/app/services/fop_renderer.rb
+++ b/app/services/fop_renderer.rb
@@ -18,9 +18,10 @@ class FopRenderer
     @template_path = Rails.root.join("lib", "foptemplate")
     @fop_conf = @template_path.join("fop-conf.xml")
     # Pin the font cache to tmp/. Otherwise FOP writes it relative to
-    # <base>.</base> in fop-conf.xml, which resolves to the cwd we set in
-    # build_fop_command (lib/foptemplate/), leaving an untracked .fop/
-    # directory in the source tree after every render.
+    # <base>.</base> in fop-conf.xml, which resolves to the cwd we set when
+    # spawning FOP (lib/foptemplate/, via the chdir: option in
+    # execute_fop_command), leaving an untracked .fop/ directory in the
+    # source tree after every render.
     @fop_cache = @rails_tmp.join("fop-fonts.cache")
   end
 
@@ -72,11 +73,15 @@ class FopRenderer
 
       fop_command = build_fop_command(fop_binary, xml_path, xsl_path, pdf_path)
 
-      Rails.logger.debug "Calling fop: #{fop_command}"
+      Rails.logger.debug "Calling fop: #{fop_command.inspect}"
 
       fop_result = nil
       exit_status = nil
-      IO.popen(fop_command, "r", err: [ :child, :out ]) do |fop_io|
+      # Array form (no shell): each argument is passed verbatim to FOP, so a
+      # path containing shell metacharacters can't be interpreted as a command.
+      # chdir runs FOP with cwd at the template dir, which fop-conf.xml's
+      # relative <base> requires.
+      IO.popen(fop_command, "r", err: [ :child, :out ], chdir: @template_path.to_s) do |fop_io|
         fop_result = fop_io.read
         fop_io.close
         exit_status = $?.exitstatus
@@ -116,11 +121,17 @@ class FopRenderer
     end
   end
 
+  # Returns an argv array for IO.popen; cwd is set via the popen chdir:
+  # option, so no shell is involved.
   def build_fop_command(fop_binary, xml_path, xsl_path, pdf_path)
-    "cd \"#{@template_path}\" && " +
-    "\"#{fop_binary}\" " +
-    "-xml \"#{xml_path}\" -xsl \"#{xsl_path}\" -pdf \"#{pdf_path}\" -c \"#{@fop_conf}\" " +
-    "-cache \"#{@fop_cache}\""
+    [
+      fop_binary.to_s,
+      "-xml", xml_path.to_s,
+      "-xsl", xsl_path.to_s,
+      "-pdf", pdf_path.to_s,
+      "-c", @fop_conf.to_s,
+      "-cache", @fop_cache.to_s
+    ]
   end
 
   # Write file with explicit permissions to work around restrictive umask

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -18,7 +18,9 @@ Rails.application.configure do
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
-  # config.require_master_key = true
+  # Fail fast at boot rather than starting up with a silently-degraded crypto
+  # state (e.g. unreadable encrypted credentials / cookie signing material).
+  config.require_master_key = true
 
   # Cache assets for far-future expiry since they are all digest stamped.
   config.public_file_server.headers = { "cache-control" => "public, max-age=#{1.year.to_i}" }

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -93,6 +93,7 @@ For cross-resource navigation in a breadcrumb action cluster, use `nav_button` (
 ## Comments
 - Default to none. Add a one-liner only when the *why* isn't obvious from the code (workaround, invariant, hidden constraint).
 - Don't reference the current PR/task in comments — that belongs in the PR description.
+- Describe the present, not the history. Say what the code does now and why; don't note what it "previously" did, what a change "replaces", or contrast against an earlier version — that belongs in the commit message.
 
 ## Code quality
 - DRY when refactoring or fixing, but don't overdo it. Prefer clarity and maintainability over excessive abstraction.


### PR DESCRIPTION
Two independent hardening changes from the security review, one per commit.

## 1. FopRenderer: spawn FOP via argv array instead of a shell string

`build_fop_command` previously returned a `cd "<dir>" && "<fop>" -xml ...`
shell string passed to `IO.popen`, which runs it through `/bin/sh`. All
interpolated values are server-controlled today, so this was not
exploitable, but constructing a shell command line is fragile: if any path
(e.g. a future logo/tempfile name) ever carried shell metacharacters it
would become command injection.

Return an argv array and set the working directory via `IO.popen`'s
`chdir:` option instead of a `cd` prefix. No shell is involved, so every
argument is passed to FOP verbatim. FOP still runs with cwd at
`lib/foptemplate/` so `fop-conf.xml`'s relative `<base>` resolves
correctly. Verified against `fop_renderer_test.rb` and
`invoice_renderer_test.rb` (real FOP PDF generation).

## 2. production: require a master key at boot

`config.action_mailer.mailgun_settings` reads
`Rails.application.credentials` (`config/application.rb`), so production
already depends on a master key being present (via `config/master.key` or
`RAILS_MASTER_KEY`) to decrypt credentials. Without `require_master_key`, a
missing/unreadable key fails silently — credentials return nil and the app
boots with degraded crypto state (no mailgun settings, etc.) rather than
refusing to start.

Enable `config.require_master_key` so production fails fast at boot
instead.

https://claude.ai/code/session_01FjpkqYqDAnEuEBrupv9aS6