### PR TITLE
Localize the delivery-note Lieferzeitraum value

### DIFF
--- a/app/models/delivery_note.rb
+++ b/app/models/delivery_note.rb
@@ -117,29 +117,28 @@ class DeliveryNote < ApplicationRecord
   def delivery_timeframe
     return nil unless delivery_start_date
 
+    connector = I18n.t("delivery_notes.timeframe.connector")
+    month_year = ->(date) { I18n.l(date, format: "%B %Y") }
+
     if delivery_end_date.nil? || delivery_start_date == delivery_end_date
-      # Single day
       format_date_for_timeframe(delivery_start_date)
     elsif same_month?(delivery_start_date, delivery_end_date)
-      # Same month - show date range or just month if full month
       if full_month?(delivery_start_date, delivery_end_date)
-        delivery_start_date.strftime("%B %Y")
+        month_year.call(delivery_start_date)
       else
-        "#{delivery_start_date.day}. to #{delivery_end_date.day}. #{delivery_start_date.strftime("%B %Y")}"
+        "#{delivery_start_date.day}. #{connector} #{delivery_end_date.day}. #{month_year.call(delivery_start_date)}"
       end
     elsif same_year?(delivery_start_date, delivery_end_date)
-      # Same year - show month range
       if day_is_first_of_month?(delivery_start_date) && day_is_last_of_month?(delivery_end_date)
-        "#{delivery_start_date.strftime("%B")} to #{delivery_end_date.strftime("%B %Y")}"
+        "#{I18n.l(delivery_start_date, format: "%B")} #{connector} #{month_year.call(delivery_end_date)}"
       else
-        "#{format_date_for_timeframe(delivery_start_date)} to #{format_date_for_timeframe(delivery_end_date)}"
+        "#{format_date_for_timeframe(delivery_start_date)} #{connector} #{format_date_for_timeframe(delivery_end_date)}"
       end
     else
-      # Different years
       if day_is_first_of_month?(delivery_start_date) && day_is_last_of_month?(delivery_end_date)
-        "#{delivery_start_date.strftime("%B %Y")} to #{delivery_end_date.strftime("%B %Y")}"
+        "#{month_year.call(delivery_start_date)} #{connector} #{month_year.call(delivery_end_date)}"
       else
-        "#{format_date_for_timeframe(delivery_start_date)} to #{format_date_for_timeframe(delivery_end_date)}"
+        "#{format_date_for_timeframe(delivery_start_date)} #{connector} #{format_date_for_timeframe(delivery_end_date)}"
       end
     end
   end
@@ -147,7 +146,7 @@ class DeliveryNote < ApplicationRecord
   private
 
   def format_date_for_timeframe(date)
-    date.strftime("%B %-d, %Y")
+    I18n.l(date, format: :timeframe_day)
   end
 
   def same_month?(date1, date2)

--- a/app/services/delivery_note_renderer.rb
+++ b/app/services/delivery_note_renderer.rb
@@ -58,7 +58,8 @@ class DeliveryNoteRenderer
       xml_root.prelude @delivery_note.prelude
       xml_root.number draft_aware_number
       xml_root.tag! "issue-date", @delivery_note.date || "2999-01-01"
-      xml_root.tag! "delivery-timeframe", @delivery_note.delivery_timeframe if @delivery_note.delivery_timeframe.present?
+      timeframe = I18n.with_locale(locale) { @delivery_note.delivery_timeframe }
+      xml_root.tag! "delivery-timeframe", timeframe if timeframe.present?
 
       xml_root.items do |xml_items|
         @delivery_note.delivery_note_lines.each do |line|

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -2,6 +2,7 @@ de:
   date:
     formats:
       default: "%d.%m.%Y"
+      timeframe_day: "%-d. %B %Y"
     month_names:
       [~, Jänner, Februar, März, April, Mai, Juni, Juli, August, September, Oktober, November, Dezember]
 
@@ -66,6 +67,10 @@ de:
 
   invoice_conversion:
     reference_line: "Lieferschein %{number} vom %{date}"
