### PR TITLE
Fix invalid dependabot.yml cooldown for github-actions/docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,11 +30,9 @@ updates:
     commit-message:
       prefix: "ci"
       include: "scope"
+    # github-actions is not semver-aware, so only default-days is supported here.
     cooldown:
       default-days: 7
-      semver-major-days: 7
-      semver-minor-days: 7
-      semver-patch-days: 7
 
   # Enable version updates for Docker
   - package-ecosystem: "docker"
@@ -47,8 +45,6 @@ updates:
     commit-message:
       prefix: "docker"
       include: "scope"
+    # docker is not semver-aware, so only default-days is supported here.
     cooldown:
       default-days: 7
-      semver-major-days: 7
-      semver-minor-days: 7
-      semver-patch-days: 7


### PR DESCRIPTION
## Summary

GitHub's Dependabot config validation was failing on `.github/dependabot.yml`:

```
The property '#/updates/1/cooldown/semver-major-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/1/cooldown/semver-minor-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/1/cooldown/semver-patch-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/2/cooldown/semver-major-days' is not supported for the package ecosystem 'docker'.
... (semver-minor/-patch-days for docker)
```

The `semver-{major,minor,patch}-days` cooldown keys are only valid for **semver-aware** ecosystems. `github-actions` and `docker` support only `default-days`. The config applied the full set to all three ecosystems, so the file was invalid.

## Fix
Keep only `default-days: 7` in the cooldown for the `github-actions` and `docker` entries (with a comment noting why); `bundler` keeps its full `default-days` + `semver-*-days` cooldown.

## Notes
- The invalid config is on `main`; the failure only *surfaced* as a check on PR #54 because that PR touches `.github/`. This fix corrects it repo-wide — once merged, #54's check (and Dependabot itself) will validate cleanly.
- Validated locally: `yaml.safe_load` parses; cooldown keys are now `[default-days, semver-major-days, semver-minor-days, semver-patch-days]` for bundler and `[default-days]` for github-actions/docker. pre-commit (check-yaml) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
