### PR TITLE
Render FOP temp files owner-only (0700/0600)

### DIFF
--- a/app/services/fop_renderer.rb
+++ b/app/services/fop_renderer.rb
@@ -31,21 +31,26 @@ class FopRenderer
     # Resolve FOP binary path, can be relative
     fop_binary = resolve_fop_binary_path
 
-    # Create dedicated temp directory with proper permissions
+    # Dedicated owner-only temp dir. The input XML carries customer data and
+    # the payment token, and the output PDF is attached/emailed verbatim, so
+    # no other local OS user may read or substitute these files. FOP always
+    # runs as this same uid (native bin/abt-fop directly; bin/abt-fop-container
+    # via -u "$(id -u):$(id -g)" + podman --userns=keep-id), so 0700/0600
+    # suffices everywhere — group/other bits would only widen exposure.
     Dir.mktmpdir("abt-fop-", @rails_tmp) do |temp_dir|
-      File.chmod(0755, temp_dir)
+      File.chmod(0700, temp_dir)
 
       logo_path = nil
       if logo_data
         logo_path = File.join(temp_dir, "logo.pdf")
-        write_file_with_permissions(logo_path, logo_data, 0644, binary: true)
+        write_file_with_permissions(logo_path, logo_data, 0600, binary: true)
       end
 
       # Call block to emit XML
       xml_data = yield logo_path
 
       xml_path = File.join(temp_dir, "input.xml")
-      write_file_with_permissions(xml_path, xml_data, 0644)
+      write_file_with_permissions(xml_path, xml_data, 0600)
 
       Rails.logger.info "FopRenderer wrote XML to: #{xml_path}"
       Rails.logger.debug File.read(xml_path)
@@ -68,24 +73,12 @@ class FopRenderer
     begin
       pdf_path = File.join(temp_dir, "output.pdf")
 
-      # Create empty output file with correct permissions that FOP can write to
-      write_file_with_permissions(pdf_path, "", 0666)
+      # Pre-create the output file owner-only; FOP (same uid) overwrites it.
+      write_file_with_permissions(pdf_path, "", 0600)
 
       fop_command = build_fop_command(fop_binary, xml_path, xsl_path, pdf_path)
 
-      Rails.logger.debug "Calling fop: #{fop_command.inspect}"
-
-      fop_result = nil
-      exit_status = nil
-      # Array form (no shell): each argument is passed verbatim to FOP, so a
-      # path containing shell metacharacters can't be interpreted as a command.
-      # chdir runs FOP with cwd at the template dir, which fop-conf.xml's
-      # relative <base> requires.
-      IO.popen(fop_command, "r", err: [ :child, :out ], chdir: @template_path.to_s) do |fop_io|
-        fop_result = fop_io.read
-        fop_io.close
-        exit_status = $?.exitstatus
-      end
+      fop_result, exit_status = run_fop(fop_command)
 
       Rails.logger.debug "fop result: #{fop_result}"
       Rails.logger.debug "fop exit status: #{exit_status}"
@@ -121,6 +114,24 @@ class FopRenderer
     end
   end
 
+  # Spawn FOP and return [combined stdout/stderr, exit status].
+  # Array form (no shell): each argument is passed verbatim to FOP, so a
+  # path containing shell metacharacters can't be interpreted as a command.
+  # chdir runs FOP with cwd at the template dir, which fop-conf.xml's
+  # relative <base> requires.
+  def run_fop(fop_command)
+    Rails.logger.debug "Calling fop: #{fop_command.inspect}"
+
+    fop_result = nil
+    exit_status = nil
+    IO.popen(fop_command, "r", err: [ :child, :out ], chdir: @template_path.to_s) do |fop_io|
+      fop_result = fop_io.read
+      fop_io.close
+      exit_status = $?.exitstatus
+    end
+    [ fop_result, exit_status ]
+  end
+
   # Returns an argv array for IO.popen; cwd is set via the popen chdir:
   # option, so no shell is involved.
   def build_fop_command(fop_binary, xml_path, xsl_path, pdf_path)
@@ -134,8 +145,9 @@ class FopRenderer
     ]
   end
 
