### PR TITLE
Back Customer/Project delete guards with invoice foreign keys

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -58,7 +58,7 @@ class Customer < ApplicationRecord
   end
 
   def can_be_deleted?
-    !used_in_invoices? && !used_in_delivery_notes?
+    deletion_blocker.nil?
   end
 
   def latest_vat_verification
@@ -108,14 +108,17 @@ class Customer < ApplicationRecord
     self.invoice_email_auto_to = invoice_email_auto_to.to_s.strip if invoice_email_auto_to
   end
 
+  # The document type (if any) that blocks deletion. Single source for both the
+  # UI gate (can_be_deleted?) and the destroy guard's error message.
+  def deletion_blocker
+    return "invoices" if used_in_invoices?
+    "delivery notes" if used_in_delivery_notes?
+  end
+
   def check_if_used
-    if used_in_invoices?
-      errors.add(:base, "Cannot delete customer that has been used in invoices")
-      throw :abort
-    elsif used_in_delivery_notes?
-      errors.add(:base, "Cannot delete customer that has been used in delivery notes")
-      throw :abort
-    end
+    return unless (blocker = deletion_blocker)
+    errors.add(:base, "Cannot delete customer that has been used in #{blocker}")
+    throw :abort
   end
 
   def sync_project_teams

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -15,6 +15,7 @@ class Customer < ApplicationRecord
   belongs_to :language
   has_many :sales_tax_rates, through: :sales_tax_customer_class
   has_many :invoices
+  has_many :delivery_notes
   has_many :customer_contacts, dependent: :destroy
   has_many :vat_verifications, class_name: "CustomerVatVerification", dependent: :destroy
 
@@ -50,6 +51,14 @@ class Customer < ApplicationRecord
 
   def used_in_invoices?
     invoices.exists?
+  end
+
+  def used_in_delivery_notes?
+    delivery_notes.exists?
+  end
+
+  def can_be_deleted?
+    !used_in_invoices? && !used_in_delivery_notes?
   end
 
   def latest_vat_verification
@@ -102,6 +111,9 @@ class Customer < ApplicationRecord
   def check_if_used
     if used_in_invoices?
       errors.add(:base, "Cannot delete customer that has been used in invoices")
+      throw :abort
+    elsif used_in_delivery_notes?
+      errors.add(:base, "Cannot delete customer that has been used in delivery notes")
       throw :abort
     end
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -26,7 +26,7 @@ class Project < ApplicationRecord
 
   # Allow deactivation instead of deletion for used projects
   def can_be_deleted?
-    !used_in_invoices? && !used_in_delivery_notes?
+    deletion_blocker.nil?
   end
 
   def display_name
@@ -39,14 +39,17 @@ class Project < ApplicationRecord
 
   private
 
+  # The document type (if any) that blocks deletion. Single source for both the
+  # UI gate (can_be_deleted?) and the destroy guard's error message.
+  def deletion_blocker
+    return "invoices" if used_in_invoices?
+    "delivery notes" if used_in_delivery_notes?
+  end
+
   def check_if_used
-    if used_in_invoices?
-      errors.add(:base, "Cannot delete project that has been used in invoices")
-      throw :abort
-    elsif used_in_delivery_notes?
-      errors.add(:base, "Cannot delete project that has been used in delivery notes")
-      throw :abort
-    end
+    return unless (blocker = deletion_blocker)
+    errors.add(:base, "Cannot delete project that has been used in #{blocker}")
+    throw :abort
   end
 
   # Reusable projects (no bill_to_customer) are free to pick any team.

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -4,6 +4,7 @@ class Project < ApplicationRecord
 
   belongs_to :bill_to_customer, class_name: "Customer", optional: true
   has_many :invoices
+  has_many :delivery_notes
 
   validate :team_must_match_customer
 
@@ -16,12 +17,16 @@ class Project < ApplicationRecord
     invoices.exists?
   end
 
+  def used_in_delivery_notes?
+    delivery_notes.exists?
+  end
+
   # Prevent deletion if project has been used
   before_destroy :check_if_used
 
   # Allow deactivation instead of deletion for used projects
   def can_be_deleted?
-    !used_in_invoices?
+    !used_in_invoices? && !used_in_delivery_notes?
   end
 
   def display_name
@@ -37,6 +42,9 @@ class Project < ApplicationRecord
   def check_if_used
     if used_in_invoices?
       errors.add(:base, "Cannot delete project that has been used in invoices")
+      throw :abort
+    elsif used_in_delivery_notes?
+      errors.add(:base, "Cannot delete project that has been used in delivery notes")
       throw :abort
     end
   end

--- a/app/views/customers/index.html.haml
+++ b/app/views/customers/index.html.haml
@@ -30,5 +30,5 @@
       %td
         = list_action_link('Edit', edit_customer_path(customer), :edit, permission: 'customers.edit')
       %td
-        - unless customer.used_in_invoices?
+        - if customer.can_be_deleted?
           = destroy_link(customer, "Are you sure you want to delete customer \"#{customer.matchcode}\" (#{customer.name})?", permission: 'customers.edit')

--- a/app/views/customers/show.html.haml
+++ b/app/views/customers/show.html.haml
@@ -1,6 +1,6 @@
 - invoices_action = nav_button('Invoices', invoices_path(customer_id: @customer.id, year: 'all'), permission: 'invoices.view', data: { turbo_prefetch: false })
 - delivery_notes_action = nav_button('Delivery Notes', delivery_notes_path(customer_id: @customer.id, year: 'all'), permission: 'delivery_notes.view', data: { turbo_prefetch: false })
