### PR TITLE
Delivery-note acceptance upload via the customer portal

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -26,6 +26,12 @@ class AttachmentsController < ApplicationController
     if DeliveryNote.visible_to(current_user).where(acceptance_attachment_id: attachment.id).exists?
       return require_permission!("delivery_notes.view")
     end
+    pending_scope = AcceptanceSubmission.pending
+      .where(attachment_id: attachment.id)
+      .where(delivery_note_id: DeliveryNote.visible_to(current_user).select(:id))
+    if pending_scope.exists?
+      return require_permission!("delivery_notes.review_acceptance")
+    end
     raise ApplicationController::PermissionDenied, "attachment##{attachment.id}"
   end
 end

--- a/app/controllers/concerns/emailable_document.rb
+++ b/app/controllers/concerns/emailable_document.rb
@@ -1,6 +1,9 @@
 # Customer-email actions — preview and send — shared by documents that can be
-# emailed (Invoice, DeliveryNote). The host controller supplies the document
-# and the mail via #email_preview_document and #email_preview_mail.
+# emailed (Invoice, DeliveryNote). The host controller supplies the document via
+# #email_preview_document and the mail for each context via three argument-free
+# methods it must define: #email_preview_mail (preview, with attachments),
+# #email_preview_html_mail (HTML-body preview, attachments skipped), and
+# #email_for_sending (the mail actually delivered).
 module EmailableDocument
   extend ActiveSupport::Concern
   include EmailPreviewHelper
@@ -40,7 +43,7 @@ module EmailableDocument
   # skipped — only the body is needed here — and html_safe is reached solely on
   # the genuine-body branch; the empty fallback renders as plain text.
   def preview_email_html
-    body = extract_html_body(email_preview_mail(skip_attachments: true))
+    body = extract_html_body(email_preview_html_mail)
     if body.present?
       render html: body.html_safe, layout: false
     else
@@ -65,8 +68,4 @@ module EmailableDocument
       format.json { head :ok }
     end
   end
-
-  # The mail to actually deliver. Defaults to the previewed mail; subclasses that
-  # need a send-only side effect (e.g. minting a one-time token) override this.
-  def email_for_sending = email_preview_mail
 end

--- a/app/controllers/concerns/emailable_document.rb
+++ b/app/controllers/concerns/emailable_document.rb
@@ -59,10 +59,14 @@ module EmailableDocument
       end
       return
     end
-    email_preview_mail.deliver_later
+    email_for_sending.deliver_later
     respond_to do |format|
       format.html { redirect_to document, notice: "E-Mail queued for sending." }
       format.json { head :ok }
     end
   end
+
+  # The mail to actually deliver. Defaults to the previewed mail; subclasses that
+  # need a send-only side effect (e.g. minting a one-time token) override this.
+  def email_for_sending = email_preview_mail
 end

--- a/app/controllers/customer_portal/acceptances_controller.rb
+++ b/app/controllers/customer_portal/acceptances_controller.rb
@@ -1,0 +1,46 @@
+module CustomerPortal
+  class AcceptancesController < BaseController
+    before_action :load_delivery_note
+
+    def show
+      return render(:closed) unless @delivery_note&.acceptance_upload_open?
+      render :show
+    end
+
+    def create
+      return render(:closed) unless @delivery_note&.acceptance_upload_open?
+
+      uploaded = params[:acceptance_pdf]
+      if (error = file_error(uploaded))
+        flash.now[:error] = error
+        return render(:show, status: :unprocessable_content)
+      end
+
+      begin
+        AcceptanceSubmission.submit!(delivery_note: @delivery_note, uploaded_file: uploaded, ip: request.remote_ip)
+      rescue AcceptanceSubmission::CapReached
+        @closed_reason = :capped
+        return render(:closed)
+      rescue AcceptanceSubmission::NotOpen
+        return render(:closed)
+      end
+
+      AcceptanceSubmissionMailer.with(delivery_note: @delivery_note).submitted.deliver_later
+      render :success
+    end
+
+    private
+
+    def load_delivery_note
+      @delivery_note = DeliveryNote.find_by_acceptance_upload_token(params[:token])
+    end
+
+    # Returns a user-facing error string, or nil when the file is an acceptable PDF.
+    def file_error(file)
+      return t("customer_portal.acceptance.errors.missing") if file.blank?
+      return t("customer_portal.acceptance.errors.too_large", max: Attachment::MAX_SIZE_BYTES / 1.megabyte) if file.size > Attachment::MAX_SIZE_BYTES
+      return t("customer_portal.acceptance.errors.not_pdf") if Attachment.detect_content_type(file.tempfile) != "application/pdf"
+      nil
+    end
+  end
+end

--- a/app/controllers/delivery_notes_controller.rb
+++ b/app/controllers/delivery_notes_controller.rb
@@ -328,14 +328,14 @@ protected
   # EmailableDocument hooks.
   def email_preview_document = @delivery_note
 
-  def email_preview_mail(skip_attachments: false, acceptance_token: preview_acceptance_token)
-    DeliveryNoteMailer.with(delivery_note: @delivery_note, skip_attachments:, acceptance_token:).customer_email
-  end
+  # Previews carry a non-persisted placeholder token; sending mints a fresh real
+  # one. Keeping the two apart means previewing never rotates the live token.
+  def email_preview_mail = build_customer_email(skip_attachments: false, acceptance_token: preview_acceptance_token)
+  def email_preview_html_mail = build_customer_email(skip_attachments: true, acceptance_token: preview_acceptance_token)
+  def email_for_sending = build_customer_email(skip_attachments: false, acceptance_token: acceptance_token_for(@delivery_note))
 
-  # Sending mints a fresh upload token; the preview uses a placeholder instead
-  # (see email_preview_mail's default), so previewing never rotates the token.
-  def email_for_sending
-    email_preview_mail(acceptance_token: acceptance_token_for(@delivery_note))
+  def build_customer_email(skip_attachments:, acceptance_token:)
+    DeliveryNoteMailer.with(delivery_note: @delivery_note, skip_attachments:, acceptance_token:).customer_email
   end
 
   def acceptance_token_for(delivery_note)

--- a/app/controllers/delivery_notes_controller.rb
+++ b/app/controllers/delivery_notes_controller.rb
@@ -281,9 +281,14 @@ class DeliveryNotesController < ApplicationController
       end
 
       if dns.length == 1
-        DeliveryNoteMailer.with(delivery_note: dns.first).customer_email.deliver_later
+        token = acceptance_token_for(dns.first)
+        DeliveryNoteMailer.with(delivery_note: dns.first, acceptance_token: token).customer_email.deliver_later
       else
-        DeliveryNoteMailer.with(delivery_notes: dns, recipients: recipients).bulk_customer_email.deliver_later
+        acceptance_tokens = dns.each_with_object({}) do |dn, tokens|
+          token = acceptance_token_for(dn)
+          tokens[dn.id.to_s] = token if token
+        end
+        DeliveryNoteMailer.with(delivery_notes: dns, recipients: recipients, acceptance_tokens: acceptance_tokens).bulk_customer_email.deliver_later
       end
       queued_count += dns.length
     end
@@ -301,8 +306,26 @@ protected
   # EmailableDocument hooks.
   def email_preview_document = @delivery_note
 
-  def email_preview_mail(skip_attachments: false)
-    DeliveryNoteMailer.with(delivery_note: @delivery_note, skip_attachments:).customer_email
+  def email_preview_mail(skip_attachments: false, acceptance_token: preview_acceptance_token)
+    DeliveryNoteMailer.with(delivery_note: @delivery_note, skip_attachments:, acceptance_token:).customer_email
+  end
+
+  # Sending mints a fresh upload token; the preview uses a placeholder instead
+  # (see email_preview_mail's default), so previewing never rotates the token.
+  def email_for_sending
+    email_preview_mail(acceptance_token: acceptance_token_for(@delivery_note))
+  end
+
+  def acceptance_token_for(delivery_note)
+    return nil if Settings.customer_portal.host.blank?
+    delivery_note.acceptance_attachment_id.nil? ? delivery_note.issue_acceptance_upload_token! : nil
+  end
+
+  # A non-persisted placeholder token so the email preview shows the acceptance
+  # link the customer will receive, without minting or rotating a real token.
+  def preview_acceptance_token
+    return nil if Settings.customer_portal.host.blank?
+    @delivery_note&.acceptance_attachment_id.nil? ? "preview" : nil
   end
 
   # Document numbers are issued from a gap-free sequence; once assigned they

