### PR TITLE
Auto-create a focused starter line on document creation

### DIFF
--- a/app/controllers/delivery_notes_controller.rb
+++ b/app/controllers/delivery_notes_controller.rb
@@ -59,6 +59,11 @@ class DeliveryNotesController < ApplicationController
   # GET /delivery_notes/1/edit
   def edit
     set_form_options
+    # A freshly created delivery note arrives with one empty line, title focused, ready to fill in.
+    if flash[:build_starter_line]
+      @delivery_note.delivery_note_lines.build(type: "item", quantity: 1)
+      @autofocus_first_line = true
+    end
   end
 
   # POST /delivery_notes
@@ -66,7 +71,8 @@ class DeliveryNotesController < ApplicationController
     @delivery_note = DeliveryNote.new(delivery_note_params)
 
     if @delivery_note.save
-      redirect_to @delivery_note, notice: "Delivery Note was successfully created."
+      redirect_to edit_delivery_note_path(@delivery_note),
+        flash: { notice: "Delivery Note was successfully created.", build_starter_line: true }
     else
       render :new, status: :unprocessable_content
     end

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -58,6 +58,11 @@ class InvoicesController < ApplicationController
   # GET /invoices/1/edit
   def edit
     set_form_options
+    # A freshly created invoice arrives with one empty line, title focused, ready to fill in.
+    if flash[:build_starter_line]
+      @invoice.invoice_lines.build(type: "item", amount: 0, rate: 0, quantity: 1)
+      @autofocus_first_line = true
+    end
   end
 
   # POST /invoices
@@ -65,7 +70,8 @@ class InvoicesController < ApplicationController
     @invoice = Invoice.new(invoice_params)
 
     if @invoice.save
-      redirect_to @invoice, notice: "Invoice was successfully created."
+      redirect_to edit_invoice_path(@invoice),
+        flash: { notice: "Invoice was successfully created.", build_starter_line: true }
     else
       render :new, status: :unprocessable_content
     end

--- a/app/views/delivery_notes/_delivery_note_line_fields.html.haml
+++ b/app/views/delivery_notes/_delivery_note_line_fields.html.haml
@@ -11,7 +11,7 @@
       .col-6
         .mb-3
           %label.form-label Title
-          = f.text_field :title, class: 'form-control', data: { action: 'input->delivery-note-lines#fieldChanged' }, required: true
+          = f.text_field :title, class: 'form-control', data: { action: 'input->delivery-note-lines#fieldChanged' }, required: true, autofocus: local_assigns[:autofocus]
       .col-2
         %div{data: {line_type_target: 'itemOnly'}}
           .mb-3

--- a/app/views/delivery_notes/_form.html.haml
+++ b/app/views/delivery_notes/_form.html.haml
@@ -109,7 +109,7 @@
         / Lines container
         %div{data: {delivery_note_lines_target: 'container'}}
           = f.fields_for :delivery_note_lines do |line_form|
-            = render 'delivery_note_line_fields', f: line_form, line: line_form.object
+            = render 'delivery_note_line_fields', f: line_form, line: line_form.object, autofocus: @autofocus_first_line && line_form.index.zero?
 
         / Template for new lines
         %template{data: {delivery_note_lines_target: 'template'}}

--- a/app/views/invoices/_form.html.haml
+++ b/app/views/invoices/_form.html.haml
@@ -94,7 +94,7 @@
           / Lines container
           %div{data: {invoice_lines_target: 'container'}}
             = f.fields_for :invoice_lines do |line_form|
-              = render 'invoice_line_fields', f: line_form, line: line_form.object
+              = render 'invoice_line_fields', f: line_form, line: line_form.object, autofocus: @autofocus_first_line && line_form.index.zero?
 
           / Template for new lines
           %template{data: {invoice_lines_target: 'template'}}

--- a/app/views/invoices/_invoice_line_fields.html.haml
+++ b/app/views/invoices/_invoice_line_fields.html.haml
@@ -11,7 +11,7 @@
       .col-sm-6.col-md-8
         .mb-3
           %label.form-label Title
-          = f.text_field :title, class: 'form-control', data: { action: 'input->invoice-lines#fieldChanged' }, required: true
+          = f.text_field :title, class: 'form-control', data: { action: 'input->invoice-lines#fieldChanged' }, required: true, autofocus: local_assigns[:autofocus]
       .col-sm-4.col-md-2.text-end
         %label.form-label &nbsp;
         %div

--- a/test/controllers/delivery_notes_controller_test.rb
+++ b/test/controllers/delivery_notes_controller_test.rb
@@ -53,7 +53,7 @@ class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
       }
     end
 
-    assert_redirected_to delivery_note_url(DeliveryNote.last)
+    assert_redirected_to edit_delivery_note_url(DeliveryNote.last)
 
     delivery_note = DeliveryNote.last
     assert_equal Date.new(2025, 5, 1), delivery_note.delivery_start_date

--- a/test/controllers/invoices_controller_test.rb
+++ b/test/controllers/invoices_controller_test.rb
@@ -132,7 +132,16 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
         }
       }
     end
-    assert_response :redirect
+    assert_redirected_to edit_invoice_url(Invoice.last)
+  end
+
+  test "editing a freshly created invoice shows a focused starter line" do
+    post invoices_url, params: { invoice: { customer_id: customers(:good_eu).id, project_id: projects(:test_project).id } }
+    follow_redirect!
+    assert_select "[data-invoice-lines-target='container']" do
+      assert_select "[data-line-index]", 1
+      assert_select "input[name*='[title]'][autofocus]", 1
+    end
   end
 
   test "should show invoice" do
@@ -232,6 +241,7 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
     invoice = create_draft_invoice(cust_reference: "TEST")
     get edit_invoice_url(invoice)
     assert_response :success
+    assert_select "[data-invoice-lines-target='container'] [data-line-index]", 0
   end
 
   test "should get edit with existing lines" do


### PR DESCRIPTION
## What

Creating an invoice or delivery note from the UI now lands you in the edit form with one empty item line already present and its **title field focused** — so you can start typing right away instead of: create → show → Edit → Add Line.

## How

- `create` redirects to the **edit** form (instead of the show page) and sets a one-shot `flash[:build_starter_line]`.
- `edit` builds a single in-memory starter line when that flag is present (matching the "Add Line" template defaults) and flags the first line for autofocus.
- The line partials autofocus the title only for that first starter line; the hidden `<template>` line and normal edits never get it (exactly one `autofocus` on the page).

## Scope guard

The flag is set **only** by the standard `create` action. `convert_to_invoice` redirects to its show page and never sets it, so converted invoices keep exactly their copied lines — verified by existing convert tests.

## Notes

- The starter line is built in-memory, never persisted; `accepts_nested_attributes`' `reject_if: :all_blank` drops it if you submit a genuinely empty form via the hidden template path. Because it is pre-typed as an item, it behaves like any manually added line: fill in the title to save it, or delete it. The draft is already persisted by `create`, so saving the form empty is never required — autofocus steers you to the title instead.

## Tests

- Updated both create tests for the new edit redirect.
- Added `editing a freshly created invoice shows a focused starter line` (one line + autofocus).
- Folded the "no starter line on a normal edit" assertion into the existing `should get edit`.
- Per repo convention, the render assertions live on the invoice side only; the delivery-note path is mirrored in the controller and covered by its redirect test.

Full test suite, line/edit system tests, JS lint, and pre-commit all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)