-- delete_action = delete_button(@customer, confirm: "Are you sure you want to delete customer \"#{@customer.matchcode}\" (#{@customer.name})?", permission: 'customers.edit') unless @customer.used_in_invoices?
+- delete_action = delete_button(@customer, confirm: "Are you sure you want to delete customer \"#{@customer.matchcode}\" (#{@customer.name})?", permission: 'customers.edit') if @customer.can_be_deleted?
 - edit_action = action_button('Edit', edit_customer_path(@customer), permission: 'customers.edit')
 = breadcrumbs ['Customers', customers_path], @customer.matchcode, actions: [invoices_action, delivery_notes_action, delete_action], action: edit_action do
   - unless @customer.active?

--- a/db/migrate/20260610120000_add_invoice_customer_and_project_foreign_keys.rb
+++ b/db/migrate/20260610120000_add_invoice_customer_and_project_foreign_keys.rb
@@ -1,0 +1,11 @@
+class AddInvoiceCustomerAndProjectForeignKeys < ActiveRecord::Migration[8.1]
+  # invoices.customer_id / project_id were NOT NULL but had no FK, so the
+  # before_destroy guards on Customer/Project were the only thing stopping a
+  # delete — a check-then-delete race a concurrent invoice create can slip
+  # through. The FKs make the database the source of truth (delivery_notes
+  # already has the equivalent constraints).
+  def change
+    add_foreign_key :invoices, :customers
+    add_foreign_key :invoices, :projects
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_09_153655) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_10_120000) do
   create_table "acceptance_submissions", force: :cascade do |t|
     t.integer "attachment_id"
     t.datetime "created_at", null: false
@@ -462,6 +462,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_09_153655) do
   add_foreign_key "group_memberships", "groups"
   add_foreign_key "group_memberships", "users"
   add_foreign_key "group_permissions", "groups"
+  add_foreign_key "invoices", "customers"
+  add_foreign_key "invoices", "projects"
   add_foreign_key "projects", "teams"
   add_foreign_key "team_memberships", "teams"
   add_foreign_key "team_memberships", "users"

--- a/test/models/customer_test.rb
+++ b/test/models/customer_test.rb
@@ -120,6 +120,25 @@ class CustomerTest < ActiveSupport::TestCase
     assert create_customer.destroy
   end
 
+  test "before_destroy rejects destroy when delivery notes reference the customer" do
+    customer = create_customer
+    DeliveryNote.create!(customer: customer, project: projects(:reusable_project), delivery_start_date: Date.current)
+    assert_not customer.destroy
+    assert_includes customer.errors[:base], "Cannot delete customer that has been used in delivery notes"
+  end
+
+  test "used_in_delivery_notes? is true for a customer with delivery notes" do
+    customer = create_customer
+    DeliveryNote.create!(customer: customer, project: projects(:reusable_project), delivery_start_date: Date.current)
+    assert customer.used_in_delivery_notes?
+  end
+
+  test "database rejects deleting a customer still referenced by an invoice" do
+    # no_email_customer has an invoice but no delivery note, so this exercises
+    # the invoices FK specifically (not the pre-existing delivery_notes FK).
+    assert_raises(ActiveRecord::InvalidForeignKey) { customers(:no_email_customer).delete }
+  end
+
   test "active scope returns only active customers" do
     inactive = create_customer(active: false)
     assert_includes Customer.active, customers(:good_eu)

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -113,6 +113,11 @@ class ProjectTest < ActiveSupport::TestCase
     assert @project.destroy
   end
 
+  test "database rejects deleting a project still referenced by an invoice" do
+    Invoice.create!(customer: @customer, project: @project)
+    assert_raises(ActiveRecord::InvalidForeignKey) { @project.delete }
+  end
+
   test "display_name should return description when present" do
     @project.description = "My Project Description"
     assert_equal "My Project Description", @project.display_name


### PR DESCRIPTION
## Problem

`Customer` and `Project` have `before_destroy` guards that block deletion when the record is referenced by an invoice (`invoices.exists?`). Two flaws:

1. **Unbacked by FKs / TOCTOU race.** `invoices.customer_id` and `invoices.project_id` were `NOT NULL` but had **no foreign key constraint**. The Ruby existence check is the only thing stopping a delete, and it can interleave with a concurrent invoice create: the check sees no invoices, a parallel transaction inserts one, then the DELETE goes through — leaving an invoice pointing at a deleted customer/project, with nothing at the DB to prevent it.

2. **Customer guard ignored delivery notes.** `Customer#check_if_used` only checked invoices, and `Customer` had no `delivery_notes` association. But `delivery_notes.customer_id` is `NOT NULL` *with* an FK to customers — so deleting a customer that had delivery notes passed the Ruby guard, then raised an unrescued `ActiveRecord::InvalidForeignKey` (500). `Project` had the same gap.

## Fix

- **Migration**: add the missing `invoices → customers` and `invoices → projects` foreign keys (`delivery_notes` already had the equivalent constraints). The database is now the source of truth, so the check-then-delete race can no longer corrupt data.
- **Models**: add `has_many :delivery_notes` + `used_in_delivery_notes?` to both `Customer` and `Project`; both guards now block on invoices **and** delivery notes with a specific message; `can_be_deleted?` (drives delete-button visibility) reflects both document types.
- **Views**: customer index/show delete buttons now use `can_be_deleted?` so the button hides when delivery notes exist (matching the projects index, which already used `can_be_deleted?`).

## Tests

- DB rejects deleting a customer/project still referenced by an invoice (exercises the new FKs via `delete`, bypassing the Ruby guard).
- Customer destroy is blocked gracefully (no exception) when only delivery notes reference it.
- Full suite green (806 runs, 0 failures); customer/project system tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)