### PR TITLE
Store money as decimal, round at compute time (issuer-configurable)

### DIFF
--- a/app/controllers/issuer_companies_controller.rb
+++ b/app/controllers/issuer_companies_controller.rb
@@ -72,6 +72,7 @@ class IssuerCompaniesController < ApplicationController
       :document_accent_color,
       :invoice_footer,
       :currency,
+      :money_decimal_places,
       :document_email_from,
       :document_email_reply_to,
       :document_email_auto_bcc,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,6 +9,10 @@ module ApplicationHelper
     @current_currency ||= IssuerCompany.get_the_issuer!&.currency || "EUR"
   end
 
+  def current_money_decimal_places
+    @current_money_decimal_places ||= IssuerCompany.get_the_issuer!&.money_decimal_places || 2
+  end
+
   # Symbol for the issuer currency, falling back to the raw code. Single source
   # of truth — the invoice line-total JS reads this via a Stimulus value rather
   # than mapping symbols itself. Never carries a trailing space, so callers
@@ -24,7 +28,7 @@ module ApplicationHelper
 
   def format_currency(amount)
     return "" if amount.nil?
-    "#{currency_symbol}#{sprintf('%.2f', amount)}"
+    "#{currency_symbol}#{sprintf("%.#{current_money_decimal_places}f", amount)}"
   end
 
   # Renders the breadcrumb strip that serves as the page header on every

