### PR TITLE
Upload test coverage to Codecov from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,8 @@ jobs:
         RAILS_ENV: test
         DATABASE_URL: postgres://postgres:postgres@localhost:5432/abt_test
         RAILS_LOG_LEVEL: debug
+        COVERAGE: "1"
+        COVERAGE_COMMAND: unit
       run: |
         bundle exec rails test --verbose
 
@@ -83,8 +85,21 @@ jobs:
         RAILS_ENV: test
         DATABASE_URL: postgres://postgres:postgres@localhost:5432/abt_test
         RAILS_LOG_LEVEL: debug
+        COVERAGE: "1"
+        COVERAGE_COMMAND: system
       run: |
         HEADLESS=1 bundle exec rails test:system --verbose
+
+    # The system run merges its results with the unit run's (same coverage/ dir)
+    # and rewrites coverage/coverage.xml, so this uploads the combined report.
+    # Runs even if a test step failed so partial coverage still lands.
+    - name: Upload coverage to Codecov
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+      with:
+        files: ./coverage/coverage.xml
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: false
 
   brakeman:
     name: Brakeman

--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ group :test do
   gem "cuprite"
   # Opt-in test coverage: COVERAGE=1 bin/rails test (see test_helper.rb).
   gem "simplecov", require: false
+  gem "simplecov-cobertura", require: false # Cobertura XML for Codecov in CI
 end
 
 group :test, :prod do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -360,6 +360,9 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
+    simplecov-cobertura (3.1.0)
+      rexml
+      simplecov (~> 0.19)
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
     solid_cache (1.0.10)
@@ -470,6 +473,7 @@ DEPENDENCIES
   sass-rails
   simple_form
   simplecov
+  simplecov-cobertura
   solid_cache
   solid_queue
   sqlite3 (>= 2.1)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+# Coverage is reported for information only — neither a project-wide drop nor an
+# uncovered patch fails a PR. Flip informational to false (and set a target) to
+# start enforcing once a baseline settles.
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  layout: "reach, diff, files"
+  require_changes: true

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,11 +1,23 @@
 ENV["RAILS_ENV"] = "test"
 
-# Opt-in line + branch coverage. Off by default (no overhead on normal runs
-# or CI); enable with COVERAGE=1 bin/rails test.
+# Opt-in line + branch coverage. Off by default (no overhead on normal runs);
+# enable with COVERAGE=1 bin/rails test. CI sets it on both the unit and system
+# steps and uploads the merged report to Codecov.
 if ENV["COVERAGE"]
   require "simplecov"
+  require "simplecov-cobertura"
   SimpleCov.start "rails" do
     enable_coverage :branch
+    # Distinct per run (unit vs system in CI) so the two results merge in
+    # .resultset.json instead of overwriting each other.
+    command_name ENV.fetch("COVERAGE_COMMAND", "test")
+    # CI runs the suites in separate steps; widen the window so the later run
+    # still merges the earlier run's results.
+    merge_timeout 3600
+    formatter SimpleCov::Formatter::MultiFormatter.new([
+      SimpleCov::Formatter::HTMLFormatter,
+      SimpleCov::Formatter::CoberturaFormatter
+    ])
   end
 end
 


### PR DESCRIPTION
Hooks the opt-in SimpleCov coverage (landed in #479) up to Codecov.

## How it works
- Both CI test steps now run with `COVERAGE=1`: the unit step (`rails test`) and the system step (`rails test:system`).
- Each run gets a distinct SimpleCov `command_name` (`unit` / `system`) and a widened `merge_timeout`, so the system step **merges** with the unit step's results in the shared `coverage/` dir instead of overwriting them. Verified locally: run 1 → "unit", run 2 → "system, unit" (combined).
- `simplecov-cobertura` makes SimpleCov also emit `coverage/coverage.xml` (the format Codecov ingests); the HTML report is still produced for local `COVERAGE=1 bin/rails test` use.
- A final step uploads the merged `coverage.xml` to Codecov (`codecov/codecov-action` pinned to the v6.0.1 commit, matching the repo's SHA-pinning convention). It runs `if: !cancelled()` so coverage still lands if a test fails, and `fail_ci_if_error: false` so a Codecov hiccup never breaks the build.
- `codecov.yml` keeps project and patch status **informational** — coverage is reported but never fails a PR until a baseline settles.

Default behavior is unchanged: without `COVERAGE`, no report is generated and there's no overhead (verified — a plain `rails test` produces no `coverage/`).

## Action required before this is useful
Add a **`CODECOV_TOKEN`** repository secret (Settings → Secrets and variables → Actions). Get it from the Codecov dashboard after enabling the repo at app.codecov.io. Recommended even for public repos — tokenless uploads have become unreliable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)