### PR TITLE
Backfill delivery_notes.review_acceptance onto the Admin group

### DIFF
--- a/db/migrate/20260613120000_grant_review_acceptance_to_admin_group.rb
+++ b/db/migrate/20260613120000_grant_review_acceptance_to_admin_group.rb
@@ -1,0 +1,35 @@
+class GrantReviewAcceptanceToAdminGroup < ActiveRecord::Migration[8.1]
+  # delivery_notes.review_acceptance was added after the Admin group's
+  # permission set was frozen into CreateGroupsAndTeams::ADMIN_PERMISSIONS.
+  # Fresh installs pick it up via db/seeds.rb (which grants every current
+  # Permission::ALL_KEYS), but installs upgraded by `db:migrate` alone never
+  # got the row — so the acceptance-review card stayed hidden for everyone,
+  # admins included. Backfill it here.
+  #
+  # Literals are intentional: migrations stay self-contained and don't depend
+  # on app constants (Permission / Group::ADMIN_NAME) that may later rename.
+  PERMISSION = "delivery_notes.review_acceptance".freeze
+
+  class MigrationGroup < ActiveRecord::Base
+    self.table_name = "groups"
+    has_many :group_permissions,
+             class_name: "GrantReviewAcceptanceToAdminGroup::MigrationGroupPermission",
+             foreign_key: :group_id
+  end
+
+  class MigrationGroupPermission < ActiveRecord::Base
+    self.table_name = "group_permissions"
+  end
+
+  def up
+    admin = MigrationGroup.find_by(builtin: true, name: "Admin")
+    return unless admin
+
+    admin.group_permissions.find_or_create_by!(permission: PERMISSION)
+  end
+
+  def down
+    # No-op: the permission legitimately belongs to the Admin group on every
+    # current install, so removing it on rollback would reintroduce the bug.
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_10_130001) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_13_120000) do
   create_table "acceptance_submissions", force: :cascade do |t|
     t.integer "attachment_id"
     t.datetime "created_at", null: false

--- a/test/migrations/grant_review_acceptance_to_admin_group_test.rb
+++ b/test/migrations/grant_review_acceptance_to_admin_group_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+require Rails.root.join("db/migrate/20260613120000_grant_review_acceptance_to_admin_group")
+
+class GrantReviewAcceptanceToAdminGroupTest < ActiveSupport::TestCase
+  PERMISSION = "delivery_notes.review_acceptance".freeze
+
+  def admin_has_permission?
+    # Fresh instance each call: Group#permissions memoizes in an ivar that
+    # reload doesn't clear, so reusing one object would mask the change.
+    Group.find(groups(:admin).id).permission?(PERMISSION)
+  end
+
+  test "backfills the permission on an Admin group that lacks it" do
+    groups(:admin).group_permissions.where(permission: PERMISSION).delete_all
+    assert_not admin_has_permission?
+
+    GrantReviewAcceptanceToAdminGroup.new.up
+
+    assert admin_has_permission?
+  end
+
+  test "is idempotent when the permission already exists" do
+    GrantReviewAcceptanceToAdminGroup.new.up
+    assert_equal 1, groups(:admin).group_permissions.where(permission: PERMISSION).count
+  end
+end


### PR DESCRIPTION
## Problem

Delivery notes weren't showing the customer-supplied acceptance document for review. The reporter noticed it on notes that had an invoice, but the invoice was a red herring — none of the acceptance code references `invoice`.

The acceptance-review card (`delivery_notes/show.html.haml:135`) renders only `if can?("delivery_notes.review_acceptance")`. There is no admin bypass: `Group#permission?` / `User#permissions` resolve purely from `group_permissions` rows.

That permission was added (commit `f0be9ad`) **after** `CreateGroupsAndTeams` froze the Admin group's `ADMIN_PERMISSIONS` snapshot. Fresh installs pick it up via `db/seeds.rb` (which grants every current `Permission::ALL_KEYS`), but installs upgraded by `db:migrate` alone never got the row — so the card stayed hidden for **everyone, admins included**.

## Fix

A self-contained, idempotent data migration that grants `delivery_notes.review_acceptance` to the builtin Admin group. Verified it is the **only** key in `Permission::ALL_KEYS` missing from the frozen migration snapshot — after this migration the Admin group matches `Permission::ALL_KEYS` exactly (no missing, no stale keys).

## Test

`test/migrations/grant_review_acceptance_to_admin_group_test.rb` — the migration adds the permission to an Admin group that lacks it, and is idempotent.

Full non-system suite: 839 runs, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)