### PR TITLE
Show linked invoice on draft delivery notes; unlink on invoice delete

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -70,7 +70,7 @@ class Invoice < ApplicationRecord
   belongs_to :project
   belongs_to :attachment, optional: true
 
-  has_one :delivery_note
+  has_one :delivery_note, dependent: :nullify
 
   has_many :invoice_lines, -> { order(:position, :id) }, after_add: :line_addedremoved, after_remove: :line_addedremoved
   accepts_nested_attributes_for :invoice_lines, allow_destroy: true, reject_if: :all_blank

--- a/app/views/delivery_notes/show.html.haml
+++ b/app/views/delivery_notes/show.html.haml
@@ -89,7 +89,7 @@
                     %button.btn.btn-sm.btn-info{disabled: true} Publish…
         - if @delivery_note.published?
           = render 'shared/email_status_row', resource: @delivery_note, can_edit: can_edit_dn, show_send_button: true
-        - if @delivery_note.published?
+        - if @delivery_note.published? || @delivery_note.invoice
           .row.mb-2
             .col-sm-4
               %strong Invoice:

--- a/test/controllers/delivery_notes_controller_test.rb
+++ b/test/controllers/delivery_notes_controller_test.rb
@@ -26,6 +26,17 @@ class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "draft delivery note show displays the linked invoice" do
+    note = delivery_notes(:published_delivery_note)
+    invoice = Invoice.create!(customer: note.customer, project: note.project)
+    note.update!(invoice: invoice, published: false)
+
+    get delivery_note_url(note)
+    assert_response :success
+    assert_select "strong", text: "Invoice:"
+    assert_select "a[href=?]", invoice_path(invoice)
+  end
+
   test "published delivery note show offers PDF action, not the unusable Preview" do
     note = delivery_notes(:published_delivery_note)
     get delivery_note_url(note)

--- a/test/controllers/invoices_controller_test.rb
+++ b/test/controllers/invoices_controller_test.rb
@@ -435,6 +435,18 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
   # Published-invoice guards (edit/update/destroy/preview/publish) live in
   # test/controllers/concerns/publishable_document_test.rb.
 
+  test "destroying a draft invoice unlinks its delivery note" do
+    invoice = create_draft_invoice(cust_reference: "LINKED")
+    note = delivery_notes(:published_delivery_note)
+    note.update!(invoice: invoice)
+
+    assert_difference("Invoice.count", -1) do
+      delete invoice_url(invoice)
+    end
+
+    assert_nil note.reload.invoice_id
+  end
+
   test "import_lines returns invoice lines parsed from the uploaded CSV" do
     invoice = create_draft_invoice(cust_reference: "IMPORT")
 


### PR DESCRIPTION
## Summary
- The delivery note show page rendered the Invoice row only for published notes; a draft note that carries an invoice link (published → converted → unpublished) showed nothing. The row now also renders for drafts with a linked invoice. The "Create…" convert button remains published-only.
- Deleting a draft invoice that a delivery note points at crashed with `ActiveRecord::InvalidForeignKey` (`delivery_notes.invoice_id` is a restrictive FK). `Invoice has_one :delivery_note` is now `dependent: :nullify`, so deleting the draft unlinks the delivery note, which returns to "Not invoiced" and can be converted again. Published invoices remain undeletable via the existing `require_unpublished` guard.

## Testing
- `bundle exec rails test` — 879 runs, 0 failures
- `bundle exec rails test test/system/` — 58 runs, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)