### PR TITLE
Import Tyme CSV into the invoice line editor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,9 @@ gem "solid_queue"
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
 
+# CSV parsing for Tyme invoice-line imports (no longer a default gem on Ruby 3.4+)
+gem "csv"
+
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,7 @@ GEM
     countries (8.1.0)
       unaccent (~> 0.3)
     crass (1.0.6)
+    csv (3.3.5)
     cuprite (0.17)
       capybara (~> 3.0)
       ferrum (~> 0.17.0)
@@ -458,6 +459,7 @@ DEPENDENCIES
   capybara
   config
   countries (~> 8.1)
+  csv
   cuprite
   debug
   haml-rails

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -127,9 +127,8 @@ class InvoicesController < ApplicationController
     redirect_to @invoice, notice: "Invoice marked as unpaid."
   end
 
-  # Parses an uploaded Tyme CSV into invoice line attributes and returns them as
-  # JSON. The client (invoice-lines Stimulus controller) injects the lines into
-  # the open editor for review — nothing is persisted here.
+  # Parses an uploaded Tyme CSV into invoice line attributes, returned as JSON for
+  # the editor to inject. Read-only — nothing is persisted here.
   def import_lines
     file = params[:file]
     raise ArgumentError, "No file uploaded" if file.blank?

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -9,10 +9,10 @@ class InvoicesController < ApplicationController
   before_action -> { require_permission!("invoices.view") }, only: %i[index show preview preview_email preview_email_html]
   before_action -> { require_permission!("invoices.edit") }, only: %i[
     new create edit update destroy
-    publish send_email mark_paid mark_unpaid bulk_send_emails
+    publish send_email mark_paid mark_unpaid bulk_send_emails import_lines
   ]
 
-  before_action :set_invoice, only: %i[show edit update destroy publish preview preview_email preview_email_html send_email mark_paid mark_unpaid]
+  before_action :set_invoice, only: %i[show edit update destroy publish preview preview_email preview_email_html send_email mark_paid mark_unpaid import_lines]
 
   before_action :require_unpublished, only: %i[edit update destroy preview publish]
   before_action :require_published, only: %i[send_email mark_paid mark_unpaid]
@@ -125,6 +125,19 @@ class InvoicesController < ApplicationController
   def mark_unpaid
     @invoice.update!(paid_at: nil)
     redirect_to @invoice, notice: "Invoice marked as unpaid."
+  end
+
+  # Parses an uploaded Tyme CSV into invoice line attributes and returns them as
+  # JSON. The client (invoice-lines Stimulus controller) injects the lines into
+  # the open editor for review — nothing is persisted here.
+  def import_lines
+    file = params[:file]
+    raise ArgumentError, "No file uploaded" if file.blank?
+
+    lines = TymeCsvImporter.new(file, customer: @invoice.customer).lines
+    render json: { lines: lines }
+  rescue ArgumentError => e
+    render json: { error: e.message }, status: :unprocessable_content
   end
 
   def bulk_send_emails