+
+  delivery_notes:
+    timeframe:
+      connector: "bis"
 
   invoices:
     import:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,7 @@ en:
   date:
     formats:
       default: "%d.%m.%Y"
+      timeframe_day: "%B %-d, %Y"
     month_names:
       [~, January, February, March, April, May, June, July, August, September, October, November, December]
   time:
@@ -142,6 +143,10 @@ en:
 
   invoice_conversion:
     reference_line: "Delivery Note %{number}, Date: %{date}"
+
+  delivery_notes:
+    timeframe:
+      connector: "to"
 
   invoices:
     import:

--- a/test/integration/delivery_note_pdf_test.rb
+++ b/test/integration/delivery_note_pdf_test.rb
@@ -107,9 +107,12 @@ class DeliveryNotePdfTest < ActionDispatch::IntegrationTest
     xml_en = renderer_en.emit_xml(nil)
     assert_includes xml_en, "<language>en</language>", "English delivery note should include language en"
 
+    assert_includes xml_en, "<delivery-timeframe>August 1, 2025</delivery-timeframe>"
+
     renderer_de = DeliveryNoteRenderer.new(delivery_note_de, @issuer)
     xml_de = renderer_de.emit_xml(nil)
     assert_includes xml_de, "<language>de</language>", "German delivery note should include language de"
+    assert_includes xml_de, "<delivery-timeframe>1. August 2025</delivery-timeframe>"
   end
 
   test "publishing an empty delivery note is blocked" do

--- a/test/models/delivery_note_test.rb
+++ b/test/models/delivery_note_test.rb
@@ -135,6 +135,36 @@ class DeliveryNoteTest < ActiveSupport::TestCase
     assert_nil delivery_note.delivery_timeframe
   end
 
+  test "delivery_timeframe localizes single day in German" do
+    delivery_note = DeliveryNote.new(
+      delivery_start_date: Date.new(2025, 5, 1),
+      delivery_end_date: Date.new(2025, 5, 1)
+    )
+    I18n.with_locale(:de) do
+      assert_equal "1. Mai 2025", delivery_note.delivery_timeframe
+    end
+  end
+
+  test "delivery_timeframe localizes date range in same month in German" do
+    delivery_note = DeliveryNote.new(
+      delivery_start_date: Date.new(2025, 5, 1),
+      delivery_end_date: Date.new(2025, 5, 10)
+    )
+    I18n.with_locale(:de) do
+      assert_equal "1. bis 10. Mai 2025", delivery_note.delivery_timeframe
+    end
+  end
+
+  test "delivery_timeframe localizes month range in German" do
+    delivery_note = DeliveryNote.new(
+      delivery_start_date: Date.new(2025, 4, 1),
+      delivery_end_date: Date.new(2025, 8, 31)
+    )
+    I18n.with_locale(:de) do
+      assert_equal "April bis August 2025", delivery_note.delivery_timeframe
+    end
+  end
+
   test "should validate delivery end date is not before start date" do
     delivery_note = DeliveryNote.new(
       customer: customers(:good_eu),


### PR DESCRIPTION
## Problem

The delivery-note PDF translated the **label** ("Delivery Period" → "Lieferzeitraum") but `DeliveryNote#delivery_timeframe` built the **value** with hard-coded English: `strftime("%B")` always emits English month names, plus a literal `"to"` connector and a US date format (`%B %-d, %Y`). A German note showed "Lieferzeitraum" over "August 1, 2025".

## Fix

- `delivery_timeframe` now formats via `I18n.l`/`I18n.t`: localized month names, a per-locale `date.formats.timeframe_day` picture, and a `to`/`bis` connector.
- The method reads ambient `I18n.locale` — the idiom the mailers already establish via `with_customer_locale` — so the mailer path is fixed for free. The renderer (the one caller outside a locale context) wraps its call in `I18n.with_locale(locale)`.
- The English UI `show` view is unchanged (default `:en`), and English PDF output is byte-identical to before.

German output now: `1. August 2025`, `1. bis 10. Mai 2025`, `April bis August 2025`, `Mai 2025`.

## Tests

Three German model cases plus en/de timeframe assertions in the PDF integration test. Model, integration, and mailer suites pass; `pre-commit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)