--- a/app/controllers/delivery_notes_controller.rb
+++ b/app/controllers/delivery_notes_controller.rb
@@ -14,18 +14,20 @@ class DeliveryNotesController < ApplicationController
     publish unpublish send_email upload_acceptance delete_acceptance
     convert_to_invoice bulk_send_emails
   ]
+  before_action -> { require_permission!("delivery_notes.review_acceptance") }, only: %i[accept_acceptance reject_acceptance]
 
-  before_action :set_delivery_note, only: %i[show edit update destroy publish preview pdf unpublish upload_acceptance delete_acceptance convert_to_invoice preview_email preview_email_html send_email]
+  before_action :set_delivery_note, only: %i[show edit update destroy publish preview pdf unpublish upload_acceptance delete_acceptance convert_to_invoice preview_email preview_email_html send_email accept_acceptance reject_acceptance]
 
   before_action :require_unpublished, only: %i[edit update destroy publish preview]
   before_action :require_unnumbered, only: :destroy
-  before_action :require_published, only: %i[pdf unpublish upload_acceptance delete_acceptance convert_to_invoice send_email]
+  before_action :require_published, only: %i[pdf unpublish upload_acceptance delete_acceptance convert_to_invoice send_email accept_acceptance reject_acceptance]
   before_action :require_item_line, only: %i[preview preview_email]
 
   # GET /delivery_notes
   def index
     @selected_year = params[:year] == "all" ? "all" : (params[:year]&.to_i || Date.current.year)
     @email_filter = params[:email_filter] || "all"
+    @acceptance_filter = params[:acceptance_filter]
     @selected_customer_id = params[:customer_id].presence&.to_i
 
     @delivery_notes = DeliveryNote.visible_to(current_user).ordered
@@ -37,6 +39,8 @@ class DeliveryNotesController < ApplicationController
     when "unsent"
       @delivery_notes = @delivery_notes.email_unsent.published
     end
+
+    @delivery_notes = @delivery_notes.with_pending_acceptance.published if @acceptance_filter == "pending"
 
     @delivery_notes = @delivery_notes.where(customer_id: @selected_customer_id) if @selected_customer_id
 
@@ -131,6 +135,24 @@ class DeliveryNotesController < ApplicationController
     respond_to do |format|
       format.html { redirect_to @delivery_note }
     end
+  end
+
+  def accept_acceptance
+    submission = @delivery_note.acceptance_submissions.find(params[:submission_id])
+    submission.accept!(by: current_user)
+    redirect_to @delivery_note, notice: "Acceptance document confirmed."
+  rescue AcceptanceSubmission::StaleSubmission
+    redirect_to @delivery_note, alert: "A newer submission arrived — review it before accepting."
+  rescue AcceptanceSubmission::AlreadyAccepted
+    redirect_to @delivery_note, alert: "This note already has an accepted acceptance document."
+  end
+
+  def reject_acceptance
+    submission = @delivery_note.acceptance_submissions.find(params[:submission_id])
+    submission.reject!(by: current_user)
+    redirect_to @delivery_note, notice: "Submission rejected; the upload link is open again."
+  rescue AcceptanceSubmission::StaleSubmission
+    redirect_to @delivery_note, alert: "That submission is no longer pending."
   end
 
   def upload_acceptance

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -173,7 +173,11 @@ protected
   # EmailableDocument hooks.
   def email_preview_document = @invoice
 
-  def email_preview_mail(skip_attachments: false)
+  def email_preview_mail = build_customer_email(skip_attachments: false)
+  def email_preview_html_mail = build_customer_email(skip_attachments: true)
+  def email_for_sending = build_customer_email(skip_attachments: false)
+
+  def build_customer_email(skip_attachments:)
     InvoiceMailer.with(invoice: @invoice, skip_attachments:).customer_email
   end
 

--- a/app/mailers/acceptance_submission_mailer.rb
+++ b/app/mailers/acceptance_submission_mailer.rb
@@ -1,0 +1,9 @@
+class AcceptanceSubmissionMailer < ApplicationMailer
+  def submitted
+    @delivery_note = params[:delivery_note]
+    @url = AbsoluteUrl.delivery_note(@delivery_note)
+    mail(to: @issuer.reporting_email,
+         subject: I18n.t("mailers.acceptance_submission.subject",
+                         document_number: sanitize_header_value(@delivery_note.document_number)))
+  end
+end

--- a/app/mailers/delivery_note_mailer.rb
+++ b/app/mailers/delivery_note_mailer.rb
@@ -1,6 +1,9 @@
 class DeliveryNoteMailer < ApplicationMailer
   def customer_email
     @delivery_note = params[:delivery_note]
+    if params[:acceptance_token].present?
+      @delivery_acceptance_upload_url = AbsoluteUrl.delivery_acceptance_upload(params[:acceptance_token])
+    end
     attach_pdf(@delivery_note) unless params[:skip_attachments]
 
     customer = @delivery_note.customer
@@ -23,6 +26,9 @@ class DeliveryNoteMailer < ApplicationMailer
   def bulk_customer_email
     @delivery_notes = params[:delivery_notes]
     @customer = @delivery_notes.first.customer
+    # Per-note upload links, keyed by delivery-note id (string keys keep the
+    # mailer params serializable for deliver_later).
+    @acceptance_upload_urls = (params[:acceptance_tokens] || {}).transform_values { |token| AbsoluteUrl.delivery_acceptance_upload(token) }
     to = params[:recipients] || @customer.contacts_for_delivery_note(@delivery_notes.first).map(&:email)
 
     @delivery_notes.each { |dn| attach_pdf(dn) }

--- a/app/models/acceptance_submission.rb
+++ b/app/models/acceptance_submission.rb
@@ -1,0 +1,64 @@
+class AcceptanceSubmission < ApplicationRecord
+  class StaleSubmission < StandardError; end
+  class AlreadyAccepted < StandardError; end
+  class CapReached < StandardError; end
+  class NotOpen < StandardError; end
+
+  STATUSES = %w[pending superseded accepted rejected].freeze
+
+  belongs_to :delivery_note
+  belongs_to :attachment, optional: true
+  belongs_to :reviewed_by, class_name: "User", optional: true
+
+  validates :status, inclusion: { in: STATUSES }
+
+  scope :pending, -> { where(status: "pending") }
+  scope :recent_first, -> { order(submitted_at: :desc) }
+
+  # Creates a new pending submission, superseding any prior pending one and
+  # dropping its blob. Serialized per note via with_lock; eligibility and cap
+  # are re-checked inside the lock. Caller must already have validated the
+  # file is a PDF within size limits.
+  def self.submit!(delivery_note:, uploaded_file:, ip:)
+    delivery_note.with_lock do
+      raise NotOpen unless delivery_note.acceptance_upload_open?
+      raise CapReached if delivery_note.acceptance_upload_cap_reached?
+
+      delivery_note.acceptance_submissions.pending.each do |prev|
+        att = prev.attachment
+        prev.update!(status: "superseded", attachment: nil)
+        att&.destroy!
+      end
+
+      attachment = Attachment.new(title: "Acceptance submission for #{delivery_note.display_name}")
+      attachment.set_data(uploaded_file.read, "application/pdf")
+      attachment.filename = uploaded_file.original_filename
+      attachment.save!
+
+      delivery_note.acceptance_submissions.create!(
+        attachment: attachment, status: "pending",
+        submitted_at: Time.current, submitted_ip: ip
+      )
+    end
+  end
+
+  def accept!(by:)
+    delivery_note.with_lock do
+      reload
+      raise StaleSubmission unless status == "pending"
+      raise AlreadyAccepted if delivery_note.acceptance_attachment_id.present?
+      delivery_note.update!(acceptance_attachment: attachment)
+      update!(status: "accepted", reviewed_by: by, reviewed_at: Time.current)
+    end
+  end
+
+  def reject!(by:)
+    delivery_note.with_lock do
+      reload
+      raise StaleSubmission unless status == "pending"
+      att = attachment
+      update!(status: "rejected", attachment: nil, reviewed_by: by, reviewed_at: Time.current)
+      att&.destroy!
+    end
+  end
+end

