### PR TITLE
Add issuer Reply-To for customer document emails

### DIFF
--- a/app/controllers/issuer_companies_controller.rb
+++ b/app/controllers/issuer_companies_controller.rb
@@ -73,6 +73,7 @@ class IssuerCompaniesController < ApplicationController
       :invoice_footer,
       :currency,
       :document_email_from,
+      :document_email_reply_to,
       :document_email_auto_bcc,
       :pdf_logo_width, :pdf_logo_height,
       :vat_id_recheck_days,

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -18,13 +18,15 @@ class ApplicationMailer < ActionMailer::Base
   end
 
   # Send the standard document email envelope. From comes from the default
-  # configured at class level, bcc from the issuer. No-op when `to` is blank.
+  # configured at class level, bcc from the issuer, reply-to from the issuer
+  # when set (blank → header omitted). No-op when `to` is blank.
   def document_mail(to:, subject:, cc: nil)
     return if to.blank?
     mail(
       to: to,
       cc: cc,
       bcc: @issuer.document_email_auto_bcc,
+      reply_to: @issuer.document_email_reply_to.presence,
       subject: subject
     )
   end

--- a/app/models/issuer_company.rb
+++ b/app/models/issuer_company.rb
@@ -7,7 +7,7 @@ class IssuerCompany < ApplicationRecord
             allow_blank: true
   validates :vat_id_recheck_days, numericality: { only_integer: true, greater_than: 0 }
   validates :reporting_email, presence: true
-  validates :reporting_email, :document_email_from, :document_email_auto_bcc,
+  validates :reporting_email, :document_email_from, :document_email_auto_bcc, :document_email_reply_to,
             format: { with: URI::MailTo::EMAIL_REGEXP, allow_blank: true }
 
   # This app requires that there is exactly *one* issuer_company in the database.

--- a/app/views/issuer_companies/edit.html.haml
+++ b/app/views/issuer_companies/edit.html.haml
@@ -93,6 +93,10 @@
             = form.email_field :document_email_from, class: 'form-control'
 
           .mb-3
+            = form.label :document_email_reply_to, 'Email Reply-To', class: 'form-label'
+            = form.email_field :document_email_reply_to, class: 'form-control'
+
+          .mb-3
             = form.label :document_email_auto_bcc, 'Email Auto BCC', class: 'form-label'
             = form.email_field :document_email_auto_bcc, class: 'form-control'
 

--- a/app/views/issuer_companies/show.html.haml
+++ b/app/views/issuer_companies/show.html.haml
@@ -95,6 +95,12 @@
 
         .row.mb-2
           .col-sm-4
+            %strong Email Reply-To:
+          .col-sm-8
+            = @issuer_company.document_email_reply_to
+
+        .row.mb-2
+          .col-sm-4
             %strong Email Auto BCC:
           .col-sm-8
             = @issuer_company.document_email_auto_bcc

--- a/db/migrate/20260601113943_add_document_email_reply_to_to_issuer_companies.rb
+++ b/db/migrate/20260601113943_add_document_email_reply_to_to_issuer_companies.rb
@@ -1,0 +1,5 @@
+class AddDocumentEmailReplyToToIssuerCompanies < ActiveRecord::Migration[8.1]
+  def change
+    add_column :issuer_companies, :document_email_reply_to, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_27_052131) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_01_113943) do
   create_table "attachments", force: :cascade do |t|
     t.string "content_type"
     t.datetime "created_at", null: false
@@ -242,6 +242,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_27_052131) do
     t.string "document_contact_line2"
     t.string "document_email_auto_bcc", default: "bcc@example.com", null: false
     t.string "document_email_from", default: "from@example.com", null: false
+    t.string "document_email_reply_to"
     t.string "invoice_footer"
     t.string "legal_name"
     t.binary "pdf_logo"

--- a/test/mailers/invoice_mailer_test.rb
+++ b/test/mailers/invoice_mailer_test.rb
@@ -23,6 +23,19 @@ class InvoiceMailerTest < ActionMailer::TestCase
     assert_equal "test_invoice.pdf", mail.attachments.first.filename
   end
 
+  test "customer_email sets Reply-To from the issuer when configured" do
+    issuer_companies(:one).update!(document_email_reply_to: "replies@example.com")
+    mail = InvoiceMailer.with(invoice: invoices(:published_invoice)).customer_email
+
+    assert_equal [ "replies@example.com" ], mail.reply_to
+  end
+
+  test "customer_email omits Reply-To when the issuer has none configured" do
+    mail = InvoiceMailer.with(invoice: invoices(:published_invoice)).customer_email
+
+    assert_nil mail.reply_to
+  end
+
   test "customer_email skips contacts whose project does not match the invoice's project" do
     # good_eu_project_one_lead is scoped to project `one`. An invoice on
     # project `two` should NOT include that contact.


### PR DESCRIPTION
## Summary
Adds a `document_email_reply_to` config field to the issuer company and sets it as the `Reply-To` header on customer-facing document mail (invoices and delivery notes). This lets the branded `From:` address differ from where customer replies should land.

- Migration adds `document_email_reply_to` (string, nullable, no default) to `issuer_companies`.
- `IssuerCompany` validates the field with the existing email-format rule (`allow_blank`), so it's optional.
- `ApplicationMailer#document_mail` passes `reply_to: @issuer.document_email_reply_to.presence` — blank ⇒ header omitted. Internal report (`reporting_email`) and user mailers are untouched.
- Config UI: editable field on the edit form, displayed on the show page.

## Testing
- `bundle exec rails test test/mailers/` — 45 runs, 0 failures (2 new: Reply-To present when configured, absent when blank).
- `bundle exec rails test test/controllers/issuer_companies_controller_test.rb test/models/issuer_company_test.rb` — 24 runs, 0 failures.

The change lives in the shared `document_mail` helper, so both invoice and delivery-note mail inherit it; the regression test sits in the invoice mailer test only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)