### PR TITLE
Add admin-only dashboard consistency checks

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -17,5 +17,13 @@ class HomeController < ApplicationController
     @data = {}
     @data[:is_setup_done] = (SalesTaxCustomerClass.count > 0 and SalesTaxProductClass.count > 0 and SalesTaxProductClass.exists?(is_default: true) and SalesTaxRate.count > 0)
     @data[:issuer_company] = IssuerCompany.get_the_issuer!
+
+    @consistency_issues = if current_user.admin?
+      DashboardConsistencyChecks.new(
+        host: request.host, protocol: request.scheme, script_name: request.script_name
+      ).issues
+    else
+      []
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,6 +50,10 @@ class User < ApplicationRecord
     permissions.include?(key)
   end
 
+  def admin?
+    groups.exists?(builtin: true, name: Group::ADMIN_NAME)
+  end
+
   # Same per-instance memoization caveat as #permissions — reload the user
   # if you mutate group memberships and need to re-check on the same object.
   def bypass_team_scoping?

--- a/app/services/dashboard_consistency_checks.rb
+++ b/app/services/dashboard_consistency_checks.rb
@@ -1,0 +1,81 @@
+# Read-only health checks surfaced on the dashboard for admins. Each returns
+# zero or one Issue. Pure: the live request context (host/protocol/script_name)
+# is injected, so the checks are testable without a real request.
+class DashboardConsistencyChecks
+  include Rails.application.routes.url_helpers
+
+  Issue = Struct.new(:key, :title, :details, :fix_path, :fix_label, keyword_init: true)
+
+  def initialize(host:, protocol:, script_name:)
+    @host = host
+    @protocol = protocol
+    @script_name = script_name
+  end
+
+  def issues
+    [ admin_permissions_issue, absolute_url_issue ].compact
+  end
+
+  private
+
+  # The Admin group's permissions are frozen into a migration snapshot, so a
+  # newly-added Permission key only reaches existing installs via a follow-up
+  # data migration (or db:seed). This catches the gap if one is ever missed.
+  def admin_permissions_issue
+    admin = Group.admin
+    return nil unless admin
+
+    missing = Permission::ALL_KEYS - admin.permissions
+    return nil if missing.empty?
+
+    Issue.new(
+      key: :admin_permissions,
+      title: "Admin group is missing permissions",
+      details: missing.map { |key| Permission.label_for(key) },
+      fix_path: edit_group_path(admin),
+      fix_label: "Review Admin group permissions"
+    )
+  end
+
+  # Absolute URLs baked into emails and tokens are built from Settings.app
+  # (see AbsoluteUrl), independent of the request. If the configured values
+  # drift from how the app is actually reached, those links break silently
+  # while in-app browsing keeps working. Compare against the live request.
+  def absolute_url_issue
+    mismatches = []
+    mismatches << url_line("Host", Settings.app.host, @host) unless host_match?
+    mismatches << url_line("Protocol", Settings.app.protocol, @protocol) unless protocol_match?
+    mismatches << url_line("Path prefix", Settings.app.script_name, @script_name) unless script_name_match?
+    return nil if mismatches.empty?
+
+    Issue.new(
+      key: :absolute_url,
+      title: "Link base URL doesn't match how you're accessing the app",
+      details: [ "Links in emails and customer-portal tokens use the configured values below, not the address in your browser:" ] + mismatches
+    )
+  end
+
+  def host_match?
+    normalize_host(Settings.app.host) == normalize_host(@host)
+  end
+
+  def protocol_match?
+    Settings.app.protocol.to_s.downcase == @protocol.to_s.downcase
+  end
+
+  def script_name_match?
+    normalize_path(Settings.app.script_name) == normalize_path(@script_name)
+  end
+
+  def normalize_host(value)
+    value.to_s.downcase.sub(/:\d+\z/, "")
+  end
+
+  def normalize_path(value)
+    value.to_s.chomp("/")
+  end
+
+  def url_line(label, configured, actual)
+    "#{label}: configured #{configured.to_s.inspect}, but you're using #{actual.to_s.inspect}"
+  end
+end

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -65,6 +65,18 @@
             = " • "
             = @data[:issuer_company].bankaccount_number
 
+- if @consistency_issues.any?
+  .row.mt-4
+    .col-12
+      - @consistency_issues.each do |issue|
+        .alert.alert-warning{role: 'alert'}
+          %h5= issue.title
+          %ul.mb-0
+            - issue.details.each do |line|
+              %li= line
+          - if issue.fix_path
+            .mt-2= link_to issue.fix_label, issue.fix_path, class: 'alert-link'
+
 - if not @data[:is_setup_done]
   .row.mt-4
     .col-12

