### PR TITLE
Adopt Rails 8.1 framework defaults (load_defaults 8.1)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -9,7 +9,7 @@ Bundler.require(*Rails.groups)
 module Abt
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 8.0
+    config.load_defaults 8.1
 
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.


### PR DESCRIPTION
## Summary

Adopt Rails 8.1's framework defaults. The app already runs the **Rails 8.1.3 gem** but `config/application.rb` still had `config.load_defaults 8.0` and there was no `new_framework_defaults_*` initializer — so it never picked up 8.1's defaults. This bumps it to `load_defaults 8.1`, the prerequisite for a future Rails 8.2 upgrade.

## How it was validated (not a blind flip)
The six 8.1 default flags were enabled explicitly first, via a transitional `new_framework_defaults_8_1.rb`, and verified before consolidating:

- `action_controller.escape_json_responses = false`
- `active_support.escape_js_separators_in_json = false`
- `active_record.raise_on_missing_required_finder_order_columns = true`
- `action_controller.action_on_path_relative_redirect = :raise`
- `action_view.render_tracker = :ruby`
- `action_view.remove_hidden_field_autocomplete = true`

Full suite **758 runs / 0 failures** and system tests **61 runs / 0 failures** with all six on. Then consolidated to `config.load_defaults 8.1` and removed the initializer (which sets exactly those values) — re-ran the suite, still **758 / 0**. `schema.rb` is already in 8.1's alphabetical column order, so no schema diff.

Net change: one line in `config/application.rb`.

## For the eventual Rails 8.2 upgrade (watch-items, not in this PR)
Filtered to what actually touches this app:
- **CSRF.** 8.2 deprecates `InvalidAuthenticityToken` in favor of `InvalidCrossOriginRequest` and adds header-based (`Sec-Fetch-Site`) CSRF. ABT's custom CSRF-failure handling in `application_controller.rb` rescues/logs `InvalidAuthenticityToken` by name (the documented `errors/csrf_failure` flow), so that handler will need updating at the 8.2 step. (`protect_from_forgery with: :exception` is already explicit, so the "no strategy" deprecation doesn't apply.)
- **`config.active_job.enqueue_after_transaction_commit` defaults to `true` in 8.2.** ABT relies on `deliver_later`/`perform_later` widely (invoices, delivery notes, user mailers, VAT job); the new default enqueues after the surrounding transaction commits — generally safer, but a behavior change to validate when adopting 8.2 defaults.
- Not applicable to ABT: Argon2 `has_secure_password` (passwordless/WebAuthn), Active Job adapter deprecations (uses Solid Queue), Action Text/Trix.

Sources: [Rails 8.2 release notes](https://edgeguides.rubyonrails.org/8_2_release_notes.html), [Upgrading Ruby on Rails](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html), [Rails 8.1 release notes](https://guides.rubyonrails.org/8_1_release_notes.html).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
