### PR TITLE
Tighten NOT NULL constraints on invoices & delivery_notes

### DIFF
--- a/db/migrate/20260609153655_tighten_invoice_delivery_note_null_constraints.rb
+++ b/db/migrate/20260609153655_tighten_invoice_delivery_note_null_constraints.rb
@@ -1,0 +1,33 @@
+class TightenInvoiceDeliveryNoteNullConstraints < ActiveRecord::Migration[8.1]
+  def up
+    # invoices
+    change_column_default :invoices, :sum_net,   from: nil, to: 0
+    change_column_default :invoices, :sum_total, from: nil, to: 0
+    change_column_default :invoices, :published, from: nil, to: false
+    change_column_null :invoices, :sum_net,    false, 0
+    change_column_null :invoices, :sum_total,  false, 0
+    change_column_null :invoices, :published,  false, false
+    change_column_null :invoices, :customer_id, false # validated; no backfill (fail loud if any NULL)
+    change_column_null :invoices, :project_id,  false
+
+    # delivery_notes
+    change_column_default :delivery_notes, :published, from: nil, to: false
+    change_column_null :delivery_notes, :published, false, false
+    change_column_null :delivery_notes, :delivery_start_date, false
+  end
+
+  def down
+    change_column_null :delivery_notes, :delivery_start_date, true
+    change_column_null :delivery_notes, :published, true
+    change_column_default :delivery_notes, :published, from: false, to: nil
+
+    change_column_null :invoices, :project_id,  true
+    change_column_null :invoices, :customer_id, true
+    change_column_null :invoices, :published,  true
+    change_column_null :invoices, :sum_total,  true
+    change_column_null :invoices, :sum_net,    true
+    change_column_default :invoices, :published, from: false, to: nil
+    change_column_default :invoices, :sum_total, from: 0, to: nil
+    change_column_default :invoices, :sum_net,   from: 0, to: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_01_210051) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_09_153655) do
   create_table "acceptance_submissions", force: :cascade do |t|
     t.integer "attachment_id"
     t.datetime "created_at", null: false
@@ -127,13 +127,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_210051) do
     t.integer "customer_id", null: false
     t.date "date"
     t.date "delivery_end_date"
-    t.date "delivery_start_date"
+    t.date "delivery_start_date", null: false
     t.string "document_number"
     t.datetime "email_sent_at"
     t.integer "invoice_id"
     t.text "prelude"
     t.integer "project_id", null: false
-    t.boolean "published"
+    t.boolean "published", default: false, null: false
     t.datetime "updated_at", null: false
     t.index ["acceptance_attachment_id"], name: "index_delivery_notes_on_acceptance_attachment_id"
     t.index ["acceptance_upload_token_digest"], name: "index_delivery_notes_on_acceptance_upload_token_digest", unique: true
@@ -223,7 +223,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_210051) do
     t.text "customer_account_number"
     t.text "customer_address"
     t.string "customer_country_iso2", limit: 2, null: false
-    t.integer "customer_id"
+    t.integer "customer_id", null: false
     t.text "customer_name"
     t.text "customer_supplier_number"
     t.text "customer_vat_id"
@@ -234,10 +234,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_210051) do
     t.date "paid_at"
     t.integer "payment_terms_days", default: 30, null: false
     t.text "prelude"
-    t.integer "project_id"
-    t.boolean "published"
-    t.decimal "sum_net"
-    t.decimal "sum_total"
+    t.integer "project_id", null: false
+    t.boolean "published", default: false, null: false
+    t.decimal "sum_net", default: "0.0", null: false
+    t.decimal "sum_total", default: "0.0", null: false
     t.text "tax_note"
     t.string "token"
     t.datetime "updated_at", null: false


### PR DESCRIPTION
## What

Add `NOT NULL` to the subset of `invoices` / `delivery_notes` columns that are populated for **every** row (draft or published) but were still nullable at the DB level, and turn the nullable `published` booleans into honest `default: false, null: false`.

| Table | Column | Change |
|---|---|---|
| invoices | `customer_id` | `null: false` |
| invoices | `project_id` | `null: false` |
| invoices | `sum_net` | `default: 0, null: false` |
| invoices | `sum_total` | `default: 0, null: false` |
| invoices | `published` | `default: false, null: false` |
| delivery_notes | `published` | `default: false, null: false` |
| delivery_notes | `delivery_start_date` | `null: false` |

## Why

Most nullability on these tables is **by design**: drafts have NULL `date` / `document_number` / `due_date` / `token` / `attachment_id` until publish, so those must stay nullable. But the columns above are always set — by non-optional `belongs_to`, `validates presence`, or `Invoice#set_defaults` — yet relied solely on the app layer to enforce it. This makes the schema state the invariant. The `published` booleans previously used NULL to mean "false"; now that's explicit.

No model or behavior changes.

## Deliberately left nullable

Publish-time fields (`date`, `document_number`, `due_date`, `token`, `attachment_id`), optional tracking (`email_sent_at`, `paid_at`), customer snapshots that depend on customer data (`customer_vat_id`, …), and `delivery_end_date` (optional — drives single-day vs. range rendering in `delivery_timeframe`).

## Verification

- Pre-check: 0 existing NULLs in every target column.
- Migration applies cleanly; `down` fully reversible (rollback → clean schema diff → re-migrate).
- `bundle exec rails test`: 799 runs, 0 failures (SQLite).
- `./bin/postgres-dev test`: 799 runs, 0 failures (PostgreSQL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)