--- a/app/javascript/controllers/base_lines_controller.js
+++ b/app/javascript/controllers/base_lines_controller.js
@@ -30,7 +30,9 @@ export default class extends Controller {
 
   // Clones the line template, appends a fresh row, and returns it so callers
   // (addLine, CSV import) can populate its fields. Returns null if no template.
-  appendLineFromTemplate() {
+  // openProductDropdown opens the product picker on the new row — wanted for a
+  // blank manual add, but not for CSV import where the line is already filled.
+  appendLineFromTemplate({ openProductDropdown = true } = {}) {
     const template = document.querySelector(`[data-${this.getLineType().replace(/_/g, '-')}-target="template"]`)
     if (!template) return null
 
@@ -61,7 +63,9 @@ export default class extends Controller {
       this.updateFieldVisibility(newLine, typeField.value)
     }
 
-    this.toggleProductDropdownForLine(newLine)
+    if (openProductDropdown) {
+      this.toggleProductDropdownForLine(newLine)
+    }
     this.initializeAutoResizeTextareas(newLine)
 
     return newLine

--- a/app/javascript/controllers/base_lines_controller.js
+++ b/app/javascript/controllers/base_lines_controller.js
@@ -28,10 +28,8 @@ export default class extends Controller {
     this.appendLineFromTemplate()
   }
 
-  // Clones the line template, appends a fresh row, and returns it so callers
-  // (addLine, CSV import) can populate its fields. Returns null if no template.
-  // openProductDropdown opens the product picker on the new row — wanted for a
-  // blank manual add, but not for CSV import where the line is already filled.
+  // Clones the template, appends the row, and returns it for callers to fill.
+  // openProductDropdown: open the product picker (wanted for manual add, not import).
   appendLineFromTemplate({ openProductDropdown = true } = {}) {
     const template = document.querySelector(`[data-${this.getLineType().replace(/_/g, '-')}-target="template"]`)
     if (!template) return null

--- a/app/javascript/controllers/base_lines_controller.js
+++ b/app/javascript/controllers/base_lines_controller.js
@@ -25,8 +25,14 @@ export default class extends Controller {
   }
 
   addLine() {
+    this.appendLineFromTemplate()
+  }
+
+  // Clones the line template, appends a fresh row, and returns it so callers
+  // (addLine, CSV import) can populate its fields. Returns null if no template.
+  appendLineFromTemplate() {
     const template = document.querySelector(`[data-${this.getLineType().replace(/_/g, '-')}-target="template"]`)
-    if (!template) return
+    if (!template) return null
 
     const newContent = template.content.cloneNode(true)
 
@@ -57,6 +63,8 @@ export default class extends Controller {
 
     this.toggleProductDropdownForLine(newLine)
     this.initializeAutoResizeTextareas(newLine)
+
+    return newLine
   }
 
   removeLine(event) {

--- a/app/javascript/controllers/invoice_lines_controller.js
+++ b/app/javascript/controllers/invoice_lines_controller.js
@@ -31,8 +31,7 @@ export default class extends BaseLinesController {
     this.updateTotal()
   }
 
-  // Uploads the chosen Tyme CSV, then injects the parsed lines into the open
-  // editor as new rows the user reviews before saving.
+  // Uploads the CSV and injects the parsed lines into the open editor for review.
   async importCsv(event) {
     const input = event.target
     const file = input.files[0]
@@ -60,6 +59,7 @@ export default class extends BaseLinesController {
         return
       }
 
+      // Append, don't replace: imports add to whatever is already in the editor.
       data.lines.forEach(line => this.fillLine(this.appendLineFromTemplate({ openProductDropdown: false }), line))
       this.updateTotal()
     } catch (e) {
@@ -85,8 +85,7 @@ export default class extends BaseLinesController {
     this.autoSelectSoleTaxClass(line)
   }
 
-  // Imported lines have no tax class. When the catalogue offers exactly one,
-  // pre-select it so the line is publish-ready without manual input.
+  // Imported lines have no tax class; when the catalogue has exactly one, pick it.
   autoSelectSoleTaxClass(line) {
     const taxClass = line.querySelector('select[name*="[sales_tax_product_class_id]"]')
     if (!taxClass) return

--- a/app/javascript/controllers/invoice_lines_controller.js
+++ b/app/javascript/controllers/invoice_lines_controller.js
@@ -1,8 +1,8 @@
 import BaseLinesController from "controllers/base_lines_controller"
 
 export default class extends BaseLinesController {
-  static targets = ["container", "total"]
-  static values = { currencySymbol: String, moneyDecimalPlaces: Number }
+  static targets = ["container", "total", "importError"]
+  static values = { currencySymbol: String, moneyDecimalPlaces: Number, importUrl: String }
 
   connect() {
     super.connect()
@@ -29,6 +29,71 @@ export default class extends BaseLinesController {
   typeChanged(event) {
     super.typeChanged(event)
     this.updateTotal()
+  }
+
+  // Uploads the chosen Tyme CSV, then injects the parsed lines into the open
+  // editor as new rows the user reviews before saving.
+  async importCsv(event) {
+    const input = event.target
+    const file = input.files[0]
+    if (!file) return
+
+    this.clearImportError()
+
+    try {
+      const formData = new FormData()
+      formData.append("file", file)
+
+      const response = await fetch(this.importUrlValue, {
+        method: "POST",
+        credentials: "same-origin",
+        headers: {
+          "Accept": "application/json",
+          "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]')?.content
+        },
+        body: formData
+      })
+
+      const data = await response.json().catch(() => ({}))
+      if (!response.ok) {
+        this.showError(data.error || `Import failed (${response.status})`)
+        return
+      }
+
+      data.lines.forEach(line => this.fillLine(this.appendLineFromTemplate(), line))
+      this.updateTotal()
+    } catch (e) {
+      this.showError(e.message)
+    } finally {
+      input.value = "" // allow re-selecting the same file
+    }
+  }
+
+  fillLine(line, data) {
+    if (!line) return
+
+    line.querySelector('select[name*="[type]"]').value = "item"
+    line.querySelector('input[name*="[title]"]').value = data.title
+    line.querySelector('input[name*="[rate]"]').value = data.rate
+    line.querySelector('input[name*="[quantity]"]').value = data.quantity
+
+    const description = line.querySelector('textarea[name*="[description]"]')
+    description.value = data.description
+
+    this.updateFieldVisibility(line, "item")
+    this.autoResizeTextarea(description)
+  }
+
+  showError(message) {
+    if (!this.hasImportErrorTarget) return
+    this.importErrorTarget.textContent = message
+    this.importErrorTarget.classList.remove("d-none")
+  }
+
+  clearImportError() {
+    if (!this.hasImportErrorTarget) return
+    this.importErrorTarget.textContent = ""
+    this.importErrorTarget.classList.add("d-none")
   }
 
   updateFieldVisibility(line, type) {

--- a/app/javascript/controllers/invoice_lines_controller.js
+++ b/app/javascript/controllers/invoice_lines_controller.js
@@ -60,7 +60,7 @@ export default class extends BaseLinesController {
         return
       }
 
-      data.lines.forEach(line => this.fillLine(this.appendLineFromTemplate(), line))
+      data.lines.forEach(line => this.fillLine(this.appendLineFromTemplate({ openProductDropdown: false }), line))
       this.updateTotal()
     } catch (e) {
       this.showError(e.message)

--- a/app/javascript/controllers/invoice_lines_controller.js
+++ b/app/javascript/controllers/invoice_lines_controller.js
@@ -82,6 +82,19 @@ export default class extends BaseLinesController {
 
     this.updateFieldVisibility(line, "item")
     this.autoResizeTextarea(description)
+    this.autoSelectSoleTaxClass(line)
+  }
+
+  // Imported lines have no tax class. When the catalogue offers exactly one,
+  // pre-select it so the line is publish-ready without manual input.
+  autoSelectSoleTaxClass(line) {
+    const taxClass = line.querySelector('select[name*="[sales_tax_product_class_id]"]')
+    if (!taxClass) return
+
+    const options = Array.from(taxClass.options).filter(option => option.value)
+    if (options.length === 1) {
+      taxClass.value = options[0].value
+    }
   }
 
   showError(message) {

--- a/app/services/tyme_csv_importer.rb
+++ b/app/services/tyme_csv_importer.rb
@@ -1,0 +1,118 @@
+require "csv"
+require "time"
+
+# Parses a Tyme time-tracking CSV export into invoice line attributes.
+#
+# One line is produced per (task, calendar month). The rate comes from the CSV;
+# the quantity is the group's summed duration in decimal hours. The description
+# itemizes each entry as "<date> <duration> <note>" (no clock times), prefixed by
+# a localized month header and an optional "end customer" line when the tracked
+# client differs from the invoice's customer. All text is rendered in the
+# customer's locale.
+class TymeCsvImporter
+  REQUIRED_COLUMNS = %w[project task start duration rate note].freeze
+  LEGAL_SUFFIXES = /\b(gmbh|ag|ltd|inc|llc|kg|co|corp|b\.?v|e\.?u)\.?\b/
+
+  def initialize(source, customer: nil)
+    @source = source.respond_to?(:read) ? source.read : source.to_s
+    @customer = customer
+  end
+
+  def lines
+    locale = @customer&.language&.iso_code.presence || I18n.default_locale
+    I18n.with_locale(locale) { build_lines }
+  end
+
+  private
+
+  def build_lines
+    rows = parse_rows
+    grouped = rows.group_by { |r| [ r[:task], r[:date].year, r[:date].month ] }
+
+    grouped
+      .sort_by { |(task, year, month), _| [ year, month, task ] }
+      .map { |(task, _year, _month), entries| build_line(task, entries) }
+  end
+
+  def parse_rows
+    table = CSV.parse(@source, col_sep: ";", headers: true, quote_char: '"')
+    raise ArgumentError, "CSV has no data rows" if table.headers.compact.empty? || table.empty?
+
+    missing = REQUIRED_COLUMNS - table.headers
+    raise ArgumentError, "CSV is missing columns: #{missing.join(', ')}" if missing.any?
+
+    table.map do |row|
+      {
+        client: row["project"],
+        task: row["task"],
+        date: Time.parse(row["start"]).to_date,
+        minutes: row["duration"].to_i,
+        rate: row["rate"],
+        note: row["note"]
+      }
+    end
+  rescue CSV::MalformedCSVError => e
+    raise ArgumentError, "CSV could not be parsed: #{e.message}"
+  end
+
+  def build_line(task, entries)
+    client = entries.first[:client]
+    date = entries.first[:date]
+    total_minutes = entries.sum { |e| e[:minutes] }
+
+    {
+      title: I18n.t("invoices.import.line_title", project: task),
+      description: description(client, date, entries),
+      rate: entries.first[:rate],
+      quantity: format_quantity(total_minutes)
+    }
+  end
+
+  def description(client, date, entries)
+    rows = []
+    rows << I18n.t("invoices.import.end_customer", client: client) unless matches_customer?(client)
+    rows << month_header(date)
+    entries.each do |e|
+      rows << "#{I18n.l(e[:date])} #{format_duration(e[:minutes])} #{flatten_note(e[:note])}".strip
+    end
+    rows.join("\n")
+  end
+
+  def month_header(date)
+    I18n.t("invoices.import.month_year", month: I18n.t("date.month_names")[date.month], year: date.year)
+  end
+
+  def format_quantity(minutes)
+    format("%.4f", minutes / 60.0).sub(/\.?0+\z/, "")
+  end
+
+  def format_duration(minutes)
+    hours, mins = minutes.divmod(60)
+    parts = []
+    parts << "#{hours}h" if hours.positive?
+    parts << "#{mins}m" if mins.positive?
+    parts.empty? ? "0m" : parts.join
+  end
+
+  def flatten_note(raw)
+    raw.to_s.split(/\r?\n/).map { |line| line.strip.sub(/;+\s*\z/, "") }.reject(&:blank?).join("; ")
+  end
+
+  def matches_customer?(client)
+    return false if @customer.nil?
+
+    [ @customer.name, @customer.matchcode ].any? { |candidate| roughly_equal?(client, candidate) }
+  end
+
+  def roughly_equal?(a, b)
+    na = normalize(a)
+    nb = normalize(b)
+    return false if na.blank? || nb.blank?
+
+    na.include?(nb) || nb.include?(na)
+  end
+
+  def normalize(value)
+    value.to_s.downcase.gsub(LEGAL_SUFFIXES, "").gsub(/[[:space:]]+/, " ").strip
+  end
+end

--- a/app/services/tyme_csv_importer.rb
+++ b/app/services/tyme_csv_importer.rb
@@ -1,14 +1,9 @@
 require "csv"
 require "time"
 
-# Parses a Tyme time-tracking CSV export into invoice line attributes.
-#
-# One line is produced per (task, calendar month). The rate comes from the CSV;
-# the quantity is the group's summed duration in decimal hours. The description
-# itemizes each entry as "<date> <duration> <note>" (no clock times), prefixed by
-# a localized month header and an optional "end customer" line when the tracked
-# client differs from the invoice's customer. All text is rendered in the
-# customer's locale.
+# Parses a Tyme time-tracking CSV export into invoice line attributes, one line
+# per (task, calendar month). Rate comes from the CSV, quantity is the summed
+# duration in decimal hours, and all text is rendered in the customer's locale.
 class TymeCsvImporter
   REQUIRED_COLUMNS = %w[project task start duration rate note].freeze
   LEGAL_SUFFIXES = /\b(gmbh|ag|ltd|inc|llc|kg|co|corp|b\.?v|e\.?u)\.?\b/

--- a/app/views/invoices/_form.html.haml
+++ b/app/views/invoices/_form.html.haml
@@ -89,7 +89,8 @@
             = f.text_area :prelude, class: 'form-control', rows: 2, placeholder: 'Thank you for your business...', data: { action: 'input->auto-resize-form#fieldChanged' }
 
       - unless @invoice.id.nil?
-        %div{data: {controller: 'invoice-lines', invoice_lines_currency_symbol_value: currency_symbol, invoice_lines_money_decimal_places_value: current_money_decimal_places}}
+        %div{data: {controller: 'invoice-lines', invoice_lines_currency_symbol_value: currency_symbol, invoice_lines_money_decimal_places_value: current_money_decimal_places, invoice_lines_import_url_value: import_lines_invoice_path(@invoice)}}
+          .alert.alert-danger.d-none{data: {invoice_lines_target: 'importError'}}
           / Lines container
           %div{data: {invoice_lines_target: 'container'}}
             = f.fields_for :invoice_lines do |line_form|
@@ -104,6 +105,9 @@
           = action_buttons_wrapper do
             %button.btn.btn-info{type: 'button', data: {action: 'click->invoice-lines#addLine'}}
               + Add Line
+            %label.btn.btn-outline-secondary.mb-0
+              Import CSV
+              = file_field_tag :file, accept: 'text/csv,.csv', class: 'd-none', data: {action: 'change->invoice-lines#importCsv'}
 
           .card.mb-3
             .card-body

--- a/app/views/invoices/_form.html.haml
+++ b/app/views/invoices/_form.html.haml
@@ -90,7 +90,7 @@
 
       - unless @invoice.id.nil?
         %div{data: {controller: 'invoice-lines', invoice_lines_currency_symbol_value: currency_symbol, invoice_lines_money_decimal_places_value: current_money_decimal_places, invoice_lines_import_url_value: import_lines_invoice_path(@invoice)}}
-          .alert.alert-danger.d-none{data: {invoice_lines_target: 'importError'}}
+          .alert.alert-danger.d-none{role: 'alert', data: {invoice_lines_target: 'importError'}}
           / Lines container
           %div{data: {invoice_lines_target: 'container'}}
             = f.fields_for :invoice_lines do |line_form|

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -2,6 +2,8 @@ de:
   date:
     formats:
       default: "%d.%m.%Y"
+    month_names:
+      [~, Jänner, Februar, März, April, Mai, Juni, Juli, August, September, Oktober, November, Dezember]
 
   mailers:
     overdue_invoices:
@@ -64,6 +66,12 @@ de:
 
   invoice_conversion:
     reference_line: "Lieferschein %{number} vom %{date}"
+
+  invoices:
+    import:
+      line_title: "IT-Beratung pro Stunde: %{project}"
+      end_customer: "Endkunde: %{client}"
+      month_year: "%{month} %{year}"
 
   customer_portal:
     pages:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -146,7 +146,7 @@ en:
   invoices:
     import:
       line_title: "IT Consulting per hour: %{project}"
-      end_customer: "End customer: %{client}"
+      end_customer: "End client: %{client}"
       month_year: "%{month} %{year}"
 
   customer_portal:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,8 @@ en:
   date:
     formats:
       default: "%d.%m.%Y"
+    month_names:
+      [~, January, February, March, April, May, June, July, August, September, October, November, December]
   time:
     formats:
       default: "%d.%m.%Y %H:%M"
@@ -140,6 +142,12 @@ en:
 
   invoice_conversion:
     reference_line: "Delivery Note %{number}, Date: %{date}"
+
+  invoices:
+    import:
+      line_title: "IT Consulting per hour: %{project}"
+      end_customer: "End customer: %{client}"
+      month_year: "%{month} %{year}"
 
   customer_portal:
     pages:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,6 +77,7 @@ Rails.application.routes.draw do
       post "send_email"
       post "mark_paid"
       post "mark_unpaid"
+      post "import_lines"
     end
     collection do
       post "bulk_send_emails"

--- a/test/controllers/invoices_controller_test.rb
+++ b/test/controllers/invoices_controller_test.rb
@@ -422,4 +422,26 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
 
   # Published-invoice guards (edit/update/destroy/preview/publish) live in
   # test/controllers/concerns/publishable_document_test.rb.
+
+  test "import_lines returns invoice lines parsed from the uploaded CSV" do
+    invoice = create_draft_invoice(cust_reference: "IMPORT")
+
+    post import_lines_invoice_url(invoice),
+      params: { file: fixture_file_upload("tyme_sample.csv", "text/csv") }
+
+    assert_response :success
+    lines = JSON.parse(response.body)["lines"]
+    assert_equal 3, lines.length
+    assert_equal "IT Consulting per hour: Project Alpha", lines.first["title"]
+    assert_equal "1.25", lines.first["quantity"]
+  end
+
+  test "import_lines returns a 422 error when no file is uploaded" do
+    invoice = create_draft_invoice(cust_reference: "IMPORT")
+
+    post import_lines_invoice_url(invoice)
+
+    assert_response :unprocessable_content
+    assert JSON.parse(response.body)["error"].present?
+  end
 end

--- a/test/fixtures/files/tyme_sample.csv
+++ b/test/fixtures/files/tyme_sample.csv
@@ -1,0 +1,13 @@
+type;category;project;task;subtask;unix_start;unix_end;start;end;date;start_time;end_time;duration;distance;quantity;rate;sum;rounding_minutes;rounding_method;billing;"note";user
+timed;;Northwind Ltd;Project Alpha;;1742929500;1742933820;2025-03-25T20:05:00+01:00;2025-03-25T21:17:00+01:00;25.03.2025;20:05;21:17;75;0;0;120;150;15;UP;UNBILLED;"API + collector maintenance;
+API fix CI pipeline after linter update
+collector fix bugs identified by review";
+timed;;Northwind Ltd;Public Website;;1743006120;1743007620;2025-03-26T17:22:00+01:00;2025-03-26T17:47:00+01:00;26.03.2025;17:22;17:47;30;0;0;120;60;15;UP;UNBILLED;"Fix example.com landing page + reproduce issues reported by partner";
+timed;;Northwind Ltd;Project Alpha;;1743502500;1743507900;2025-04-01T12:15:00+02:00;2025-04-01T13:45:00+02:00;01.04.2025;12:15;13:45;90;0;0;120;180;15;UP;UNBILLED;"software maintenance (version updates);
+Install on host-01;
+API backend URL fix";
+timed;;Northwind Ltd;Project Alpha;;1743528900;1743534180;2025-04-01T19:35:00+02:00;2025-04-01T21:03:00+02:00;01.04.2025;19:35;21:03;90;0;0;120;180;15;UP;UNBILLED;"API maintenance and cleanup; OS upgrade fix";
+timed;;Northwind Ltd;Project Alpha;;1743580320;1743582900;2025-04-02T09:52:00+02:00;2025-04-02T10:35:00+02:00;02.04.2025;09:52;10:35;45;0;0;120;90;15;UP;UNBILLED;"Finish installation on host-01";
+timed;;Northwind Ltd;Project Alpha;;1744008900;1744013700;2025-04-07T08:55:00+02:00;2025-04-07T10:15:00+02:00;07.04.2025;08:55;10:15;90;0;0;120;180;15;UP;UNBILLED;"Planning meeting; Setup fail2ban";
+timed;;Northwind Ltd;Project Alpha;;1744015800;1744018800;2025-04-07T10:50:00+02:00;2025-04-07T11:40:00+02:00;07.04.2025;10:50;11:40;60;0;0;120;120;15;UP;UNBILLED;"Setup fail2ban; fix existing rules";
+timed;;Northwind Ltd;Project Alpha;;1744023780;1744025580;2025-04-07T13:03:00+02:00;2025-04-07T13:33:00+02:00;07.04.2025;13:03;13:33;30;0;0;120;60;15;UP;UNBILLED;"Investigate fail2ban failures";

--- a/test/services/tyme_csv_importer_test.rb
+++ b/test/services/tyme_csv_importer_test.rb
@@ -53,7 +53,7 @@ class TymeCsvImporterTest < ActiveSupport::TestCase
 
   test "includes the end-customer line when the project differs from the customer" do
     assert_includes import(customer: customers(:good_eu)).first[:description],
-      "End customer: Northwind Ltd"
+      "End client: Northwind Ltd"
   end
 
   test "omits the end-customer line when the project matches the customer name" do
@@ -67,7 +67,7 @@ class TymeCsvImporterTest < ActiveSupport::TestCase
     customer = customers(:good_eu)
     customer.matchcode = "Northwind Ltd GmbH"
     refute_includes TymeCsvImporter.new(csv, customer: customer).lines.first[:description],
-      "End customer:"
+      "End client:"
   end
 
   test "groups by the tracked local date regardless of the application time zone" do

--- a/test/services/tyme_csv_importer_test.rb
+++ b/test/services/tyme_csv_importer_test.rb
@@ -1,0 +1,96 @@
+require "test_helper"
+
+class TymeCsvImporterTest < ActiveSupport::TestCase
+  def csv
+    file_fixture("tyme_sample.csv").read
+  end
+
+  def import(customer: customers(:good_eu))
+    TymeCsvImporter.new(csv, customer: customer).lines
+  end
+
+  test "produces one line per task and month" do
+    titles = import.map { |l| l[:title] }
+    assert_equal [
+      "IT Consulting per hour: Project Alpha",
+      "IT Consulting per hour: Public Website",
+      "IT Consulting per hour: Project Alpha"
+    ], titles
+  end
+
+  test "sums durations into decimal hours as quantity" do
+    assert_equal [ "1.25", "0.5", "6.75" ], import.map { |l| l[:quantity] }
+  end
+
+  test "carries the rate from the CSV" do
+    assert_equal [ "120", "120", "120" ], import.map { |l| l[:rate] }
+  end
+
+  test "itemizes each entry as date and duration without clock times" do
+    description = import.last[:description]
+    assert_includes description, "02.04.2025 45m Finish installation on host-01"
+    assert_includes description, "07.04.2025 1h Setup fail2ban; fix existing rules"
+    refute_includes description, "09:52"
+    refute_includes description, "13:03"
+  end
+
+  test "flattens multi-line notes into a single semicolon-separated row" do
+    assert_includes import.first[:description],
+      "25.03.2025 1h15m API + collector maintenance; API fix CI pipeline after linter update; collector fix bugs identified by review"
+  end
+
+  test "renders title and month header in an English customer's locale" do
+    line = import(customer: customers(:good_eu)).first
+    assert_equal "IT Consulting per hour: Project Alpha", line[:title]
+    assert_includes line[:description], "March 2025"
+  end
+
+  test "renders title and month header in a German customer's locale" do
+    line = import(customer: customers(:good_national)).first
+    assert_equal "IT-Beratung pro Stunde: Project Alpha", line[:title]
+    assert_includes line[:description], "März 2025"
+  end
+
+  test "includes the end-customer line when the project differs from the customer" do
+    assert_includes import(customer: customers(:good_eu)).first[:description],
+      "End customer: Northwind Ltd"
+  end
+
+  test "omits the end-customer line when the project matches the customer name" do
+    customer = customers(:good_eu)
+    customer.name = "Northwind Ltd"
+    refute_includes TymeCsvImporter.new(csv, customer: customer).lines.first[:description],
+      "Northwind Ltd"
+  end
+
+  test "omits the end-customer line when the project matches the customer matchcode" do
+    customer = customers(:good_eu)
+    customer.matchcode = "Northwind Ltd GmbH"
+    refute_includes TymeCsvImporter.new(csv, customer: customer).lines.first[:description],
+      "End customer:"
+  end
+
+  test "groups by the tracked local date regardless of the application time zone" do
+    csv = "project;task;start;duration;rate;note\nClient;Boundary;2025-05-01T00:30:00+02:00;60;100;Late night\n"
+    Time.use_zone("Pacific/Honolulu") do
+      description = TymeCsvImporter.new(csv, customer: customers(:good_eu)).lines.first[:description]
+      assert_includes description, "May 2025"
+      assert_includes description, "01.05.2025"
+    end
+  end
+
+  test "uses the Austrian spelling Jänner for January in German" do
+    csv = "project;task;start;duration;rate;note\nClient;Jan;2025-01-15T10:00:00+01:00;60;100;Work\n"
+    description = TymeCsvImporter.new(csv, customer: customers(:good_national)).lines.first[:description]
+    assert_includes description, "Jänner 2025"
+  end
+
+  test "raises on empty input" do
+    assert_raises(ArgumentError) { TymeCsvImporter.new("", customer: customers(:good_eu)).lines }
+  end
+
+  test "raises when a required column is missing" do
+    headerless = "type;project;task\ntimed;X;Y\n"
+    assert_raises(ArgumentError) { TymeCsvImporter.new(headerless, customer: customers(:good_eu)).lines }
+  end
+end

--- a/test/services/tyme_csv_importer_test.rb
+++ b/test/services/tyme_csv_importer_test.rb
@@ -39,13 +39,7 @@ class TymeCsvImporterTest < ActiveSupport::TestCase
       "25.03.2025 1h15m API + collector maintenance; API fix CI pipeline after linter update; collector fix bugs identified by review"
   end
 
-  test "renders title and month header in an English customer's locale" do
-    line = import(customer: customers(:good_eu)).first
-    assert_equal "IT Consulting per hour: Project Alpha", line[:title]
-    assert_includes line[:description], "March 2025"
-  end
-
-  test "renders title and month header in a German customer's locale" do
+  test "renders title and month header in the customer's locale" do
     line = import(customer: customers(:good_national)).first
     assert_equal "IT-Beratung pro Stunde: Project Alpha", line[:title]
     assert_includes line[:description], "März 2025"

--- a/test/system/invoice_csv_import_test.rb
+++ b/test/system/invoice_csv_import_test.rb
@@ -1,0 +1,27 @@
+require "application_system_test_case"
+
+class InvoiceCsvImportTest < ApplicationSystemTestCase
+  setup do
+    @invoice = invoices(:draft_invoice)
+  end
+
+  test "importing a Tyme CSV injects localized lines into the editor" do
+    visit edit_invoice_path(@invoice)
+    initial = all("[data-line-index]").count
+
+    attach_file("file", Rails.root.join("test/fixtures/files/tyme_sample.csv"), make_visible: true)
+
+    assert_selector "[data-line-index]", count: initial + 3
+    new_lines = all("[data-line-index]").last(3)
+
+    titles = new_lines.map { |line| line.find('input[name*="[title]"]').value }
+    assert_includes titles, "IT-Beratung pro Stunde: Project Alpha"
+
+    quantities = new_lines.map { |line| line.find('input[name*="[quantity]"]', visible: false).value }
+    assert_includes quantities, "6.75"
+
+    descriptions = new_lines.map { |line| line.find('textarea[name*="[description]"]').value }
+    assert descriptions.any? { |d| d.include?("März 2025") }, "expected a line with a localized month header"
+    assert descriptions.any? { |d| d.include?("Endkunde: Northwind Ltd") }, "expected the end-customer line"
+  end
+end

--- a/test/system/invoice_csv_import_test.rb
+++ b/test/system/invoice_csv_import_test.rb
@@ -28,5 +28,11 @@ class InvoiceCsvImportTest < ApplicationSystemTestCase
       assert line.has_no_selector?("[data-product-dropdown]", visible: true),
         "imported lines should not open the product picker"
     end
+
+    sole_tax_class = sales_tax_product_classes(:standard).id.to_s
+    new_lines.each do |line|
+      assert_equal sole_tax_class, line.find('select[name*="[sales_tax_product_class_id]"]').value,
+        "the only tax class should be auto-selected"
+    end
   end
 end

--- a/test/system/invoice_csv_import_test.rb
+++ b/test/system/invoice_csv_import_test.rb
@@ -23,5 +23,10 @@ class InvoiceCsvImportTest < ApplicationSystemTestCase
     descriptions = new_lines.map { |line| line.find('textarea[name*="[description]"]').value }
     assert descriptions.any? { |d| d.include?("März 2025") }, "expected a line with a localized month header"
     assert descriptions.any? { |d| d.include?("Endkunde: Northwind Ltd") }, "expected the end-customer line"
+
+    new_lines.each do |line|
+      assert line.has_no_selector?("[data-product-dropdown]", visible: true),
+        "imported lines should not open the product picker"
+    end
   end
 end


### PR DESCRIPTION
## Summary

Adds an **Import CSV** button to the invoice line editor that parses a [Tyme](https://www.tyme-app.com/) time-tracking export and injects `item` lines into the open draft for review. Nothing is persisted until the user saves — the lines arrive as ordinary new rows they can tweak first.

## Behavior

- **One line per (task, calendar month).** The Tyme `task` column drives the title (`IT Consulting per hour: <task>`); rows spanning multiple months split into separate lines.
- **Rate** is taken from the CSV; **quantity** is the group's summed `duration` converted to decimal hours (so `rate × hours` reproduces Tyme's `sum`).
- **Description** itemizes each entry as `<date> <duration> <note>` (e.g. `02.04.2025 45m Finish installation…`) — durations like `1h30m`/`45m`/`1h`, no clock start/end times, multi-line notes flattened. It's prefixed by a localized month header and an optional `End customer: <client>` line, shown only when the tracked client doesn't roughly match the invoice's customer (compared against **name and matchcode**, ignoring case and common legal suffixes).
- **Localized to the customer's locale.** A German customer gets `IT-Beratung pro Stunde:` / `Endkunde:` / `Jänner 2025` (Austrian spelling); English gets the English wording.

## Implementation

- `TymeCsvImporter` service does the parsing/grouping/formatting (robust to the multi-line quoted `note` fields), wrapped in `I18n.with_locale(customer.language.iso_code)`.
- `import_lines` member action returns the parsed lines as JSON; the `invoice-lines` Stimulus controller uploads the file and injects the rows, surfacing the server's `error` on failure.
- New `invoices.import.*` keys and `date.month_names` in `en.yml`/`de.yml`; `csv` added to the Gemfile (no longer a default gem on Ruby 3.4+).

## Test plan

- `TymeCsvImporter` unit tests: grouping, decimal-hour quantities, rate, itemized/flattened descriptions, the end-customer name/matchcode rules, en/de localization, the Austrian Jänner spelling, a timezone-boundary regression, and error cases.
- Controller tests for the JSON success and 422-no-file paths.
- A headless system test driving the real Import button end-to-end (incl. localized output).
- Full suite green (`bundle exec rails test`, `test/system/`), `npm run lint` and `pre-commit run --all-files` clean.

The committed fixture (`test/fixtures/files/tyme_sample.csv`) is anonymized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)