### PR TITLE
Fix navbar burger-menu breakpoint and toggler contrast

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.scss
@@ -31,8 +31,11 @@ body { padding-top: 60px; }
     border-color: #333 !important;
   }
 
+  // The gradient's right edge (where the toggler always sits) is light in
+  // both color modes, so pin the icon to the light-background variant
+  // instead of following data-bs-theme.
   .navbar-toggler-icon {
-    filter: invert(1);
+    --bs-navbar-toggler-icon-bg: #{escape-svg($navbar-light-toggler-icon-bg)};
   }
 }
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -30,7 +30,7 @@
         })();
     = yield :head
   %body.d-flex.flex-column.min-vh-100
-    %nav.navbar.navbar-expand-lg.bg-body-tertiary.fixed-top{"data-controller" => "navbar"}
+    %nav.navbar.navbar-expand-sm.bg-body-tertiary.fixed-top{"data-controller" => "navbar"}
       .container-fluid
         = render 'layouts/navigation'
     %main#main{:role => "main", :class => "flex-grow-1"}


### PR DESCRIPTION
## Summary
- Navbar collapsed to a burger menu below 992px (`navbar-expand-lg`), but the nav content actually fits without wrapping down to 576px — switched to `navbar-expand-sm` so the full menu stays visible at common ~750px window widths.
- The toggler icon used `filter: invert(1)`, which inverted Bootstrap's own theme-aware icon color. Since the toggler always sits on the light/silvery end of the rainbow gradient background regardless of light/dark mode, this made the icon nearly invisible ("grey on grey") in light mode. Pinned the icon to Bootstrap's light-background variant instead so it stays legible in both themes.

## Test plan
- [x] `bundle exec rails test test/system/` (56 runs, 0 failures)
- [x] `pre-commit run --all-files`
- [x] Verified visually via headless screenshots at 750px (both themes, menu now expanded) and 500px (both themes, toggler icon now high-contrast)