### PR TITLE
Send passkey-reset invite only to confirmed emails

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -57,11 +57,11 @@ class UsersController < ApplicationController
                             request: request,
                             metadata: { purpose: "passkey_reset", username: @user.username })
 
-    @user.emails.find_each do |email|
+    @user.confirmed_emails.find_each do |email|
       UserMailer.passkey_reset_invite(@user, invite_url, email.address).deliver_later
     end
 
-    redirect_to user_path(@user), notice: "Passkeys reset; invite sent to #{@user.emails.count} email address(es)."
+    redirect_to user_path(@user), notice: "Passkeys reset; invite sent to #{@user.confirmed_emails.count} email address(es)."
   end
 
   def audit

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -114,6 +114,20 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_empty carol.reload.credentials
   end
 
+  test "reset_passkeys only emails confirmed addresses" do
+    sign_in_as(users(:alice))
+    carol = users(:blocked_carol)
+    carol.emails.create!(address: "attacker@example.com", confirmed_at: nil)
+
+    perform_enqueued_jobs do
+      post reset_passkeys_user_path(carol)
+    end
+
+    recipients = ActionMailer::Base.deliveries.flat_map(&:to)
+    assert_includes recipients, "carol@example.com"
+    refute_includes recipients, "attacker@example.com"
+  end
+
   test "audit returns events for the user" do
     sign_in_as(users(:alice))
     UserAuditEvent.record!(action: "login_success", user: users(:bob), actor: users(:bob))


### PR DESCRIPTION
## Security fix

`reset_passkeys` (`app/controllers/users_controller.rb`) mailed the single-use passkey-reset invite — which registers a new passkey, unblocks the account, and signs in — to `@user.emails`, **including unconfirmed addresses any signed-in user can attach**. Combined with the email-add primitive, this is an account-takeover vector.

The rest of the app's security mail correctly uses `confirmed_emails`. This change does the same here (both the `find_each` loop and the notice count).

## Test

Added a regression test: an unconfirmed address attached to a blocked user does **not** receive the invite, while the confirmed address does. Verified it fails before the fix and passes after. Full `users_controller_test.rb` suite green (15 runs, 71 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)