### PR TITLE
Unify delivery-note publish with the shared controller shape

### DIFF
--- a/app/controllers/concerns/publishable_document.rb
+++ b/app/controllers/concerns/publishable_document.rb
@@ -34,6 +34,19 @@ module PublishableDocument
 
   protected
 
+  # The shared "check problems → publish → redirect" shape. The block performs
+  # the type-specific publish and must return truthy on success, false when
+  # publish_problems block it (Invoice via InvoicePublisher#publish!,
+  # DeliveryNote via DeliveryNote#publish!).
+  def publish_document
+    if yield
+      redirect_to polymorphic_path(publishable_record, published: 1)
+    else
+      flash[:error] = "Publishing failed: #{publishable_record.publish_problems.join('; ')}"
+      redirect_to publishable_record
+    end
+  end
+
   def require_unpublished
     if publishable_record.published?
       flash[:error] = "Published #{self.class.publishable_label.pluralize} can not be modified."

--- a/app/controllers/delivery_notes_controller.rb
+++ b/app/controllers/delivery_notes_controller.rb
@@ -92,18 +92,7 @@ class DeliveryNotesController < ApplicationController
   end
 
   def publish
-    problems = @delivery_note.publish_problems
-    if problems.any?
-      flash[:error] = "Publishing failed: #{problems.join('; ')}"
-      redirect_to @delivery_note
-      return
-    end
-
-    @delivery_note.publish!
-    redirect_to delivery_note_path(@delivery_note, published: 1)
-  rescue StandardError => e
-    flash[:error] = "Failed to publish delivery note: #{e.message}"
-    redirect_to @delivery_note
+    publish_document { @delivery_note.publish! }
   end
 
   def preview

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -91,13 +91,7 @@ class InvoicesController < ApplicationController
   end
 
   def publish
-    publisher = InvoicePublisher.new @invoice, IssuerCompany.get_the_issuer!
-    if publisher.publish!
-      redirect_to invoice_path(@invoice, published: 1)
-    else
-      flash[:error] = "Publishing failed: #{@invoice.publish_problems.join('; ')}"
-      redirect_to @invoice
-    end
+    publish_document { InvoicePublisher.new(@invoice, IssuerCompany.get_the_issuer!).publish! }
   end
 
   def preview

--- a/app/models/delivery_note.rb
+++ b/app/models/delivery_note.rb
@@ -77,15 +77,18 @@ class DeliveryNote < ApplicationRecord
       .count >= ACCEPTANCE_SUBMISSIONS_PER_TOKEN
   end
 
+  # Mirrors InvoicePublisher#publish!: returns false without mutating when the
+  # document can't be published (already published, or publish_problems present)
+  # and true after a successful publish.
   def publish!
-    return if self.published?
+    return false if published?
+    return false if publish_problems.any?
 
     self.date = Date.today
-    if self.document_number.nil?
-      self.document_number = DocumentNumber.get_next_for "delivery_note", self.date
-    end
+    self.document_number ||= DocumentNumber.get_next_for("delivery_note", date)
     self.published = true
-    self.save!
+    save!
+    true
   end
 
   # Mirrors Invoice#publish_problems: returns user-facing strings describing

--- a/test/controllers/delivery_notes_controller_test.rb
+++ b/test/controllers/delivery_notes_controller_test.rb
@@ -158,8 +158,9 @@ class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
     assert_equal original_date, published_note.date
     assert_match "reverted to draft status", flash[:notice]
 
-    # Re-publishing keeps the preserved number but refreshes the date — the
-    # publish event genuinely happened now.
+    # Re-publishing keeps the preserved number without consuming a new one,
+    # and refreshes the date — the publish event genuinely happened now.
+    sequence_before = DocumentNumber.find_by_code("delivery_note").sequence
     travel_to original_date + 2.days do
       post publish_delivery_note_url(published_note)
     end
@@ -167,6 +168,7 @@ class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
     published_note.reload
     assert published_note.published?
     assert_equal original_number, published_note.document_number
+    assert_equal sequence_before, DocumentNumber.find_by_code("delivery_note").sequence
     assert_equal original_date + 2.days, published_note.date
   end
 

--- a/test/models/delivery_note_test.rb
+++ b/test/models/delivery_note_test.rb
@@ -37,14 +37,22 @@ class DeliveryNoteTest < ActiveSupport::TestCase
     assert_equal Date.today, delivery_note.date
   end
 
-  test "publish! does nothing if already published" do
+  test "publish! does nothing and returns false if already published" do
     delivery_note = delivery_notes(:published_delivery_note)
     original_document_number = delivery_note.document_number
 
-    delivery_note.publish!
+    assert_not delivery_note.publish!
 
     delivery_note.reload
     assert_equal original_document_number, delivery_note.document_number
+  end
+
+  test "publish! returns false without publishing when there are problems" do
+    delivery_note = create_draft_delivery_note
+    delivery_note.delivery_note_lines.create!(type: "text", title: "Just a note", position: 1)
+
+    assert_not delivery_note.publish!
+    assert_not delivery_note.reload.published?
   end
 
   # Method shape (empty for valid draft / for published doc) is verified


### PR DESCRIPTION
Tier 3 (controller dedup), item 1 — surfaced by the SimpleCov diff in #477: `delivery_notes_controller#publish` reimplemented the publish flow inline instead of using the shape the `PublishableDocument` concern was built to share.

## Before
- `DeliveryNote#publish!` published *unconditionally* and didn't check `publish_problems`.
- The controller therefore checked `publish_problems` itself, early-returned, then called `publish!`, all wrapped in a `rescue StandardError` that Invoice's publish doesn't have — and which no test covered.

## After
- `DeliveryNote#publish!` mirrors `InvoicePublisher#publish!`: guards on `publish_problems`, returns `false` without mutating when it can't publish, `true` on success.
- Extracted the shared "check → publish → redirect" flow into `PublishableDocument#publish_document` (the concern's own comment already described this shape as shareable).
- Both `publish` actions now route through it via a block; the publish *mechanisms* stay type-specific (InvoicePublisher vs. the model method).

User-facing behavior is unchanged for the tested paths (success redirect with `?published=1`, failure flash `Publishing failed: …`). The only change is dropping the untested `rescue` so DeliveryNote behaves like Invoice on unexpected errors.

## Tests
- New model tests pin the boolean contract (`publish!` returns false when already published / when problems exist), added TDD-first (RED → green).
- Full non-system suite green (770 runs); publish-related system tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)