### PR TITLE
Extract SearchableDropdownIndex concern (customers/projects index)

### DIFF
--- a/app/controllers/concerns/searchable_dropdown_index.rb
+++ b/app/controllers/concerns/searchable_dropdown_index.rb
@@ -1,0 +1,34 @@
+# Index actions that back a searchable dropdown (matchcode-named, active-flagged
+# resources like Customer and Project). Shares the active/inactive/all filter and
+# the HTML-or-dropdown-options response shape.
+module SearchableDropdownIndex
+  extend ActiveSupport::Concern
+
+  private
+
+  # Filter a base relation by params[:filter], defaulting to active records.
+  # Assigns params[:filter] so the view reflects the effective filter.
+  def filtered_by_active(scope)
+    params[:filter] ||= "active"
+    case params[:filter]
+    when "all"
+      scope
+    when "inactive"
+      scope.where(active: false)
+    else
+      scope.where(active: true)
+    end
+  end
+
+  # Index pages render a normal HTML page, plus a turbo_stream of <option>s for
+  # the searchable_dropdown Stimulus controller's XHR fetch. That controller sets
+  # X-Requested-With; the xhr guard keeps Turbo navigation (whose Accept also
+  # lists turbo_stream) from rendering options into a missing target on
+  # post-delete redirects.
+  def respond_to_index_or_dropdown
+    respond_to do |format|
+      format.html
+      format.turbo_stream { render :filter_options } if request.xhr?
+    end
+  end
+end

--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -1,31 +1,13 @@
 class CustomersController < ApplicationController
+  include SearchableDropdownIndex
+
   before_action -> { require_permission!("customers.view") }, only: [ :index, :show ]
   before_action -> { require_permission!("customers.edit") }, only: [ :new, :create, :edit, :update, :destroy, :verify_vat_id ]
 
   # GET /customers
   def index
-    # Show active customers by default
-    params[:filter] ||= "active"
-    base = Customer.visible_to(current_user)
-    @customers = case params[:filter]
-    when "all"
-      base
-    when "inactive"
-      base.where(active: false)
-    else
-      base.where(active: true)
-    end
-
-    @customers = @customers.order(:matchcode)
-
-    respond_to do |format|
-      format.html # index.html.erb
-      # Only the searchable_dropdown Stimulus controller hits this branch; it sets
-      # X-Requested-With explicitly. Turbo's navigation Accept also lists turbo_stream,
-      # so without this guard the post-delete redirect would render dropdown options
-      # into a missing target and leave the index page stale.
-      format.turbo_stream { render :filter_options } if request.xhr?
-    end
+    @customers = filtered_by_active(Customer.visible_to(current_user)).order(:matchcode)
+    respond_to_index_or_dropdown
   end
 
   # GET /customers/1

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,21 +1,13 @@
 class ProjectsController < ApplicationController
+  include SearchableDropdownIndex
+
   before_action -> { require_permission!("projects.view") }, only: [ :index, :show ]
   before_action -> { require_permission!("projects.edit") }, only: [ :new, :create, :edit, :update, :destroy ]
   before_action :load_customer_options, only: [ :new, :create, :edit, :update ]
 
   # GET /projects
   def index
-    params[:filter] ||= "active"
-
-    base = Project.visible_to(current_user)
-    @projects = case params[:filter]
-    when "all"
-      base
-    when "inactive"
-      base.where(active: false)
-    else
-      base.where(active: true)
-    end
+    @projects = filtered_by_active(Project.visible_to(current_user))
 
     # Filters for AJAX requests
     if params[:customer_id].present?
@@ -32,15 +24,7 @@ class ProjectsController < ApplicationController
     end
 
     @projects = @projects.order(:matchcode, :description)
-
-    respond_to do |format|
-      format.html # index.html.erb
-      # Only the searchable_dropdown Stimulus controller hits this branch; it sets
-      # X-Requested-With explicitly. Turbo's navigation Accept also lists turbo_stream,
-      # so without this guard the post-delete redirect would render dropdown options
-      # into a missing target and leave the index page stale.
-      format.turbo_stream { render :filter_options } if request.xhr?
-    end
+    respond_to_index_or_dropdown
   end
 
   # GET /projects/1


### PR DESCRIPTION
## Summary

`CustomersController#index` and `ProjectsController#index` shared two pieces of logic: an active/inactive/all filter on a base scope, and a verbatim-identical `respond_to` block serving HTML plus an XHR-guarded turbo_stream of dropdown options. Extracts both into a new `SearchableDropdownIndex` concern.

- `filtered_by_active(scope)` — the `params[:filter] ||= "active"` → active/inactive/all case.
- `respond_to_index_or_dropdown` — the HTML + `format.turbo_stream { render :filter_options } if request.xhr?` block (with the load-bearing xhr-guard comment).

Projects keeps its AJAX `customer_id` / `include_reusable` filtering and `.order(:matchcode, :description)` inline. Behavior is identical: same default filter, scoping, ordering, and responses.

> **Stacked on #455** (`claude/remove-dead-index-json`) — this PR's base is that branch, since it builds on the dead-`format.json` removal. Merge #455 first; the diff shown here is C-only.

## Tests
`bundle exec rails test test/controllers/customers_controller_test.rb test/controllers/projects_controller_test.rb` → 37 runs, 188 assertions, 0 failures. pre-commit (rubocop) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
