### PR TITLE
Tier 3 controller dedup (index, bulk email, set_*, CSS)

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.scss
@@ -105,28 +105,3 @@ nav[aria-label="breadcrumb"] > div {
 .document-details .row {
   border-bottom: 1px solid var(--bs-border-color-translucent);
 }
-
-.document-lines table th {
-  background-color: var(--bs-secondary-bg) !important;
-  color: var(--bs-secondary-color) !important;
-  border-color: var(--bs-border-color);
-  font-weight: 600;
-  padding: 0.75rem 0.5rem;
-}
-
-.document-lines table td {
-  padding: 0.5rem;
-  vertical-align: top;
-  background-color: var(--bs-body-bg);
-  color: var(--bs-body-color);
-  border-color: var(--bs-border-color);
-}
-
-.document-lines table tr:nth-child(even) td {
-  background-color: var(--bs-secondary-bg-subtle);
-}
-
-.document-lines table .table-secondary {
-  background-color: var(--bs-secondary-bg) !important;
-  color: var(--bs-secondary-color) !important;
-}

--- a/app/assets/stylesheets/documents.css.scss
+++ b/app/assets/stylesheets/documents.css.scss
@@ -1,12 +1,38 @@
 // Document line tables on invoices/show and delivery_notes/show
-// (shared via the DocumentWithLines concern).
+// (shared via the DocumentWithLines concern). The `table.` prefix keeps these
+// at the same specificity the cell rules need to win over Bootstrap's .table.
 
-.document-lines-table {
+table.document-lines-table {
   th.col-description { width: 55%; }
   th.col-quantity    { width: 10%; }
   th.col-rate        { width: 15%; }
   th.col-tax-class   { width: 10%; }
   th.col-amount      { width: 15%; }
+
+  th {
+    background-color: var(--bs-secondary-bg) !important;
+    color: var(--bs-secondary-color) !important;
+    border-color: var(--bs-border-color);
+    font-weight: 600;
+    padding: 0.75rem 0.5rem;
+  }
+
+  td {
+    padding: 0.5rem;
+    vertical-align: top;
+    background-color: var(--bs-body-bg);
+    color: var(--bs-body-color);
+    border-color: var(--bs-border-color);
+  }
+
+  tr:nth-child(even) td {
+    background-color: var(--bs-secondary-bg-subtle);
+  }
+
+  .table-secondary {
+    background-color: var(--bs-secondary-bg) !important;
+    color: var(--bs-secondary-color) !important;
+  }
 
   td.document-section-row { padding: 12px 8px; }
   td.document-text-row    { padding: 8px; }

--- a/app/controllers/concerns/emailable_document.rb
+++ b/app/controllers/concerns/emailable_document.rb
@@ -68,4 +68,24 @@ module EmailableDocument
       format.json { head :ok }
     end
   end
+
+  # Shared scaffolding for the bulk "email the selected published documents"
+  # action: parse the checkbox ids, guard an empty selection, load the
+  # visible-and-published scope, and build the queued/skipped notice. The block
+  # receives that scope and returns [queued, skipped]; how each document type
+  # groups recipients and delivers differs, so that stays in the host.
+  def bulk_send_document_emails(model, ids_param:, redirect_path:, noun:)
+    ids = (params[ids_param] || []).reject(&:blank?)
+    if ids.empty?
+      redirect_to redirect_path, alert: "No #{noun} selected."
+      return
+    end
+
+    scope = model.visible_to(current_user).where(id: ids, published: true)
+    queued, skipped = yield(scope)
+
+    notice = "#{queued} emails queued for sending."
+    notice += " #{skipped} skipped (no recipients)." if skipped > 0
+    redirect_to redirect_path, notice: notice
+  end
 end

--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -3,6 +3,7 @@ class CustomersController < ApplicationController
 
   before_action -> { require_permission!("customers.view") }, only: [ :index, :show ]
   before_action -> { require_permission!("customers.edit") }, only: [ :new, :create, :edit, :update, :destroy, :verify_vat_id ]
+  before_action :set_customer, only: %i[show edit update destroy verify_vat_id]
 
   # GET /customers
   def index
@@ -12,7 +13,6 @@ class CustomersController < ApplicationController
 
   # GET /customers/1
   def show
-    @customer = Customer.visible_to(current_user).find(params[:id])
   end
 
   # GET /customers/new
@@ -24,7 +24,6 @@ class CustomersController < ApplicationController
 
   # GET /customers/1/edit
   def edit
-    @customer = Customer.visible_to(current_user).find(params[:id])
   end
 
   # POST /customers
@@ -40,8 +39,6 @@ class CustomersController < ApplicationController
 
   # PUT /customers/1
   def update
-    @customer = Customer.visible_to(current_user).find(params[:id])
-
     if @customer.update(customers_params)
       redirect_to @customer, notice: "Customer was successfully updated."
     else
@@ -51,7 +48,6 @@ class CustomersController < ApplicationController
 
   # POST /customers/1/verify_vat_id
   def verify_vat_id
-    @customer = Customer.visible_to(current_user).find(params[:id])
     if @customer.vat_id.blank?
       redirect_to @customer, alert: "Customer has no VAT ID to verify." and return
     end
@@ -63,8 +59,6 @@ class CustomersController < ApplicationController
 
   # DELETE /customers/1
   def destroy
-    @customer = Customer.visible_to(current_user).find(params[:id])
-
     if @customer.destroy
       redirect_to customers_url, notice: "Customer was successfully deleted."
     else
@@ -73,6 +67,10 @@ class CustomersController < ApplicationController
   end
 
 private
+  def set_customer
+    @customer = Customer.visible_to(current_user).find(params[:id])
+  end
+
   def customers_params
     params.require(:customer).permit(
         :matchcode, :name, :address, :country_iso2, :vat_id, :supplier_number, :notes, :sales_tax_customer_class_id, :language_id, :payment_terms_days,

--- a/app/controllers/delivery_notes_controller.rb
+++ b/app/controllers/delivery_notes_controller.rb
@@ -43,10 +43,7 @@ class DeliveryNotesController < ApplicationController
     @delivery_notes = @delivery_notes.where(customer_id: @selected_customer_id) if @selected_customer_id
 
     @available_years = DeliveryNote.visible_to(current_user).available_years
-    @available_customers = Customer.visible_to(current_user)
-                                   .where(id: DeliveryNote.visible_to(current_user).select(:customer_id))
-                                   .where("active = ? OR id = ?", true, @selected_customer_id)
-                                   .order(:name)
+    @available_customers = DeliveryNote.available_customers(current_user, including: @selected_customer_id)
   end
 
   # GET /delivery_notes/1

--- a/app/controllers/delivery_notes_controller.rb
+++ b/app/controllers/delivery_notes_controller.rb
@@ -265,43 +265,33 @@ class DeliveryNotesController < ApplicationController
   end
 
   def bulk_send_emails
-    delivery_note_ids = params[:delivery_note_ids] || []
-    delivery_note_ids = delivery_note_ids.reject(&:blank?)
+    bulk_send_document_emails(DeliveryNote, ids_param: :delivery_note_ids, redirect_path: delivery_notes_path, noun: "delivery notes") do |delivery_notes|
+      queued = skipped = 0
 
-    if delivery_note_ids.empty?
-      redirect_to delivery_notes_path, alert: "No delivery notes selected."
-      return
-    end
-
-    delivery_notes = DeliveryNote.visible_to(current_user).where(id: delivery_note_ids, published: true)
-    queued_count = 0
-    skipped_count = 0
-
-    # Partition by [customer_id, resolved-recipient-set]. Two DNs to the same
-    # customer with different project-scoped contacts must NOT be combined,
-    # otherwise we leak DN A's recipients onto DN B.
-    delivery_notes.group_by { |dn| [ dn.customer_id, dn.email_recipients.sort ] }.each do |(_cid, recipients), dns|
-      if recipients.empty?
-        skipped_count += dns.length
-        next
-      end
-
-      if dns.length == 1
-        token = acceptance_token_for(dns.first)
-        DeliveryNoteMailer.with(delivery_note: dns.first, acceptance_token: token).customer_email.deliver_later
-      else
-        acceptance_tokens = dns.each_with_object({}) do |dn, tokens|
-          token = acceptance_token_for(dn)
-          tokens[dn.id.to_s] = token if token
+      # Partition by [customer_id, resolved-recipient-set]. Two DNs to the same
+      # customer with different project-scoped contacts must NOT be combined,
+      # otherwise we leak DN A's recipients onto DN B.
+      delivery_notes.group_by { |dn| [ dn.customer_id, dn.email_recipients.sort ] }.each do |(_cid, recipients), dns|
+        if recipients.empty?
+          skipped += dns.length
+          next
         end
-        DeliveryNoteMailer.with(delivery_notes: dns, recipients: recipients, acceptance_tokens: acceptance_tokens).bulk_customer_email.deliver_later
-      end
-      queued_count += dns.length
-    end
 
-    notice = "#{queued_count} emails queued for sending."
-    notice += " #{skipped_count} skipped (no recipients)." if skipped_count > 0
-    redirect_to delivery_notes_path, notice: notice
+        if dns.length == 1
+          token = acceptance_token_for(dns.first)
+          DeliveryNoteMailer.with(delivery_note: dns.first, acceptance_token: token).customer_email.deliver_later
+        else
+          acceptance_tokens = dns.each_with_object({}) do |dn, tokens|
+            token = acceptance_token_for(dn)
+            tokens[dn.id.to_s] = token if token
+          end
+          DeliveryNoteMailer.with(delivery_notes: dns, recipients: recipients, acceptance_tokens: acceptance_tokens).bulk_customer_email.deliver_later
+        end
+        queued += dns.length
+      end
+
+      [ queued, skipped ]
+    end
   end
 
 protected

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -42,10 +42,7 @@ class InvoicesController < ApplicationController
     @invoices = @invoices.where(customer_id: @selected_customer_id) if @selected_customer_id
 
     @available_years = Invoice.visible_to(current_user).available_years
-    @available_customers = Customer.visible_to(current_user)
-                                   .where(id: Invoice.visible_to(current_user).select(:customer_id))
-                                   .where("active = ? OR id = ?", true, @selected_customer_id)
-                                   .order(:name)
+    @available_customers = Invoice.available_customers(current_user, including: @selected_customer_id)
   end
 
   # GET /invoices/1

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -128,30 +128,18 @@ class InvoicesController < ApplicationController
   end
 
   def bulk_send_emails
-    invoice_ids = params[:invoice_ids] || []
-    invoice_ids = invoice_ids.reject(&:blank?)
-
-    if invoice_ids.empty?
-      redirect_to invoices_path, alert: "No invoices selected."
-      return
-    end
-
-    invoices = Invoice.visible_to(current_user).where(id: invoice_ids, published: true)
-    queued_count = 0
-    skipped_count = 0
-
-    invoices.each do |invoice|
-      if invoice.emailable?
-        InvoiceMailer.with(invoice: invoice).customer_email.deliver_later
-        queued_count += 1
-      else
-        skipped_count += 1
+    bulk_send_document_emails(Invoice, ids_param: :invoice_ids, redirect_path: invoices_path, noun: "invoices") do |invoices|
+      queued = skipped = 0
+      invoices.each do |invoice|
+        if invoice.emailable?
+          InvoiceMailer.with(invoice: invoice).customer_email.deliver_later
+          queued += 1
+        else
+          skipped += 1
+        end
       end
+      [ queued, skipped ]
     end
-
-    notice = "#{queued_count} emails queued for sending."
-    notice += " #{skipped_count} skipped (no recipients)." if skipped_count > 0
-    redirect_to invoices_path, notice: notice
   end
 
 protected

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -3,6 +3,7 @@ class ProjectsController < ApplicationController
 
   before_action -> { require_permission!("projects.view") }, only: [ :index, :show ]
   before_action -> { require_permission!("projects.edit") }, only: [ :new, :create, :edit, :update, :destroy ]
+  before_action :set_project, only: %i[show edit update destroy]
   before_action :load_customer_options, only: [ :new, :create, :edit, :update ]
 
   # GET /projects
@@ -21,7 +22,6 @@ class ProjectsController < ApplicationController
 
   # GET /projects/1
   def show
-    @project = Project.visible_to(current_user).find(params[:id])
   end
 
   # GET /projects/new
@@ -33,7 +33,6 @@ class ProjectsController < ApplicationController
 
   # GET /projects/1/edit
   def edit
-    @project = Project.visible_to(current_user).find(params[:id])
   end
 
   # POST /projects
@@ -49,8 +48,6 @@ class ProjectsController < ApplicationController
 
   # PUT /projects/1
   def update
-    @project = Project.visible_to(current_user).find(params[:id])
-
     if @project.update(projects_params)
       redirect_to @project, notice: "Project was successfully updated."
     else
@@ -60,8 +57,6 @@ class ProjectsController < ApplicationController
 
   # DELETE /projects/1
   def destroy
-    @project = Project.visible_to(current_user).find(params[:id])
-
     if @project.destroy
       redirect_to projects_url, notice: "Project was successfully deleted."
     else
@@ -70,6 +65,10 @@ class ProjectsController < ApplicationController
   end
 
 private
+  def set_project
+    @project = Project.visible_to(current_user).find(params[:id])
+  end
+
   def projects_params
     params.require(:project).permit(:bill_to_customer_id, :description, :matchcode, :active, :team_id, :department)
   end

--- a/app/models/concerns/scoped_through_customer.rb
+++ b/app/models/concerns/scoped_through_customer.rb
@@ -32,6 +32,17 @@ module ScopedThroughCustomer
       return all if user.bypass_team_scoping?
       where(customer_id: Customer.visible_to(user).select(:id))
     end
+
+    # Customers owning at least one of these documents visible to the user,
+    # for the index filter dropdown. `including:` keeps a specific customer in
+    # the list even when inactive, so an active-only default doesn't drop the
+    # currently-selected one.
+    def available_customers(user, including: nil)
+      Customer.visible_to(user)
+              .where(id: visible_to(user).select(:customer_id))
+              .where("active = ? OR id = ?", true, including)
+              .order(:name)
+    end
   end
 
   private

--- a/app/views/delivery_notes/show.html.haml
+++ b/app/views/delivery_notes/show.html.haml
@@ -141,7 +141,7 @@
         .card-body
           = simple_format(@delivery_note.prelude)
 
-  .document-lines.mb-2
+  .mb-2
     %table.table.table-bordered.document-lines-table
       %thead
         %tr

--- a/app/views/invoices/show.html.haml
+++ b/app/views/invoices/show.html.haml
@@ -152,7 +152,7 @@
         - warnings.each do |w|
           %li= w
 
-  .document-lines.mb-2
+  .mb-2
     %table.table.table-bordered.document-lines-table
       %thead
         %tr


### PR DESCRIPTION
Tier 3 of the reduction audit — the remaining controller/CSS dedup after the publish unification (#480). Four independent commits.

## Changes
1. **`set_*` before_action** — CustomersController and ProjectsController repeated `Model.visible_to(current_user).find(params[:id])` inline across show/edit/update/destroy (+ verify_vat_id); replaced with the `set_customer`/`set_project` before_action pattern the document controllers already use.
2. **`ScopedThroughCustomer.available_customers`** — both index actions built the same four-line "customers owning a visible document, active-or-currently-selected, ordered by name" query. Moved it into the concern that already owns `visible_to`/`ordered`; each controller now calls `Model.available_customers(current_user, including: @selected_customer_id)`.
3. **`EmailableDocument#bulk_send_document_emails`** — both `bulk_send_emails` actions shared the same envelope (parse ids, guard empty, load visible+published scope, build the "N queued / M skipped" notice). Extracted it; the block yields the scope and returns `[queued, skipped]`. The per-type delivery stays in each controller (invoice per-record; delivery note grouped by customer+recipients to avoid recipient leakage).
4. **CSS consolidation** — the lines table was styled through two selectors in two files (`.document-lines table …` via the wrapper div, and `.document-lines-table` via the table class). Folded the wrapper rules into `table.document-lines-table` and dropped the now-unused `document-lines` class from both show wrappers. The `table.` prefix preserves the (0,1,2) specificity the cell rules need to beat Bootstrap's `.table`.

Net: 10 files, +107/−106 (the insertions are mostly relocated code + doc comments; the dedup shows as fewer duplicated lines per call site).

## Verification
- Full non-system suite green (770 runs). Index active/selected-customer filtering, both bulk-email envelopes (queued + empty-guard), and customer/project CRUD are all covered by existing tests.
- CSS: confirmed `application.css` compiles via sprockets, the consolidated `table.document-lines-table` rules are present, no bare `.document-lines` selectors remain, and visually confirmed the rendered lines table (header shading, column widths, dark sum-total row) via a throwaway screenshot.

Rebased onto current main so it stacks cleanly on #479/#480 (which merged mid-work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)