### PR TITLE
Wire issuer currency into invoice line-total JS

### DIFF
--- a/app/javascript/controllers/invoice_lines_controller.js
+++ b/app/javascript/controllers/invoice_lines_controller.js
@@ -2,6 +2,7 @@ import BaseLinesController from "controllers/base_lines_controller"
 
 export default class extends BaseLinesController {
   static targets = ["container", "total"]
+  static values = { currency: String }
 
   connect() {
     super.connect()
@@ -106,8 +107,7 @@ export default class extends BaseLinesController {
   }
 
   formatCurrency(amount) {
-    // Get currency from a data attribute or default to EUR
-    const currency = document.querySelector('[data-currency]')?.getAttribute('data-currency') || 'EUR'
+    const currency = this.currencyValue
     const formatted = parseFloat(amount).toFixed(2)
 
     switch(currency) {

--- a/app/views/invoices/_form.html.haml
+++ b/app/views/invoices/_form.html.haml
@@ -89,7 +89,7 @@
             = f.text_area :prelude, class: 'form-control', rows: 2, placeholder: 'Thank you for your business...', data: { action: 'input->auto-resize-form#fieldChanged' }
 
       - unless @invoice.id.nil?
-        %div{data: {controller: 'invoice-lines'}}
+        %div{data: {controller: 'invoice-lines', invoice_lines_currency_value: current_currency}}
           / Lines container
           %div{data: {invoice_lines_target: 'container'}}
             = f.fields_for :invoice_lines do |line_form|

--- a/test/system/line_management_test.rb
+++ b/test/system/line_management_test.rb
@@ -143,8 +143,8 @@ class LineManagementTest < ApplicationSystemTestCase
     end
   end
 
-  # Test total calculation for invoices (delivery notes don't have totals)
-  test "invoice total updates when modifying line values" do
+  test "invoice total updates in the issuer currency when modifying line values" do
+    issuer_companies(:one).update!(currency: "USD")
     visit edit_invoice_path(@invoice)
 
     total_element = find('[data-invoice-lines-target="total"]')
@@ -159,9 +159,8 @@ class LineManagementTest < ApplicationSystemTestCase
       find('input[name*="[rate]"]').native.send_keys(:tab)
     end
 
-    # Capybara auto-waits on assert_selector with :text — wait for the line
-    # total to update before reading the running total.
-    assert_selector "[data-line-total]", text: "€60.00"
+    # assert_selector auto-waits for the line total before we read the running total.
+    assert_selector "[data-line-total]", text: "$60.00"
     assert_not_equal initial_total, total_element.text
   end
 


### PR DESCRIPTION
## Problem

`invoice_lines_controller.js#formatCurrency` read the currency from `document.querySelector('[data-currency]')`, but **no view ever emitted a `data-currency` attribute**. The optional-chained lookup always returned `null`, so the JS always fell back to `'EUR'` (`€`).

For a non-EUR issuer, the live draft line totals and running total showed `€` while the server-rendered totals (`format_currency` helper → `IssuerCompany#currency`) and the published PDF used the correct symbol — a silent inconsistency.

## Fix

Pass `current_currency` to the `invoice-lines` Stimulus controller as a value (`invoice_lines_currency_value`) and read `this.currencyValue` in `formatCurrency`, removing the fragile global `querySelector` hack. The EUR fallback now lives only in the `current_currency` helper (`IssuerCompany#currency || "EUR"`) — its single source.

Delivery notes don't do JS currency formatting (no `formatCurrency` override; the shared base controller has none), so no mirroring was needed.

## Test

Exercise the existing `line_management_test` total-update test under a non-default issuer currency (USD), asserting the live line total renders `$60.00`. One test now covers both the running total and the currency symbol; it fails on the old code (renders `€60.00`) and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)