### PR TITLE
Give sessions an absolute lifetime instead of sliding expiry

### DIFF
--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -1,13 +1,16 @@
 class UserSession < ApplicationRecord
   include DigestedToken
 
+  # Absolute lifetime measured from sign-in (created_at). There is no sliding
+  # renewal: activity refreshes last_seen_at for display only, never the expiry.
+  # A stolen cookie is therefore guaranteed dead this long after it was issued.
   EXPIRY = 30.days
 
   belongs_to :user
   belongs_to :terminated_by_user, class_name: "User", optional: true
 
   scope :active, -> {
-    where(terminated_at: nil).where("last_seen_at > ?", EXPIRY.ago)
+    where(terminated_at: nil).where("created_at > ?", EXPIRY.ago)
   }
 
   def self.create_for!(user:, request:)

--- a/test/models/user_session_test.rb
+++ b/test/models/user_session_test.rb
@@ -22,7 +22,13 @@ class UserSessionTest < ActiveSupport::TestCase
   test "active scope excludes terminated and expired" do
     session, _plaintext = UserSession.create_for!(user: users(:alice), request: fake_request)
     assert_includes UserSession.active.to_a, session
-    session.update_column(:last_seen_at, 31.days.ago)
+    session.update_column(:created_at, 31.days.ago)
+    assert_not_includes UserSession.active.to_a, session
+  end
+
+  test "active scope expires by absolute age regardless of recent activity" do
+    session, _plaintext = UserSession.create_for!(user: users(:alice), request: fake_request)
+    session.update_columns(created_at: 31.days.ago, last_seen_at: Time.current)
     assert_not_includes UserSession.active.to_a, session
   end
 


### PR DESCRIPTION
## Problem

`UserSession.active` (`app/models/user_session.rb:9`) gated only on `last_seen_at > EXPIRY.ago` — a **sliding** 30-day idle window. Every authenticated request calls `touch_seen!` (`application_controller.rb:135`), which refreshes `last_seen_at`. The auth cookie is `cookies.signed.permanent` (≈20yr, `application_controller.rb:213`).

Net effect: a session used at least once every 30 days never expired. A stolen cookie used roughly monthly survived **indefinitely** — there was no absolute ceiling on session lifetime.

## Fix

Gate the `active` scope on `created_at` instead of `last_seen_at`. A session is now guaranteed dead 30 days after sign-in, regardless of activity. No sliding renewal.

`last_seen_at` / `touch_seen!` are retained — they still drive the "Last seen" / current-IP display in the session management UI — but no longer influence expiry. `created_at` already exists on the table, so no migration is needed.

The duration stays 30 days (per discussion: collapse the sliding window into a flat absolute lifetime rather than add a separate, longer absolute cap). Passkey re-auth is low-friction.

## Tests

- Updated `active scope excludes terminated and expired` to age `created_at`.
- Added `active scope expires by absolute age regardless of recent activity` — sets `created_at` 31 days back with `last_seen_at` = now, asserts the session is excluded (this is the regression guard for the reported issue).
- Full suite green (803 runs, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)