### PR TITLE
Require a default product tax class in the setup check

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -15,7 +15,7 @@ class HomeController < ApplicationController
     }
 
     @data = {}
-    @data[:is_setup_done] = (SalesTaxCustomerClass.count > 0 and SalesTaxProductClass.count > 0 and SalesTaxRate.count > 0)
+    @data[:is_setup_done] = (SalesTaxCustomerClass.count > 0 and SalesTaxProductClass.count > 0 and SalesTaxProductClass.exists?(is_default: true) and SalesTaxRate.count > 0)
     @data[:issuer_company] = IssuerCompany.get_the_issuer!
   end
 end

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -76,6 +76,7 @@
           %li
             Create
             %a{:href => new_sales_tax_product_class_path} product classes
+            and mark one as the default
           %li
             Create
             %a{:href => new_sales_tax_customer_class_path} customer classes

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -35,4 +35,12 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select ".alert-warning h5", text: "Quick Setup Required"
   end
+
+  test "should display setup warning when no default product class is set" do
+    SalesTaxProductClass.update_all(is_default: false)
+
+    get root_url
+    assert_response :success
+    assert_select ".alert-warning h5", text: "Quick Setup Required"
+  end
 end


### PR DESCRIPTION
## What

The dashboard "Quick Setup Required" check verified that customer classes, product classes, and tax rates each exist, but not that a product class is flagged as the default.

Delivery-note-to-invoice conversion relies on `SalesTaxProductClass.default` to seed line tax classes, so a setup with product classes but no default would still report "setup done" while leaving that path without a default.

## Changes

- `home_controller.rb`: add `SalesTaxProductClass.exists?(is_default: true)` to the `is_setup_done` check (`exists?` avoids loading a row).
- `home/index.html.haml`: extend the setup-warning step so a user who created product classes but didn't flag a default is told to "mark one as the default" — otherwise the warning fires with no actionable guidance.
- `home_controller_test.rb`: regression test — with all tax config present but `is_default` cleared, the dashboard still shows "Quick Setup Required".

## Testing

Full suite green: 759 runs, 2759 assertions, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)