--- a/app/models/delivery_note.rb
+++ b/app/models/delivery_note.rb
@@ -2,12 +2,16 @@ class DeliveryNote < ApplicationRecord
   include YearFilterable
   include HasLineItems
   include ScopedThroughCustomer
+  include DigestedToken
 
+  ACCEPTANCE_TOKEN_TTL = (Settings.customer_portal.link_expiry_days || 30).days
+  ACCEPTANCE_SUBMISSIONS_PER_TOKEN = Settings.customer_portal.submissions_per_token || 20
   has_line_items :delivery_note_lines
 
   validates :customer_id, presence: true
   validates :delivery_start_date, presence: true
   validate :delivery_end_date_after_start_date
+  scope :with_pending_acceptance, -> { where(id: AcceptanceSubmission.pending.select(:delivery_note_id)) }
   scope :email_unsent, -> {
     where(email_sent_at: nil).where(<<~SQL.squish)
       EXISTS (
@@ -43,6 +47,34 @@ class DeliveryNote < ApplicationRecord
 
   has_many :delivery_note_lines, -> { order(:position, :id) }, dependent: :delete_all
   accepts_nested_attributes_for :delivery_note_lines, allow_destroy: true, reject_if: :all_blank
+
+  has_many :acceptance_submissions, dependent: :destroy
+
+  def issue_acceptance_upload_token!(now: Time.current)
+    plaintext, digest = self.class.generate_token
+    update!(acceptance_upload_token_digest: digest,
+            acceptance_upload_token_minted_at: now,
+            acceptance_upload_token_expires_at: now + ACCEPTANCE_TOKEN_TTL)
+    plaintext
+  end
+
+  def self.find_by_acceptance_upload_token(plaintext)
+    return nil if plaintext.blank?
+    find_by(acceptance_upload_token_digest: digest_token(plaintext))
+  end
+
+  def acceptance_upload_open?(now: Time.current)
+    published? && acceptance_attachment_id.nil? &&
+      acceptance_upload_token_expires_at.present? &&
+      acceptance_upload_token_expires_at > now
+  end
+
+  def acceptance_upload_cap_reached?
+    return false if acceptance_upload_token_minted_at.blank?
+    acceptance_submissions
+      .where("submitted_at >= ?", acceptance_upload_token_minted_at)
+      .count >= ACCEPTANCE_SUBMISSIONS_PER_TOKEN
+  end
 
   def publish!
     return if self.published?

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -16,6 +16,7 @@ module Permission
     Entry.new(key: "invoices.edit",       label: "Create / publish / send invoices", category: "Operations"),
     Entry.new(key: "delivery_notes.view", label: "View delivery notes",     category: "Operations"),
     Entry.new(key: "delivery_notes.edit", label: "Create / publish / send delivery notes", category: "Operations"),
+    Entry.new(key: "delivery_notes.review_acceptance", label: "Review delivery-note acceptance submissions", category: "Operations"),
 
     # Catalog & tax
     Entry.new(key: "products.view", label: "View product catalog",          category: "Catalog & tax"),

--- a/app/services/absolute_url.rb
+++ b/app/services/absolute_url.rb
@@ -24,4 +24,12 @@ module AbsoluteUrl
   def customer_portal_host_options
     options.merge(host: Settings.customer_portal.host.presence || Settings.app.host)
   end
+
+  def delivery_acceptance_upload(token)
+    Rails.application.routes.url_helpers.delivery_acceptance_upload_url(token: token, **customer_portal_host_options)
+  end
+
+  def delivery_note(dn)
+    Rails.application.routes.url_helpers.delivery_note_url(dn, **options)
+  end
 end

--- a/app/views/acceptance_submission_mailer/submitted.html.haml
+++ b/app/views/acceptance_submission_mailer/submitted.html.haml
@@ -1,0 +1,2 @@
+%p= t("mailers.acceptance_submission.body", document_number: @delivery_note.document_number)
+%p= link_to t("mailers.acceptance_submission.cta"), @url

--- a/app/views/acceptance_submission_mailer/submitted.text.haml
+++ b/app/views/acceptance_submission_mailer/submitted.text.haml
@@ -1,0 +1,2 @@
+#{t("mailers.acceptance_submission.body", document_number: @delivery_note.document_number)}
+#{@url}

--- a/app/views/customer_portal/acceptances/_form.html.haml
+++ b/app/views/customer_portal/acceptances/_form.html.haml
@@ -1,0 +1,7 @@
+- if flash.now[:error] || flash[:error]
+  .alert.alert-danger= flash.now[:error] || flash[:error]
+= form_with url: delivery_acceptance_upload_submit_path(token: params[:token]), method: :post, multipart: true do |f|
+  .mb-2
+    = f.file_field :acceptance_pdf, accept: "application/pdf", class: "form-control", required: true
+  %small.text-muted.d-block.mb-3= t("customer_portal.acceptance.hint", max: Attachment::MAX_SIZE_BYTES / 1.megabyte)
+  = f.submit t("customer_portal.acceptance.submit"), class: "btn btn-primary"

--- a/app/views/customer_portal/acceptances/closed.html.haml
+++ b/app/views/customer_portal/acceptances/closed.html.haml
@@ -1,0 +1,3 @@
+- reason = @closed_reason || (@delivery_note&.acceptance_attachment_id ? :accepted : :invalid)
+%h1.h4= t("customer_portal.acceptance.closed.#{reason}_title")
+%p.text-muted= t("customer_portal.acceptance.closed.#{reason}_body")

--- a/app/views/customer_portal/acceptances/show.html.haml
+++ b/app/views/customer_portal/acceptances/show.html.haml
@@ -1,0 +1,4 @@
+- content_for :title, t("customer_portal.acceptance.title", number: @delivery_note.document_number)
+%h1.h4= t("customer_portal.acceptance.title", number: @delivery_note.document_number)
+%p.text-muted= t("customer_portal.acceptance.dated", date: l(@delivery_note.date))
+= render "form"

--- a/app/views/customer_portal/acceptances/success.html.haml
+++ b/app/views/customer_portal/acceptances/success.html.haml
@@ -1,0 +1,2 @@
+%h1.h4= t("customer_portal.acceptance.success_title")
+%p.text-muted= t("customer_portal.acceptance.success_body")

--- a/app/views/delivery_note_mailer/bulk_customer_email.html.haml
+++ b/app/views/delivery_note_mailer/bulk_customer_email.html.haml
@@ -21,6 +21,9 @@
       - if delivery_note.delivery_timeframe.present?
         .document-detail
           #{t('mailers.delivery_note.delivery_period_label')} #{delivery_note.delivery_timeframe}
+      - if @acceptance_upload_urls[delivery_note.id.to_s]
+        .document-detail
+          = link_to t('mailers.delivery_note.next_steps_upload'), @acceptance_upload_urls[delivery_note.id.to_s]
 
 .instructions
   %strong= t('mailers.delivery_note.next_steps_title')

--- a/app/views/delivery_note_mailer/bulk_customer_email.text.haml
+++ b/app/views/delivery_note_mailer/bulk_customer_email.text.haml
@@ -12,6 +12,8 @@
     #{t('mailers.delivery_note.reference_label')} #{delivery_note.cust_reference}
   - if delivery_note.delivery_timeframe.present?
     #{t('mailers.delivery_note.delivery_period_label')} #{delivery_note.delivery_timeframe}
+  - if @acceptance_upload_urls[delivery_note.id.to_s]
+    #{t('mailers.delivery_note.next_steps_upload')}: #{@acceptance_upload_urls[delivery_note.id.to_s]}
 \
 #{t('mailers.delivery_note.next_steps_title')}
 - t('mailers.delivery_note.bulk_next_steps').each_with_index do |step, index|

--- a/app/views/delivery_note_mailer/customer_email.html.haml
+++ b/app/views/delivery_note_mailer/customer_email.html.haml
@@ -25,8 +25,12 @@
 .instructions
   %strong= t('mailers.delivery_note.next_steps_title')
   %ol
-    - t('mailers.delivery_note.next_steps').each do |step|
-      %li= step
+    - steps = t('mailers.delivery_note.next_steps')
+    - steps.each_with_index do |step, i|
+      - if @delivery_acceptance_upload_url && i == steps.size - 1
+        %li= link_to t('mailers.delivery_note.next_steps_upload'), @delivery_acceptance_upload_url
+      - else
+        %li= step
 
 .closing
   = t('mailers.delivery_note.closing')

--- a/app/views/delivery_note_mailer/customer_email.text.haml
+++ b/app/views/delivery_note_mailer/customer_email.text.haml
@@ -14,7 +14,11 @@
   #{t('mailers.delivery_note.delivery_period_label')} #{@delivery_note.delivery_timeframe}
 \
 #{t('mailers.delivery_note.next_steps_title')}
-- t('mailers.delivery_note.next_steps').each_with_index do |step, index|
-  #{index + 1}. #{step}
+- steps = t('mailers.delivery_note.next_steps')
+- steps.each_with_index do |step, index|
+  - if @delivery_acceptance_upload_url && index == steps.size - 1
+    #{index + 1}. #{t('mailers.delivery_note.next_steps_upload')}: #{@delivery_acceptance_upload_url}
+  - else
+    #{index + 1}. #{step}
 \
 #{t('mailers.delivery_note.closing')}

--- a/app/views/delivery_notes/_acceptance_submissions.html.haml
+++ b/app/views/delivery_notes/_acceptance_submissions.html.haml
@@ -1,0 +1,20 @@
+- pending = delivery_note.acceptance_submissions.pending.first
+-# The card only exists to review a pending customer submission; with nothing
+-# pending there is nothing actionable, so hide it (covers awaiting-upload,
+-# accepted, and accepted-then-deleted notes alike).
+- if pending
+  - history = delivery_note.acceptance_submissions.where.not(id: pending.id).recent_first
+  .mb-4
+    .card
+      .card-header
+        %h5.mb-0 Customer acceptance submissions
+      .card-body
+        .d-flex.align-items-center.gap-2.mb-3
+          %i.fas.fa-file-pdf.text-danger
+          = link_to pending.attachment.filename, attachment_path(pending.attachment), target: "_blank", class: "me-auto"
+          = button_to "Accept", accept_acceptance_delivery_note_path(delivery_note, submission_id: pending.id), method: :post, class: "btn btn-success btn-sm"
+          = button_to "Reject", reject_acceptance_delivery_note_path(delivery_note, submission_id: pending.id), method: :post, class: "btn btn-outline-danger btn-sm", form: { data: { turbo_confirm: "Reject this submission?" } }
+        - if history.any?
+          %ul.list-unstyled.small.mb-0
+            - history.each do |s|
+              %li= "#{s.status.titleize} · #{l(s.submitted_at)}"

--- a/app/views/delivery_notes/index.html.haml
+++ b/app/views/delivery_notes/index.html.haml
@@ -8,15 +8,17 @@
     -# intentionally empty
 
   .btn-toolbar.mb-3{:role=>"toolbar", "aria-label"=>"List toolbar"}
-    .btn-group.btn-group-sm.me-2.email-filter{:role=>"group", "aria-label"=>"E-Mail status"}
-      = link_to 'All', delivery_notes_path(year: @selected_year, email_filter: 'all', customer_id: @selected_customer_id), class: (@email_filter == 'all' ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
+    .btn-group.btn-group-sm.me-2.status-filter{:role=>"group", "aria-label"=>"Status filter"}
+      = link_to 'All', delivery_notes_path(year: @selected_year, email_filter: 'all', customer_id: @selected_customer_id), class: (@email_filter == 'all' && @acceptance_filter != 'pending' ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
       = link_to 'Unsent', delivery_notes_path(year: @selected_year, email_filter: 'unsent', customer_id: @selected_customer_id), class: (@email_filter == 'unsent' ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
+      - if can?('delivery_notes.review_acceptance')
+        = link_to 'Pending acceptance', delivery_notes_path(year: @selected_year, customer_id: @selected_customer_id, acceptance_filter: 'pending'), class: (@acceptance_filter == 'pending' ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
 
     = render 'shared/customer_filter',
         form_url: delivery_notes_path,
         customers: @available_customers,
         selected_customer_id: @selected_customer_id,
-        hidden_fields: { year: @selected_year, email_filter: @email_filter }
+        hidden_fields: { year: @selected_year, email_filter: @email_filter, acceptance_filter: @acceptance_filter }
 
     - if @email_filter == 'unsent'
       = submit_tag 'Send Selected Emails', form: 'bulk-email-form', class: 'btn btn-warning btn-sm me-2 align-self-start', disabled: true, data: { confirm: 'Are you sure you want to send emails for the selected delivery notes?', 'bulk-select-target': 'submitButton' }

--- a/app/views/delivery_notes/show.html.haml
+++ b/app/views/delivery_notes/show.html.haml
@@ -132,6 +132,9 @@
             %small.text-muted.d-block.mt-2
               Upload the signed acceptance document (PDF only)
 
+  - if can?("delivery_notes.review_acceptance")
+    = render "acceptance_submissions", delivery_note: @delivery_note
+
   - if @delivery_note.prelude.present?
     .mb-4
       .card

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -77,6 +77,15 @@ class Rack::Attack
     end
   end
 
+  # Customer portal delivery-acceptance page (separate host, unauthenticated).
+  throttle("delivery-acceptance-fetch/ip", limit: 60, period: 1.minute) do |req|
+    ip_key(req) if req.get? && req.path.start_with?("/delivery-acceptance/")
+  end
+
+  throttle("delivery-acceptance-upload/ip", limit: 10, period: 1.minute) do |req|
+    ip_key(req) if req.post? && req.path.start_with?("/delivery-acceptance/")
+  end
+
   # Backstop. Skips static assets and authenticated requests (signed auth
   # cookie present) so a chatty SPA does not hit this limit. /up is NOT
   # exempted: see the file-level note above.

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -51,7 +51,13 @@ de:
         - "Abnahme der gelieferten Leistungen"
         - "Bestätigung der Leistungserbringung"
         - "Rücksendung des unterfertigten Lieferscheins per E-Mail"
+      next_steps_upload: "Unterfertigen Lieferschein hochladen"
       closing: "Vielen Dank für Ihr Vertrauen. Wir freuen uns auf die weitere Zusammenarbeit."
+
+    acceptance_submission:
+      subject: "Neues Abnahmedokument für %{document_number}"
+      body: "Ein Kunde hat ein unterschriebenes Abnahmedokument für Lieferschein %{document_number} hochgeladen. Bitte prüfen Sie es."
+      cta: "Lieferschein prüfen"
 
   customer_contacts:
     salutation_line_hint: "In der Sprache des Kunden verfassen: %{language_name}"
@@ -64,3 +70,22 @@ de:
       portal_title: "%{issuer} Dokumentenportal"
       portal_body: "Bitte verwenden Sie den Upload-Link aus der E-Mail, die wir Ihnen gesendet haben."
       not_found_title: "Hier gibt es nichts zu sehen"
+
+    acceptance:
+      title: "Abnahme für Lieferschein %{number}"
+      dated: "Datiert %{date}"
+      hint: "Nur PDF · maximal %{max} MB"
+      submit: "Unterschriebene Abnahme senden"
+      success_title: "Erhalten – vielen Dank"
+      success_body: "Ihre unterschriebene Abnahme wurde empfangen und wird geprüft."
+      errors:
+        missing: "Bitte wählen Sie eine PDF-Datei zum Hochladen."
+        not_pdf: "Es werden nur PDF-Dateien akzeptiert."
+        too_large: "Die Datei ist zu groß – maximal %{max} MB."
+      closed:
+        invalid_title: "Dieser Link ist nicht mehr gültig"
+        invalid_body: "Bitte kontaktieren Sie uns, falls Sie Ihre Abnahme noch senden möchten."
+        accepted_title: "Bereits abgenommen"
+        accepted_body: "Dieser Lieferschein wurde bereits abgenommen. Vielen Dank."
+        capped_title: "Zu viele Uploads"
+        capped_body: "Bitte kontaktieren Sie uns, um Ihre Abnahme auf anderem Weg zu senden."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -127,7 +127,13 @@ en:
         - "Please review the delivery note and verify all details are correct"
         - "Sign the delivery note to confirm acceptance of the delivered services"
         - "Return the signed delivery note to us via email"
+      next_steps_upload: "Upload the signed delivery note"
       closing: "Thank you for your business. We appreciate your continued partnership."
+
+    acceptance_submission:
+      subject: "New acceptance document for %{document_number}"
+      body: "A customer uploaded a signed acceptance document for delivery note %{document_number}. Please review it."
+      cta: "Review the delivery note"
 
   customer_contacts:
     salutation_line_hint: "Write in the customer's language: %{language_name}"
@@ -140,3 +146,22 @@ en:
       portal_title: "%{issuer} document portal"
       portal_body: "Please use the upload link from the email we sent you."
       not_found_title: "Nothing to see here"
+
+    acceptance:
+      title: "Acceptance for Delivery Note %{number}"
+      dated: "Dated %{date}"
+      hint: "PDF only · maximum %{max} MB"
+      submit: "Submit signed acceptance"
+      success_title: "Received — thank you"
+      success_body: "Your signed acceptance was received and is pending review."
+      errors:
+        missing: "Please choose a PDF file to upload."
+        not_pdf: "Only PDF files are accepted."
+        too_large: "File is too large — maximum %{max} MB."
+      closed:
+        invalid_title: "This link is no longer valid"
+        invalid_body: "Please contact us if you still need to send your acceptance."
+        accepted_title: "Already accepted"
+        accepted_body: "This delivery note has already been accepted. Thank you."
+        capped_title: "Too many uploads"
+        capped_body: "Please contact us to send your acceptance another way."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   constraints(CustomerPortalHostConstraint.new) do
     scope module: :customer_portal do
+      get  "delivery-acceptance/:token", to: "acceptances#show",   as: :delivery_acceptance_upload
+      post "delivery-acceptance/:token", to: "acceptances#create", as: :delivery_acceptance_upload_submit
       get  "/", to: "pages#root", as: :public_root
       get  "*path", to: "pages#not_found", format: false
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,11 +94,14 @@ Rails.application.routes.draw do
       post "upload_acceptance"
       post "delete_acceptance"
       post "convert_to_invoice"
+      post "accept_acceptance"
+      post "reject_acceptance"
     end
     collection do
       post "bulk_send_emails"
     end
   end
+
   resources :products
   resources :projects
   resources :sales_tax_customer_classes

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,6 +13,8 @@ customer_portal:
   # blank to disable the public flow (no route is mounted). In production set
   # to e.g. 'accept.example.com' and add a matching Apache ServerAlias.
   host: ''
+  link_expiry_days: 30
+  submissions_per_token: 20
 
 webauthn:
   rp_name: 'ABT'

--- a/db/migrate/20260601200104_add_acceptance_upload_token_to_delivery_notes.rb
+++ b/db/migrate/20260601200104_add_acceptance_upload_token_to_delivery_notes.rb
@@ -1,0 +1,15 @@
+class AddAcceptanceUploadTokenToDeliveryNotes < ActiveRecord::Migration[8.1]
+  def up
+    add_column :delivery_notes, :acceptance_upload_token_digest, :string
+    add_column :delivery_notes, :acceptance_upload_token_minted_at, :datetime
+    add_column :delivery_notes, :acceptance_upload_token_expires_at, :datetime
+    add_index :delivery_notes, :acceptance_upload_token_digest, unique: true
+  end
+
+  def down
+    remove_index :delivery_notes, :acceptance_upload_token_digest
+    remove_column :delivery_notes, :acceptance_upload_token_expires_at
+    remove_column :delivery_notes, :acceptance_upload_token_minted_at
+    remove_column :delivery_notes, :acceptance_upload_token_digest
+  end
+end

--- a/db/migrate/20260601200105_create_acceptance_submissions.rb
+++ b/db/migrate/20260601200105_create_acceptance_submissions.rb
@@ -1,0 +1,20 @@
+class CreateAcceptanceSubmissions < ActiveRecord::Migration[8.1]
+  def up
+    create_table :acceptance_submissions do |t|
+      t.references :delivery_note, null: false, foreign_key: true
+      t.references :attachment, foreign_key: true
+      t.string :status, null: false, default: "pending"
+      t.datetime :submitted_at, null: false
+      t.string :submitted_ip
+      t.datetime :reviewed_at
+      t.references :reviewed_by, foreign_key: { to_table: :users }
+      t.timestamps
+    end
+    add_index :acceptance_submissions, :delivery_note_id, unique: true,
+              where: "status = 'pending'", name: "index_one_pending_submission_per_note"
+  end
+
+  def down
+    drop_table :acceptance_submissions
+  end
+end

--- a/db/migrate/20260601210051_nullify_acceptance_submission_attachment_on_delete.rb
+++ b/db/migrate/20260601210051_nullify_acceptance_submission_attachment_on_delete.rb
@@ -1,0 +1,11 @@
+class NullifyAcceptanceSubmissionAttachmentOnDelete < ActiveRecord::Migration[8.1]
+  def up
+    remove_foreign_key :acceptance_submissions, :attachments
+    add_foreign_key :acceptance_submissions, :attachments, on_delete: :nullify
+  end
+
+  def down
+    remove_foreign_key :acceptance_submissions, :attachments
+    add_foreign_key :acceptance_submissions, :attachments
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_01_175606) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_01_210051) do
+  create_table "acceptance_submissions", force: :cascade do |t|
+    t.integer "attachment_id"
+    t.datetime "created_at", null: false
+    t.integer "delivery_note_id", null: false
+    t.datetime "reviewed_at"
+    t.integer "reviewed_by_id"
+    t.string "status", default: "pending", null: false
+    t.datetime "submitted_at", null: false
+    t.string "submitted_ip"
+    t.datetime "updated_at", null: false
+    t.index ["attachment_id"], name: "index_acceptance_submissions_on_attachment_id"
+    t.index ["delivery_note_id"], name: "index_acceptance_submissions_on_delivery_note_id"
+    t.index ["delivery_note_id"], name: "index_one_pending_submission_per_note", unique: true, where: "status = 'pending'"
+    t.index ["reviewed_by_id"], name: "index_acceptance_submissions_on_reviewed_by_id"
+  end
+
   create_table "attachments", force: :cascade do |t|
     t.string "content_type"
     t.datetime "created_at", null: false
@@ -102,6 +118,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_175606) do
 
   create_table "delivery_notes", force: :cascade do |t|
     t.integer "acceptance_attachment_id"
+    t.string "acceptance_upload_token_digest"
+    t.datetime "acceptance_upload_token_expires_at"
+    t.datetime "acceptance_upload_token_minted_at"
     t.datetime "created_at", null: false
     t.string "cust_order"
     t.string "cust_reference"
@@ -117,6 +136,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_175606) do
     t.boolean "published"
     t.datetime "updated_at", null: false
     t.index ["acceptance_attachment_id"], name: "index_delivery_notes_on_acceptance_attachment_id"
+    t.index ["acceptance_upload_token_digest"], name: "index_delivery_notes_on_acceptance_upload_token_digest", unique: true
     t.index ["customer_id"], name: "index_delivery_notes_on_customer_id"
     t.index ["date"], name: "index_delivery_notes_on_date"
     t.index ["document_number"], name: "index_delivery_notes_on_document_number", unique: true
@@ -424,6 +444,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_175606) do
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 
+  add_foreign_key "acceptance_submissions", "attachments", on_delete: :nullify
+  add_foreign_key "acceptance_submissions", "delivery_notes"
+  add_foreign_key "acceptance_submissions", "users", column: "reviewed_by_id"
   add_foreign_key "customer_contact_projects", "customer_contacts"
   add_foreign_key "customer_contact_projects", "projects"
   add_foreign_key "customer_contacts", "customers"

--- a/test/controllers/delivery_notes_controller_test.rb
+++ b/test/controllers/delivery_notes_controller_test.rb
@@ -422,4 +422,40 @@ class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to delivery_notes_url
     assert_match "2 emails queued for sending", flash[:notice]
   end
+
+  test "send_email mints an acceptance upload token" do
+    note = delivery_notes(:published_delivery_note)
+    note.update!(email_sent_at: nil, acceptance_upload_token_digest: nil)
+    assert_nil note.acceptance_upload_token_digest
+    post send_email_delivery_note_url(note)
+    assert note.reload.acceptance_upload_token_digest.present?
+  end
+
+  test "previewing the email does not mint a token" do
+    note = delivery_notes(:published_delivery_note)
+    note.update!(acceptance_upload_token_digest: nil)
+    get preview_email_html_delivery_note_url(note)
+    assert_nil note.reload.acceptance_upload_token_digest
+  end
+
+  test "email preview shows the acceptance link without minting a token" do
+    note = delivery_notes(:published_delivery_note)
+    note.update!(acceptance_upload_token_digest: nil)
+    get preview_email_html_delivery_note_url(note)
+    assert_match "/delivery-acceptance/", response.body
+    assert_nil note.reload.acceptance_upload_token_digest
+  end
+
+  test "send_email does not mint a token when the customer portal is disabled" do
+    note = delivery_notes(:published_delivery_note)
+    note.update!(email_sent_at: nil, acceptance_upload_token_digest: nil)
+    original_host = Settings.customer_portal.host
+    Settings.customer_portal.host = ""
+    begin
+      post send_email_delivery_note_url(note)
+    ensure
+      Settings.customer_portal.host = original_host
+    end
+    assert_nil note.reload.acceptance_upload_token_digest
+  end
 end

--- a/test/controllers/delivery_notes_controller_test.rb
+++ b/test/controllers/delivery_notes_controller_test.rb
@@ -335,6 +335,21 @@ class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
     assert_match "deleted successfully", flash[:notice]
   end
 
+  test "deleting an acceptance promoted from a submission does not error" do
+    dn = delivery_notes(:published_delivery_note)
+    dn.issue_acceptance_upload_token!
+    sub = AcceptanceSubmission.submit!(delivery_note: dn,
+      uploaded_file: fixture_file_upload("acceptance.pdf", "application/pdf"), ip: "1.1.1.1")
+    sub.accept!(by: users(:alice))
+    attachment_id = sub.attachment_id
+
+    post delete_acceptance_delivery_note_url(dn)
+    assert_redirected_to delivery_note_path(dn)
+    assert_nil dn.reload.acceptance_attachment_id
+    assert_nil sub.reload.attachment_id
+    assert_not Attachment.exists?(attachment_id)
+  end
+
   test "should not delete acceptance document if none exists" do
     published_note = delivery_notes(:published_delivery_note)
     assert_nil published_note.acceptance_attachment
@@ -457,5 +472,85 @@ class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
       Settings.customer_portal.host = original_host
     end
     assert_nil note.reload.acceptance_upload_token_digest
+  end
+
+  test "accept_acceptance promotes the submission and redirects" do
+    dn, sub = pending_submission
+    post accept_acceptance_delivery_note_url(dn, submission_id: sub.id)
+    assert_redirected_to delivery_note_path(dn)
+    assert_equal sub.attachment_id, dn.reload.acceptance_attachment_id
+  end
+
+  test "accept_acceptance of a superseded submission shows an error, no promotion" do
+    dn, sub = pending_submission
+    AcceptanceSubmission.submit!(delivery_note: dn,
+      uploaded_file: fixture_file_upload("acceptance.pdf", "application/pdf"), ip: "1.1.1.1")
+    post accept_acceptance_delivery_note_url(dn, submission_id: sub.id)
+    assert_redirected_to delivery_note_path(dn)
+    assert_nil dn.reload.acceptance_attachment_id
+    assert_match(/newer submission/i, flash[:alert])
+  end
+
+  test "reject_acceptance marks the submission rejected and redirects" do
+    dn, sub = pending_submission
+    post reject_acceptance_delivery_note_url(dn, submission_id: sub.id)
+    assert_redirected_to delivery_note_path(dn)
+    assert_equal "rejected", sub.reload.status
+  end
+
+  test "a user without review_acceptance cannot accept a submission" do
+    dn, sub = pending_submission
+    sign_in_as users(:bob)
+    post accept_acceptance_delivery_note_url(dn, submission_id: sub.id)
+    assert_redirected_to root_path
+    assert_nil dn.reload.acceptance_attachment_id
+  end
+
+  test "index filtered by pending acceptance lists only notes with a pending submission" do
+    dn, = pending_submission
+    other = create_published_delivery_note(document_number: "DN-2025-099", cust_reference: "NO-PENDING")
+
+    get delivery_notes_url(acceptance_filter: "pending")
+    assert_response :success
+    assert_select "a[href=?]", delivery_note_path(dn)
+    assert_select "a[href=?]", delivery_note_path(other), count: 0
+  end
+
+  test "reviewer can view a pending submission's attachment" do
+    _dn, sub = pending_submission
+    get attachment_url(sub.attachment)
+    assert_response :success
+  end
+
+  test "show keeps the submissions card while a submission is pending" do
+    dn, = pending_submission
+    get delivery_note_url(dn)
+    assert_select "h5", text: "Customer acceptance submissions"
+  end
+
+  test "show hides the submissions card once accepted with no pending submission" do
+    dn, sub = pending_submission
+    sub.accept!(by: users(:alice))
+    get delivery_note_url(dn)
+    assert_select "h5", text: "Customer acceptance submissions", count: 0
+  end
+
+  test "show hides the submissions card after an accepted document is deleted" do
+    dn, sub = pending_submission
+    sub.accept!(by: users(:alice))
+    post delete_acceptance_delivery_note_url(dn)
+    assert_nil dn.reload.acceptance_attachment_id
+    get delivery_note_url(dn)
+    assert_select "h5", text: "Customer acceptance submissions", count: 0
+  end
+
+  private
+
+  def pending_submission
+    dn = delivery_notes(:published_delivery_note)
+    dn.issue_acceptance_upload_token!
+    sub = AcceptanceSubmission.submit!(delivery_note: dn,
+      uploaded_file: fixture_file_upload("acceptance.pdf", "application/pdf"), ip: "1.1.1.1")
+    [ dn, sub ]
   end
 end

--- a/test/controllers/rack_attack_test.rb
+++ b/test/controllers/rack_attack_test.rb
@@ -21,6 +21,10 @@ class RackAttackTest < ActiveSupport::TestCase
     assert_equal "203.0.113.7", Rack::Attack.client_ip(stub_req(env))
   end
 
+  test "delivery-acceptance-upload/ip throttle is registered" do
+    assert Rack::Attack.throttles.key?("delivery-acceptance-upload/ip")
+  end
+
   private
 
   def stub_req(env_or_ip)

--- a/test/fixtures/files/acceptance.pdf
+++ b/test/fixtures/files/acceptance.pdf
@@ -1,0 +1,4 @@
+%PDF-1.4
+1 0 obj<</Type/Catalog>>endobj
+trailer<</Root 1 0 R>>
+%%EOF

--- a/test/fixtures/files/notpdf.html
+++ b/test/fixtures/files/notpdf.html
@@ -1,0 +1,1 @@
+<html>x</html>

--- a/test/fixtures/group_permissions.yml
+++ b/test/fixtures/group_permissions.yml
@@ -22,6 +22,9 @@ admin_delivery_notes_view:
 admin_delivery_notes_edit:
   group: admin
   permission: delivery_notes.edit
+admin_delivery_notes_review_acceptance:
+  group: admin
+  permission: delivery_notes.review_acceptance
 admin_products_view:
   group: admin
   permission: products.view

--- a/test/integration/public_acceptances_test.rb
+++ b/test/integration/public_acceptances_test.rb
@@ -1,0 +1,69 @@
+require "test_helper"
+class PublicAcceptancesTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+  setup { host! Settings.customer_portal.host }
+
+  def open_note
+    dn = delivery_notes(:published_delivery_note)
+    @token = dn.issue_acceptance_upload_token!
+    dn
+  end
+
+  def pdf
+    fixture_file_upload("acceptance.pdf", "application/pdf")
+  end
+
+  test "GET with a valid token shows the upload form" do
+    open_note
+    get delivery_acceptance_upload_url(token: @token, host: Settings.customer_portal.host)
+    assert_response :success
+    assert_select "form[action=?]", delivery_acceptance_upload_submit_path(token: @token)
+    assert_select "small", text: /maximum 25 MB/i
+  end
+
+  test "renders the upload page in the visitor's Accept-Language locale" do
+    dn = delivery_notes(:published_delivery_note)
+    token = dn.issue_acceptance_upload_token!
+    get delivery_acceptance_upload_url(token: token, host: Settings.customer_portal.host),
+        headers: { "Accept-Language" => "de-DE,de;q=0.9,en;q=0.8" }
+    assert_select "h1", text: /Abnahme/
+  end
+
+  test "GET with an unknown token shows the closed page" do
+    get delivery_acceptance_upload_url(token: "nope", host: Settings.customer_portal.host)
+    assert_response :success
+    assert_select "form", count: 0
+  end
+
+  test "GET on an already-accepted note shows closed" do
+    dn = open_note
+    AcceptanceSubmission.submit!(delivery_note: dn, uploaded_file: pdf, ip: "1.1.1.1").accept!(by: users(:alice))
+    get delivery_acceptance_upload_url(token: @token, host: Settings.customer_portal.host)
+    assert_select "form", count: 0
+  end
+
+  test "POST a PDF creates a pending submission and notifies the issuer" do
+    dn = open_note
+    assert_difference -> { dn.acceptance_submissions.pending.count }, 1 do
+      assert_enqueued_emails 1 do
+        post delivery_acceptance_upload_submit_url(token: @token, host: Settings.customer_portal.host), params: { acceptance_pdf: pdf }
+      end
+    end
+    assert_response :success
+    assert_select "h1", text: /received/i
+  end
+
+  test "POST a non-PDF re-renders the form with an error" do
+    open_note
+    bad = fixture_file_upload("notpdf.html", "application/pdf")
+    post delivery_acceptance_upload_submit_url(token: @token, host: Settings.customer_portal.host), params: { acceptance_pdf: bad }
+    assert_response :unprocessable_content
+    assert_select ".alert", text: /PDF/i
+  end
+
+  test "the upload route is unreachable on the app host" do
+    host! "app.example.com"
+    get "/delivery-acceptance/sometoken"
+    assert_response :not_found
+  end
+end

--- a/test/mailers/acceptance_submission_mailer_test.rb
+++ b/test/mailers/acceptance_submission_mailer_test.rb
@@ -1,0 +1,10 @@
+require "test_helper"
+
+class AcceptanceSubmissionMailerTest < ActionMailer::TestCase
+  test "submitted notifies the issuer reporting_email with a link to the note" do
+    dn = delivery_notes(:published_delivery_note)
+    mail = AcceptanceSubmissionMailer.with(delivery_note: dn).submitted
+    assert_equal [ IssuerCompany.get_the_issuer!.reporting_email ], mail.to
+    assert_match dn.document_number, mail.body.encoded
+  end
+end

--- a/test/mailers/delivery_note_mailer_test.rb
+++ b/test/mailers/delivery_note_mailer_test.rb
@@ -55,6 +55,19 @@ class DeliveryNoteMailerTest < ActionMailer::TestCase
     assert_no_match(/Hi tester two,/, text_body)
   end
 
+  test "customer_email includes the acceptance upload link when a token is given" do
+    dn = delivery_notes(:published_delivery_note)
+    token = dn.issue_acceptance_upload_token!
+    mail = DeliveryNoteMailer.with(delivery_note: dn, acceptance_token: token, skip_attachments: true).customer_email
+    assert_match "/delivery-acceptance/#{token}", mail.body.encoded
+  end
+
+  test "customer_email omits the link when no token is given" do
+    dn = delivery_notes(:published_delivery_note)
+    mail = DeliveryNoteMailer.with(delivery_note: dn, skip_attachments: true).customer_email
+    assert_no_match "/delivery-acceptance/", mail.body.encoded
+  end
+
   test "customer_email skips PDF rendering when skip_attachments is set" do
     delivery_note = delivery_notes(:published_delivery_note)
 
@@ -66,6 +79,24 @@ class DeliveryNoteMailerTest < ActionMailer::TestCase
       mail = DeliveryNoteMailer.with(delivery_note: delivery_note, skip_attachments: true).customer_email
       assert_not_nil mail.html_part
       assert_equal 0, mail.attachments.size
+    ensure
+      DeliveryNoteRenderer.define_method(:render, original)
+    end
+  end
+
+  test "bulk_customer_email renders a per-note acceptance link for eligible notes" do
+    dn = delivery_notes(:published_delivery_note)
+    token = dn.issue_acceptance_upload_token!
+
+    # Avoid invoking the real FOP renderer for the combined email's attachments.
+    original = DeliveryNoteRenderer.instance_method(:render)
+    DeliveryNoteRenderer.define_method(:render) { "%PDF-1.4 fake" }
+    begin
+      mail = DeliveryNoteMailer.with(
+        delivery_notes: [ dn ], recipients: [ "x@example.com" ],
+        acceptance_tokens: { dn.id.to_s => token }
+      ).bulk_customer_email
+      assert_match "/delivery-acceptance/#{token}", mail.body.encoded
     ensure
       DeliveryNoteRenderer.define_method(:render, original)
     end

--- a/test/models/acceptance_submission_test.rb
+++ b/test/models/acceptance_submission_test.rb
@@ -1,0 +1,90 @@
+require "test_helper"
+
+class AcceptanceSubmissionTest < ActiveSupport::TestCase
+  def published_note
+    dn = delivery_notes(:published_delivery_note)
+    dn.issue_acceptance_upload_token!
+    dn
+  end
+
+  def pdf_upload
+    Rack::Test::UploadedFile.new(
+      Rails.root.join("test/fixtures/files/acceptance.pdf"), "application/pdf")
+  end
+
+  test "submit! creates a pending submission with an attachment" do
+    dn = published_note
+    sub = AcceptanceSubmission.submit!(delivery_note: dn, uploaded_file: pdf_upload, ip: "203.0.113.5")
+    assert_equal "pending", sub.status
+    assert sub.attachment.present?
+    assert_equal "203.0.113.5", sub.submitted_ip
+  end
+
+  test "a second submit supersedes the first and drops its blob" do
+    dn = published_note
+    first = AcceptanceSubmission.submit!(delivery_note: dn, uploaded_file: pdf_upload, ip: "1.1.1.1")
+    first_attachment_id = first.attachment_id
+    AcceptanceSubmission.submit!(delivery_note: dn, uploaded_file: pdf_upload, ip: "1.1.1.1")
+    first.reload
+    assert_equal "superseded", first.status
+    assert_nil first.attachment_id
+    assert_not Attachment.exists?(first_attachment_id)
+    assert_equal 1, dn.acceptance_submissions.pending.count
+  end
+
+  test "accept! promotes the reviewed attachment to the official slot" do
+    dn = published_note
+    sub = AcceptanceSubmission.submit!(delivery_note: dn, uploaded_file: pdf_upload, ip: "1.1.1.1")
+    sub.accept!(by: users(:alice))
+    dn.reload
+    assert_equal sub.attachment_id, dn.acceptance_attachment_id
+    assert_equal "accepted", sub.reload.status
+    assert_not dn.acceptance_upload_open?
+  end
+
+  test "accept! refuses a superseded submission" do
+    dn = published_note
+    stale = AcceptanceSubmission.submit!(delivery_note: dn, uploaded_file: pdf_upload, ip: "1.1.1.1")
+    AcceptanceSubmission.submit!(delivery_note: dn, uploaded_file: pdf_upload, ip: "1.1.1.1")
+    assert_raises(AcceptanceSubmission::StaleSubmission) { stale.accept!(by: users(:alice)) }
+  end
+
+  test "reject! drops the blob, keeps the row, and reopens the link" do
+    dn = published_note
+    sub = AcceptanceSubmission.submit!(delivery_note: dn, uploaded_file: pdf_upload, ip: "1.1.1.1")
+    att_id = sub.attachment_id
+    sub.reject!(by: users(:alice))
+    assert_equal "rejected", sub.reload.status
+    assert_nil sub.attachment_id
+    assert_not Attachment.exists?(att_id)
+    assert dn.reload.acceptance_upload_open?, "link stays open after rejection"
+  end
+
+  test "submit! refuses when the note is no longer open" do
+    dn = published_note
+    AcceptanceSubmission.submit!(delivery_note: dn, uploaded_file: pdf_upload, ip: "1.1.1.1").accept!(by: users(:alice))
+    assert_raises(AcceptanceSubmission::NotOpen) do
+      AcceptanceSubmission.submit!(delivery_note: dn, uploaded_file: pdf_upload, ip: "1.1.1.1")
+    end
+  end
+
+  test "submit! refuses once the per-token cap is reached" do
+    dn = published_note
+    DeliveryNote::ACCEPTANCE_SUBMISSIONS_PER_TOKEN.times do
+      AcceptanceSubmission.submit!(delivery_note: dn, uploaded_file: pdf_upload, ip: "1.1.1.1")
+    end
+    assert_raises(AcceptanceSubmission::CapReached) do
+      AcceptanceSubmission.submit!(delivery_note: dn, uploaded_file: pdf_upload, ip: "1.1.1.1")
+    end
+  end
+
+  test "rotating the token resets the per-token submission window" do
+    dn = published_note
+    DeliveryNote::ACCEPTANCE_SUBMISSIONS_PER_TOKEN.times do
+      AcceptanceSubmission.submit!(delivery_note: dn, uploaded_file: pdf_upload, ip: "1.1.1.1")
+    end
+    assert dn.acceptance_upload_cap_reached?
+    dn.issue_acceptance_upload_token!(now: 1.hour.from_now)
+    assert_not dn.acceptance_upload_cap_reached?
+  end
+end

--- a/test/models/delivery_note_test.rb
+++ b/test/models/delivery_note_test.rb
@@ -56,6 +56,28 @@ class DeliveryNoteTest < ActiveSupport::TestCase
     assert_includes delivery_note.publish_problems, "Delivery note has no item lines."
   end
 
+  test "issue_acceptance_upload_token! mints, persists digest and 30-day expiry" do
+    dn = delivery_notes(:published_delivery_note)
+    token = dn.issue_acceptance_upload_token!
+    assert token.present?
+    dn.reload
+    assert_equal Digest::SHA256.hexdigest(token), dn.acceptance_upload_token_digest
+    assert_in_delta 30.days.from_now.to_i, dn.acceptance_upload_token_expires_at.to_i, 5
+  end
+
+  test "rotating the token invalidates the old one" do
+    dn = delivery_notes(:published_delivery_note)
+    old = dn.issue_acceptance_upload_token!
+    dn.issue_acceptance_upload_token!
+    assert_nil DeliveryNote.find_by_acceptance_upload_token(old)
+  end
+
+  test "find_by_acceptance_upload_token resolves the current token" do
+    dn = delivery_notes(:published_delivery_note)
+    token = dn.issue_acceptance_upload_token!
+    assert_equal dn, DeliveryNote.find_by_acceptance_upload_token(token)
+  end
+
   test "delivery_timeframe formats single day correctly" do
     delivery_note = DeliveryNote.new(
       delivery_start_date: Date.new(2025, 5, 1),

--- a/test/models/permission_test.rb
+++ b/test/models/permission_test.rb
@@ -40,4 +40,8 @@ class PermissionTest < ActiveSupport::TestCase
     assert_equal %w[users.reset_passkeys users.auto_confirm_email].sort,
                  Permission::ADMIN_ONLY_KEYS.to_a.sort
   end
+
+  test "review_acceptance permission is registered" do
+    assert Permission.valid?("delivery_notes.review_acceptance")
+  end
 end

--- a/test/services/absolute_url_test.rb
+++ b/test/services/absolute_url_test.rb
@@ -44,4 +44,10 @@ class AbsoluteUrlTest < ActiveSupport::TestCase
 
     assert_equal "https://example.test/abt/account/email_confirmations?token=tok-xyz", url
   end
+
+  test "delivery_acceptance_upload uses the customer portal host" do
+    url = AbsoluteUrl.delivery_acceptance_upload("tok123")
+    assert_includes url, "/delivery-acceptance/tok123"
+    assert_includes url, Settings.customer_portal.host
+  end
 end

--- a/test/system/acceptance_upload_test.rb
+++ b/test/system/acceptance_upload_test.rb
@@ -1,0 +1,31 @@
+require "application_system_test_case"
+
+class AcceptanceUploadTest < ApplicationSystemTestCase
+  skip_default_signin! # customer-facing page is unauthenticated
+
+  setup do
+    @prev_app_host = Capybara.app_host
+    @prev_include_port = Capybara.always_include_port
+    Capybara.app_host = "http://#{Settings.customer_portal.host}"
+    Capybara.always_include_port = true
+  end
+
+  teardown do
+    Capybara.app_host = @prev_app_host
+    Capybara.always_include_port = @prev_include_port
+  end
+
+  test "customer uploads a signed acceptance document" do
+    dn = delivery_notes(:published_delivery_note)
+    token = dn.issue_acceptance_upload_token!
+
+    visit delivery_acceptance_upload_path(token: token)
+    assert_text "Acceptance for Delivery Note"
+
+    attach_file "acceptance_pdf", Rails.root.join("test/fixtures/files/acceptance.pdf")
+    click_button "Submit signed acceptance"
+
+    assert_text "Received"
+    assert_equal 1, dn.reload.acceptance_submissions.pending.count
+  end
+end


### PR DESCRIPTION
## Summary
Lets delivery-note customers upload a signed acceptance PDF themselves via an
expiring, unguessable link, instead of replying by email. Builds on the
**customer portal already on `main`**: the link opens a host-constrained,
issuer-branded `/delivery-acceptance/:token` page (no login). Uploads land as
**pending submissions** the issuer reviews — from the deliveries list — before
promotion to the note's official `acceptance_attachment`.

Three commits:

**1. Data model & permission**
- `DeliveryNote` acceptance-upload token: 256-bit `DigestedToken`, minted on
  send, expiry from `Settings.customer_portal.link_expiry_days`, rotates on re-send.
- `AcceptanceSubmission` audit model: supersede-and-drop (≤1 pending blob + the
  accepted one), per-token cap (`Settings.customer_portal.submissions_per_token`),
  all transitions under `delivery_note.with_lock` + a partial-unique pending
  index, attachment FK nullified on delete.
- New `delivery_notes.review_acceptance` permission.

**2. Customer upload page & emails**
- Host-constrained `/delivery-acceptance/:token` page (`CustomerPortal::AcceptancesController`
  + branded views) with Marcel PDF sniffing, 25 MB cap, and rack-attack throttles.
- Each upload notifies the issuer (`AcceptanceSubmissionMailer`); the delivery-note
  email — single and bulk — carries a per-note upload link (the link replaces the
  "return by email" step in the next-steps list), with the token minted on send.
  The email preview renders the link too (placeholder token, no minting); no link
  is embedded when the portal is disabled.
- `AbsoluteUrl` helpers + `customer_portal.acceptance` / mailer i18n (en + de).

**3. Issuer review**
- Pending submissions surface as a **"Pending acceptance" filter on the deliveries
  index** (no separate queue/page).
- Id-targeted accept/reject as delivery-note member actions, reviewed from the
  note's show page — accept promotes to the official acceptance, reject reopens
  the link. The review card shows only while a submission is pending. Reviewers
  can preview a pending submission's PDF.

The customer-portal basics (host constraint, base/pages controllers, layout,
Accept-Language localization, host config, mailer/portal CSS) are already on
`main`; this PR layers the acceptance feature on top.

## Test plan
- [ ] `bundle exec rails test` (812) and `bundle exec rails test test/system/` (62) green
- [ ] Send a delivery-note email → open the link on the portal host → upload a
      signed PDF → it appears under the deliveries "Pending acceptance" filter and on the note
- [ ] Accept promotes it to the official acceptance document; Reject reopens the link
- [ ] App login/menu remains unreachable on the portal host (covered by main's basics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)