### PR TITLE
Make document publishing transactional and race-safe

### DIFF
--- a/app/models/delivery_note.rb
+++ b/app/models/delivery_note.rb
@@ -79,16 +79,20 @@ class DeliveryNote < ApplicationRecord
 
   # Mirrors InvoicePublisher#publish!: returns false without mutating when the
   # document can't be published (already published, or publish_problems present)
-  # and true after a successful publish.
+  # and true after a successful publish. with_lock reloads under a row lock and
+  # wraps the work in a transaction so concurrent publishes are serialized and
+  # the guard is re-checked against fresh DB state.
   def publish!
-    return false if published?
-    return false if publish_problems.any?
+    with_lock do
+      next false if published?
+      next false if publish_problems.any?
 
-    self.date = Date.today
-    self.document_number ||= DocumentNumber.get_next_for("delivery_note", date)
-    self.published = true
-    save!
-    true
+      self.date = Date.today
+      self.document_number ||= DocumentNumber.get_next_for("delivery_note", date)
+      self.published = true
+      save!
+      true
+    end
   end
 
   # Mirrors Invoice#publish_problems: returns user-facing strings describing

--- a/app/models/document_number.rb
+++ b/app/models/document_number.rb
@@ -23,8 +23,11 @@ class DocumentNumber < ApplicationRecord
     self.format % { year: date.year, number: self.sequence }
   end
 
+  # Must run inside the caller's publish transaction: `lock` takes a row lock
+  # (SELECT ... FOR UPDATE) so two concurrent publishes can't read the same
+  # sequence and mint the same number.
   def self.get_next_for(code, date)
-    dn = DocumentNumber.find_by_code code
+    dn = lock.find_by(code: code)
     raise NoDocumentNumberRangeError.new "No document number config for code #{code}" if dn.nil?
     number = dn.get_next date
     dn.save!

--- a/app/services/invoice_publisher.rb
+++ b/app/services/invoice_publisher.rb
@@ -19,7 +19,22 @@ class InvoicePublisher
 
   # Performs the irreversible publish. Returns true on success, false otherwise.
   # On failure, problems are accessible via @invoice.publish_problems.
+  #
+  # with_lock reloads the invoice under a row lock and runs the whole publish —
+  # number assignment, token, and PDF render — in one transaction. The lock
+  # serializes concurrent publishes (the guard is re-checked against fresh DB
+  # state), and the transaction means a render failure rolls back the published
+  # flag, document number and token instead of stranding a numbered invoice
+  # with no PDF.
   def publish!
+    result = false
+    @invoice.with_lock { result = publish_locked! }
+    result
+  end
+
+  private
+
+  def publish_locked!
     if @invoice.published?
       @log << "E: already published"
       return false

--- a/test/services/invoice_publisher_test.rb
+++ b/test/services/invoice_publisher_test.rb
@@ -169,4 +169,53 @@ class InvoicePublisherTest < ActiveSupport::TestCase
     assert_not publisher.publish!
     assert_includes publisher.log, "E: already published"
   end
+
+  test "publish! rolls back the published flag, number, token and sequence when rendering fails" do
+    klass = sales_tax_product_classes(:standard)
+    invoice = Invoice.create!(customer: customers(:good_national), project: projects(:test_project), cust_reference: "RENDER-FAIL", date: Date.new(2024, 6, 1))
+    invoice.invoice_lines.create!(type: "item", title: "Widget", quantity: 1.0, rate: 100.0, position: 1, sales_tax_product_class: klass)
+    sequence_before = DocumentNumber.find_by!(code: "invoice").sequence
+
+    publisher = InvoicePublisher.new(invoice.reload, issuer_companies(:one))
+    assert_raises(RuntimeError) do
+      with_failing_renderer { publisher.publish! }
+    end
+
+    invoice.reload
+    assert_not invoice.published?
+    assert_nil invoice.document_number
+    assert_nil invoice.token
+    assert_nil invoice.attachment_id
+    assert_equal sequence_before, DocumentNumber.find_by!(code: "invoice").sequence
+  end
+
+  test "publish! bails without re-minting when the row was published by a concurrent request" do
+    klass = sales_tax_product_classes(:standard)
+    invoice = Invoice.create!(customer: customers(:good_national), project: projects(:test_project), cust_reference: "RACE-1", date: Date.new(2024, 6, 1))
+    invoice.invoice_lines.create!(type: "item", title: "Widget", quantity: 1.0, rate: 100.0, position: 1, sales_tax_product_class: klass)
+
+    stale = InvoicePublisher.new(Invoice.find(invoice.id), issuer_companies(:one))
+    assert InvoicePublisher.new(Invoice.find(invoice.id), issuer_companies(:one)).publish!
+    invoice.reload
+    first_number = invoice.document_number
+    first_token = invoice.token
+
+    assert_not stale.publish!
+    assert_includes stale.log, "E: already published"
+
+    invoice.reload
+    assert_equal first_number, invoice.document_number
+    assert_equal first_token, invoice.token
+  end
+
+  private
+
+  def with_failing_renderer
+    failing = Object.new
+    def failing.render = raise("FOP exploded")
+    InvoiceRenderer.define_singleton_method(:new) { |*| failing }
+    yield
+  ensure
+    InvoiceRenderer.singleton_class.send(:remove_method, :new)
+  end
 end


### PR DESCRIPTION
## Problem

`InvoicePublisher#publish!` minted a document number, flipped `published = true`, and rendered the PDF as separate unguarded saves with no wrapping transaction or lock. Three failure modes followed:

1. **Non-transactional publish.** A FOP/Saxon render failure (a known failure mode) left the invoice *irreversibly* published — there is no unpublish — with a nil `attachment` and a permanently-gapped document number. Emailing it then crashed on `attachment.filename`.
2. **Double-publish race.** The `published?` guard was check-then-act on the in-memory record. Two concurrent publishes (a double-click on multithreaded Puma) both passed it; the second overwrote the first's number and payment token and orphaned an attachment.
3. **Unlocked sequence read.** `DocumentNumber.get_next_for` did `find_by` → increment → `save!` with no row lock, so concurrent publishes of *different* documents formatted the same number — surviving only because the unique index turned it into a mid-publish `RecordNotUnique` 500.

## Fix

- Wrap the whole publish in `@invoice.with_lock { ... }`: one transaction, row lock taken on a fresh reload. A render failure now rolls back the published flag, number and token. The guard is re-checked against committed DB state, serializing concurrent publishes.
- `DocumentNumber.get_next_for` takes a `SELECT ... FOR UPDATE` row lock (`lock.find_by`) inside that transaction.
- `DeliveryNote#publish!` gets the same `with_lock` wrapper.

## Tests

Two regression tests on the invoice side (the richer path): render-failure rollback (flag, number, token, attachment, and sequence all revert) and the double-publish guard (a concurrent publish wins; the stale publisher bails without re-minting). Per repo convention the production fix is mirrored to `DeliveryNote` without duplicating the tests there.

Full suite: 801 runs, 0 failures. `pre-commit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)