### PR TITLE
Drop the include_reusable dropdown param (always include reusable)

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -9,18 +9,10 @@ class ProjectsController < ApplicationController
   def index
     @projects = filtered_by_active(Project.visible_to(current_user))
 
-    # Filters for AJAX requests
+    # The dependent project dropdown (searchable_dropdown) scopes options to the
+    # chosen customer, always including reusable (customer-less) projects.
     if params[:customer_id].present?
-      want_reusable_projects = params[:include_reusable].present? && params[:include_reusable] == "true"
-
-      if want_reusable_projects
-        @projects = @projects.where(
-          "bill_to_customer_id = ? OR bill_to_customer_id IS NULL",
-          params[:customer_id]
-        )
-      else
-        @projects = @projects.where(bill_to_customer_id: params[:customer_id])
-      end
+      @projects = @projects.where("bill_to_customer_id = ? OR bill_to_customer_id IS NULL", params[:customer_id])
     end
 
     @projects = @projects.order(:matchcode, :description)

--- a/app/javascript/controllers/searchable_dropdown_controller.js
+++ b/app/javascript/controllers/searchable_dropdown_controller.js
@@ -129,7 +129,6 @@ export default class extends Controller {
       const params = new URLSearchParams()
       if (this.dependentParamValue && this.currentDependentIdValue) {
         params.append(this.dependentParamValue, this.currentDependentIdValue)
-        params.append('include_reusable', 'true')
       }
       params.append('filter', 'active')
 

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -257,7 +257,7 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Updated to have no customer", @project.description
   end
 
-  test "dropdown filters projects to the given customer" do
+  test "dropdown scopes projects to the customer plus reusable projects" do
     customer = customers(:good_eu)
     other = customers(:good_national)
     mine = Project.create!(matchcode: "MINE", description: "x", bill_to_customer: customer, active: true, team: teams(:default))
@@ -268,19 +268,8 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
 
     assert_select %(turbo-stream[action="update"][target="project-dropdown-menu"]) do
       assert_select ".searchable-option[data-item-id=?]", mine.id.to_s
-      assert_select ".searchable-option[data-item-id=?]", theirs.id.to_s, count: 0
-      assert_select ".searchable-option[data-item-id=?]", reusable.id.to_s, count: 0
-    end
-  end
-
-  test "dropdown includes reusable projects when include_reusable is set" do
-    customer = customers(:good_eu)
-    reusable = Project.create!(matchcode: "REUSE", description: "x", bill_to_customer: nil, active: true, team: teams(:default))
-
-    get projects_url(customer_id: customer.id, include_reusable: "true"), headers: dropdown_xhr_headers
-
-    assert_select %(turbo-stream[action="update"][target="project-dropdown-menu"]) do
       assert_select ".searchable-option[data-item-id=?]", reusable.id.to_s
+      assert_select ".searchable-option[data-item-id=?]", theirs.id.to_s, count: 0
     end
   end
 


### PR DESCRIPTION
## Summary

Removes the `include_reusable` dropdown parameter and the dead branch it guarded.

`searchable_dropdown_controller.js` appended `include_reusable=true` **unconditionally**, in the same block as the dependent `customer_id`. The project dropdown (in `invoices/_form` and `delivery_notes/_form`) is the only dependent dropdown in the app, so every request that reached `projects#index`'s `if params[:customer_id].present?` branch *always* carried `include_reusable=true`. That made `want_reusable_projects` always true — the customer-only `else` branch was unreachable, and the param had a constant effect.

So:
- **JS:** drop the `params.append('include_reusable', 'true')` line.
- **Controller:** collapse the if/else — filtering by customer now always includes reusable (customer-less) projects.
- **Test:** merge the two dropdown tests into one ("scopes projects to the customer plus reusable projects").

**Live behavior is unchanged** — the dropdown already always included reusable projects; this just removes the indirection that only ever resolved one way.

(Builds on the `SearchableDropdownIndex` extraction from #457, now merged; rebased onto `main`.)

## Tests
`bundle exec rails test test/controllers/projects_controller_test.rb test/controllers/customers_controller_test.rb` → 36 runs, 185 assertions, 0 failures. `npm run lint` clean. pre-commit (rubocop) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
