### PR TITLE
Fix flaky rich-text toolbar trim when Trix initializes before connect

### DIFF
--- a/app/javascript/controllers/rich_text_controller.js
+++ b/app/javascript/controllers/rich_text_controller.js
@@ -15,6 +15,10 @@ export default class extends Controller {
     this.element.addEventListener("trix-initialize", this.trimToolbar)
     this.element.addEventListener("trix-file-accept", this.blockAttachment)
     this.element.addEventListener("trix-attachment-add", this.blockAttachment)
+    // Trix may finish initializing before this controller connects, in which
+    // case the trix-initialize listener above misses the event. Trim now if the
+    // editor is already up.
+    if (this.element.editor) this.trimToolbar({ target: this.element })
   }
 
   disconnect() {


### PR DESCRIPTION
## Summary
- CI on #534 hit an intermittent failure of `InvoicePreludeRichTextTest#test_prelude_uses_trix_editor_with_attachment_button_absent` (`expected not to find visible css "trix-toolbar [data-trix-action='link']", found 1 match: "Link"`). The failure was unrelated to that branch's diff — it reproduces on `main` at ~20% locally.
- Root cause: `rich_text_controller.js` trimmed the Trix toolbar only from a `trix-initialize` listener added in `connect()`. When Trix finished initializing *before* Stimulus connected the controller, that event had already fired and the trim never ran, leaving the Link (and quote/code/strike/nesting) buttons visible. The file-tools/attach assertions still passed because those are hidden via CSS (`actiontext.css.scss`), masking that the JS trim hadn't run.
- Fix: trim immediately in `connect()` when `this.element.editor` is already set, so the toolbar is trimmed regardless of init/connect ordering. Shared controller, so both the invoice and delivery-note prelude editors are covered.

## Testing
- `npm run lint` — clean
- `bundle exec rails test test/system/invoice_prelude_rich_text_test.rb` — 2 runs, 0 failures
- Ran the previously-flaky test 15× consecutively (was ~20% flaky before the fix) — 15/15 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)