### PR TITLE
Remove dead format.json from customers/projects index

### DIFF
--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -25,17 +25,6 @@ class CustomersController < ApplicationController
       # so without this guard the post-delete redirect would render dropdown options
       # into a missing target and leave the index page stale.
       format.turbo_stream { render :filter_options } if request.xhr?
-      format.json {
-        render json: @customers.map { |c|
-          {
-            id: c.id,
-            matchcode: c.matchcode,
-            name: c.name,
-            team_id: c.team_id,
-            team_name: c.team&.name
-          }
-        }
-      }
     end
   end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -4,7 +4,6 @@ class ProjectsController < ApplicationController
   before_action :load_customer_options, only: [ :new, :create, :edit, :update ]
 
   # GET /projects
-  # GET /projects.json
   def index
     params[:filter] ||= "active"
 
@@ -41,19 +40,6 @@ class ProjectsController < ApplicationController
       # so without this guard the post-delete redirect would render dropdown options
       # into a missing target and leave the index page stale.
       format.turbo_stream { render :filter_options } if request.xhr?
-      format.json {
-        render json: @projects.map { |project|
-          {
-            id: project.id,
-            name: project.display_name,
-            matchcode: project.matchcode,
-            description: project.description,
-            is_reusable: project.bill_to_customer_id.nil?,
-            team_id: project.team_id,
-            team_name: project.team&.name
-          }
-        }
-      }
     end
   end
 

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -257,148 +257,39 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Updated to have no customer", @project.description
   end
 
-  test "should filter projects by customer_id in JSON format" do
-    # Create additional projects for testing
-    customer_a = customers(:good_eu)
-    customer_b = customers(:good_national)
-
-    project_a = Project.create!(
-      matchcode: "CUST_A",
-      description: "Project for Customer A",
-      bill_to_customer: customer_a,
-      active: true,
-      team: teams(:default)
-    )
-
-    project_b = Project.create!(
-      matchcode: "CUST_B",
-      description: "Project for Customer B",
-      bill_to_customer: customer_b,
-      active: true,
-      team: teams(:default)
-    )
-
-    get projects_url(format: :json, customer_id: customer_a.id)
-    assert_response :success
-
-    projects = JSON.parse(response.body)
-    customer_a_project_ids = projects.map { |p| p["id"] }
-
-    assert_includes customer_a_project_ids, project_a.id
-    assert_not_includes customer_a_project_ids, project_b.id
-  end
-
-  test "should include reusable projects when include_reusable is true" do
-    # Create a reusable project (no customer)
-    reusable_project = Project.create!(
-      matchcode: "REUSABLE_INC",
-      description: "Reusable project",
-      bill_to_customer: nil,
-      active: true,
-      team: teams(:default)
-    )
-
-    get projects_url(format: :json, include_reusable: "true")
-    assert_response :success
-
-    projects = JSON.parse(response.body)
-    project_ids = projects.map { |p| p["id"] }
-    reusable_flags = projects.map { |p| p["is_reusable"] }
-
-    assert_includes project_ids, reusable_project.id
-    assert_includes reusable_flags, true
-  end
-
-  test "should filter by customer and include reusable projects" do
+  test "dropdown filters projects to the given customer" do
     customer = customers(:good_eu)
+    other = customers(:good_national)
+    mine = Project.create!(matchcode: "MINE", description: "x", bill_to_customer: customer, active: true, team: teams(:default))
+    theirs = Project.create!(matchcode: "THEIRS", description: "x", bill_to_customer: other, active: true, team: teams(:default))
+    reusable = Project.create!(matchcode: "REUSE", description: "x", bill_to_customer: nil, active: true, team: teams(:default))
 
-    # Create project assigned to customer
-    customer_project = Project.create!(
-      matchcode: "ASSIGNED",
-      description: "Project assigned to customer",
-      bill_to_customer: customer,
-      active: true,
-      team: teams(:default)
-    )
+    get projects_url(customer_id: customer.id), headers: dropdown_xhr_headers
 
