### PR TITLE
Add opt-in SimpleCov test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@
 /config/settings/production.yml
 /node_modules
 /vendor
+
+# Ignore opt-in test coverage reports (COVERAGE=1 bin/rails test).
+/coverage

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,8 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "cuprite"
+  # Opt-in test coverage: COVERAGE=1 bin/rails test (see test_helper.rb).
+  gem "simplecov", require: false
 end
 
 group :test, :prod do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,7 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     deep_merge (1.2.2)
+    docile (1.4.1)
     drb (2.2.3)
     erb (6.0.4)
     erubi (1.13.1)
@@ -355,6 +356,12 @@ GEM
     simple_form (5.4.1)
       actionpack (>= 7.0)
       activemodel (>= 7.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.2)
+    simplecov_json_formatter (0.1.4)
     solid_cache (1.0.10)
       activejob (>= 7.2)
       activerecord (>= 7.2)
@@ -462,6 +469,7 @@ DEPENDENCIES
   rubocop-rails-omakase
   sass-rails
   simple_form
+  simplecov
   solid_cache
   solid_queue
   sqlite3 (>= 2.1)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,14 @@
 ENV["RAILS_ENV"] = "test"
+
+# Opt-in line + branch coverage. Off by default (no overhead on normal runs
+# or CI); enable with COVERAGE=1 bin/rails test.
+if ENV["COVERAGE"]
+  require "simplecov"
+  SimpleCov.start "rails" do
+    enable_coverage :branch
+  end
+end
+
 require File.expand_path("../../config/environment", __FILE__)
 require "rails/test_help"
 


### PR DESCRIPTION
Keeps the coverage tooling used to verify the Tier 2 test reduction (#477), in its minimal opt-in form.

## What
- `simplecov` gem in the test group (`require: false`).
- ENV-gated `SimpleCov.start "rails"` in `test_helper.rb` with branch coverage enabled.
- `/coverage` added to `.gitignore`.

## Behavior
- **Off by default.** Plain `bundle exec rails test` and CI are untouched — no overhead, no report generated.
- **Opt-in:** `COVERAGE=1 bin/rails test` produces a line + branch coverage report under `coverage/`.

Useful for verifying test-suite reductions: run the suite, delete a candidate test, re-run, and confirm no app/lib line or branch lost coverage — the differential check that caught two mis-flagged deletions in #477.

🤖 Generated with [Claude Code](https://claude.com/claude-code)