### PR TITLE
Single-source the currency symbol between backend and frontend

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,18 +9,22 @@ module ApplicationHelper
     @current_currency ||= IssuerCompany.get_the_issuer!&.currency || "EUR"
   end
 
+  # Symbol for the issuer currency, falling back to the raw code. Single source
+  # of truth — the invoice line-total JS reads this via a Stimulus value rather
+  # than mapping symbols itself. Never carries a trailing space, so callers
+  # always prepend it the same way.
+  def currency_symbol
+    case current_currency
+    when "EUR" then "€"
+    when "USD" then "$"
+    when "GBP" then "£"
+    else current_currency
+    end
+  end
+
   def format_currency(amount)
     return "" if amount.nil?
-    case current_currency
-    when "EUR"
-      "€#{sprintf('%.2f', amount)}"
-    when "USD"
-      "$#{sprintf('%.2f', amount)}"
-    when "GBP"
-      "£#{sprintf('%.2f', amount)}"
-    else
-      "#{current_currency} #{sprintf('%.2f', amount)}"
-    end
+    "#{currency_symbol}#{sprintf('%.2f', amount)}"
   end
 
   # Renders the breadcrumb strip that serves as the page header on every

--- a/app/javascript/controllers/invoice_lines_controller.js
+++ b/app/javascript/controllers/invoice_lines_controller.js
@@ -2,7 +2,7 @@ import BaseLinesController from "controllers/base_lines_controller"
 
 export default class extends BaseLinesController {
   static targets = ["container", "total"]
-  static values = { currency: String }
+  static values = { currencySymbol: String }
 
   connect() {
     super.connect()
@@ -107,19 +107,7 @@ export default class extends BaseLinesController {
   }
 
   formatCurrency(amount) {
-    const currency = this.currencyValue
-    const formatted = parseFloat(amount).toFixed(2)
-
-    switch(currency) {
-      case 'EUR':
-        return '€' + formatted
-      case 'USD':
-        return '$' + formatted
-      case 'GBP':
-        return '£' + formatted
-      default:
-        return currency + ' ' + formatted
-    }
+    return this.currencySymbolValue + parseFloat(amount).toFixed(2)
   }
 
   getLineType() {

--- a/app/views/invoices/_form.html.haml
+++ b/app/views/invoices/_form.html.haml
@@ -89,7 +89,7 @@
             = f.text_area :prelude, class: 'form-control', rows: 2, placeholder: 'Thank you for your business...', data: { action: 'input->auto-resize-form#fieldChanged' }
 
       - unless @invoice.id.nil?
-        %div{data: {controller: 'invoice-lines', invoice_lines_currency_value: current_currency}}
+        %div{data: {controller: 'invoice-lines', invoice_lines_currency_symbol_value: currency_symbol}}
           / Lines container
           %div{data: {invoice_lines_target: 'container'}}
             = f.fields_for :invoice_lines do |line_form|

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -169,6 +169,22 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_nil action_buttons_wrapper { "" }
   end
 
+  test "currency_symbol maps each currency to its symbol, falling back to the raw code" do
+    { "EUR" => "€", "USD" => "$", "GBP" => "£", "CHF" => "CHF" }.each do |currency, symbol|
+      @current_currency = currency
+      assert_equal symbol, currency_symbol
+    end
+  end
+
+  test "format_currency prefixes the amount with the currency symbol" do
+    @current_currency = "EUR"
+    assert_equal "€60.00", format_currency(60)
+  end
+
+  test "format_currency returns blank for nil" do
+    assert_equal "", format_currency(nil)
+  end
+
   test "breadcrumbs renders plain-label middle crumbs without a link" do
     html = Nokogiri::HTML.fragment(breadcrumbs("Configuration", [ "Sales Tax", "/sales_tax_rates" ], "Edit"))
     items = html.css("li.breadcrumb-item")


### PR DESCRIPTION
Follow-up to the invoice line-total currency fix.

## Problem

The currency symbol mapping (`EUR→€`, `USD→$`, `GBP→£`) was duplicated: once in `ApplicationHelper#format_currency`, once in `invoice_lines_controller.js#formatCurrency`. Two places to keep in sync for every currency change.

## Why the frontend formats at all

The `invoice-lines` controller computes line totals **live** as the user types quantity/rate in a draft — no server round-trip — so those numbers don't exist server-side until submit. Some client-side formatting is unavoidable; the backend can't pre-format them. But the frontend shouldn't *also own the symbol table*.

## Fix

Extract `currency_symbol` in the helper as the single source of truth and pass it to the Stimulus controller as a value (`invoice_lines_currency_symbol_value`). Both `format_currency` and the JS collapse to "symbol + amount"; `formatCurrency` loses its `switch` entirely:

```js
formatCurrency(amount) {
  return this.currencySymbolValue + parseFloat(amount).toFixed(2)
}
```

`currency_symbol` never carries a trailing space — it returns the bare symbol, or the raw currency code as a fallback — so every caller prepends it identically and there's no "add a space when it's a code" rule duplicated across Ruby and JS. The one behaviour change: a non-symbol currency now renders `CHF60.00` instead of `CHF 60.00`. EUR/USD/GBP are unchanged.

Deliberately **not** using `Intl.NumberFormat` on the frontend: it would drop the symbol table but format by locale (`60,00 €`, thousands separators), diverging from the backend's fixed `€60.00` style — trading duplication for an inconsistency.

## Test

`ApplicationHelper`'s currency formatting had no coverage. Added:
- `currency_symbol` — one data-driven test over the whole mapping table (`EUR`/`USD`/`GBP` and the raw-code fallback).
- `format_currency` — composition (symbol + 2-decimal amount) and the nil case.

Each responsibility is asserted once — `currency_symbol` owns the mapping, `format_currency` owns the composition — so the format tests don't re-test the mapping through the composer. The existing `line_management_test` system test still exercises the live total end-to-end under a USD issuer (`$60.00`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)