-  # Write file with explicit permissions to work around restrictive umask
-  # This ensures FOP can access the files regardless of process umask setting
+  # Write a file and chmod it explicitly, so the mode is exactly `permissions`
+  # regardless of the process umask (a strict umask must not further restrict
+  # FOP's access; a loose one must not widen it).
   def write_file_with_permissions(path, content, permissions, binary: false)
     if binary
       File.binwrite(path, content)

--- a/test/services/fop_renderer_test.rb
+++ b/test/services/fop_renderer_test.rb
@@ -104,6 +104,40 @@ class FopRendererTest < ActiveSupport::TestCase
     File.umask(old_umask) if old_umask
   end
 
+  # Subclass that intercepts the FOP subprocess to record the on-disk
+  # permissions of every temp artifact the renderer created, then fakes a
+  # successful render so the surrounding pipeline runs unchanged.
+  class PermissionCapturingRenderer < FopRenderer
+    attr_reader :captured
+
+    def run_fop(fop_command)
+      pdf_path = fop_command[fop_command.index("-pdf") + 1]
+      temp_dir = File.dirname(pdf_path)
+      @captured = {
+        dir: File.stat(temp_dir).mode & 0777,
+        xml: File.stat(File.join(temp_dir, "input.xml")).mode & 0777,
+        logo: File.stat(File.join(temp_dir, "logo.pdf")).mode & 0777,
+        output: File.stat(pdf_path).mode & 0777
+      }
+      File.write(pdf_path, "%PDF-1.4\n%%EOF\n")
+      [ "", 0 ]
+    end
+  end
+
+  def test_temp_files_are_not_accessible_to_other_local_users
+    old_umask = File.umask(0022)
+    renderer = PermissionCapturingRenderer.new
+
+    renderer.render_pdf_with_logo("simple_test.xsl", "logo-bytes") { |_logo_path| "<x/>" }
+
+    assert_equal 0700, renderer.captured[:dir], "temp dir must be owner-only"
+    assert_equal 0600, renderer.captured[:xml], "invoice XML must be owner-only"
+    assert_equal 0600, renderer.captured[:logo], "logo must be owner-only"
+    assert_equal 0600, renderer.captured[:output], "output PDF must be owner-only"
+  ensure
+    File.umask(old_umask) if old_umask
+  end
+
   def test_fop_renderer_handles_invalid_data
     # Test with more permissive umask for temp files
     old_umask = File.umask(0022)


### PR DESCRIPTION
## Problem

`FopRenderer` created its per-render scratch files world-accessible:

- temp dir `chmod 0755`
- `input.xml` and `logo.pdf` `0644`
- pre-created `output.pdf` `0666`

On the production host that lets **any local OS user** read the full invoice XML (customer data + payment token) or race-substitute the `output.pdf` that then gets permanently attached and emailed.

## Why it was loose, and why it doesn't need to be

The loose bits came from a 2025 fix for *umask 077* blocking FOP. That overshot: the cure for a restrictive umask is forcing the **owner** bits (`chmod 0600`), not handing access to group/other.

FOP always runs as the **same uid** as the Rails process:
- native `bin/abt-fop` — same process user by definition (production, sandbox)
- `bin/abt-fop-container` — `-u "$(id -u):$(id -g)"` plus podman `--userns=keep-id` (dev, CI)

So a process accessing its **own** `0600` files works on every launcher path — no container-specific relaxation needed. I confirmed empirically by running the smoke test through the **containerized** launcher (podman + keep-id, same as CI) under the tightened perms.

## Change

- temp dir → `0700`; `input.xml`, `logo.pdf`, `output.pdf` → `0600`.
- Extract the `IO.popen` call into `run_fop` so a test can intercept the subprocess and assert the on-disk mode of all four temp artifacts (new regression test).
- Refresh the now-inaccurate comments.

## Testing

- New `test_temp_files_are_not_accessible_to_other_local_users` (red→green against the tightened perms).
- Full unit suite: 803 runs, 0 failures. Renderer smoke test exercises real FOP via the container launcher under the new perms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)