### PR TITLE
CI: run on every PR, not only those targeting main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,11 @@ permissions:
 on:
   push:
     branches: [ main ]
+  # No base-branch filter: run on every PR regardless of its target. This keeps
+  # stacked PRs (base != main) covered, and means an automatic retarget to main
+  # (which fires only an `edited` event, not a default trigger) can't leave a PR
+  # without CI — the checks are already attached to the head commit.
   pull_request:
-    branches: [ main ]
 
 jobs:
   rails-test:


### PR DESCRIPTION
## Summary

`ci.yml`'s `pull_request` trigger filtered on the base branch (`branches: [ main ]`), which broke CI for stacked PRs:

- A PR targeting any branch other than `main` (a stacked PR) ran **none** of the CI jobs — the filter excluded it. (Seen on #458, whose only check was the Dependabot workflow.)
- When such a PR is **automatically retargeted** to `main` after its parent merges, GitHub fires only a `pull_request` event with action `edited` (base-branch change). `edited` isn't in the default `opened/synchronize/reopened` set, so no run started — leaving the PR retargeted to `main` but with no checks and stuck unmergeable. (Seen on #457.)

## Fix

Drop the base-branch filter so the `pull_request` trigger runs on every PR regardless of target. Each PR is checked when opened; the check runs attach to the head commit and survive a later retarget, so the `edited`-only retarget event no longer matters. Pushes to `main` still run via the unchanged `push` trigger.

No job/step changes — only the trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
