### PR TITLE
Fix invoice line type/tax-class selects firing no Stimulus action

### DIFF
--- a/app/views/invoices/_invoice_line_fields.html.haml
+++ b/app/views/invoices/_invoice_line_fields.html.haml
@@ -7,7 +7,7 @@
       .col-sm-2
         .mb-3
           %label.form-label Type
-          = f.select :type, options_for_select(@line_type_options, f.object.type), { prompt: 'Select type...' }, { class: 'form-select', data: { action: 'change->document-lines#typeChanged' } }
+          = f.select :type, options_for_select(@line_type_options, f.object.type), { prompt: 'Select type...' }, { class: 'form-select', data: { action: 'change->invoice-lines#typeChanged' } }
       .col-sm-6.col-md-8
         .mb-3
           %label.form-label Title
@@ -49,7 +49,7 @@
       .col-sm-4.col-md-3
         .mb-3
           %label.form-label Product class
-          = f.collection_select :sales_tax_product_class_id, SalesTaxProductClass.all, :id, :name, { prompt: 'Select tax class...' }, { class: 'form-select', data: { action: 'change->document-lines#fieldChanged' } }
+          = f.collection_select :sales_tax_product_class_id, SalesTaxProductClass.all, :id, :name, { prompt: 'Select tax class...' }, { class: 'form-select', data: { action: 'change->invoice-lines#fieldChanged' } }
       .col-sm-3
       .col-sm-2.text-end
         .mb-3

--- a/test/system/line_management_test.rb
+++ b/test/system/line_management_test.rb
@@ -121,7 +121,6 @@ class LineManagementTest < ApplicationSystemTestCase
     assert_not_equal original_second, new_second
   end
 
-  # Test line type field visibility
   test "invoice line field visibility changes with type selection" do
     visit edit_invoice_path(@invoice)
 
@@ -130,20 +129,16 @@ class LineManagementTest < ApplicationSystemTestCase
 
     within new_line do
       type_select = find('select[name*="[type]"]')
-
-      # Test item type (default)
       assert_equal "item", type_select.value
       assert_selector 'div[data-line-type-target="itemOnly"]', visible: true
       assert_selector '[data-line-type-target="notSubheading"]', visible: true
 
-      # Test subheading type
       select "Subheading", from: type_select[:name]
-      assert_selector 'div[data-line-type-target="itemOnly"]', visible: false
-      assert_selector '[data-line-type-target="notSubheading"]', visible: false
+      assert_selector 'div[data-line-type-target="itemOnly"]', visible: :hidden
+      assert_selector '[data-line-type-target="notSubheading"]', visible: :hidden
 
-      # Test text type
       select "Text", from: type_select[:name]
-      assert_selector 'div[data-line-type-target="itemOnly"]', visible: false
+      assert_selector 'div[data-line-type-target="itemOnly"]', visible: :hidden
       assert_selector '[data-line-type-target="notSubheading"]', visible: true
     end
   end


### PR DESCRIPTION
The Type and Tax class selects in the invoice line form were wired to
`document-lines#`, a controller identifier that is never registered
(the wrapping controller is `invoice-lines`, matching every other
action in the partial). Changing a line's type did not toggle field
visibility and changing the tax class did not recalculate.

The existing system test missed this: its `visible: false` assertions
are existence-only checks in Capybara and pass whether the element is
shown or hidden. Strengthen them to `visible: :hidden` so they assert
the fields are actually hidden, which reproduces the bug.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
