### PR TITLE
Scope AddLanguageToCustomers migration to migration-local AR classes

### DIFF
--- a/db/migrate/20250810173512_add_language_to_customers.rb
+++ b/db/migrate/20250810173512_add_language_to_customers.rb
@@ -1,4 +1,16 @@
 class AddLanguageToCustomers < ActiveRecord::Migration[8.0]
+  # Scoped to this migration instead of using the live Customer/Language
+  # models: those models gain columns and validations over time (e.g.
+  # Customer's invoice_email_auto_contact_mode enum, added months later),
+  # which breaks this migration when it replays against an older schema.
+  class MigrationLanguage < ApplicationRecord
+    self.table_name = "languages"
+  end
+
+  class MigrationCustomer < ApplicationRecord
+    self.table_name = "customers"
+  end
+
   def change
     add_reference :customers, :language, null: true, foreign_key: true
 
@@ -6,16 +18,16 @@ class AddLanguageToCustomers < ActiveRecord::Migration[8.0]
     reversible do |dir|
       dir.up do
         # Ensure English and German languages exist
-        english = Language.find_or_create_by(iso_code: 'en') do |lang|
+        english = MigrationLanguage.find_or_create_by(iso_code: 'en') do |lang|
           lang.title = 'English'
         end
 
-        Language.find_or_create_by(iso_code: 'de') do |lang|
+        MigrationLanguage.find_or_create_by(iso_code: 'de') do |lang|
           lang.title = 'German'
         end
 
         # Update all existing customers to have English as default
-        Customer.update_all(language_id: english.id)
+        MigrationCustomer.update_all(language_id: english.id)
 
         # Now make the field required
         change_column_null :customers, :language_id, false


### PR DESCRIPTION
## Summary
- `db/migrate/20250810173512_add_language_to_customers.rb` called `Customer.update_all` and `Language.find_or_create_by` against the live app models. Those models change over time — `Customer` now declares an `enum :invoice_email_auto_contact_mode`, backed by a column that isn't added until a much later migration (`20260525120004`).
- Replaying migrations from scratch (a brand new checkout/worktree with no existing database) hits this migration before that column exists, and just loading the `Customer` class raises `Undeclared attribute type for enum 'invoice_email_auto_contact_mode' in Customer`, aborting `db:migrate`.
- Scoped the migration to two minimal, migration-local `ApplicationRecord` subclasses (`MigrationCustomer`, `MigrationLanguage`) bound only to their table names, decoupling it from future model changes.

## Test plan
- [x] Clean checkout simulation: removed all sqlite dbs, ran `bundle exec rails db:setup` — succeeds, seeds sample data, `db/schema.rb` unchanged.
- [x] Clean checkout simulation: removed dev db, ran `bundle exec rails db:create db:migrate` from scratch (development and test envs) — all 82 migrations apply, `schema_migrations` reaches the latest version, no `db/schema.rb` drift.
- [x] `bundle exec rails test` — 877 runs, 0 failures.
- [x] `pre-commit run --all-files`