--- a/app/javascript/controllers/invoice_lines_controller.js
+++ b/app/javascript/controllers/invoice_lines_controller.js
@@ -2,7 +2,7 @@ import BaseLinesController from "controllers/base_lines_controller"
 
 export default class extends BaseLinesController {
   static targets = ["container", "total"]
-  static values = { currencySymbol: String }
+  static values = { currencySymbol: String, moneyDecimalPlaces: Number }
 
   connect() {
     super.connect()
@@ -107,7 +107,7 @@ export default class extends BaseLinesController {
   }
 
   formatCurrency(amount) {
-    return this.currencySymbolValue + parseFloat(amount).toFixed(2)
+    return this.currencySymbolValue + parseFloat(amount).toFixed(this.moneyDecimalPlacesValue)
   }
 
   getLineType() {

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -79,6 +79,11 @@ class Invoice < ApplicationRecord
   before_save :update_customer
   before_save :update_sums
 
+  # Memoized so lines and tax classes resolve the issuer once, not per row.
+  def money_decimal_places
+    @money_decimal_places ||= IssuerCompany.get_the_issuer!.money_decimal_places
+  end
+
   def paid?
     self.paid_at.present?
   end
@@ -248,15 +253,15 @@ private
         # autosave will write this record (with the correct FK) when it saves.
         itc.save if itc.persisted?
       else
-        # Create new tax class
-        self.invoice_tax_classes << InvoiceTaxClass.new(
+        # build (not <<) attaches the record to the invoice before net= runs.
+        itc = self.invoice_tax_classes.build(
           sales_tax_product_class: cst.sales_tax_product_class,
           name: cst.sales_tax_product_class.name,
           indicator_code: cst.sales_tax_product_class.indicator_code,
-          rate: cst.rate,
-          net: 0,
-          total: 0
+          rate: cst.rate
         )
+        itc.net = 0
+        itc.total = 0
       end
     end
 

--- a/app/models/invoice_line.rb
+++ b/app/models/invoice_line.rb
@@ -11,7 +11,7 @@ class InvoiceLine < ApplicationRecord
 
   def calculate_amount
     if is_item? && !self[:rate].nil? && !self[:quantity].nil?
-      self[:amount] = self[:rate] * self[:quantity]
+      self[:amount] = (self[:rate] * self[:quantity]).round(invoice.money_decimal_places)
     else
       self[:amount] = 0
     end

--- a/app/models/invoice_tax_class.rb
+++ b/app/models/invoice_tax_class.rb
@@ -7,7 +7,7 @@ class InvoiceTaxClass < ApplicationRecord
 
   def net=(value)
     self[:net] = value
-    self[:value] = self[:net] * (self[:rate]/100.0)
+    self[:value] = (self[:net] * self[:rate] / 100).round(invoice.money_decimal_places)
     self[:total] = self[:net] + self[:value]
   end
 end

--- a/app/models/issuer_company.rb
+++ b/app/models/issuer_company.rb
@@ -6,6 +6,10 @@ class IssuerCompany < ApplicationRecord
             format: { with: /\A#[0-9a-fA-F]{3,8}\z/, message: "must be a hex color like #rrggbb" },
             allow_blank: true
   validates :vat_id_recheck_days, numericality: { only_integer: true, greater_than: 0 }
+  # 0..4 covers all ISO 4217 minor units (2 typical, 0 for JPY, 3 for KWD, 4 for
+  # CLF). Bounding it also keeps stored values exact on SQLite's float-backed
+  # decimal columns.
+  validates :money_decimal_places, numericality: { only_integer: true, in: 0..4 }
   validates :reporting_email, presence: true
   validates :reporting_email, :document_email_from, :document_email_auto_bcc, :document_email_reply_to,
             format: { with: URI::MailTo::EMAIL_REGEXP, allow_blank: true }

--- a/app/services/invoice_renderer.rb
+++ b/app/services/invoice_renderer.rb
@@ -62,6 +62,7 @@ class InvoiceRenderer
       end
 
       xml_root.currency "EUR"
+      xml_root.tag! "money-decimal-places", @issuer.money_decimal_places
       xml_root.prelude @invoice.prelude
       xml_root.tag! "tax-note", @invoice.tax_note
       xml_root.number @invoice.document_number

--- a/app/views/invoices/_form.html.haml
+++ b/app/views/invoices/_form.html.haml
@@ -89,7 +89,7 @@
             = f.text_area :prelude, class: 'form-control', rows: 2, placeholder: 'Thank you for your business...', data: { action: 'input->auto-resize-form#fieldChanged' }
 
       - unless @invoice.id.nil?
-        %div{data: {controller: 'invoice-lines', invoice_lines_currency_symbol_value: currency_symbol}}
+        %div{data: {controller: 'invoice-lines', invoice_lines_currency_symbol_value: currency_symbol, invoice_lines_money_decimal_places_value: current_money_decimal_places}}
           / Lines container
           %div{data: {invoice_lines_target: 'container'}}
             = f.fields_for :invoice_lines do |line_form|

--- a/app/views/issuer_companies/edit.html.haml
+++ b/app/views/issuer_companies/edit.html.haml
@@ -39,6 +39,11 @@
             = form.text_field :currency, class: 'form-control'
 
           .mb-3
+            = form.label :money_decimal_places, 'Money decimal places', class: 'form-label'
+            = form.number_field :money_decimal_places, class: 'form-control', min: 0, max: 4
+            %small.form-text.text-muted Decimal places money amounts are rounded to and displayed with (0–4).
+
+          .mb-3
             = form.label :address, 'Address', class: 'form-label'
             = form.text_area :address, rows: 4, class: 'form-control'
 

--- a/app/views/issuer_companies/show.html.haml
+++ b/app/views/issuer_companies/show.html.haml
@@ -32,6 +32,12 @@
 
         .row.mb-2
           .col-sm-4
+            %strong Money decimal places:
+          .col-sm-8
+            = @issuer_company.money_decimal_places
+
+        .row.mb-2
+          .col-sm-4
             %strong Address:
           .col-sm-8
             - @issuer_company.address.split("\n").each do |line|

--- a/db/migrate/20260610130000_money_columns_to_decimal.rb
+++ b/db/migrate/20260610130000_money_columns_to_decimal.rb
@@ -1,0 +1,24 @@
+class MoneyColumnsToDecimal < ActiveRecord::Migration[8.1]
+  # Money and quantity must be exact, not float. Columns are unbounded decimal
+  # (like sum_net/net/value/total) so the configurable rounding precision
+  # (IssuerCompany#money_decimal_places) is never truncated at the DB.
+  def up
+    change_column :invoice_lines, :rate,           :decimal
+    change_column :invoice_lines, :quantity,       :decimal
+    change_column :invoice_lines, :amount,         :decimal
+    # Per-line tax-rate snapshot was integer, truncating fractional rates
+    # (7.7 -> 7).
+    change_column :invoice_lines, :sales_tax_rate, :decimal
+
+    change_column :delivery_note_lines, :quantity, :decimal
+  end
+
+  def down
+    change_column :delivery_note_lines, :quantity, :float
+
+    change_column :invoice_lines, :sales_tax_rate, :integer
+    change_column :invoice_lines, :amount,         :float
+    change_column :invoice_lines, :quantity,       :float
+    change_column :invoice_lines, :rate,           :float
+  end
+end

--- a/db/migrate/20260610130001_add_money_decimal_places_to_issuer_companies.rb
+++ b/db/migrate/20260610130001_add_money_decimal_places_to_issuer_companies.rb
@@ -1,0 +1,5 @@
+class AddMoneyDecimalPlacesToIssuerCompanies < ActiveRecord::Migration[8.1]
+  def change
+    add_column :issuer_companies, :money_decimal_places, :integer, default: 2, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_10_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_10_130001) do
   create_table "acceptance_submissions", force: :cascade do |t|
     t.integer "attachment_id"
     t.datetime "created_at", null: false
@@ -108,7 +108,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_10_120000) do
     t.integer "delivery_note_id", null: false
     t.text "description"
     t.integer "position"
-    t.float "quantity"
+    t.decimal "quantity"
     t.text "title"
     t.text "type"
     t.datetime "updated_at", null: false
@@ -185,17 +185,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_10_120000) do
   end
 
   create_table "invoice_lines", force: :cascade do |t|
-    t.float "amount"
+    t.decimal "amount"
     t.datetime "created_at", null: false
     t.text "description"
     t.integer "invoice_id"
     t.integer "position"
-    t.float "quantity"
-    t.float "rate"
+    t.decimal "quantity"
+    t.decimal "rate"
     t.text "sales_tax_indicator_code"
     t.text "sales_tax_name"
     t.integer "sales_tax_product_class_id"
-    t.integer "sales_tax_rate"
+    t.decimal "sales_tax_rate"
     t.text "title"
     t.text "type"
     t.datetime "updated_at", null: false
@@ -265,6 +265,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_10_120000) do
     t.string "document_email_reply_to"
     t.string "invoice_footer"
     t.string "legal_name"
+    t.integer "money_decimal_places", default: 2, null: false
     t.binary "pdf_logo"
     t.string "pdf_logo_height"
     t.string "pdf_logo_width"

--- a/lib/foptemplate/document_base.xsl
+++ b/lib/foptemplate/document_base.xsl
@@ -2,6 +2,7 @@
 <xsl:stylesheet version="2.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:abt="http://deduktiva.com/Namespace/ABT/XSLT">
     <xsl:output method="xml" indent="yes"/>
     <xsl:strip-space elements="*" />
@@ -18,6 +19,12 @@
          constants change, recompute. -->
     <xsl:variable name="logo-sender-alignment-padding">4.8pt</xsl:variable>
 
+    <!-- Decimal places for money amounts, forwarded from IssuerCompany. Falls
+         back to 2 for documents that don't carry it (e.g. delivery notes). -->
+    <xsl:variable name="money-decimal-places" as="xs:integer"
+                  select="if (/document/money-decimal-places castable as xs:integer)
+                          then xs:integer(/document/money-decimal-places) else 2" />
+
     <!-- Common utility functions -->
     <xsl:function name="abt:strip-space">
         <xsl:param name="string" />
@@ -26,7 +33,10 @@
 
     <xsl:function name="abt:format-amount">
         <xsl:param name="value" />
-        <xsl:value-of select="format-number($value, '###.##0,00', 'european')" />
+        <xsl:variable name="picture" select="if ($money-decimal-places gt 0)
+            then concat('###.##0,', string-join(for $i in 1 to $money-decimal-places return '0', ''))
+            else '###.##0'" />
+        <xsl:value-of select="format-number($value, $picture, 'european')" />
     </xsl:function>
 
     <xsl:function name="abt:format-number">

--- a/test/controllers/issuer_companies_controller_test.rb
+++ b/test/controllers/issuer_companies_controller_test.rb
@@ -113,6 +113,14 @@ class IssuerCompaniesControllerTest < ActionDispatch::IntegrationTest
     assert_equal 30, @issuer_company.reload.vat_id_recheck_days
   end
 
+  test "update permits money_decimal_places and persists the new value" do
+    patch issuer_company_url, params: {
+      issuer_company: { money_decimal_places: 3 }
+    }
+    assert_redirected_to issuer_company_url
+    assert_equal 3, @issuer_company.reload.money_decimal_places
+  end
+
   test "update permits reporting_email and persists the new value" do
     patch issuer_company_url, params: {
       issuer_company: { reporting_email: "reports@example.com" }

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -21,6 +21,11 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_equal "test-version", app_version
   end
 
+  test "format_currency uses the issuer's money_decimal_places" do
+    issuer_companies(:one).update!(money_decimal_places: 3)
+    assert_equal "€12.340", format_currency(12.34)
+  end
+
   test "app_version caches result to avoid repeated calls" do
     # First call should set the instance variable
     first_call = app_version

--- a/test/models/invoice_line_test.rb
+++ b/test/models/invoice_line_test.rb
@@ -53,16 +53,29 @@ class InvoiceLineTest < ActiveSupport::TestCase
     assert_equal 0, line.amount
   end
 
-  test "calculate_amount sets amount = rate * quantity for item lines" do
+  test "calculate_amount rounds rate * quantity to cents" do
     line = InvoiceLine.new(
       invoice: invoices(:draft_invoice),
       title: "Widget",
       type: "item",
-      rate: 12.5,
-      quantity: 4
+      rate: 10.10,
+      quantity: 3.33
     )
     line.calculate_amount
-    assert_equal 50.0, line.amount
+    assert_equal BigDecimal("33.63"), line.amount
+  end
+
+  test "calculate_amount honors the issuer's money_decimal_places" do
+    IssuerCompany.get_the_issuer!.update!(money_decimal_places: 0)
+    line = InvoiceLine.new(invoice: invoices(:draft_invoice), title: "x", type: "item", rate: 1.005, quantity: 1)
+    line.calculate_amount
+    assert_equal BigDecimal("1"), line.amount
+  end
+
+  test "sales_tax_rate snapshot keeps decimal precision" do
+    line = InvoiceLine.new(type: "item")
+    line.sales_tax_rate = 7.7
+    assert_equal BigDecimal("7.7"), line.sales_tax_rate
   end
 
   test "calculate_amount sets amount = 0 for non-item lines" do

--- a/test/models/invoice_tax_class_test.rb
+++ b/test/models/invoice_tax_class_test.rb
@@ -27,12 +27,12 @@ class InvoiceTaxClassTest < ActiveSupport::TestCase
     assert_includes itc.errors[:rate], "can't be blank"
   end
 
-  test "net= computes value and total from rate" do
-    itc = build_tax_class
-    itc.net = 100
-    assert_equal 100, itc.net
-    assert_in_delta 20.0, itc.value, 0.0001
-    assert_in_delta 120.0, itc.total, 0.0001
+  test "net= rounds tax value to cents with total = net + value" do
+    itc = build_tax_class(rate: 8.25)
+    itc.net = 33.33
+    assert_equal BigDecimal("2.75"), itc.value
+    assert_equal BigDecimal("36.08"), itc.total
+    assert_equal itc.net + itc.value, itc.total
   end
 
   test "net= recomputes value and total on reassignment" do

--- a/test/models/invoice_test.rb
+++ b/test/models/invoice_test.rb
@@ -95,6 +95,23 @@ class InvoiceTest < ActiveSupport::TestCase
     assert_in_delta 21600.0, invoice.sum_total, 0.0001
   end
 
+  test "update_sums keeps cent-exact sums with no float dust under a fractional tax rate" do
+    invoice = license_invoice_with_tax_config
+    SalesTaxRate.find_by(
+      sales_tax_customer_class: sales_tax_customer_classes(:national),
+      sales_tax_product_class: sales_tax_product_classes(:standard)
+    ).update!(rate: 8.25)
+    invoice.invoice_lines.where(type: "item").update_all(rate: 33.33, quantity: 1)
+    invoice.reload.save!
+    invoice.reload
+
+    itc = invoice.invoice_tax_classes.first
+    assert_equal BigDecimal("66.66"), invoice.sum_net
+    assert_equal BigDecimal("5.50"), itc.value
+    assert_equal BigDecimal("72.16"), invoice.sum_total
+    assert_equal invoice.sum_net + itc.value, invoice.sum_total
+  end
+
   test "update_sums skips a published invoice" do
     invoice = invoices(:published_invoice)
     invoice.update_columns(sum_net: 999.99, sum_total: 1234.56)

--- a/test/models/issuer_company_test.rb
+++ b/test/models/issuer_company_test.rb
@@ -61,6 +61,14 @@ class IssuerCompanyTest < ActiveSupport::TestCase
     assert company.valid?
   end
 
+  test "money_decimal_places rejects out-of-range and non-integer values" do
+    [ -1, 5, 2.5 ].each do |value|
+      company = issuer_companies(:one)
+      company.money_decimal_places = value
+      assert_not company.valid?, "expected money_decimal_places=#{value} to be invalid"
+    end
+  end
+
   test "get_the_issuer! returns the active issuer" do
     assert_equal issuer_companies(:one), IssuerCompany.get_the_issuer!
   end

--- a/test/services/invoice_renderer_test.rb
+++ b/test/services/invoice_renderer_test.rb
@@ -20,6 +20,13 @@ class InvoiceRendererTest < ActiveSupport::TestCase
     assert_no_match %r{supplier-no}, xml
   end
 
+  test "forwards the issuer's money_decimal_places into the PDF (FOP smoke)" do
+    @issuer.update!(money_decimal_places: 0)
+    renderer = InvoiceRenderer.new(@invoice, @issuer)
+    assert_match %r{<money-decimal-places>0</money-decimal-places>}, renderer.emit_xml(nil)
+    assert renderer.render.start_with?("%PDF"), "expected a PDF"
+  end
+
   test "renders a valid PDF with and without supplier number (FOP smoke)" do
     @invoice.update_columns(customer_supplier_number: "ACME-VEND-7")
     pdf = InvoiceRenderer.new(@invoice, @issuer).render


### PR DESCRIPTION
## Problem

Two money-handling bugs in invoices:

1. **Float money, display-only rounding.** `invoice_lines.rate/quantity/amount` were `float`, and line amounts were never rounded in Ruby (`InvoiceLine#calculate_amount` did `rate * quantity`; `InvoiceTaxClass#net=` used `/100.0`). The XSL rounded net, tax, and total independently, so a printed invoice could show **net + tax ≠ total** by a cent, and the stored `sum_total` carried float dust differing from the printed amount.
2. **Truncated tax-rate snapshot.** `invoice_lines.sales_tax_rate` was `integer`; assigning the decimal `itc.rate` booked a 7.7% rate as `7`. (Write-only column — totals were unaffected, but the snapshot was wrong.)

## Change

- **Decimal columns.** `invoice_lines.rate/quantity/amount` and `sales_tax_rate` (plus the mirrored `delivery_note_lines.quantity`) become unbounded `decimal`, consistent with the existing `sum_net/net/value/total` columns. Exact on PostgreSQL; round-trips exactly on SQLite within the configured precision.
- **Round at compute time, in BigDecimal.** Amounts round per line and per tax class, so `net + value == total` holds exactly and the stored sums match the printed page.
- **Issuer-configurable precision.** `IssuerCompany` gains `money_decimal_places` (integer, default 2, validated `0..4` — the ISO 4217 range). `Invoice` memoizes the issuer lookup once per instance, so iterating lines/tax classes issues **no per-row issuer query**; lines and tax classes read it through their (required) parent.
- **Forwarded to the PDF.** `InvoiceRenderer` emits `<money-decimal-places>` and `document_base.xsl` builds the `format-amount` picture dynamically, so printed decimals match the stored rounding. Delivery notes (no money) default to 2.
- Exposed in the issuer edit/show UI.

## Testing

- Unit tests for per-line and per-tax-class rounding, the decimal-rate snapshot, configurable precision, and an invoice-level reconciliation test (`net + tax == total`, no float dust under a fractional 8.25% rate).
- Renderer test asserts the emitted element; a FOP smoke test renders a real PDF at a non-default precision. Verified rendered output: `places=0` → integers, `2` → `33,33`, `3` → `33,330`.
- Full suite (811) + system tests (55) pass; rubocop/pre-commit clean.

## Notes

- Existing **published** invoices are immutable and render from a stored PDF attachment, so legacy float values never resurface in output.
- Reviewed across two self-review rounds (N+1 elimination, removed a single-use class helper and dead nil-fallbacks, fixed a `setup_tax_classes` ordering issue by building the tax class attached to its invoice before `net=` runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)