--- a/test/integration/dashboard_consistency_test.rb
+++ b/test/integration/dashboard_consistency_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class DashboardConsistencyTest < ActionDispatch::IntegrationTest
+  test "admin sees a consistency warning when the Admin group is missing a permission" do
+    groups(:admin).group_permissions.where(permission: "delivery_notes.review_acceptance").delete_all
+
+    get root_path
+
+    assert_response :success
+    assert_select ".alert-warning h5", text: "Admin group is missing permissions"
+  end
+
+  test "non-admins never see consistency warnings" do
+    groups(:admin).group_permissions.where(permission: "delivery_notes.review_acceptance").delete_all
+    sign_in_as users(:bob)
+
+    get root_path
+
+    assert_response :success
+    assert_select "h5", text: "Admin group is missing permissions", count: 0
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -8,6 +8,11 @@ class UserTest < ActiveSupport::TestCase
     assert_includes user.errors[:full_name], "can't be blank"
   end
 
+  test "admin? is true only for members of the builtin Admin group" do
+    assert users(:alice).admin?
+    assert_not users(:bob).admin?
+  end
+
   test "auto-assigns webauthn_id on create" do
     user = User.new(username: "newone", full_name: "New User")
     assert user.valid?

--- a/test/services/dashboard_consistency_checks_test.rb
+++ b/test/services/dashboard_consistency_checks_test.rb
@@ -1,0 +1,53 @@
+require "test_helper"
+
+class DashboardConsistencyChecksTest < ActiveSupport::TestCase
+  # Build args that match the configured AbsoluteUrl settings, so the URL
+  # check is silent unless a test deliberately diverges one field.
+  def matching_request
+    { host: Settings.app.host, protocol: Settings.app.protocol, script_name: Settings.app.script_name }
+  end
+
+  def issues(overrides = {})
+    DashboardConsistencyChecks.new(**matching_request.merge(overrides)).issues
+  end
+
+  def issue(key, overrides = {})
+    issues(overrides).find { |i| i.key == key }
+  end
+
+  test "no issues when the Admin group is complete and the URL matches" do
+    assert_empty issues
+  end
+
+  test "flags the Admin group missing a permission" do
+    groups(:admin).group_permissions.where(permission: "delivery_notes.review_acceptance").delete_all
+
+    found = issue(:admin_permissions)
+    assert found
+    assert_includes found.details.join(" "), Permission.label_for("delivery_notes.review_acceptance")
+    assert found.fix_path
+  end
+
+  test "no permission issue when the Admin group has every permission" do
+    assert_nil issue(:admin_permissions)
+  end
+
+  test "flags a script_name mismatch" do
+    found = issue(:absolute_url, script_name: "/wrong-prefix")
+    assert found
+    assert_includes found.details.join(" "), "/wrong-prefix"
+  end
+
+  test "flags host and protocol mismatches" do
+    found = issue(:absolute_url, host: "elsewhere.example.com", protocol: "ftp")
+    assert found
+    assert_includes found.details.join(" "), "elsewhere.example.com"
+    assert_includes found.details.join(" "), "ftp"
+  end
+
+  test "tolerates script_name trailing slash, host case, and host port differences" do
+    assert_nil issue(:absolute_url,
+                     script_name: Settings.app.script_name.to_s + "/",
+                     host: Settings.app.host.to_s.upcase.sub(/:\d+\z/, "") + ":9999")
+  end
+end


### PR DESCRIPTION
## What

Two read-only health checks on the dashboard, visible to Admin-group members only, alongside the existing (unchanged) sales-tax setup gate.

### 1. Admin group permissions
Flags any `Permission::ALL_KEYS` missing from the builtin Admin group. This is the bug class fixed in #502: a newly-added permission only reaches existing installs via a follow-up data migration or `db:seed`, and one can get missed (`delivery_notes.review_acceptance` did — it left the acceptance-review card hidden for everyone). Now self-detecting. Links to the Admin group's edit page.

### 2. Absolute-URL config vs reality
`AbsoluteUrl` builds the links baked into emails and customer-portal tokens from `Settings.app.{host,protocol,script_name}`, independent of the request. When those drift from how the app is actually reached (e.g. a stale `/abt` `script_name` that's no longer in use), the links break silently while in-app browsing keeps working. The check compares the configured values against the live request, normalized to avoid false positives (host port/case, `script_name` trailing slash).

## How

- `DashboardConsistencyChecks` — pure service; the live request context (`host`/`protocol`/`script_name`) is injected, so checks are testable without a request.
- Adds `User#admin?` (membership in the builtin Admin group).
- `HomeController#index` runs the checks only for admins; non-admins get `[]`.
- View renders each issue as a `warning` alert.

## Tests
- Service unit (6): missing-permission detection; URL match/mismatch incl. normalization edge cases.
- `User#admin?` (1).
- Integration (2): admin sees the warning when present; non-admins never do.

Full non-system suite: 846 runs, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)