### PR TITLE
Fix mailer background and footer rendering in email clients

### DIFF
--- a/app/views/layouts/mailer.html.haml
+++ b/app/views/layouts/mailer.html.haml
@@ -5,13 +5,27 @@
     %meta{"name" => "viewport", "content" => "width=device-width, initial-scale=1.0"}
     %title= content_for?(:title) ? yield(:title) : "#{@issuer&.short_name || 'Email'}"
     :css
-      body {
+      html, body {
+        height: 100%;
         margin: 0;
         padding: 0;
+      }
+      body {
         background-color: #f8f9fa;
         font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
         line-height: 1.6;
         color: #333;
+      }
+      /* Email clients don't propagate the body background to the viewport the
+         way browsers do, so the gray canvas is carried by a full-height wrapper.
+         Its vertical padding also frames the card with a gutter, so the footer
+         reads as a finished edge instead of a truncated page. */
+      .email-wrapper {
+        width: 100%;
+        min-height: 100%;
+        background-color: #f8f9fa;
+        padding: 30px 0;
+        box-sizing: border-box;
       }
       .email-container {
         max-width: 600px;
@@ -92,17 +106,18 @@
         margin-bottom: 30px;
       }
   %body
-    .email-container
-      .header-stripe
-      .email-content
-        = yield
+    .email-wrapper
+      .email-container
+        .header-stripe
+        .email-content
+          = yield
 
-        - if @issuer
-          .footer
-            .company-info
-              .company-name= @issuer.legal_name
-              - @issuer.address.split("\n").each do |line|
-                .address-line= line
-              .address-line= AddressFormatter.country_name(@issuer.country_iso2, locale: I18n.locale)
-            - if @issuer.png_logo.present?
-              %img.company-logo{src: "data:image/png;base64,#{Base64.encode64(@issuer.png_logo).gsub(/\n/, '')}", alt: @issuer.legal_name}
+          - if @issuer
+            .footer
+              .company-info
+                .company-name= @issuer.legal_name
+                - @issuer.address.split("\n").each do |line|
+                  .address-line= line
+                .address-line= AddressFormatter.country_name(@issuer.country_iso2, locale: I18n.locale)
+              - if @issuer.png_logo.present?
+                %img.company-logo{src: "data:image/png;base64,#{Base64.encode64(@issuer.png_logo).gsub(/\n/, '')}", alt: @issuer.legal_name}


### PR DESCRIPTION
## Problem

The overdue-invoices report email (and all emails — this is the shared mailer layout) rendered with a **visually truncated end** and a **background that didn't fill the window** in real email clients:

- The gray canvas lived only on `<body>`. Browsers propagate a `<body>` background to the viewport even when content is short, but email clients (e.g. Apple Mail) inject the message HTML into their own container and scope `<body>`, so the gray collapsed to content height.
- That left the white card sitting on the client's white reading pane: no gray gutter framing it, and its bottom edge dissolving into white — so the footer read as a cut-off page rather than a finished card.

This looked fine in the Rails mailer preview / a browser (canvas propagation), which is why it slipped through.

## Fix

`app/views/layouts/mailer.html.haml`:

- Add `html, body { height: 100% }` and a new full-height `.email-wrapper` that explicitly carries the `#f8f9fa` background (`width: 100%; min-height: 100%`).
- Its `30px` vertical padding frames the card with a gray gutter top and bottom, so the footer reads as a finished edge.
- Comment in the layout explains the email-client quirk.

Shared layout, so every mailer benefits.

## Test

`bundle exec rails test test/mailers/` — green (48 runs). The change is CSS/structure that only reproduces in a real email client, so it's worth eyeballing one real send.

🤖 Generated with [Claude Code](https://claude.com/claude-code)