### PR TITLE
Install superpowers plugin during sandbox session start

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -67,3 +67,7 @@ echo "== Verifying FOP launcher =="
 ./bin/abt-fop -version
 
 echo "== FOP setup complete =="
+
+echo "== Installing superpowers plugin =="
+claude plugin marketplace add obra/superpowers-marketplace
+claude plugin install superpowers@superpowers-marketplace


### PR DESCRIPTION
Adds the obra/superpowers-marketplace and installs the superpowers
plugin so it's available in every Claude Code on the web session for
this repo. Both claude plugin commands are idempotent, safe to re-run
on every session start.