### PR TITLE
Fix customer portal styling broken under strict CSP

### DIFF
--- a/app/assets/stylesheets/customer_portal.css.scss
+++ b/app/assets/stylesheets/customer_portal.css.scss
@@ -1,0 +1,10 @@
+// Customer portal layout (layouts/customer_portal). Replaces inline
+// style="..." attributes so the portal renders under the app's strict CSP.
+
+.customer-portal-container {
+  max-width: 640px;
+}
+
+.customer-portal-logo {
+  max-height: 64px;
+}

--- a/app/views/layouts/customer_portal.html.haml
+++ b/app/views/layouts/customer_portal.html.haml
@@ -10,12 +10,12 @@
       = tag.style ":root { --issuer-accent-color: #{@issuer.document_accent_color}; }", nonce: content_security_policy_nonce
   %body.d-flex.flex-column.min-vh-100
     %main.flex-grow-1
-      .container.py-5{style: "max-width: 640px;"}
+      .container.py-5.customer-portal-container
         - if @issuer&.png_logo.present?
-          .mb-4= image_tag "data:image/png;base64,#{Base64.strict_encode64(@issuer.png_logo)}", alt: @issuer.short_name, style: "max-height: 64px;"
+          .mb-4= image_tag "data:image/png;base64,#{Base64.strict_encode64(@issuer.png_logo)}", alt: @issuer.short_name, class: "customer-portal-logo"
         = yield
     %footer.footer.mt-auto.py-3
-      .container.text-center.text-muted{style: "max-width: 640px;"}
+      .container.text-center.text-muted.customer-portal-container
         - name = @issuer&.legal_name.presence || @issuer&.short_name
         - if @issuer&.website_url.present?
           = link_to name, @issuer.website_url, target: "_blank", rel: "noopener noreferrer"

--- a/test/integration/csp_inline_handlers_structure_test.rb
+++ b/test/integration/csp_inline_handlers_structure_test.rb
@@ -127,6 +127,15 @@ class CspInlineHandlersStructureTest < ActionDispatch::IntegrationTest
     assert_no_match(/\bstyle=['"]/, body, "no inline style attributes allowed on the edit customer-contact form")
   end
 
+  test "customer portal page carries no inline style attribute" do
+    issuer_companies(:one).update!(png_logo: "fakepng")
+    get public_root_url(host: Settings.customer_portal.host)
+    assert_response :success
+    body = @response.body
+
+    assert_no_match(/\bstyle=['"]/, body, "no inline style attributes allowed on the customer portal")
+  end
+
   private
 
   def csp_nonce(response)


### PR DESCRIPTION
## Problem

The customer portal layout used inline `style=""` attributes for the 640px content/footer container width and the 64px logo cap. The app runs a strict CSP (`style-src :self`, no `'unsafe-inline'`). CSP nonces apply to `<style>` elements but **not** to inline `style=""` attributes, so the browser silently blocked these and the styling never applied.

The codebase already migrated away from inline styles for exactly this reason (see `utilities.css.scss` and the per-page assertions in `csp_inline_handlers_structure_test.rb`); the customer portal layout was missed.

## Fix

- New `app/assets/stylesheets/customer_portal.css.scss` with `.customer-portal-container` (max-width: 640px) and `.customer-portal-logo` (max-height: 64px), following the per-feature stylesheet convention.
- `layouts/customer_portal.html.haml`: replaced the three `style:` attributes with those classes.

The nonced accent-color `<style>` block is correct and untouched.

## Test

Added `customer portal page carries no inline style attribute` to `csp_inline_handlers_structure_test.rb`, alongside the other per-page checks. It attaches a `png_logo` so the logo's inline style is exercised too. Confirmed failing before the fix, passing after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)