### PR TITLE
Shorten and localize the delivery-note-to-invoice prelude

### DIFF
--- a/app/controllers/delivery_notes_controller.rb
+++ b/app/controllers/delivery_notes_controller.rb
@@ -199,15 +199,13 @@ class DeliveryNotesController < ApplicationController
     end
 
     begin
-      # Build enhanced prelude with delivery note information
-      delivery_note_info = []
-      delivery_note_info << "Based on #{@delivery_note.display_name}"
-      delivery_note_info << "Delivery Note Date: #{I18n.l(@delivery_note.date)}" if @delivery_note.date
-      if @delivery_note.acceptance_attachment
-        delivery_note_info << "Acceptance Document: #{@delivery_note.acceptance_attachment.filename} (#{I18n.l(@delivery_note.acceptance_attachment.created_at.to_date)})"
+      reference_line = I18n.with_locale(@delivery_note.customer.language.iso_code) do
+        I18n.t("invoice_conversion.reference_line",
+               number: @delivery_note.display_label,
+               date: I18n.l(@delivery_note.date))
       end
 
-      enhanced_prelude = delivery_note_info.join("\n")
+      enhanced_prelude = reference_line
       enhanced_prelude += "\n\n#{@delivery_note.prelude}" if @delivery_note.prelude.present?
 
       # Create invoice from delivery note

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,4 +1,8 @@
 de:
+  date:
+    formats:
+      default: "%d.%m.%Y"
+
   mailers:
     overdue_invoices:
       subject: "[%{issuer_name}] %{count} überfällige Rechnung(en)"
@@ -51,3 +55,6 @@ de:
 
   customer_contacts:
     salutation_line_hint: "In der Sprache des Kunden verfassen: %{language_name}"
+
+  invoice_conversion:
+    reference_line: "Lieferschein %{number} vom %{date}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -131,3 +131,6 @@ en:
 
   customer_contacts:
     salutation_line_hint: "Write in the customer's language: %{language_name}"
+
+  invoice_conversion:
+    reference_line: "Delivery Note %{number}, Date: %{date}"

--- a/test/controllers/delivery_notes_controller_test.rb
+++ b/test/controllers/delivery_notes_controller_test.rb
@@ -221,9 +221,18 @@ class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
     assert_equal published_note.project, published_note.invoice.project
     assert_equal published_note.cust_reference, published_note.invoice.cust_reference
 
-    # Check that the enhanced prelude includes delivery note information
-    assert_match "Based on Delivery Note #{published_note.document_number}", published_note.invoice.prelude
-    assert_match "Delivery Note Date:", published_note.invoice.prelude
+    assert_match "Delivery Note #{published_note.document_number}, Date: #{I18n.l(published_note.date)}", published_note.invoice.prelude
+    assert_match published_note.prelude, published_note.invoice.prelude
+  end
+
+  test "convert_to_invoice renders the reference line in the customer's language" do
+    published_note = delivery_notes(:published_delivery_note)
+    published_note.customer.update!(language: languages(:german))
+
+    post convert_to_invoice_delivery_note_url(published_note)
+
+    published_note.reload
+    assert_match "Lieferschein #{published_note.document_number} vom #{I18n.l(published_note.date, locale: :de)}", published_note.invoice.prelude
   end
 
   test "convert_to_invoice uses the default sales tax product class for item lines" do
@@ -324,36 +333,6 @@ class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to delivery_note_url(published_note)
     assert_match "No acceptance document to delete", flash[:error]
-  end
-
-  test "should include acceptance document info in invoice prelude when converting" do
-    published_note = delivery_notes(:published_delivery_note)
-
-    # First upload an acceptance document
-    pdf_file = Rack::Test::UploadedFile.new(
-      Rails.root.join("test", "fixtures", "files", "example_logo.pdf"),
-      "application/pdf",
-      original_filename: "signed_acceptance.pdf"
-    )
-    post upload_acceptance_delivery_note_url(published_note), params: { acceptance_pdf: pdf_file }
-
-    published_note.reload
-    assert published_note.acceptance_attachment.present?
-
-    # Ensure there's a sales tax product class for the conversion
-    SalesTaxProductClass.find_or_create_by(name: "Standard") do |tax_class|
-      tax_class.indicator_code = "STD"
-    end
-
-    # Convert to invoice
-    post convert_to_invoice_delivery_note_url(published_note)
-
-    published_note.reload
-    assert published_note.invoice.present?
-
-    # Check that the prelude includes acceptance document information
-    assert_match "Based on Delivery Note #{published_note.document_number}", published_note.invoice.prelude
-    assert_match "Acceptance Document: signed_acceptance.pdf", published_note.invoice.prelude
   end
 
   test "should get email preview json" do


### PR DESCRIPTION
## What

When converting a published delivery note to an invoice, the generated invoice prelude was several English-only lines regardless of the customer's language:

```
Based on Delivery Note 20260005
Delivery Note Date: 01.06.2026
Acceptance Document: foo.pdf (01.06.2026)

<original delivery-note prelude>
```

It's now a single reference line, rendered in the customer's language, followed by the original prelude:

- **en:** `Delivery Note 20260005, Date: 01.06.2026`
- **de:** `Lieferschein 20260005 vom 01.06.2026`

## Changes

- `DeliveryNotesController#convert_to_invoice` builds the reference line via `I18n.with_locale(customer.language.iso_code)`. The acceptance-document line is dropped, as is the date guard — `publish!` always sets the date and conversion requires a published note.
- New `invoice_conversion.reference_line` key in `en.yml` / `de.yml`. The strings are self-contained per locale rather than built from `model_name.human`, which has no German override and would render "Delivery note" under `:de`.
- Added `date.formats.default` to `de.yml`. Localizing a date under `:de` previously only worked in production (`i18n.fallbacks` on); test/dev raised `I18n::MissingTranslationData`. This also removes the existing PDF renderers' reliance on that fallback.

## Tests

- Updated the conversion test to assert the new single-line format.
- Added a German-locale regression test.
- Removed the obsolete acceptance-document prelude test.

Full suite green (758 runs, 0 failures); `pre-commit run --all-files` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)