### PR TITLE
Match mailer instructions/closing font size to main message

### DIFF
--- a/app/views/layouts/mailer.html.haml
+++ b/app/views/layouts/mailer.html.haml
@@ -83,7 +83,11 @@
       .due-date {
         margin-top: 8px;
       }
+      .instructions {
+        font-size: 16px;
+      }
       .closing {
+        font-size: 16px;
         margin-top: 30px;
         margin-bottom: 30px;
       }


### PR DESCRIPTION
In the invoice and delivery-note mailers, the instructions list and closing line rendered smaller than the main body text.

The `.closing` rule had no `font-size` and `.instructions` had no CSS rule at all, so both inherited the email-client default rather than matching `.main-message` (16px). Set both to 16px.

Affects the invoice mailer (`.closing`) and both delivery-note mailers (`.instructions` + `.closing`), which share `app/views/layouts/mailer.html.haml`. Plain-text variants are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)