-    # Create reusable project
-    reusable_project = Project.create!(
-      matchcode: "REUSABLE_FILT",
-      description: "Reusable project",
-      bill_to_customer: nil,
-      active: true,
-      team: teams(:default)
-    )
-
-    # Create project for different customer
-    other_customer = customers(:good_national)
-    other_project = Project.create!(
-      matchcode: "OTHER",
-      description: "Project for other customer",
-      bill_to_customer: other_customer,
-      active: true,
-      team: teams(:default)
-    )
-
-    get projects_url(format: :json, customer_id: customer.id, include_reusable: "true")
-    assert_response :success
-
-    projects = JSON.parse(response.body)
-    project_ids = projects.map { |p| p["id"] }
-
-    # Should include customer's project and reusable project
-    assert_includes project_ids, customer_project.id
-    assert_includes project_ids, reusable_project.id
-
-    # Should NOT include other customer's project
-    assert_not_includes project_ids, other_project.id
+    assert_select %(turbo-stream[action="update"][target="project-dropdown-menu"]) do
+      assert_select ".searchable-option[data-item-id=?]", mine.id.to_s
+      assert_select ".searchable-option[data-item-id=?]", theirs.id.to_s, count: 0
+      assert_select ".searchable-option[data-item-id=?]", reusable.id.to_s, count: 0
+    end
   end
 
-  test "JSON response includes all required fields" do
-    get projects_url(format: :json, filter: "active")
-    assert_response :success
+  test "dropdown includes reusable projects when include_reusable is set" do
+    customer = customers(:good_eu)
+    reusable = Project.create!(matchcode: "REUSE", description: "x", bill_to_customer: nil, active: true, team: teams(:default))
 
-    projects = JSON.parse(response.body)
-    assert projects.length > 0
+    get projects_url(customer_id: customer.id, include_reusable: "true"), headers: dropdown_xhr_headers
 
-    project = projects.first
-    assert project.key?("id")
-    assert project.key?("name")
-    assert project.key?("matchcode")
-    assert project.key?("description")
-    assert project.key?("is_reusable")
+    assert_select %(turbo-stream[action="update"][target="project-dropdown-menu"]) do
+      assert_select ".searchable-option[data-item-id=?]", reusable.id.to_s
+    end
   end
 
-  test "JSON response marks reusable projects correctly" do
-    # Create projects with and without customers
-    with_customer = Project.create!(
-      matchcode: "WITH_CUST",
-      description: "With customer",
-      bill_to_customer: customers(:good_eu),
-      active: true,
-      team: teams(:default)
-    )
+  private
 
-    without_customer = Project.create!(
-      matchcode: "NO_CUST",
-      description: "Without customer",
-      bill_to_customer: nil,
-      active: true,
-      team: teams(:default)
-    )
-
-    get projects_url(format: :json, filter: "active")
-    assert_response :success
-
-    projects = JSON.parse(response.body)
-
-    with_cust_data = projects.find { |p| p["id"] == with_customer.id }
-    without_cust_data = projects.find { |p| p["id"] == without_customer.id }
-
-    assert_not_nil with_cust_data
-    assert_not_nil without_cust_data
-
-    assert_equal false, with_cust_data["is_reusable"]
-    assert_equal true, without_cust_data["is_reusable"]
+  # The searchable_dropdown Stimulus controller fetches options as a turbo
+  # stream and sets X-Requested-With; the index only renders options for that
+  # combination (see ProjectsController#index).
+  def dropdown_xhr_headers
+    { "Accept" => "text/vnd.turbo-stream.html", "X-Requested-With" => "XMLHttpRequest" }
   end
 end


### PR DESCRIPTION
## Summary

Removes the dead `format.json` branch from `customers#index` and `projects#index`.

The live searchable dropdowns fetch their options as a **turbo stream** (`searchable_dropdown_controller.js` sends `Accept: text/vnd.turbo-stream.html` + `X-Requested-With`), so the `format.turbo_stream { render :filter_options } if request.xhr?` branch is what actually serves them. The `format.json` branch was never reached in the app:

- `customers#index` JSON had **no consumer at all** (not even a test).
- `projects#index` JSON was exercised **only by controller tests**.
- The `team_id` / `team_name` keys flagged during the audit were dead within an already-dead branch.

## Tests

The projects JSON tests for `customer_id` / `include_reusable` filtering covered **live** behavior (that filtering also runs on the turbo_stream path used by the dependent project dropdown), so they're converted to assert against the rendered dropdown options rather than deleted. The two pure JSON-shape tests ("includes all required fields", "marks reusable correctly") are dropped — they only described the removed payload.

`bundle exec rails test test/controllers/projects_controller_test.rb test/controllers/customers_controller_test.rb` → 37 runs, 188 assertions, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
