### PR TITLE
Add offers feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,9 @@ For testing against PostgreSQL (matches production environment):
 - **InvoiceLine** / **DeliveryNoteLine** - Line items with types (item, text, subheading)
 - **Product** (`app/models/product.rb`) - Product catalog
 - **Project** (`app/models/project.rb`) - Project tracking
+- **Offer** (`app/models/offer.rb`) - Quote/proposal per customer+project; draft → sent → accepted/rejected/expired lifecycle
+- **OfferVersion** - Snapshot of offer content; live/editable while draft, frozen once sent
+- **OfferMilestone** - Billable line within a version; converts to an invoice or delivery note
 - **User** + `UserCredential`, `UserEmail`, `UserInvite`, `UserSession`, `UserAuditEvent` - Passkey/WebAuthn auth, invite-only signup, audit log
 
 ### Shared Concerns
@@ -64,8 +67,15 @@ For testing against PostgreSQL (matches production environment):
 3. **InvoiceRenderer** - PDF generation using Apache FOP with XML/XSL transformation
 4. **Email System** - `DocumentMailer` delivered via `deliver_later` (Solid Queue). Bulk send marks `email_sent_at` for tracking.
 
+### Offer Processing Pipeline
+- **OffersController** - Standard CRUD + send/accept/reject/reopen, milestone scaffolding/conversion, order-PDF upload, email
+- **OfferSender** - Freezes the current draft `OfferVersion` (assigns document number on first send, snapshots customer data), transitions the offer to `sent`, and branches a fresh draft version for further edits
+- **OfferRenderer** - PDF generation for offers using Apache FOP, `lib/foptemplate/offer.xsl`
+- Lifecycle: `draft` → `sent` → `accepted` / `rejected` / `expired`; sending an offer never mutates the sent version in place — it freezes that version and opens a new draft alongside it. Milestones convert individually to invoices or delivery notes (`OfferMilestoneConverter`); conversion can be reversed with a reopen link.
+- Permissions: `offers.view`, `offers.edit` (create/send/accept/reject/reopen), `offers.convert` (milestone → invoice/delivery-note)
+
 ### Background Jobs
-- Solid Queue (`bin/jobs` worker, `solid_queue` gem). Schedule lives in `config/recurring.yml` — currently `OverdueInvoicesReportJob` (every other day at 08:00), `RefreshStaleVatVerificationsJob` (daily at 04:00), `VatVerificationsReportJob` (daily at 11:00), and finished-job cleanup.
+- Solid Queue (`bin/jobs` worker, `solid_queue` gem). Schedule lives in `config/recurring.yml` — currently `OverdueInvoicesReportJob` (every other day at 08:00), `ExpiringOffersReportJob` (daily at 07:30), `RefreshStaleVatVerificationsJob` (daily at 04:00), `VatVerificationsReportJob` (daily at 11:00), and finished-job cleanup.
 - Worker status surfaced under **Configuration → Background Jobs** (`JobsStatusController`).
 
 ### Authentication
@@ -129,6 +139,7 @@ For testing against PostgreSQL (matches production environment):
 - Invoice model: `app/models/invoice.rb`
 - Main invoice controller: `app/controllers/invoices_controller.rb`
 - Delivery notes: `app/controllers/delivery_notes_controller.rb`, `app/models/delivery_note.rb`
+- Offers: `app/controllers/offers_controller.rb`, `app/services/offer_sender.rb`, PDF template `lib/foptemplate/offer.xsl`
 - Auth flows: `app/controllers/sessions_controller.rb`, `invites_controller.rb`, `account/`, `users_controller.rb`
 - UI helpers: `app/helpers/application_helper.rb`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ For testing against PostgreSQL (matches production environment):
 4. **Email System** - `DocumentMailer` delivered via `deliver_later` (Solid Queue). Bulk send marks `email_sent_at` for tracking.
 
 ### Background Jobs
-- Solid Queue (`bin/jobs` worker, `solid_queue` gem). Schedule lives in `config/recurring.yml` — currently `OverdueInvoicesReportJob` (every other day at 08:00) and finished-job cleanup.
+- Solid Queue (`bin/jobs` worker, `solid_queue` gem). Schedule lives in `config/recurring.yml` — currently `OverdueInvoicesReportJob` (every other day at 08:00), `RefreshStaleVatVerificationsJob` (daily at 04:00), `VatVerificationsReportJob` (daily at 11:00), and finished-job cleanup.
 - Worker status surfaced under **Configuration → Background Jobs** (`JobsStatusController`).
 
 ### Authentication

--- a/app/assets/stylesheets/offers.css.scss
+++ b/app/assets/stylesheets/offers.css.scss
@@ -1,0 +1,19 @@
+// Accept-offer modal used by offers/_accept_modal.
+
+.accept-order-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1050;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.accept-order-modal-dialog {
+  max-width: 500px;
+  width: 90%;
+}

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -32,6 +32,13 @@ class AttachmentsController < ApplicationController
     if pending_scope.exists?
       return require_permission!("delivery_notes.review_acceptance")
     end
+    if OfferVersion.joins(:offer).where(attachment_id: attachment.id)
+                   .merge(Offer.visible_to(current_user)).exists?
+      return require_permission!("offers.view")
+    end
+    if Offer.visible_to(current_user).where(order_attachment_id: attachment.id).exists?
+      return require_permission!("offers.view")
+    end
     raise ApplicationController::PermissionDenied, "attachment##{attachment.id}"
   end
 end

--- a/app/controllers/customer_contacts_controller.rb
+++ b/app/controllers/customer_contacts_controller.rb
@@ -85,7 +85,7 @@ class CustomerContactsController < ApplicationController
   end
 
   def contact_params
-    params.require(:customer_contact).permit(:name, :email, :salutation_line, :receives_invoice_emails, :receives_delivery_note_emails)
+    params.require(:customer_contact).permit(:name, :email, :salutation_line, :receives_invoice_emails, :receives_delivery_note_emails, :receives_offer_emails)
   end
 
   # Server-side scope on project_ids: pick only IDs the user can see AND that

--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -75,7 +75,8 @@ private
     params.require(:customer).permit(
         :matchcode, :name, :address, :country_iso2, :vat_id, :supplier_number, :notes, :sales_tax_customer_class_id, :language_id, :payment_terms_days,
         :invoice_email_auto_to, :invoice_email_auto_subject_template, :invoice_email_auto_enabled, :invoice_email_auto_contact_mode, :active,
-        :team_id
+        :team_id,
+        :offer_validity_days, :offer_milestone_split_threshold, :offer_milestone_templates_below, :offer_milestone_templates_above, :offer_boilerplate
     )
   end
 end

--- a/app/controllers/delivery_notes_controller.rb
+++ b/app/controllers/delivery_notes_controller.rb
@@ -90,8 +90,11 @@ class DeliveryNotesController < ApplicationController
 
   # DELETE /delivery_notes/1
   def destroy
-    @delivery_note.destroy
-    redirect_to delivery_notes_url
+    if @delivery_note.destroy
+      redirect_to delivery_notes_url
+    else
+      redirect_to @delivery_note, alert: @delivery_note.errors.full_messages.to_sentence
+    end
   end
 
   def publish

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -89,8 +89,11 @@ class InvoicesController < ApplicationController
 
   # DELETE /invoices/1
   def destroy
-    @invoice.destroy
-    redirect_to invoices_url
+    if @invoice.destroy
+      redirect_to invoices_url
+    else
+      redirect_to @invoice, alert: @invoice.errors.full_messages.to_sentence
+    end
   end
 
   def publish

--- a/app/controllers/issuer_companies_controller.rb
+++ b/app/controllers/issuer_companies_controller.rb
@@ -72,6 +72,7 @@ class IssuerCompaniesController < ApplicationController
       :document_contact_line1, :document_contact_line2,
       :document_accent_color,
       :invoice_footer,
+      :offer_validity_days, :offer_footer,
       :currency,
       :money_decimal_places,
       :document_email_from,

--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -1,0 +1,220 @@
+class OffersController < ApplicationController
+  include EmailableDocument
+
+  before_action -> { require_permission!("offers.view") },
+                only: %i[index show preview preview_email preview_email_html]
+  before_action -> { require_permission!("offers.edit") },
+                only: %i[new create edit update destroy send_offer accept reject reopen
+                         scaffold_milestones update_internal_notes upload_order_pdf send_email]
+  before_action -> { require_permission!("offers.convert") },
+                only: %i[convert_milestone reopen_milestone_link]
+
+  before_action :set_offer, except: %i[index new create]
+  before_action :require_editable, only: %i[edit update preview scaffold_milestones]
+  before_action :require_deletable, only: %i[destroy]
+  before_action :require_sent_version, only: %i[send_email]
+  before_action :require_accepted, only: %i[convert_milestone reopen_milestone_link]
+
+  def index
+    @selected_year = params[:year] == "all" ? "all" : (params[:year].presence || Date.current.year).to_i
+    @state_filter = params[:state].presence_in(Offer::STATES) || "all"
+    @selected_customer_id = params[:customer_id].presence&.to_i
+
+    scope = Offer.visible_to(current_user).ordered.includes(:customer, :project)
+    scope = scope.in_year(@selected_year, include_drafts: @selected_year == Date.current.year) unless @selected_year == "all"
+    scope = scope.where(state: @state_filter) unless @state_filter == "all"
+    scope = scope.where(customer_id: @selected_customer_id) if @selected_customer_id
+    @offers = scope
+
+    @available_years = Offer.visible_to(current_user).available_years
+    @available_customers = Offer.available_customers(current_user, including: @selected_customer_id)
+  end
+
+  def show; end
+
+  def new
+    @offer = Offer.new(customer_id: params[:customer_id].presence)
+  end
+
+  def create
+    @offer = Offer.new(offer_params)
+    if @offer.save
+      redirect_to edit_offer_path(@offer), flash: { notice: "Offer created.", build_starter_milestone: true }
+    else
+      render :new, status: :unprocessable_content
+    end
+  end
+
+  def edit
+    @autofocus_first_milestone = flash[:build_starter_milestone].present?
+  end
+
+  def update
+    if @offer.update(offer_params)
+      redirect_to @offer, notice: "Offer updated."
+    else
+      render :edit, status: :unprocessable_content
+    end
+  end
+
+  def destroy
+    @offer.destroy
+    redirect_to offers_path, notice: "Offer deleted."
+  end
+
+  def preview
+    problems = @offer.send_problems
+    if problems.any?
+      redirect_to @offer, alert: problems.join("; ")
+      return
+    end
+
+    version = @offer.draft_version
+    version.date = Date.current
+    pdf = OfferRenderer.new(version, IssuerCompany.get_the_issuer!).render
+    send_data pdf, type: "application/pdf", disposition: "inline",
+              filename: "offer-draft-#{@offer.id}.pdf"
+  end
+
+  def send_offer
+    sender = OfferSender.new(@offer, IssuerCompany.get_the_issuer!)
+    if sender.send!
+      redirect_to @offer, notice: "Offer sent version #{@offer.reload.current_sent_version.version_number}."
+    else
+      redirect_to @offer, alert: sender.log.presence || "Offer could not be sent."
+    end
+  end
+
+  def accept
+    order_pdf = params[:order_pdf]
+    if order_pdf.present? && Attachment.detect_content_type(order_pdf.tempfile) != "application/pdf"
+      return redirect_to @offer, alert: "Order document must be a PDF."
+    end
+    @offer.accept!(order_number: params[:order_number], ordered_on: params[:ordered_on],
+                   order_pdf: order_pdf)
+    redirect_to @offer, notice: "Offer accepted."
+  rescue Offer::InvalidTransition => e
+    redirect_to @offer, alert: e.message
+  end
+
+  def reject
+    @offer.reject!
+    redirect_to @offer, notice: "Offer rejected."
+  rescue Offer::InvalidTransition => e
+    redirect_to @offer, alert: e.message
+  end
+
+  def reopen
+    @offer.reopen!
+    redirect_to @offer, notice: "Offer reopened."
+  rescue Offer::InvalidTransition => e
+    redirect_to @offer, alert: e.message
+  end
+
+  # Submitted by the page form via formaction, so pending edits save first.
+  def scaffold_milestones
+    if params[:offer].present? && !@offer.update(offer_params)
+      return render :edit, status: :unprocessable_content
+    end
+    OfferMilestoneScaffolder.new(@offer.customer, params[:total].to_d).apply_to(@offer.draft_version)
+    redirect_to edit_offer_path(@offer), notice: "Milestones scaffolded."
+  rescue OfferMilestoneScaffolder::MilestonesPresent
+    redirect_to edit_offer_path(@offer), alert: "Remove the existing milestones first."
+  end
+
+  def update_internal_notes
+    @offer.update!(internal_notes: params.require(:offer)[:internal_notes])
+    redirect_to @offer, notice: "Internal notes saved."
+  end
+
+  def upload_order_pdf
+    uploaded = params[:order_pdf]
+    if uploaded.blank? || Attachment.detect_content_type(uploaded.tempfile) != "application/pdf"
+      return redirect_to @offer, alert: "Order document must be a PDF."
+    end
+    @offer.attach_order_pdf(uploaded)
+    @offer.save!
+    redirect_to @offer, notice: "Order document stored."
+  end
+
+  def convert_milestone
+    milestone = accepted_milestone!
+    invoice = OfferMilestoneConverter.new(milestone).convert!
+    documents = [ invoice, milestone.reload.delivery_note ].compact.map(&:display_name)
+    redirect_to @offer, notice: "Milestone converted to #{documents.join(' and ')}."
+  rescue OfferMilestoneConverter::NotConvertible => e
+    redirect_to @offer, alert: e.message
+  end
+
+  def reopen_milestone_link
+    milestone = accepted_milestone!
+    milestone.reopen_link!
+    redirect_to @offer, notice: "Milestone link cleared."
+  end
+
+  protected
+
+  def set_offer
+    @offer = Offer.visible_to(current_user).find(params[:id])
+  end
+
+  # EmailableDocument hooks.
+  def email_preview_document = @offer
+
+  def email_preview_mail = build_customer_email(skip_attachments: false)
+  def email_preview_html_mail = build_customer_email(skip_attachments: true)
+  def email_for_sending = build_customer_email(skip_attachments: false)
+
+  def build_customer_email(skip_attachments:)
+    OfferMailer.with(offer: @offer, skip_attachments:).customer_email
+  end
+
+  private
+
+  def require_editable
+    redirect_to @offer, alert: "This offer can no longer be edited." unless @offer.editable?
+  end
+
+  def require_deletable
+    redirect_to @offer, alert: "Only draft offers can be deleted." unless @offer.deletable?
+  end
+
+  # send_email delegates to EmailableDocument, which already redirects with
+  # "No recipient configured." when #emailable? is false — but that check
+  # can't distinguish "never sent" from "sent but no contact opted in for
+  # offer emails". Offers that have never been sent have no rendered PDF at
+  # all, so give that case its own clearer message before EmailableDocument
+  # runs.
+  def require_sent_version
+    return true if @offer.current_sent_version.present?
+    redirect_to @offer, alert: "Send the offer before emailing it."
+    false
+  end
+
+  # Guards convert_milestone and reopen_milestone_link: both dig through
+  # @offer.accepted_version, which is nil unless the offer is accepted (e.g.
+  # a stale tab left open on a sent-but-not-yet-accepted offer). Without this,
+  # accepted_milestone! raises NoMethodError on nil instead of redirecting.
+  def require_accepted
+    return true if @offer.accepted?
+    redirect_to @offer, alert: "This offer must be accepted before its milestones can be converted."
+    false
+  end
+
+  def accepted_milestone!
+    @offer.accepted_version.milestones.find(params[:milestone_id])
+  end
+
+  def offer_params
+    params.require(:offer).permit(
+      :customer_id, :project_id, :customer_contact_id, :internal_reference,
+      draft_version_attributes: [
+        :id, :subject, :prelude, :salutation_override, :delivery_date, :sales_tax_product_class_id,
+        milestones_attributes: [
+          :id, :position, :title, :description, :trigger, :trigger_date,
+          :amount, :skip_delivery_note, :_destroy
+        ]
+      ]
+    )
+  end
+end

--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -30,7 +30,9 @@ class OffersController < ApplicationController
     @available_customers = Offer.available_customers(current_user, including: @selected_customer_id)
   end
 
-  def show; end
+  def show
+    @version = @offer.editable? ? @offer.draft_version : @offer.current_sent_version
+  end
 
   def new
     @offer = Offer.new(customer_id: params[:customer_id].presence)

--- a/app/javascript/controllers/offer_milestones_controller.js
+++ b/app/javascript/controllers/offer_milestones_controller.js
@@ -1,0 +1,56 @@
+import BaseLinesController from "controllers/base_lines_controller"
+
+export default class extends BaseLinesController {
+  static values = { currencySymbol: String, moneyDecimalPlaces: Number }
+
+  connect() {
+    super.connect()
+    this.containerTarget.querySelectorAll('[data-line-index]').forEach(line => this.syncTriggerFields(line))
+    this.updateTotal()
+  }
+
+  addLine() {
+    const line = this.appendLineFromTemplate({ openProductDropdown: false })
+    if (line) this.syncTriggerFields(line)
+    this.updateTotal()
+  }
+
+  removeLine(event) {
+    super.removeLine(event)
+    this.updateTotal()
+  }
+
+  triggerChanged(event) {
+    const line = event.target.closest('[data-line-index]')
+    this.syncTriggerFields(line, { applyDefaultSkip: true })
+  }
+
+  syncTriggerFields(line, { applyDefaultSkip = false } = {}) {
+    const trigger = line.querySelector('select[name*="[trigger]"]').value
+    const dateWrap = line.querySelector('[data-trigger-date-wrap]')
+    if (dateWrap) dateWrap.classList.toggle('d-none', trigger !== 'on_date')
+    if (applyDefaultSkip) {
+      const skip = line.querySelector('input[type="checkbox"][name*="[skip_delivery_note]"]')
+      if (skip) skip.checked = (trigger === 'on_order')
+    }
+  }
+
+  updateTotal() {
+    let total = 0
+    this.containerTarget.querySelectorAll('[data-line-index]').forEach(line => {
+      if (line.style.display === 'none') return
+      const amountField = line.querySelector('input[name*="[amount]"]')
+      if (amountField) total += parseFloat(amountField.value) || 0
+    })
+
+    const totalElement = document.getElementById('offer-total-net')
+    if (totalElement) totalElement.textContent = this.formatCurrency(total)
+  }
+
+  formatCurrency(amount) {
+    return this.currencySymbolValue + parseFloat(amount).toFixed(this.moneyDecimalPlacesValue)
+  }
+
+  getLineType() { return 'offer_milestones' }
+  getIdPrefix() { return 'offer_draft_version_attributes_milestones_attributes_' }
+}

--- a/app/javascript/controllers/presence_toggle_controller.js
+++ b/app/javascript/controllers/presence_toggle_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Shows the panel only while the observed input has a value.
+export default class extends Controller {
+  static targets = ["input", "panel"]
+
+  connect() {
+    this.sync()
+  }
+
+  sync() {
+    this.panelTarget.classList.toggle("d-none", this.inputTarget.value.trim() === "")
+  }
+}

--- a/app/jobs/expiring_offers_report_job.rb
+++ b/app/jobs/expiring_offers_report_job.rb
@@ -1,0 +1,16 @@
+class ExpiringOffersReportJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    expiring = Offer.where(state: "sent", reported_expired_at: nil)
+                    .where(expires_at: ...Date.current)
+                    .includes(:customer)
+                    .order(:expires_at)
+                    .to_a
+
+    return if expiring.empty?
+
+    Offer.where(id: expiring.map(&:id), state: "sent").update_all(state: "expired", reported_expired_at: Time.current)
+    ExpiringOffersMailer.with(offers: expiring).expiring_report.deliver_now
+  end
+end

--- a/app/mailers/expiring_offers_mailer.rb
+++ b/app/mailers/expiring_offers_mailer.rb
@@ -1,0 +1,15 @@
+class ExpiringOffersMailer < ApplicationMailer
+  def expiring_report
+    @offers = params[:offers]
+    @today = Date.current
+
+    I18n.with_locale(I18n.default_locale) do
+      mail(
+        to: @issuer.reporting_email,
+        subject: I18n.t("mailers.expiring_offers.subject",
+                        issuer_name: sanitize_header_value(@issuer.short_name),
+                        count: @offers.size)
+      )
+    end
+  end
+end

--- a/app/mailers/offer_mailer.rb
+++ b/app/mailers/offer_mailer.rb
@@ -1,0 +1,25 @@
+class OfferMailer < ApplicationMailer
+  def customer_email
+    @offer = params[:offer]
+    @version = @offer.current_sent_version
+
+    unless params[:skip_attachments]
+      if (pdf = @version&.attachment)
+        attachments[pdf.filename] = { mime_type: pdf.safe_content_type, content: pdf.data }
+      end
+    end
+
+    customer = @offer.customer
+    to = @offer.email_recipients
+
+    with_customer_locale(customer) do
+      @salutation = @version&.salutation_override.presence ||
+                    @offer.email_salutation_contact&.salutation_line.presence
+
+      subject = I18n.t("mailers.offer.subject",
+                       issuer_name: sanitize_header_value(@issuer.short_name),
+                       document_number: sanitize_header_value(@offer.document_number))
+      document_mail(to: to, subject: subject)
+    end
+  end
+end

--- a/app/models/concerns/strips_rich_text_edges.rb
+++ b/app/models/concerns/strips_rich_text_edges.rb
@@ -1,0 +1,42 @@
+# Drops empty lines that Trix leaves at the start or end of a rich-text body,
+# so preludes and boilerplate don't render stray blank lines on the PDF.
+module StripsRichTextEdges
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def strips_rich_text_edges(*names)
+      before_save do
+        names.each do |name|
+          rich = public_send(name)
+          next if rich.nil? || rich.body.nil?
+
+          html = rich.body.to_html
+          stripped = StripsRichTextEdges.strip(html)
+          rich.body = stripped if stripped != html
+        end
+      end
+    end
+  end
+
+  def self.strip(html)
+    fragment = Nokogiri::HTML5.fragment(html)
+    trim_children(fragment.children)
+    first = fragment.children.find(&:element?)
+    trim_children(first.children) if first
+    last = fragment.children.reverse.find(&:element?)
+    trim_children(last.children) if last && last != first
+    fragment.to_html
+  end
+
+  def self.trim_children(children)
+    children.each { |node| blank_line?(node) ? node.remove : break }
+    children.reverse.each { |node| blank_line?(node) ? node.remove : break }
+  end
+
+  def self.blank_line?(node)
+    return true if node.text? && node.text.strip.empty?
+    return true if node.element? && node.name == "br"
+    node.element? && %w[div p].include?(node.name) &&
+      node.text.strip.empty? && node.css("img, figure, action-text-attachment").empty?
+  end
+end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -1,11 +1,13 @@
 class Customer < ApplicationRecord
   include TeamOwned
   include HasMatchcode
+  include StripsRichTextEdges
 
   validates :name, presence: true
   validates :vat_id, presence: true, if: -> { sales_tax_customer_class&.vat_id_required? }
   validates :country_iso2, presence: true, inclusion: { in: ISO3166::Country.codes, message: "must be a valid country" }
   validates :invoice_email_auto_to, format: { with: URI::MailTo::EMAIL_REGEXP, allow_blank: true }
+  validates :offer_validity_days, numericality: { greater_than: 0, allow_nil: true }
 
   # Set default language (English) for new customers
   before_validation :set_default_language, on: :create
@@ -16,11 +18,15 @@ class Customer < ApplicationRecord
   has_many :sales_tax_rates, through: :sales_tax_customer_class
   has_many :invoices
   has_many :delivery_notes
+  has_many :offers
   has_many :customer_contacts, dependent: :destroy
   has_many :vat_verifications, class_name: "CustomerVatVerification", dependent: :destroy
 
   before_save :normalise_vat_id
   before_save :clear_vat_id_verified_at_if_vat_id_changed
+
+  has_rich_text :offer_boilerplate
+  strips_rich_text_edges :offer_boilerplate
 
   enum :invoice_email_auto_contact_mode, {
     replace_contacts: "replace_contacts",
@@ -57,6 +63,10 @@ class Customer < ApplicationRecord
     delivery_notes.exists?
   end
 
+  def used_in_offers?
+    offers.exists?
+  end
+
   def can_be_deleted?
     deletion_blocker.nil?
   end
@@ -87,6 +97,10 @@ class Customer < ApplicationRecord
     customer_contacts.for_delivery_notes.select { |c| c.applies_to_project?(delivery_note.project) }
   end
 
+  def contacts_for_offer(offer)
+    customer_contacts.for_offers.select { |c| c.applies_to_project?(offer.project) }
+  end
+
   before_destroy :check_if_used
 
   # When a customer moves to a different team, cascade the change to every
@@ -112,7 +126,8 @@ class Customer < ApplicationRecord
   # UI gate (can_be_deleted?) and the destroy guard's error message.
   def deletion_blocker
     return "invoices" if used_in_invoices?
-    "delivery notes" if used_in_delivery_notes?
+    return "delivery notes" if used_in_delivery_notes?
+    "offers" if used_in_offers?
   end
 
   def check_if_used

--- a/app/models/customer_contact.rb
+++ b/app/models/customer_contact.rb
@@ -1,6 +1,7 @@
 class CustomerContact < ApplicationRecord
   belongs_to :customer
   has_and_belongs_to_many :projects, join_table: :customer_contact_projects
+  has_many :offers, dependent: :nullify
 
   before_validation :normalize_email_and_name
 
@@ -12,6 +13,7 @@ class CustomerContact < ApplicationRecord
 
   scope :for_invoices,       -> { where(receives_invoice_emails: true) }
   scope :for_delivery_notes, -> { where(receives_delivery_note_emails: true) }
+  scope :for_offers,         -> { where(receives_offer_emails: true) }
 
   # No projects assigned == applies to all projects of this customer.
   def applies_to_project?(project)

--- a/app/models/delivery_note.rb
+++ b/app/models/delivery_note.rb
@@ -46,6 +46,8 @@ class DeliveryNote < ApplicationRecord
   belongs_to :project
   belongs_to :acceptance_attachment, class_name: "Attachment", optional: true
   belongs_to :invoice, optional: true
+  has_one :offer_milestone
+  before_destroy :check_offer_milestone_link
 
   has_many :delivery_note_lines, -> { order(:position, :id) }, dependent: :delete_all
   accepts_nested_attributes_for :delivery_note_lines, allow_destroy: true, reject_if: :all_blank
@@ -196,5 +198,11 @@ class DeliveryNote < ApplicationRecord
     if delivery_end_date < delivery_start_date
       errors.add(:delivery_end_date, "cannot be before the start date")
     end
+  end
+
+  def check_offer_milestone_link
+    return if offer_milestone.nil?
+    errors.add(:base, "This delivery note was converted from #{offer_milestone.offer.display_name}; remove the milestone link there first.")
+    throw :abort
   end
 end

--- a/app/models/document_number.rb
+++ b/app/models/document_number.rb
@@ -13,14 +13,15 @@ class DocumentNumber < ApplicationRecord
   end
 
   def wraparound_if_needed(date)
-    return unless self.format.include? "year"
-    if self.last_date.nil? or (date.year != self.last_date.year)
-      self.sequence = 0
+    if self.format.include? "date"
+      self.sequence = 0 if self.last_date.nil? or date != self.last_date
+    elsif self.format.include? "year"
+      self.sequence = 0 if self.last_date.nil? or date.year != self.last_date.year
     end
   end
 
   def format_at(date)
-    self.format % { year: date.year, number: self.sequence }
+    self.format % { year: date.year, number: self.sequence, date: date.strftime("%Y%m%d") }
   end
 
   # Must run inside the caller's publish transaction: `lock` takes a row lock

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -71,6 +71,7 @@ class Invoice < ApplicationRecord
   belongs_to :attachment, optional: true
 
   has_one :delivery_note, dependent: :nullify
+  has_one :offer_milestone
 
   has_many :invoice_lines, -> { order(:position, :id) }, after_add: :line_addedremoved, after_remove: :line_addedremoved
   accepts_nested_attributes_for :invoice_lines, allow_destroy: true, reject_if: :all_blank
@@ -79,6 +80,7 @@ class Invoice < ApplicationRecord
 
   before_save :update_customer
   before_save :update_sums
+  before_destroy :check_offer_milestone_link
 
   # Memoized so lines and tax classes resolve the issuer once, not per row.
   def money_decimal_places
@@ -268,5 +270,11 @@ private
 
     # Delete tax classes that are no longer needed
     self.invoice_tax_classes.where.not(sales_tax_product_class_id: required_product_class_ids).destroy_all
+  end
+
+  def check_offer_milestone_link
+    return if offer_milestone.nil?
+    errors.add(:base, "This invoice was converted from #{offer_milestone.offer.display_name}; remove the milestone link there first.")
+    throw :abort
   end
 end

--- a/app/models/issuer_company.rb
+++ b/app/models/issuer_company.rb
@@ -6,6 +6,7 @@ class IssuerCompany < ApplicationRecord
             format: { with: /\A#[0-9a-fA-F]{3,8}\z/, message: "must be a hex color like #rrggbb" },
             allow_blank: true
   validates :vat_id_recheck_days, numericality: { only_integer: true, greater_than: 0 }
+  validates :offer_validity_days, numericality: { greater_than: 0 }
   # 0..4 covers all ISO 4217 minor units (2 typical, 0 for JPY, 3 for KWD, 4 for
   # CLF). Bounding it also keeps stored values exact on SQLite's float-backed
   # decimal columns.

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -1,0 +1,162 @@
+class Offer < ApplicationRecord
+  include YearFilterable
+  include ScopedThroughCustomer
+  include DocumentIdentity
+  include StripsRichTextEdges
+
+  class InvalidTransition < StandardError; end
+
+  STATES = %w[draft sent accepted rejected expired].freeze
+
+  belongs_to :customer
+  belongs_to :project
+  belongs_to :customer_contact, optional: true
+  belongs_to :accepted_version, class_name: "OfferVersion", optional: true
+  belongs_to :order_attachment, class_name: "Attachment", optional: true
+
+  has_many :versions, -> { order(:version_number) }, class_name: "OfferVersion", dependent: :destroy
+  has_one :draft_version, -> { where(sent_at: nil) }, class_name: "OfferVersion"
+  accepts_nested_attributes_for :draft_version
+
+  has_rich_text :internal_notes
+  strips_rich_text_edges :internal_notes
+
+  validates :state, inclusion: { in: STATES }
+  validate :customer_contact_must_belong_to_customer, if: :will_save_change_to_customer_contact_id?
+
+  after_create :create_initial_version
+
+  STATES.each do |s|
+    define_method("#{s}?") { state == s }
+  end
+
+  def current_sent_version
+    return accepted_version if accepted_version
+    versions.where.not(sent_at: nil).order(:version_number).last
+  end
+
+  def validity_days
+    customer.offer_validity_days.presence || IssuerCompany.get_the_issuer!.offer_validity_days
+  end
+
+  def editable?
+    %w[draft sent expired].include?(state) && draft_version.present?
+  end
+
+  def deletable?
+    draft?
+  end
+
+  def send_problems
+    problems = []
+    problems << "No draft version to send." if draft_version.nil?
+    problems << "Add at least one milestone before sending." if draft_version && draft_version.milestones.none?
+    problems << "Offer is #{state}; reopen it before sending a revision." unless %w[draft sent expired].include?(state)
+    problems
+  end
+
+  def accept!(order_number:, ordered_on:, order_pdf: nil)
+    with_lock do
+      raise InvalidTransition, "accept requires state sent, was #{state}" unless sent?
+      raise InvalidTransition, "order date is required" if ordered_on.blank?
+      self.accepted_version = versions.where.not(sent_at: nil).order(:version_number).last
+      self.accepted_at = Time.current
+      self.order_number = order_number
+      self.ordered_on = ordered_on
+      attach_order_pdf(order_pdf) if order_pdf
+      self.state = "accepted"
+      draft_version&.destroy
+      save!
+    end
+  end
+
+  def reject!
+    with_lock do
+      raise InvalidTransition, "reject requires sent or expired, was #{state}" unless sent? || expired?
+      update!(state: "rejected", rejected_at: Time.current)
+    end
+  end
+
+  def reopen!
+    with_lock do
+      case state
+      when "accepted"
+        source = accepted_version
+        assign_attributes(state: "sent", accepted_at: nil, accepted_version: nil, reported_expired_at: nil)
+        save!
+        if draft_version.nil?
+          source.branch_draft!
+          # draft_version is a has_one keyed on `sent_at IS NULL`; the branch
+          # above just created that row through a different in-memory Offer
+          # instance (source.offer), so this object's cached "no draft" result
+          # from the nil? check above would otherwise linger stale.
+          association(:draft_version).reset
+        end
+      when "rejected"
+        # reported_expired_at must be cleared here too: an offer that was
+        # auto-expired by ExpiringOffersReportJob, then rejected (reject!
+        # allows expired -> rejected), still carries that stamp. Left in
+        # place, the job's `reported_expired_at: nil` filter would never
+        # pick this offer up again after it lands back in "sent" below.
+        update!(state: "sent", rejected_at: nil, reported_expired_at: nil)
+      else
+        raise InvalidTransition, "reopen requires accepted or rejected, was #{state}"
+      end
+    end
+  end
+
+  def email_recipients
+    customer.contacts_for_offer(self).map(&:to_email_address)
+  end
+
+  def email_cc_recipients
+    []
+  end
+
+  def email_salutation_contact
+    contacts = customer.contacts_for_offer(self)
+    contacts.size == 1 ? contacts.first : nil
+  end
+
+  def emailable?
+    current_sent_version&.attachment.present? && email_recipients.any?
+  end
+
+  def status_badge
+    { "draft" => [ "Draft", "bg-secondary" ],
+      "sent" => [ "Sent", "bg-info text-dark" ],
+      "accepted" => [ "Accepted", "bg-success" ],
+      "rejected" => [ "Rejected", "bg-danger" ],
+      "expired" => [ "Expired", "bg-warning text-dark" ] }.fetch(state)
+  end
+
+  def attach_order_pdf(uploaded_file)
+    attachment = order_attachment || Attachment.new
+    attachment.set_data(uploaded_file.read, "application/pdf")
+    attachment.filename = "Order-#{display_label}.pdf"
+    attachment.title = "Customer order for #{display_name}"
+    attachment.save!
+    self.order_attachment = attachment
+  end
+
+  private
+
+  def create_initial_version
+    versions.create!(version_number: 1, sales_tax_product_class: sole_customer_tax_class)
+  end
+
+  # Preselect the tax class when the customer's rate table offers no real choice.
+  def sole_customer_tax_class
+    classes = SalesTaxProductClass
+      .where(id: customer.sales_tax_rates.select(:sales_tax_product_class_id))
+      .limit(2).to_a
+    classes.size == 1 ? classes.first : nil
+  end
+
+  def customer_contact_must_belong_to_customer
+    return if customer_contact_id.nil?
+    return if customer_id.nil?
+    return if CustomerContact.where(id: customer_contact_id, customer_id: customer_id).exists?
+    errors.add(:customer_contact, "must belong to the offer's customer")
+  end
+end

--- a/app/models/offer_milestone.rb
+++ b/app/models/offer_milestone.rb
@@ -33,6 +33,10 @@ class OfferMilestone < ApplicationRecord
     trigger == "on_order"
   end
 
+  def reopen_link!
+    update!(invoice: nil, delivery_note: nil)
+  end
+
   private
 
   def refresh_version_sum

--- a/app/models/offer_milestone.rb
+++ b/app/models/offer_milestone.rb
@@ -7,6 +7,7 @@ class OfferMilestone < ApplicationRecord
   }.freeze
 
   belongs_to :offer_version
+  delegate :offer, to: :offer_version
   belongs_to :invoice, optional: true
   belongs_to :delivery_note, optional: true
 

--- a/app/models/offer_milestone.rb
+++ b/app/models/offer_milestone.rb
@@ -1,0 +1,41 @@
+class OfferMilestone < ApplicationRecord
+  TRIGGERS = %w[on_order on_acceptance on_date].freeze
+  TRIGGER_LABELS = {
+    "on_order" => "Upon order",
+    "on_acceptance" => "Upon acceptance",
+    "on_date" => "On date"
+  }.freeze
+
+  belongs_to :offer_version
+  belongs_to :invoice, optional: true
+  belongs_to :delivery_note, optional: true
+
+  validates :title, presence: true
+  validates :amount, presence: true, numericality: true
+  validates :trigger, presence: true, inclusion: { in: TRIGGERS }
+  validates :trigger_date, presence: true, if: -> { trigger == "on_date" }
+  validates :invoice_id, uniqueness: true, allow_nil: true
+  validates :delivery_note_id, uniqueness: true, allow_nil: true
+
+  after_save :refresh_version_sum
+  after_destroy :refresh_version_sum
+
+  def trigger_label
+    label = TRIGGER_LABELS.fetch(trigger, trigger)
+    trigger == "on_date" && trigger_date ? "#{label} #{I18n.l(trigger_date)}" : label
+  end
+
+  def converted?
+    invoice_id.present?
+  end
+
+  def default_skip_delivery_note
+    trigger == "on_order"
+  end
+
+  private
+
+  def refresh_version_sum
+    offer_version.recalculate_sum_net!
+  end
+end

--- a/app/models/offer_version.rb
+++ b/app/models/offer_version.rb
@@ -1,0 +1,49 @@
+class OfferVersion < ApplicationRecord
+  belongs_to :offer
+  belongs_to :sales_tax_product_class, optional: true
+  belongs_to :attachment, optional: true
+
+  has_many :milestones, -> { order(:position, :id) }, class_name: "OfferMilestone", dependent: :destroy
+  accepts_nested_attributes_for :milestones, allow_destroy: true, reject_if: :all_blank
+
+  include StripsRichTextEdges
+
+  has_rich_text :prelude
+  has_rich_text :boilerplate
+  strips_rich_text_edges :prelude
+
+  validates :version_number, presence: true, uniqueness: { scope: :offer_id }
+
+  # Deliberately shadows Object#frozen? to match the domain language
+  # ("frozen once sent"). ActiveRecord persistence does not consult
+  # Object#frozen?, but don't duck-type this against Ruby's freeze protocol.
+  def frozen?
+    sent_at.present?
+  end
+
+  def recalculate_sum_net!
+    update_column(:sum_net, milestones.reload.sum(:amount))
+  end
+
+  # Copies customer-facing content into a new draft version. Frozen
+  # customer-derived values (snapshot, boilerplate) deliberately do NOT copy —
+  # drafts return to the live customer reference.
+  def branch_draft!
+    offer.versions.create!(
+      version_number: offer.versions.maximum(:version_number) + 1,
+      subject: subject,
+      salutation_override: salutation_override,
+      delivery_date: delivery_date,
+      sales_tax_product_class_id: sales_tax_product_class_id,
+      prelude: prelude.body
+    ).tap do |draft|
+      milestones.each do |m|
+        draft.milestones.create!(
+          position: m.position, title: m.title, description: m.description,
+          trigger: m.trigger, trigger_date: m.trigger_date,
+          amount: m.amount, skip_delivery_note: m.skip_delivery_note
+        )
+      end
+    end
+  end
+end

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -17,6 +17,9 @@ module Permission
     Entry.new(key: "delivery_notes.view", label: "View delivery notes",     category: "Operations"),
     Entry.new(key: "delivery_notes.edit", label: "Create / publish / send delivery notes", category: "Operations"),
     Entry.new(key: "delivery_notes.review_acceptance", label: "Review delivery-note acceptance submissions", category: "Operations"),
+    Entry.new(key: "offers.view",    label: "View offers",                        category: "Operations"),
+    Entry.new(key: "offers.edit",    label: "Create / send / accept offers",      category: "Operations"),
+    Entry.new(key: "offers.convert", label: "Convert offer milestones to invoices", category: "Operations"),
 
     # Catalog & tax
     Entry.new(key: "products.view", label: "View product catalog",          category: "Catalog & tax"),

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -5,6 +5,7 @@ class Project < ApplicationRecord
   belongs_to :bill_to_customer, class_name: "Customer", optional: true
   has_many :invoices
   has_many :delivery_notes
+  has_many :offers
 
   validate :team_must_match_customer
 
@@ -19,6 +20,10 @@ class Project < ApplicationRecord
 
   def used_in_delivery_notes?
     delivery_notes.exists?
+  end
+
+  def used_in_offers?
+    offers.exists?
   end
 
   # Prevent deletion if project has been used
@@ -43,7 +48,8 @@ class Project < ApplicationRecord
   # UI gate (can_be_deleted?) and the destroy guard's error message.
   def deletion_blocker
     return "invoices" if used_in_invoices?
-    "delivery notes" if used_in_delivery_notes?
+    return "delivery notes" if used_in_delivery_notes?
+    "offers" if used_in_offers?
   end
 
   def check_if_used

--- a/app/services/delivery_note_renderer.rb
+++ b/app/services/delivery_note_renderer.rb
@@ -56,7 +56,7 @@ class DeliveryNoteRenderer
       end
 
       xml_root.prelude do |xml_prelude|
-        xml_prelude << RichTextFoConverter.new(@delivery_note.prelude.body&.to_html).to_fo_fragment if @delivery_note.prelude.present?
+        xml_prelude << RichTextFoConverter.new(@delivery_note.prelude.body&.to_html, heading_color: @issuer.document_accent_color).to_fo_fragment if @delivery_note.prelude.present?
       end
       xml_root.number draft_aware_number
       xml_root.tag! "issue-date", @delivery_note.date || "2999-01-01"

--- a/app/services/invoice_renderer.rb
+++ b/app/services/invoice_renderer.rb
@@ -64,7 +64,7 @@ class InvoiceRenderer
       xml_root.currency "EUR"
       xml_root.tag! "money-decimal-places", @issuer.money_decimal_places
       xml_root.prelude do |xml_prelude|
-        xml_prelude << RichTextFoConverter.new(@invoice.prelude.body&.to_html).to_fo_fragment if @invoice.prelude.present?
+        xml_prelude << RichTextFoConverter.new(@invoice.prelude.body&.to_html, heading_color: @issuer.document_accent_color).to_fo_fragment if @invoice.prelude.present?
       end
       xml_root.tag! "tax-note", @invoice.tax_note
       xml_root.number @invoice.document_number

--- a/app/services/offer_milestone_converter.rb
+++ b/app/services/offer_milestone_converter.rb
@@ -1,0 +1,76 @@
+class OfferMilestoneConverter
+  class NotConvertible < StandardError; end
+
+  def initialize(milestone)
+    @milestone = milestone
+    @version = milestone.offer_version
+    @offer = @version.offer
+  end
+
+  def convert!
+    raise NotConvertible, "offer is not accepted" unless @offer.accepted?
+    raise NotConvertible, "milestone belongs to a non-accepted version" unless @version.id == @offer.accepted_version_id
+    raise NotConvertible, "milestone already converted" if @milestone.converted?
+
+    ActiveRecord::Base.transaction do
+      invoice = build_invoice
+      invoice.save!
+      delivery_note = @milestone.skip_delivery_note? ? nil : build_delivery_note(invoice).tap(&:save!)
+      @milestone.update!(invoice: invoice, delivery_note: delivery_note)
+      invoice
+    end
+  end
+
+  private
+
+  # The offer's internal reference carries over; with several milestones each
+  # document gets the milestone's ordinal appended so they stay tellable apart.
+  def internal_reference
+    ordinal = @version.milestones.index(@milestone) + 1 if @version.milestones.many?
+    [ @offer.internal_reference.presence, ordinal ].compact.join(" ").presence
+  end
+
+  # A delivery date predating the order date would fail the delivery-note
+  # date-range validation; the admin sets the range on the draft instead.
+  def delivery_end_date
+    date = @version.delivery_date
+    date if date.present? && date >= @offer.ordered_on
+  end
+
+  def line_title
+    @version.subject.presence || @milestone.title
+  end
+
+  def line_description
+    reference =
+      if @offer.customer.language&.iso_code == "de"
+        "Angebot Nummer #{@offer.document_number} v#{@version.version_number}"
+      else
+        "Offer #{@offer.document_number} v#{@version.version_number}"
+      end
+    [ @milestone.title, reference, @milestone.description.presence ].compact.join("\n")
+  end
+
+  def build_invoice
+    invoice = Invoice.new(customer: @offer.customer, project: @offer.project,
+                          cust_order: @offer.order_number,
+                          internal_reference: internal_reference)
+    invoice.prelude = @version.prelude.body.to_html if @version.prelude.present?
+    invoice.invoice_lines.build(type: "item", position: 1, title: line_title,
+                                description: line_description, quantity: 1,
+                                rate: @milestone.amount,
+                                sales_tax_product_class_id: @version.sales_tax_product_class_id)
+    invoice
+  end
+
+  def build_delivery_note(invoice)
+    dn = DeliveryNote.new(customer: @offer.customer, project: @offer.project,
+                          invoice: invoice, cust_order: @offer.order_number,
+                          internal_reference: internal_reference,
+                          delivery_start_date: @offer.ordered_on,
+                          delivery_end_date: delivery_end_date)
+    dn.delivery_note_lines.build(type: "item", position: 1, title: line_title,
+                                 description: line_description, quantity: 1)
+    dn
+  end
+end

--- a/app/services/offer_milestone_scaffolder.rb
+++ b/app/services/offer_milestone_scaffolder.rb
@@ -1,0 +1,54 @@
+class OfferMilestoneScaffolder
+  class MilestonesPresent < StandardError; end
+
+  Row = Struct.new(:title, :trigger, :percentage)
+
+  def initialize(customer, total)
+    @customer = customer
+    @total = BigDecimal(total.to_s)
+  end
+
+  def apply_to(version)
+    raise MilestonesPresent if version.milestones.any?
+
+    rows = parse_rows
+    places = IssuerCompany.get_the_issuer!.money_decimal_places
+    milestones =
+      if rows.empty?
+        [ version.milestones.create!(position: 1, title: "Milestone", trigger: "on_acceptance",
+                                    amount: @total.round(places)) ]
+      else
+        amounts = rows[0..-2].map { |r| (@total * r.percentage / 100).round(places) }
+        amounts << @total - amounts.sum
+        rows.each_with_index.map do |row, i|
+          version.milestones.create!(position: i + 1, title: row.title, trigger: row.trigger,
+                                     trigger_date: (Date.current if row.trigger == "on_date"),
+                                     amount: amounts[i],
+                                     skip_delivery_note: row.trigger == "on_order")
+        end
+      end
+    milestones
+  end
+
+  private
+
+  # Without a threshold the "below" template always applies.
+  def template_source
+    threshold = @customer.offer_milestone_split_threshold
+    if threshold.present? && @total >= threshold
+      @customer.offer_milestone_templates_above
+    else
+      @customer.offer_milestone_templates_below
+    end
+  end
+
+  def parse_rows
+    template_source.to_s.each_line.filter_map do |line|
+      title, trigger, percentage = line.strip.split("|").map(&:strip)
+      next if title.blank? || !OfferMilestone::TRIGGERS.include?(trigger)
+      percentage = Float(percentage, exception: false)
+      next if percentage.nil? || percentage <= 0 || percentage > 100
+      Row.new(title, trigger, BigDecimal(percentage.to_s))
+    end
+  end
+end

--- a/app/services/offer_renderer.rb
+++ b/app/services/offer_renderer.rb
@@ -1,10 +1,109 @@
+require "builder"
+
 class OfferRenderer
   def initialize(version, issuer)
     @version = version
+    @offer = version.offer
     @issuer = issuer
   end
 
+  def emit_xml(logo_file_path)
+    frozen = @version.frozen?
+    customer = @offer.customer
+
+    recipient_name = frozen ? @version.customer_name : customer.name
+    recipient_address = frozen ? @version.customer_address : customer.address
+    recipient_country = frozen ? @version.customer_country_iso2 : customer.country_iso2
+    supplier_number = frozen ? @version.customer_supplier_number : customer.supplier_number
+    payment_terms = frozen ? @version.payment_terms_days : customer.payment_terms_days
+    boilerplate =
+      if frozen
+        @version.boilerplate.presence && @version.boilerplate
+      else
+        customer.offer_boilerplate.presence && customer.offer_boilerplate
+      end
+    date = @version.date || Date.current
+    valid_until = frozen ? @offer.expires_at : Date.current + @offer.validity_days
+
+    issuer_country = @issuer.country_iso2
+    locale = customer.language.iso_code
+
+    xml = Builder::XmlMarkup.new(indent: 2)
+    xml.instruct! :xml, encoding: "UTF-8", version: "1.0"
+
+    xml.document class: "offer", "xmlns:fo" => "http://www.w3.org/1999/XSL/Format" do |xml_root|
+      xml_root.language locale
+      xml_root.tag! "accent-color", @issuer.document_accent_color
+      xml_root.tag! "footer", @issuer.offer_footer
+
+      if logo_file_path
+        xml_root.tag! "logo-path", logo_file_path
+        xml_root.tag! "logo-width", @issuer.pdf_logo_width
+        xml_root.tag! "logo-height", @issuer.pdf_logo_height
+      end
+
+      xml_root.issuer do |xml_issuer|
+        xml_issuer.address AddressFormatter.build(
+          name: @issuer.legal_name,
+          address: @issuer.address,
+          self_country: issuer_country,
+          other_country: recipient_country,
+          locale: locale
+        )
+        xml_issuer.tag! "short-name", @issuer.short_name
+        xml_issuer.tag! "legal-name", @issuer.legal_name
+        xml_issuer.tag! "contact-line1", @issuer.document_contact_line1
+        xml_issuer.tag! "contact-line2", @issuer.document_contact_line2
+      end
+
+      xml_root.recipient do |xml_recipient|
+        xml_recipient.address AddressFormatter.build(
+          name: recipient_name,
+          address: recipient_address,
+          self_country: recipient_country,
+          other_country: issuer_country,
+          locale: locale
+        )
+        xml_recipient.tag! "supplier-no", supplier_number if supplier_number.present?
+      end
+
+      xml_root.currency @issuer.currency
+      xml_root.tag! "money-decimal-places", @issuer.money_decimal_places
+      xml_root.subject @version.subject
+      xml_root.number @offer.document_number.presence || "DRAFT"
+      xml_root.tag! "issue-date", date.iso8601
+      xml_root.tag! "valid-until", valid_until.iso8601
+      xml_root.tag! "version-number", @version.version_number if @version.version_number >= 2
+      xml_root.tag! "delivery-date", @version.delivery_date&.iso8601
+      xml_root.tag! "payment-terms-days", payment_terms
+
+      xml_root.prelude do |xml_prelude|
+        xml_prelude << RichTextFoConverter.new(@version.prelude.body&.to_html).to_fo_fragment if @version.prelude.present?
+      end
+      xml_root.boilerplate do |xml_boilerplate|
+        xml_boilerplate << RichTextFoConverter.new(boilerplate.body&.to_html).to_fo_fragment if boilerplate
+      end
+
+      xml_root.milestones do |xml_milestones|
+        @version.milestones.each do |milestone|
+          xml_milestones.milestone do |xml_milestone|
+            xml_milestone.title milestone.title
+            xml_milestone.description milestone.description
+            xml_milestone.trigger milestone.trigger
+            xml_milestone.tag! "trigger-date", milestone.trigger_date&.iso8601
+            xml_milestone.amount milestone.amount
+          end
+        end
+      end
+    end
+
+    xml.target!
+  end
+
   def render
-    raise NotImplementedError
+    logo_data = @issuer.pdf_logo.present? ? @issuer.pdf_logo : nil
+    FopRenderer.new.render_pdf_with_logo("offer.xsl", logo_data) do |logo_file_path|
+      emit_xml(logo_file_path)
+    end
   end
 end

--- a/app/services/offer_renderer.rb
+++ b/app/services/offer_renderer.rb
@@ -1,0 +1,10 @@
+class OfferRenderer
+  def initialize(version, issuer)
+    @version = version
+    @issuer = issuer
+  end
+
+  def render
+    raise NotImplementedError
+  end
+end

--- a/app/services/offer_renderer.rb
+++ b/app/services/offer_renderer.rb
@@ -78,10 +78,10 @@ class OfferRenderer
       xml_root.tag! "payment-terms-days", payment_terms
 
       xml_root.prelude do |xml_prelude|
-        xml_prelude << RichTextFoConverter.new(@version.prelude.body&.to_html).to_fo_fragment if @version.prelude.present?
+        xml_prelude << rich_text_fragment(@version.prelude.body&.to_html) if @version.prelude.present?
       end
       xml_root.boilerplate do |xml_boilerplate|
-        xml_boilerplate << RichTextFoConverter.new(boilerplate.body&.to_html).to_fo_fragment if boilerplate
+        xml_boilerplate << rich_text_fragment(boilerplate.body&.to_html) if boilerplate
       end
 
       xml_root.milestones do |xml_milestones|
@@ -105,5 +105,9 @@ class OfferRenderer
     FopRenderer.new.render_pdf_with_logo("offer.xsl", logo_data) do |logo_file_path|
       emit_xml(logo_file_path)
     end
+  end
+
+  def rich_text_fragment(html)
+    RichTextFoConverter.new(html, heading_color: @issuer.document_accent_color).to_fo_fragment
   end
 end

--- a/app/services/offer_sender.rb
+++ b/app/services/offer_sender.rb
@@ -1,0 +1,68 @@
+class OfferSender
+  attr_reader :log
+
+  def initialize(offer, issuer)
+    @offer = offer
+    @issuer = issuer
+    @log = ""
+  end
+
+  def send!
+    @offer.with_lock { send_locked! }
+  end
+
+  private
+
+  def send_locked!
+    problems = @offer.send_problems
+    if problems.any?
+      problems.each { |p| @log += "E: #{p}\n" }
+      return false
+    end
+
+    version = @offer.draft_version
+    today = Date.current
+    customer = @offer.customer
+
+    @offer.document_number ||= DocumentNumber.get_next_for("offer", today)
+
+    version.assign_attributes(
+      date: today,
+      sent_at: Time.current,
+      customer_name: customer.name,
+      customer_address: customer.address,
+      customer_country_iso2: customer.country_iso2,
+      customer_supplier_number: customer.supplier_number,
+      payment_terms_days: customer.payment_terms_days
+    )
+    version.boilerplate = customer.offer_boilerplate.body if customer.offer_boilerplate.present?
+    version.save!
+
+    # expires_at must land on @offer before rendering: OfferRenderer reads
+    # frozen-version valid-until from @offer.expires_at once the version is
+    # frozen (sent_at present), which it already is by this point. Rendering
+    # first would hand the XSL a nil expires_at and crash. If rendering below
+    # raises, the whole with_lock transaction (including this assignment)
+    # rolls back, so an offer never surfaces as "sent" without a PDF.
+    @offer.assign_attributes(
+      state: "sent",
+      date: today,
+      sent_at: Time.current,
+      expires_at: today + @offer.validity_days,
+      reported_expired_at: nil
+    )
+    @offer.save!
+
+    pdf = OfferRenderer.new(version, @issuer).render
+    version.attachment ||= Attachment.new
+    version.attachment.set_data(pdf, "application/pdf")
+    version.attachment.filename = "#{@issuer.short_name}-Offer-#{@offer.document_number}-v#{version.version_number}.pdf"
+    version.attachment.title = "#{@issuer.short_name} Offer #{@offer.document_number} (version #{version.version_number})"
+    version.attachment.save!
+    version.save!
+
+    version.branch_draft!
+    @log += "I: sent version #{version.version_number} as #{@offer.document_number}\n"
+    true
+  end
+end

--- a/app/services/rich_text_fo_converter.rb
+++ b/app/services/rich_text_fo_converter.rb
@@ -10,8 +10,9 @@ require "nokogiri"
 class RichTextFoConverter
   LINE_SEPARATOR = " "
 
-  def initialize(html)
+  def initialize(html, heading_color: nil)
     @html = html.to_s
+    @heading_color = heading_color
   end
 
   def to_fo_fragment
@@ -28,8 +29,7 @@ class RichTextFoConverter
     when "ul", "ol"
       render_list(node, xml)
     when "h1"
-      xml.tag!("fo:block", "font-size" => "14pt", "font-weight" => "bold",
-               "space-before" => "6pt", "space-after" => "4pt") do |b|
+      xml.tag!("fo:block", heading_attributes) do |b|
         render_inline(node.children, b)
       end
     when "div", "p"
@@ -39,6 +39,15 @@ class RichTextFoConverter
     else
       xml.tag!("fo:block") { |b| render_inline(node.children, b) } if node.element?
     end
+  end
+
+  # Headings match the document line-table headers: accent color at body size,
+  # not the browser's big-and-bold default. No space-before: an author's empty
+  # line above a heading already carries the full line of spacing.
+  def heading_attributes
+    attrs = { "space-after" => "4pt" }
+    attrs["color"] = @heading_color if @heading_color
+    attrs
   end
 
   def render_list(node, xml)

--- a/app/services/rich_text_fo_converter.rb
+++ b/app/services/rich_text_fo_converter.rb
@@ -33,12 +33,22 @@ class RichTextFoConverter
         render_inline(node.children, b)
       end
     when "div", "p"
-      xml.tag!("fo:block") { |b| render_inline(node.children, b) }
+      if blank_block?(node)
+        # A lone <br> in a block is Trix's empty line; U+2028 would render as
+        # two line areas, so emit a single non-breaking-space line instead.
+        xml.tag!("fo:block") { |b| b.text!("\u00A0") }
+      else
+        xml.tag!("fo:block") { |b| render_inline(node.children, b) }
+      end
     when "text"
       xml.tag!("fo:block") { |b| render_inline([ node ], b) } unless node.text.strip.empty?
     else
       xml.tag!("fo:block") { |b| render_inline(node.children, b) } if node.element?
     end
+  end
+
+  def blank_block?(node)
+    node.text.strip.empty? && node.children.all? { |c| c.name == "br" || (c.text? && c.text.strip.empty?) }
   end
 
   # Headings match the document line-table headers: accent color at body size,

--- a/app/views/customer_contacts/_form_fields.html.haml
+++ b/app/views/customer_contacts/_form_fields.html.haml
@@ -4,7 +4,7 @@
     = form.text_field :name, class: "form-control form-control-sm", required: true, autofocus: true, placeholder: "Name", autocomplete: "off"
     - if contact.errors[:name].any?
       .invalid-feedback.d-block= contact.errors[:name].to_sentence
-  .col-md-3
+  .col-md-2
     = form.email_field :email, class: "form-control form-control-sm", required: true, placeholder: "Email", autocomplete: "off"
     - if contact.errors[:email].any?
       .invalid-feedback.d-block= contact.errors[:email].to_sentence
@@ -14,6 +14,9 @@
   .col-md-1.text-center
     .form-check.d-inline-block
       = form.check_box :receives_delivery_note_emails, class: "form-check-input"
+  .col-md-1.text-center
+    .form-check.d-inline-block
+      = form.check_box :receives_offer_emails, class: "form-check-input"
   .col-md-3
     = form.select :project_ids,
                   options_from_collection_for_select(eligible_projects, :id, :matchcode, contact.project_ids),

--- a/app/views/customer_contacts/_row.html.haml
+++ b/app/views/customer_contacts/_row.html.haml
@@ -1,7 +1,7 @@
 = turbo_frame_tag dom_id(contact), class: "contact-row d-block border-bottom py-2" do
   .row.align-items-center.gx-2
     .col-md-2.fw-medium= contact.name
-    .col-md-3= mail_to contact.email
+    .col-md-2= mail_to contact.email
     .col-md-1.text-center
       - if contact.receives_invoice_emails?
         %span.badge.bg-success Invoice
@@ -10,6 +10,11 @@
     .col-md-1.text-center
       - if contact.receives_delivery_note_emails?
         %span.badge.bg-success Del.Note
+      - else
+        %span.text-muted —
+    .col-md-1.text-center
+      - if contact.receives_offer_emails?
+        %span.badge.bg-success Offer
       - else
         %span.text-muted —
     .col-md-3

--- a/app/views/customers/_contacts_table.html.haml
+++ b/app/views/customers/_contacts_table.html.haml
@@ -3,9 +3,10 @@
   .card-body.pt-2
     .row.gx-2.pb-2.border-bottom.text-muted.small.fw-bold
       .col-md-2 Name
-      .col-md-3 Email
+      .col-md-2 Email
       .col-md-1.text-center Invoice
       .col-md-1.text-center Del.Note
+      .col-md-1.text-center Offer
       .col-md-3 Projects
       .col-md-2.text-end &nbsp;
 

--- a/app/views/customers/_form.html.haml
+++ b/app/views/customers/_form.html.haml
@@ -79,6 +79,39 @@
       .col-lg-5.col-md-4
         = f.number_field :payment_terms_days, :class => 'form-control', :min => 1, :max => 365, :value => (@customer.payment_terms_days || 30)
     %hr
+    %h5.mb-3 Offer settings
+    .row.mb-3
+      = f.label :offer_validity_days, 'Validity (days)', class: 'col-lg-2 col-md-3 col-form-label'
+      .col-lg-3.col-md-4
+        = f.number_field :offer_validity_days, class: 'form-control', min: 1, placeholder: "Default: #{IssuerCompany.get_the_issuer!.offer_validity_days}"
+        .form-text Leave blank to use the issuer default.
+    %div{data: { controller: 'presence-toggle' }}
+      .row.mb-3
+        = f.label :offer_milestone_split_threshold, 'Milestone split threshold', class: 'col-lg-2 col-md-3 col-form-label'
+        .col-lg-3.col-md-4
+          = f.number_field :offer_milestone_split_threshold, class: 'form-control', step: 'any', min: 0, data: { presence_toggle_target: 'input', action: 'input->presence-toggle#sync' }
+          .form-text Scaffolding compares the offer's total net against this amount: below it the "below" template applies, at or above it the "above" one. Without a threshold the "below" template is always used.
+      .row.mb-3
+        = f.label :offer_milestone_templates_below, 'Milestone template (below)', class: 'col-lg-2 col-md-3 col-form-label'
+        .col-lg-8
+          = f.text_area :offer_milestone_templates_below, class: 'form-control', rows: 3
+          .form-text
+            One per line: Title|trigger|percent.
+            Triggers: on_order, on_acceptance, on_date — on_order milestones skip the delivery note by default.
+            Percent = share of the offer total (0–100, summing to 100; the last line absorbs rounding).
+      .row.mb-3{data: { presence_toggle_target: 'panel' }}
+        = f.label :offer_milestone_templates_above, 'Milestone template (above)', class: 'col-lg-2 col-md-3 col-form-label'
+        .col-lg-8
+          = f.text_area :offer_milestone_templates_above, class: 'form-control', rows: 3
+          .form-text
+            One per line: Title|trigger|percent.
+            Triggers: on_order, on_acceptance, on_date — on_order milestones skip the delivery note by default.
+            Percent = share of the offer total (0–100, summing to 100; the last line absorbs rounding).
+    .row.mb-3
+      = f.label :offer_boilerplate, class: 'col-lg-2 col-md-3 col-form-label'
+      .col-lg-8
+        = f.rich_text_area :offer_boilerplate, data: { controller: 'rich-text' }
+    %hr
     .row.mb-3
       = f.label :notes, class: 'col-lg-2 col-md-3 col-form-label'
       .col-lg-10.col-md-9

--- a/app/views/customers/show.html.haml
+++ b/app/views/customers/show.html.haml
@@ -1,8 +1,9 @@
+- offers_action = nav_button('Offers', offers_path(customer_id: @customer.id, year: 'all'), permission: 'offers.view', data: { turbo_prefetch: false })
 - invoices_action = nav_button('Invoices', invoices_path(customer_id: @customer.id, year: 'all'), permission: 'invoices.view', data: { turbo_prefetch: false })
 - delivery_notes_action = nav_button('Delivery Notes', delivery_notes_path(customer_id: @customer.id, year: 'all'), permission: 'delivery_notes.view', data: { turbo_prefetch: false })
 - delete_action = delete_button(@customer, confirm: "Are you sure you want to delete customer \"#{@customer.matchcode}\" (#{@customer.name})?", permission: 'customers.edit') if @customer.can_be_deleted?
 - edit_action = action_button('Edit', edit_customer_path(@customer), permission: 'customers.edit')
-= breadcrumbs ['Customers', customers_path], @customer.matchcode, actions: [invoices_action, delivery_notes_action, delete_action], action: edit_action do
+= breadcrumbs ['Customers', customers_path], @customer.matchcode, actions: [offers_action, delivery_notes_action, invoices_action, delete_action], action: edit_action do
   - unless @customer.active?
     %span.badge.bg-secondary Inactive
 
@@ -146,6 +147,44 @@
               = @customer.invoice_email_auto_contact_mode_label
 
 = render "customers/contacts_table", customer: @customer
+
+.row.mt-4
+  .col-md-12
+    .card
+      .card-header
+        Offer settings
+      .card-body
+        .row.mb-2
+          .col-sm-3
+            %strong Validity:
+          .col-sm-9
+            = pluralize(@customer.offer_validity_days || IssuerCompany.get_the_issuer!.offer_validity_days, 'day')
+            - if @customer.offer_validity_days.blank?
+              %span.text-muted (issuer default)
+        - if @customer.offer_milestone_split_threshold.present?
+          .row.mb-2
+            .col-sm-3
+              %strong Milestone split threshold:
+            .col-sm-9
+              = format_currency(@customer.offer_milestone_split_threshold)
+        - if @customer.offer_milestone_templates_below.present?
+          .row.mb-2
+            .col-sm-3
+              %strong Template (below):
+            .col-sm-9
+              %pre.mb-0= @customer.offer_milestone_templates_below
+        - if @customer.offer_milestone_templates_above.present?
+          .row.mb-2
+            .col-sm-3
+              %strong Template (above):
+            .col-sm-9
+              %pre.mb-0= @customer.offer_milestone_templates_above
+        - if @customer.offer_boilerplate.present?
+          .row.mb-2
+            .col-sm-3
+              %strong Boilerplate:
+            .col-sm-9
+              = @customer.offer_boilerplate
 
 - if @customer.notes.present?
   .row.mt-4

--- a/app/views/delivery_notes/show.html.haml
+++ b/app/views/delivery_notes/show.html.haml
@@ -4,7 +4,7 @@
 - pdf_action = pdf_button(pdf_delivery_note_path(@delivery_note))
 - preview_action = preview_button(preview_delivery_note_path(@delivery_note)) unless @delivery_note.published?
 - unpublish_action = unpublish_button(unpublish_delivery_note_path(@delivery_note), permission: 'delivery_notes.edit', confirm: 'Are you sure you want to revert this delivery note to draft status?')
-- delete_action = delete_button(@delivery_note, confirm: "Are you sure you want to delete delivery note \"#{@delivery_note.display_label}\"?") if can_edit_dn
+- delete_action = delete_button(@delivery_note, confirm: "Are you sure you want to delete delivery note \"#{@delivery_note.display_label}\"?") if can_edit_dn && !@delivery_note.offer_milestone
 - main_action = @delivery_note.published? ? pdf_action : edit_action
 - workflow_actions = @delivery_note.published? ? [unpublish_action] : [preview_action, delete_action]
 = breadcrumbs ['Delivery Notes', delivery_notes_path], @delivery_note.display_label, actions: workflow_actions, action: main_action do
@@ -104,6 +104,12 @@
                 Not invoiced
                 - if can_edit_dn
                   = button_to '🚀 Create…', convert_to_invoice_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-sm btn-info', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Create an invoice draft from this delivery note?' }
+        - if @delivery_note.offer_milestone
+          .row.mb-2
+            .col-sm-4
+              %strong Source:
+            .col-sm-8
+              = link_to @delivery_note.offer_milestone.offer.display_name, @delivery_note.offer_milestone.offer
 
 
   - if @delivery_note.published?

--- a/app/views/expiring_offers_mailer/expiring_report.html.haml
+++ b/app/views/expiring_offers_mailer/expiring_report.html.haml
@@ -1,0 +1,43 @@
+- content_for :title, t('mailers.expiring_offers.title', count: @offers.size)
+
+:css
+  table.expiring {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 20px 0;
+    font-size: 14px;
+  }
+  table.expiring th, table.expiring td {
+    border: 1px solid #dee2e6;
+    padding: 8px 10px;
+    text-align: left;
+  }
+  table.expiring th {
+    background-color: #f8f9fa;
+    font-weight: 600;
+  }
+  table.expiring td.numeric {
+    text-align: right;
+    white-space: nowrap;
+  }
+
+.greeting
+  = t('mailers.expiring_offers.heading', date: l(@today))
+
+.main-message
+  = t('mailers.expiring_offers.main_message', count: @offers.size)
+
+%table.expiring
+  %thead
+    %tr
+      %th= t('mailers.expiring_offers.columns.offer_number')
+      %th= t('mailers.expiring_offers.columns.customer')
+      %th= t('mailers.expiring_offers.columns.expired_on')
+      %th.numeric= t('mailers.expiring_offers.columns.total')
+  %tbody
+    - @offers.each do |offer|
+      %tr
+        %td= offer.document_number
+        %td= offer.customer.name
+        %td= l(offer.expires_at) if offer.expires_at
+        %td.numeric= sprintf('%.2f', offer.current_sent_version.sum_net)

--- a/app/views/expiring_offers_mailer/expiring_report.text.haml
+++ b/app/views/expiring_offers_mailer/expiring_report.text.haml
@@ -1,0 +1,6 @@
+= t('mailers.expiring_offers.heading', date: l(@today))
+\
+= t('mailers.expiring_offers.main_message', count: @offers.size)
+\
+- @offers.each do |offer|
+  = "#{offer.document_number}  #{offer.customer.name}  #{t('mailers.expiring_offers.short.expired_on')} #{l(offer.expires_at) if offer.expires_at}  #{sprintf('%.2f', offer.current_sent_version.sum_net)}"

--- a/app/views/invoices/show.html.haml
+++ b/app/views/invoices/show.html.haml
@@ -3,7 +3,7 @@
 - edit_action = action_button('Edit', edit_invoice_path(@invoice), permission: 'invoices.edit') unless @invoice.published?
 - problems = @invoice.published? ? [] : @invoice.publish_problems
 - pdf_or_preview = @invoice.attachment ? pdf_button(@invoice.attachment) : preview_button(preview_invoice_path(@invoice))
-- delete_action = delete_button(@invoice, confirm: "Are you sure you want to delete invoice \"#{@invoice.display_label}\"?") if !@invoice.published? && can_edit_invoice
+- delete_action = delete_button(@invoice, confirm: "Are you sure you want to delete invoice \"#{@invoice.display_label}\"?") if !@invoice.published? && can_edit_invoice && !@invoice.offer_milestone
 = breadcrumbs ['Invoices', invoices_path], @invoice.display_label, actions: [pdf_or_preview, delete_action], action: edit_action do
   - if !@invoice.published?
     %span.badge.bg-warning Draft
@@ -136,6 +136,12 @@
               %strong Source:
             .col-sm-8
               = link_to @invoice.delivery_note.display_name, @invoice.delivery_note
+        - if @invoice.offer_milestone
+          .row.mb-2
+            .col-sm-4
+              %strong Source:
+            .col-sm-8
+              = link_to @invoice.offer_milestone.offer.display_name, @invoice.offer_milestone.offer
 
   - if @invoice.prelude.present?
     .mb-4

--- a/app/views/issuer_companies/edit.html.haml
+++ b/app/views/issuer_companies/edit.html.haml
@@ -149,3 +149,18 @@
           .mb-3
             = form.label :invoice_footer, 'Invoice Footer', class: 'form-label'
             = form.text_area :invoice_footer, rows: 6, class: 'form-control'
+
+  .row.mt-4
+    .col-md-6
+      .card
+        .card-header
+          Offer Settings
+        .card-body
+          .mb-3
+            = form.label :offer_validity_days, 'Validity (days)', class: 'form-label'
+            = form.number_field :offer_validity_days, class: 'form-control', min: 1, required: true
+            %small.form-text.text-muted Default validity used when a customer has no override.
+
+          .mb-3
+            = form.label :offer_footer, 'Offer Footer', class: 'form-label'
+            = form.text_area :offer_footer, rows: 6, class: 'form-control'

--- a/app/views/issuer_companies/show.html.haml
+++ b/app/views/issuer_companies/show.html.haml
@@ -162,3 +162,23 @@
           = simple_format(@issuer_company.invoice_footer)
         - else
           %em No footer text set
+
+  .col-md-6
+    .card
+      .card-header
+        Offer Settings
+      .card-body
+        .row.mb-2
+          .col-sm-4
+            %strong Validity:
+          .col-sm-8
+            = pluralize(@issuer_company.offer_validity_days, 'day')
+
+        .row.mb-2
+          .col-sm-4
+            %strong Offer Footer:
+          .col-sm-8
+            - if @issuer_company.offer_footer.present?
+              = simple_format(@issuer_company.offer_footer)
+            - else
+              %em No footer text set

--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -10,6 +10,9 @@
       - if can?('projects.view')
         %li.nav-item
           = nav_link_to('Projects', projects_path, active_for: 'projects')
+      - if can?('offers.view')
+        %li.nav-item
+          = nav_link_to('Offers', offers_path, active_for: 'offers')
       - if can?('delivery_notes.view')
         %li.nav-item
           = nav_link_to('Deliveries', delivery_notes_path, active_for: 'delivery_notes')

--- a/app/views/offer_mailer/customer_email.html.haml
+++ b/app/views/offer_mailer/customer_email.html.haml
@@ -1,0 +1,23 @@
+- content_for :title, t('mailers.offer.document_number', document_number: @offer.document_number)
+
+.greeting
+  - if @salutation.present?
+    = @salutation
+  - else
+    = t('mailers.offer.greeting', customer_name: @offer.customer.name)
+
+.main-message
+  = t('mailers.offer.main_message')
+
+.document-highlight
+  .document-number
+    = t('mailers.offer.document_number', document_number: @offer.document_number)
+  - if @version&.subject.present?
+    .document-detail
+      #{t('mailers.offer.subject_label')} #{@version.subject}
+  - if @offer.expires_at.present?
+    .document-detail
+      #{t('mailers.offer.expires_label')} #{l(@offer.expires_at)}
+
+.closing
+  = t('mailers.offer.closing')

--- a/app/views/offer_mailer/customer_email.text.haml
+++ b/app/views/offer_mailer/customer_email.text.haml
@@ -1,0 +1,14 @@
+- if @salutation.present?
+  #{@salutation}
+- else
+  #{t('mailers.offer.greeting', customer_name: @offer.customer.name)}
+\
+#{t('mailers.offer.main_message')}
+\
+#{t('mailers.offer.document_number', document_number: @offer.document_number)}
+- if @version&.subject.present?
+  #{t('mailers.offer.subject_label')} #{@version.subject}
+- if @offer.expires_at.present?
+  #{t('mailers.offer.expires_label')} #{l(@offer.expires_at)}
+\
+#{t('mailers.offer.closing')}

--- a/app/views/offers/_accept_modal.html.haml
+++ b/app/views/offers/_accept_modal.html.haml
@@ -1,0 +1,27 @@
+-# Accept-offer modal. Caller must render this inside the element carrying
+-# data-controller="modal". The Accept button triggers modal#open.
+.modal.d-none.accept-order-modal{data: {"modal-target": "modal", action: "click->modal#closeOnBackdrop keydown@window->modal#closeOnEscape"}}
+  .modal-dialog.accept-order-modal-dialog
+    .modal-content
+      .modal-header.d-flex.justify-content-between.align-items-center
+        %h5.modal-title.mb-0 Accept offer
+        %button.btn-close{type: "button", data: {action: "click->modal#close"}, "aria-label": "Close"}
+      .modal-body
+        .alert.alert-warning
+          Version #{@offer.current_sent_version.version_number} (sent #{l(@offer.current_sent_version.sent_at.to_date)}) becomes the accepted version.
+          - if @offer.draft_version
+            The in-progress draft version #{@offer.draft_version.version_number} will be discarded.
+        = form_with url: accept_offer_path(@offer), method: :post, multipart: true do |form|
+          .mb-3
+            = form.label :order_number, 'Order number', class: 'form-label'
+            = text_field_tag :order_number, nil, class: 'form-control'
+          .mb-3
+            = form.label :ordered_on, 'Ordered on', class: 'form-label'
+            = date_field_tag :ordered_on, Date.current, class: 'form-control', required: true
+          .mb-3
+            = form.label :order_pdf, 'Order PDF', class: 'form-label'
+            = file_field_tag :order_pdf, accept: 'application/pdf', class: 'form-control'
+          .text-end
+            %button.btn.btn-secondary.me-2{type: "button", data: {action: "click->modal#close"}}
+              Cancel
+            = submit_tag 'Accept offer', class: 'btn btn-success'

--- a/app/views/offers/_conversion_rows.html.haml
+++ b/app/views/offers/_conversion_rows.html.haml
@@ -1,0 +1,29 @@
+%table.table.table-bordered
+  %thead
+    %tr
+      %th Milestone
+      %th Trigger
+      %th.numeric Amount
+      %th Conversion
+  %tbody
+    - @offer.accepted_version.milestones.each do |milestone|
+      %tr
+        %td
+          %strong= milestone.title
+          - if milestone.description.present?
+            %br
+            %small.text-muted= simple_format(milestone.description, {}, wrapper_tag: 'span')
+        %td= milestone.trigger_label
+        %td.numeric= format_currency(milestone.amount)
+        %td
+          -# Safari renders td borders oddly when the td itself is a flexbox,
+          -# so the flex classes live on an inner div.
+          .d-flex.align-items-center.gap-2.flex-wrap
+            - if milestone.converted?
+              = link_to milestone.invoice.display_name, milestone.invoice
+              - if milestone.delivery_note
+                = link_to milestone.delivery_note.display_name, milestone.delivery_note
+              - if can?('offers.convert')
+                = button_to 'Reopen link', reopen_milestone_link_offer_path(@offer, milestone_id: milestone.id), method: :post, class: 'btn btn-sm btn-outline-secondary', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Clear the conversion link for this milestone?' }
+            - elsif can?('offers.convert')
+              = button_to '🚀 Convert', convert_milestone_offer_path(@offer, milestone_id: milestone.id), method: :post, class: 'btn btn-sm btn-info', form: { class: 'button_to ms-auto' }

--- a/app/views/offers/_form.html.haml
+++ b/app/views/offers/_form.html.haml
@@ -1,0 +1,145 @@
+%div{data: {controller: 'auto-resize-form'}}
+  = form_with model: @offer, id: ActionButtonsHelper::PAGE_FORM_ID do |f|
+    - if @offer.errors.any?
+      .alert.alert-danger
+        %h4
+          = pluralize(@offer.errors.count, 'error')
+          prohibited saving:
+        %ul
+          - @offer.errors.full_messages.each do |msg|
+            %li= msg
+
+    .form-inputs
+      .row
+        .col-sm-4
+          .mb-3
+            %label.form-label Customer
+            %div{ data: {
+                controller: 'searchable-dropdown',
+                searchable_dropdown_current_item_id_value: @offer.customer_id,
+                searchable_dropdown_url_value: customers_path,
+                searchable_dropdown_item_name_value: 'customer',
+                searchable_dropdown_item_id_param_value: 'customer_id',
+                searchable_dropdown_select_prompt_value: 'Select customer...'
+              } }
+              = f.hidden_field :customer_id, id: 'offer_customer_id'
+              .dropdown.searchable-dropdown.customer-dropdown
+                %button.btn.btn-outline-secondary.form-control.text-start.d-flex.justify-content-between.align-items-center{ type: 'button', data: { searchable_dropdown_target: 'select' } }
+                  .select-display
+                    - if @offer.customer && @offer.customer.id
+                      .fw-normal= @offer.customer.name
+                      .small.text-muted= @offer.customer.matchcode
+                    - else
+                      %span.text-muted Select customer...
+                  %span.text-muted ▼
+                .dropdown-menu{ id: 'customer-dropdown-menu', data: { searchable_dropdown_target: 'dropdown' } }
+                  .p-2.border-bottom
+                    %input.form-control.form-control-sm{ type: 'text', placeholder: 'Search customers...', data: { searchable_dropdown_target: 'search' } }
+                  .dropdown-content
+                    .dropdown-item.text-muted Loading...
+        .col-sm-4
+          .mb-3
+            %label.form-label Project
+            %div{ data: {
+                controller: 'searchable-dropdown',
+                searchable_dropdown_current_dependent_id_value: @offer.customer_id,
+                searchable_dropdown_current_item_id_value: @offer.project_id,
+                searchable_dropdown_url_value: projects_path,
+                searchable_dropdown_dependent_param_value: 'customer_id',
+                searchable_dropdown_item_name_value: 'project',
+                searchable_dropdown_item_id_param_value: 'project_id',
+                searchable_dropdown_select_prompt_value: 'Select project...',
+                searchable_dropdown_dependent_select_prompt_value: 'Select customer first...',
+                searchable_dropdown_dependent_field_selector_value: '#offer_customer_id'
+              } }
+              = f.hidden_field :project_id, id: 'offer_project_id'
+              .dropdown.searchable-dropdown.project-dropdown
+                %button.btn.btn-outline-secondary.form-control.text-start.d-flex.justify-content-between.align-items-center{ type: 'button', data: { searchable_dropdown_target: 'select' } }
+                  .select-display
+                    - if @offer.project && @offer.project.id
+                      .fw-normal= @offer.project.display_name
+                      .small.text-muted= @offer.project.matchcode
+                    - else
+                      %span.text-muted Select project...
+                  %span.text-muted ▼
+                .dropdown-menu{ id: 'project-dropdown-menu', data: { searchable_dropdown_target: 'dropdown' } }
+                  .p-2.border-bottom
+                    %input.form-control.form-control-sm{ type: 'text', placeholder: 'Search projects...', data: { searchable_dropdown_target: 'search' } }
+                  .dropdown-content
+                    .dropdown-item.text-muted Loading...
+        .col-sm-4
+          .mb-3
+            = f.label :internal_reference, 'Internal Reference', class: 'form-label'
+            = f.text_field :internal_reference, class: 'form-control'
+
+      .row
+        .col-sm-4
+          .mb-3
+            = f.label :customer_contact_id, 'Addressed Contact', class: 'form-label'
+            = f.collection_select :customer_contact_id, @offer.customer&.customer_contacts || [], :id, :name, { include_blank: 'None' }, { class: 'form-select' }
+        .col-sm-4
+          .mb-3
+            %label.form-label Document number
+            .form-control-plaintext
+              = @offer.document_number.presence || '(assigned at first send)'
+
+      - if @offer.draft_version
+        = f.fields_for :draft_version, @offer.draft_version do |vf|
+          .row
+            .col-sm-8
+              .mb-3
+                = vf.label :subject, 'Subject', class: 'form-label'
+                = vf.text_field :subject, class: 'form-control'
+            .col-sm-4
+              .mb-3
+                = vf.label :delivery_date, 'Delivery date', class: 'form-label'
+                = vf.date_field :delivery_date, class: 'form-control'
+
+          .row
+            .col-sm-8
+              .mb-3
+                = vf.label :prelude, 'Prelude', class: 'form-label'
+                = vf.rich_text_area :prelude, data: { controller: 'rich-text' }
+            .col-sm-4
+              .mb-3
+                = vf.label :salutation_override, 'Salutation override', class: 'form-label'
+                = vf.text_field :salutation_override, class: 'form-control'
+              .mb-3
+                = vf.label :sales_tax_product_class_id, 'Tax class', class: 'form-label'
+                = vf.collection_select :sales_tax_product_class_id, SalesTaxProductClass.all, :id, :name, { prompt: 'Select tax class...' }, { class: 'form-select' }
+
+          - if @offer.customer
+            .card.mb-3
+              .card-header.d-flex.justify-content-between.align-items-center
+                %span Boilerplate
+                %small.text-muted live in drafts · frozen on send
+              .card-body
+                = @offer.customer.offer_boilerplate
+                = link_to 'Edit on customer', edit_customer_path(@offer.customer), class: 'btn btn-sm btn-outline-secondary mt-2', target: '_blank', rel: 'noopener'
+
+          .card.mb-3
+            .card-body
+              .row
+                .col-sm-10.text-end
+                  Total Net
+                .col-sm-2.text-end
+                  %span#offer-total-net
+                    = format_currency(@offer.draft_version.milestones.sum(:amount))
+
+          %div{data: { controller: 'offer-milestones', offer_milestones_currency_symbol_value: currency_symbol, offer_milestones_money_decimal_places_value: current_money_decimal_places }}
+            %div{data: { offer_milestones_target: 'container' }}
+              = vf.fields_for :milestones do |mf|
+                = render 'milestone_fields', f: mf, autofocus: @autofocus_first_milestone && mf.index.zero?
+            %template{data: { offer_milestones_target: 'template' }}
+              = vf.fields_for :milestones, OfferMilestone.new, child_index: 'NEW_RECORD' do |mf|
+                = render 'milestone_fields', f: mf
+            %button.btn.btn-outline-primary{type: 'button', data: { action: 'click->offer-milestones#addLine' }} + Add Milestone
+
+          - if @offer.persisted? && @offer.draft_version.milestones.none? && @offer.customer
+            .card.mb-3.mt-3
+              .card-header Scaffold milestones
+              .card-body
+                %p.text-muted Generate milestones from the customer's default rule for a target total. Your other changes are saved along the way.
+                .input-group.w-fixed-400
+                  = number_field_tag :total, nil, step: :any, class: 'form-control', placeholder: 'Target total net'
+                  %button.btn.btn-outline-primary{type: 'submit', formaction: scaffold_milestones_offer_path(@offer), formmethod: 'post'} Apply milestone rule

--- a/app/views/offers/_milestone_fields.html.haml
+++ b/app/views/offers/_milestone_fields.html.haml
@@ -1,0 +1,42 @@
+.card.mb-3{data: {line_index: f.index}}
+  .card-body
+    = f.hidden_field :id
+    = f.hidden_field :position
+
+    .row
+      .col-sm-8.col-md-9
+        .mb-3
+          = f.label :title, 'Title', class: 'form-label'
+          = f.text_field :title, class: 'form-control', required: true, autofocus: local_assigns[:autofocus]
+      .col-sm-4.col-md-3.text-end
+        %label.form-label &nbsp;
+        %div
+          %button.btn.btn-sm.btn-secondary{type: 'button', data: {action: 'click->offer-milestones#moveLineUp'}} ▲
+          %button.btn.btn-sm.btn-secondary{type: 'button', data: {action: 'click->offer-milestones#moveLineDown'}} ▼
+          %button.btn.btn-sm.btn-danger{type: 'button', data: {action: 'click->offer-milestones#removeLine'}} 🗑
+
+    .row.mt-2
+      .col-sm-12
+        .mb-3
+          = f.label :description, 'Description', class: 'form-label'
+          = f.text_area :description, rows: 2, class: 'form-control'
+
+    .row.mt-2
+      .col-sm-4
+        .mb-3
+          = f.label :trigger, 'Trigger', class: 'form-label'
+          = f.select :trigger, OfferMilestone::TRIGGER_LABELS.invert.to_a, {}, class: 'form-select', data: { action: 'change->offer-milestones#triggerChanged' }
+      .col-sm-4{data: {trigger_date_wrap: true}, class: ('d-none' unless f.object.trigger == 'on_date')}
+        .mb-3
+          = f.label :trigger_date, 'Trigger date', class: 'form-label'
+          = f.date_field :trigger_date, class: 'form-control'
+      .col-sm-4
+        .mb-3
+          = f.label :amount, 'Amount', class: 'form-label'
+          = f.number_field :amount, step: :any, class: 'form-control', data: { action: 'change->offer-milestones#updateTotal' }
+
+    .row.mt-2
+      .col-sm-12
+        .form-check
+          = f.check_box :skip_delivery_note, class: 'form-check-input'
+          = f.label :skip_delivery_note, 'Skip delivery note', class: 'form-check-label'

--- a/app/views/offers/edit.html.haml
+++ b/app/views/offers/edit.html.haml
@@ -1,0 +1,4 @@
+- content_for :title, @offer.display_name
+= breadcrumbs ['Offers', offers_path], [@offer.display_label, offer_path(@offer)], 'Edit', action: save_button
+
+= render 'form'

--- a/app/views/offers/index.html.haml
+++ b/app/views/offers/index.html.haml
@@ -1,0 +1,47 @@
+= breadcrumbs 'Offers', action: action_button('+ New', new_offer_path(customer_id: @selected_customer_id), permission: 'offers.edit')
+
+.btn-toolbar.mb-3{:role=>"toolbar", "aria-label"=>"List toolbar"}
+  .btn-group.btn-group-sm.me-2.offer-filter{:role=>"group", "aria-label"=>"Filter"}
+    - ([ [ 'all', 'All' ] ] + Offer::STATES.map { |s| [ s, s.capitalize ] }).each do |state, label|
+      = link_to label, offers_path(state: state, year: @selected_year, customer_id: @selected_customer_id), class: (@state_filter == state ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
+
+  = render 'shared/customer_filter',
+      form_url: offers_path,
+      customers: @available_customers,
+      selected_customer_id: @selected_customer_id,
+      hidden_fields: { year: @selected_year, state: @state_filter }
+
+  - if @available_years.any?
+    .btn-group.btn-group-sm.ms-auto.year-pagination{:role=>"group", "aria-label"=>"Year navigation"}
+      - @available_years.each do |year|
+        = link_to year, offers_path(year: year, state: @state_filter, customer_id: @selected_customer_id), class: (@selected_year == year ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
+      = link_to 'All', offers_path(year: 'all', state: @state_filter, customer_id: @selected_customer_id), class: (@selected_year == 'all' ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
+
+%table.table.table-striped.table-sm
+  %tr
+    %th Number
+    %th Int.Reference
+    - if @selected_customer_id.nil?
+      %th Customer
+    %th Project
+    %th Subject
+    - if @state_filter == 'all'
+      %th State
+    %th.numeric Total Net
+    %th Valid until
+
+  - @offers.each do |offer|
+    - version = offer.draft_version || offer.current_sent_version
+    %tr
+      %td= link_to(offer.display_label, offer)
+      %td= offer.internal_reference
+      - if @selected_customer_id.nil?
+        %td{:title => offer.customer.name}= offer.customer.matchcode
+      %td{:title => offer.project && offer.project.display_name}= offer.project && offer.project.matchcode
+      %td= version&.subject
+      - if @state_filter == 'all'
+        %td
+          - label, badge_class = offer.status_badge
+          %span.badge{class: badge_class}= label
+      %td.numeric= format_currency(version&.sum_net || 0)
+      %td= l(offer.expires_at) if offer.expires_at

--- a/app/views/offers/index.html.haml
+++ b/app/views/offers/index.html.haml
@@ -19,25 +19,25 @@
 
 %table.table.table-striped.table-sm
   %tr
-    %th Number
-    %th Int.Reference
+    %th Document#
     - if @selected_customer_id.nil?
       %th Customer
     %th Project
+    %th Int.Reference
     %th Subject
     - if @state_filter == 'all'
-      %th State
-    %th.numeric Total Net
+      %th Status
+    %th.numeric Sum Net
     %th Valid until
 
   - @offers.each do |offer|
     - version = offer.draft_version || offer.current_sent_version
     %tr
       %td= link_to(offer.display_label, offer)
-      %td= offer.internal_reference
       - if @selected_customer_id.nil?
         %td{:title => offer.customer.name}= offer.customer.matchcode
       %td{:title => offer.project && offer.project.display_name}= offer.project && offer.project.matchcode
+      %td= offer.internal_reference
       %td= version&.subject
       - if @state_filter == 'all'
         %td

--- a/app/views/offers/new.html.haml
+++ b/app/views/offers/new.html.haml
@@ -1,0 +1,4 @@
+- content_for :title, 'New offer'
+= breadcrumbs ['Offers', offers_path], 'New', action: save_button
+
+= render 'form'

--- a/app/views/offers/show.html.haml
+++ b/app/views/offers/show.html.haml
@@ -1,0 +1,203 @@
+- content_for :title, @offer.display_name
+- edit_action = action_button('Edit', edit_offer_path(@offer), permission: 'offers.edit') if @offer.editable?
+- preview_action = preview_button(preview_offer_path(@offer), permission: 'offers.view') if @offer.draft_version && @offer.draft_version.milestones.any?
+- delete_action = delete_button(@offer) if @offer.deletable? && can?('offers.edit')
+= breadcrumbs ['Offers', offers_path], @offer.display_label, actions: [preview_action, delete_action], action: edit_action do
+  - label, badge_class = @offer.status_badge
+  %span.badge{class: badge_class}= label
+
+%div{data: (@offer.current_sent_version ? email_preview_data(@offer) : {})}
+  .row.mb-2
+    .col-md-6
+      .document-details
+        .row.mb-2
+          .col-sm-4
+            %strong Customer:
+          .col-sm-8
+            = link_to @offer.customer.name, @offer.customer
+        - if @offer.project
+          .row.mb-2
+            .col-sm-4
+              %strong Project:
+            .col-sm-8
+              = link_to @offer.project.display_name, @offer.project
+        - if @offer.customer_contact
+          .row.mb-2
+            .col-sm-4
+              %strong Addressed Contact:
+            .col-sm-8
+              = @offer.customer_contact.name
+        - if @offer.internal_reference.present?
+          .row.mb-2
+            .col-sm-4
+              %strong Internal Reference:
+            .col-sm-8
+              = @offer.internal_reference
+
+    .col-md-6
+      .document-details
+        .row.mb-2
+          .col-sm-4
+            %strong Document Number:
+          .col-sm-8
+            = @offer.document_number.presence || content_tag(:em, '(assigned at first send)')
+        .row.mb-2
+          .col-sm-4
+            %strong Document Date:
+          .col-sm-8
+            = @offer.date ? l(@offer.date) : content_tag(:em, '(assigned at first send)')
+        - if @offer.expires_at
+          .row.mb-2
+            .col-sm-4
+              %strong Valid Until:
+            .col-sm-8
+              = l(@offer.expires_at)
+        - if @version&.delivery_date
+          .row.mb-2
+            .col-sm-4
+              %strong Delivery Date:
+            .col-sm-8
+              = l(@version.delivery_date)
+        - if @version&.sales_tax_product_class
+          .row.mb-2
+            .col-sm-4
+              %strong Tax Class:
+            .col-sm-8
+              = @version.sales_tax_product_class.name
+
+  - if @offer.editable?
+    .row.mb-2
+      .col-sm-4
+        %strong Send:
+      .col-sm-8.d-flex.align-items-center.gap-2
+        - problems = @offer.send_problems
+        - if problems.any?
+          %span.badge.bg-warning= pluralize(problems.size, 'problem')
+          - if can?('offers.edit')
+            %span.ms-auto{title: problems.join("\n")}
+              %button.btn.btn-sm.btn-info{disabled: true} 🚀 Send
+        - else
+          %span.badge.bg-success Ready
+          - if can?('offers.edit')
+            = button_to '🚀 Send', send_offer_offer_path(@offer), method: :post, class: 'btn btn-sm btn-info', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Send this offer to the customer? A PDF is generated and this version is frozen.' }
+
+  - if @offer.current_sent_version
+    - sent_version = @offer.current_sent_version
+    .mb-4
+      .card
+        .card-header.d-flex.justify-content-between.align-items-center
+          %h5.mb-0 Sent version #{sent_version.version_number}
+          - if sent_version.attachment
+            = pdf_button(attachment_path(sent_version.attachment))
+        .card-body
+          - if sent_version.sent_at
+            .row.mb-2
+              .col-sm-4
+                %strong Sent:
+              .col-sm-8
+                = l(sent_version.sent_at.to_date)
+          = render 'shared/email_status_row', resource: @offer, can_edit: can?('offers.edit'), show_send_button: sent_version.attachment.present?
+          - if can?('offers.edit')
+            .row.mb-2{data: {controller: 'modal'}}
+              .col-sm-4
+                %strong Decision:
+              .col-sm-8.d-flex.align-items-center.gap-2
+                - if @offer.sent?
+                  %button.btn.btn-sm.btn-success.ms-auto{data: {action: 'click->modal#open'}} Accept…
+                  = button_to 'Reject', reject_offer_path(@offer), method: :post, class: 'btn btn-sm btn-outline-danger', data: { 'turbo-confirm': 'Reject this offer?' }
+                  = render 'accept_modal'
+                - elsif @offer.accepted? || @offer.rejected?
+                  = button_to 'Reopen', reopen_offer_path(@offer), method: :post, class: 'btn btn-sm btn-outline-secondary', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Reopen this offer? A fresh draft version branches from the accepted version.' }
+
+  - if @offer.accepted?
+    .mb-4
+      .card
+        .card-header
+          %h5.mb-0 Order
+        .card-body
+          .row.mb-2
+            .col-sm-4
+              %strong Accepted:
+            .col-sm-8
+              = l(@offer.accepted_at.to_date) if @offer.accepted_at
+              %span.text-muted.ms-2 (version #{@offer.accepted_version.version_number})
+          - if @offer.order_number.present?
+            .row.mb-2
+              .col-sm-4
+                %strong Order Number:
+              .col-sm-8
+                = @offer.order_number
+          - if @offer.ordered_on
+            .row.mb-2
+              .col-sm-4
+                %strong Ordered On:
+              .col-sm-8
+                = l(@offer.ordered_on)
+          .row.mb-2
+            .col-sm-4
+              %strong Order PDF:
+            .col-sm-8
+              - if @offer.order_attachment
+                = link_to @offer.order_attachment.filename, attachment_path(@offer.order_attachment), target: '_blank', data: { turbo: false }
+              - elsif can?('offers.edit')
+                = form_with url: upload_order_pdf_offer_path(@offer), method: :post, multipart: true, data: { controller: 'file-upload-validation' } do |form|
+                  .input-group.w-fixed-400
+                    = file_field_tag :order_pdf, accept: 'application/pdf', class: 'form-control', data: { file_upload_validation_target: 'fileInput' }
+                    = form.submit 'Upload PDF', class: 'btn btn-primary', data: { file_upload_validation_target: 'submitButton' }
+
+  .mb-4
+    .card
+      .card-header
+        %h5.mb-0 Milestones
+      .card-body
+        - if @offer.accepted?
+          = render 'conversion_rows'
+        - elsif @version
+          %table.table.table-bordered
+            %thead
+              %tr
+                %th Milestone
+                %th Trigger
+                %th.numeric Amount
+            %tbody
+              - @version.milestones.each do |milestone|
+                %tr
+                  %td
+                    %strong= milestone.title
+                    - if milestone.description.present?
+                      %br
+                      %small.text-muted= simple_format(milestone.description, {}, wrapper_tag: 'span')
+                  %td= milestone.trigger_label
+                  %td.numeric= format_currency(milestone.amount)
+              %tr
+                %td.text-end{colspan: 2}
+                  %strong Total Net:
+                %td.numeric
+                  %strong= format_currency(@version.milestones.sum(:amount))
+
+  - if can?('offers.edit')
+    .mb-4
+      .card
+        .card-header
+          %h5.mb-0 Internal Notes
+        .card-body
+          = form_with model: @offer, url: update_internal_notes_offer_path(@offer), method: :patch do |form|
+            = form.rich_text_area :internal_notes, data: { controller: 'rich-text' }
+            .text-end.mt-2
+              = form.submit 'Save', class: 'btn btn-primary'
+
+  - if @version&.prelude&.present?
+    .mb-4
+      .card
+        .card-body
+          = @version.prelude
+
+  - boilerplate = @version&.frozen? ? @version.boilerplate : @offer.customer.offer_boilerplate
+  - if boilerplate&.present?
+    .mb-4
+      .card
+        .card-body
+          = boilerplate
+
+  - if @offer.current_sent_version
+    = render 'shared/email_preview_modal', title: "Preview - #{@offer.display_name}"

--- a/config/initializers/mail_delivery_tracker.rb
+++ b/config/initializers/mail_delivery_tracker.rb
@@ -18,5 +18,7 @@ ActiveSupport::Notifications.subscribe("perform.active_job") do |*args|
     elsif (dns = params[:delivery_notes])
       DeliveryNote.where(id: dns.map(&:id)).update_all(email_sent_at: now)
     end
+  when "OfferMailer"
+    params[:offer]&.update_column(:email_sent_at, now)
   end
 end

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -57,6 +57,15 @@ de:
       next_steps_upload: "Unterfertigen Lieferschein hochladen"
       closing: "Vielen Dank für Ihr Vertrauen. Wir freuen uns auf die weitere Zusammenarbeit."
 
+    offer:
+      subject: "%{issuer_name} Angebot %{document_number}"
+      greeting: "Sehr geehrte Damen und Herren,"
+      main_message: "Anbei finden Sie unser Angebot für die beschriebenen Leistungen. Bei Fragen dazu wenden Sie sich gerne an uns."
+      document_number: "Angebot %{document_number}"
+      subject_label: "Betreff:"
+      expires_label: "Gültig bis:"
+      closing: "Wir freuen uns auf die Zusammenarbeit mit Ihnen."
+
     acceptance_submission:
       subject: "Neues Abnahmedokument für %{document_number}"
       body: "Ein Kunde hat ein unterschriebenes Abnahmedokument für Lieferschein %{document_number} hochgeladen. Bitte prüfen Sie es."

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -24,6 +24,23 @@ de:
         due_date: "Fällig:"
         days_overdue: "%{days} Tage überfällig"
 
+    expiring_offers:
+      subject:
+        one: "[%{issuer_name}] 1 abgelaufenes Angebot"
+        other: "[%{issuer_name}] %{count} abgelaufene Angebote"
+      title: "Bericht über abgelaufene Angebote"
+      heading: "Abgelaufene Angebote am %{date}"
+      main_message:
+        one: "Ein Angebot ist abgelaufen."
+        other: "Es gibt %{count} Angebote, deren Gültigkeit abgelaufen ist."
+      columns:
+        offer_number: "Angebotsnr."
+        customer: "Kunde"
+        expired_on: "Abgelaufen am"
+        total: "Summe"
+      short:
+        expired_on: "Abgelaufen:"
+
     invoice:
       subject: "%{issuer_name} Rechnung %{document_number}"
       greeting: "Sehr geehrte Damen und Herren,"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -133,6 +133,15 @@ en:
       next_steps_upload: "Upload the signed delivery note"
       closing: "Thank you for your business. We appreciate your continued partnership."
 
+    offer:
+      subject: "%{issuer_name} Offer %{document_number}"
+      greeting: "Dear %{customer_name},"
+      main_message: "We've attached our offer for the services described below. Please review the details and let us know if you have any questions."
+      document_number: "Offer %{document_number}"
+      subject_label: "Subject:"
+      expires_label: "Valid until:"
+      closing: "We look forward to working with you."
+
     acceptance_submission:
       subject: "New acceptance document for %{document_number}"
       body: "A customer uploaded a signed acceptance document for delivery note %{document_number}. Please review it."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,6 +100,23 @@ en:
         due_date: "Due:"
         days_overdue: "%{days} days overdue"
 
+    expiring_offers:
+      subject:
+        one: "[%{issuer_name}] 1 expired offer"
+        other: "[%{issuer_name}] %{count} expired offers"
+      title: "Expired offers report"
+      heading: "Expired offers as of %{date}"
+      main_message:
+        one: "There is 1 offer whose validity has expired."
+        other: "There are %{count} offers whose validity has expired."
+      columns:
+        offer_number: "Offer no."
+        customer: "Customer"
+        expired_on: "Expired on"
+        total: "Total"
+      short:
+        expired_on: "Expired:"
+
     invoice:
       subject: "%{issuer_name} Invoice %{document_number}"
       greeting: "Dear %{customer_name},"

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -13,6 +13,10 @@ production:
   clear_solid_queue_finished_jobs:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
     schedule: every hour at minute 12
+  expiring_offers_report:
+    class: ExpiringOffersReportJob
+    queue: default
+    schedule: every day at 07:30
   overdue_invoices_report:
     class: OverdueInvoicesReportJob
     queue: default

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,6 +102,23 @@ Rails.application.routes.draw do
       post "bulk_send_emails"
     end
   end
+  resources :offers do
+    member do
+      get "preview"
+      get "preview_email"
+      get "preview_email_html"
+      post "send_offer"
+      post "accept"
+      post "reject"
+      post "reopen"
+      post "scaffold_milestones"
+      patch "update_internal_notes"
+      post "upload_order_pdf"
+      post "send_email"
+      post "milestones/:milestone_id/convert", action: :convert_milestone, as: :convert_milestone
+      post "milestones/:milestone_id/reopen_link", action: :reopen_milestone_link, as: :reopen_milestone_link
+    end
+  end
 
   resources :products
   resources :projects

--- a/db/migrate/20260705120000_create_offers.rb
+++ b/db/migrate/20260705120000_create_offers.rb
@@ -1,0 +1,26 @@
+class CreateOffers < ActiveRecord::Migration[8.1]
+  def change
+    create_table :offers do |t|
+      t.references :customer, null: false, foreign_key: true
+      t.references :project, null: false, foreign_key: true
+      t.references :customer_contact, foreign_key: true
+      t.string :state, null: false, default: "draft"
+      t.string :document_number
+      t.date :date
+      t.datetime :sent_at
+      t.datetime :accepted_at
+      t.datetime :rejected_at
+      t.date :expires_at
+      t.datetime :reported_expired_at
+      t.bigint :accepted_version_id
+      t.text :order_number
+      t.date :ordered_on
+      t.references :order_attachment, foreign_key: { to_table: :attachments }
+      t.text :internal_reference
+      t.datetime :email_sent_at
+      t.timestamps
+    end
+    add_index :offers, :document_number, unique: true
+    add_index :offers, :state
+  end
+end

--- a/db/migrate/20260705120001_create_offer_versions.rb
+++ b/db/migrate/20260705120001_create_offer_versions.rb
@@ -1,0 +1,27 @@
+class CreateOfferVersions < ActiveRecord::Migration[8.1]
+  def change
+    create_table :offer_versions do |t|
+      t.references :offer, null: false, foreign_key: true
+      t.integer :version_number, null: false
+      t.string :subject
+      t.string :salutation_override
+      t.date :delivery_date
+      t.date :date
+      t.references :sales_tax_product_class, foreign_key: true
+      t.decimal :sum_net, default: "0.0"
+      t.datetime :sent_at
+      t.text :customer_name
+      t.text :customer_address
+      t.string :customer_country_iso2, limit: 2
+      t.text :customer_supplier_number
+      t.integer :payment_terms_days
+      t.references :attachment, foreign_key: true
+      t.timestamps
+    end
+    add_index :offer_versions, [ :offer_id, :version_number ], unique: true
+    add_index :offer_versions, :offer_id, unique: true, where: "sent_at IS NULL",
+              name: "index_offer_versions_one_draft_per_offer"
+
+    add_foreign_key :offers, :offer_versions, column: :accepted_version_id
+  end
+end

--- a/db/migrate/20260705120002_create_offer_milestones.rb
+++ b/db/migrate/20260705120002_create_offer_milestones.rb
@@ -1,0 +1,19 @@
+class CreateOfferMilestones < ActiveRecord::Migration[8.1]
+  def change
+    create_table :offer_milestones do |t|
+      t.references :offer_version, null: false, foreign_key: true
+      t.integer :position
+      t.string :title, null: false
+      t.text :description
+      t.string :trigger, null: false, default: "on_acceptance"
+      t.date :trigger_date
+      t.decimal :amount, null: false
+      t.boolean :skip_delivery_note, null: false, default: false
+      t.references :invoice, foreign_key: true, index: false
+      t.references :delivery_note, foreign_key: true, index: false
+      t.timestamps
+    end
+    add_index :offer_milestones, :invoice_id, unique: true, where: "invoice_id IS NOT NULL"
+    add_index :offer_milestones, :delivery_note_id, unique: true, where: "delivery_note_id IS NOT NULL"
+  end
+end

--- a/db/migrate/20260705120003_add_offer_fields_to_customers_and_contacts.rb
+++ b/db/migrate/20260705120003_add_offer_fields_to_customers_and_contacts.rb
@@ -1,0 +1,9 @@
+class AddOfferFieldsToCustomersAndContacts < ActiveRecord::Migration[8.1]
+  def change
+    add_column :customers, :offer_validity_days, :integer
+    add_column :customers, :offer_milestone_split_threshold, :decimal
+    add_column :customers, :offer_milestone_templates_below, :text
+    add_column :customers, :offer_milestone_templates_above, :text
+    add_column :customer_contacts, :receives_offer_emails, :boolean, null: false, default: false
+  end
+end

--- a/db/migrate/20260705120004_add_offer_settings_to_issuer_companies.rb
+++ b/db/migrate/20260705120004_add_offer_settings_to_issuer_companies.rb
@@ -1,0 +1,6 @@
+class AddOfferSettingsToIssuerCompanies < ActiveRecord::Migration[8.1]
+  def change
+    add_column :issuer_companies, :offer_validity_days, :integer, null: false, default: 30
+    add_column :issuer_companies, :offer_footer, :string
+  end
+end

--- a/db/migrate/20260705120005_add_offer_document_number.rb
+++ b/db/migrate/20260705120005_add_offer_document_number.rb
@@ -1,0 +1,14 @@
+class AddOfferDocumentNumber < ActiveRecord::Migration[8.1]
+  class MigrationDocumentNumber < ActiveRecord::Base
+    self.table_name = "document_numbers"
+  end
+
+  def up
+    return if MigrationDocumentNumber.exists?(code: "offer")
+    MigrationDocumentNumber.create!(code: "offer", format: "%{date}-%<number>02d", sequence: 0)
+  end
+
+  def down
+    MigrationDocumentNumber.where(code: "offer").delete_all
+  end
+end

--- a/db/migrate/20260705120006_grant_offer_permissions_to_admin_group.rb
+++ b/db/migrate/20260705120006_grant_offer_permissions_to_admin_group.rb
@@ -1,0 +1,20 @@
+class GrantOfferPermissionsToAdminGroup < ActiveRecord::Migration[8.1]
+  PERMISSIONS = %w[offers.view offers.edit offers.convert].freeze
+
+  class MigrationGroup < ActiveRecord::Base
+    self.table_name = "groups"
+    has_many :group_permissions, class_name: "GrantOfferPermissionsToAdminGroup::MigrationGroupPermission", foreign_key: :group_id
+  end
+
+  class MigrationGroupPermission < ActiveRecord::Base
+    self.table_name = "group_permissions"
+  end
+
+  def up
+    admin = MigrationGroup.find_by(builtin: true, name: "Admin")
+    return unless admin
+    PERMISSIONS.each { |p| admin.group_permissions.find_or_create_by!(permission: p) }
+  end
+
+  def down; end
+end

--- a/db/migrate/20260705120007_add_date_index_to_offers.rb
+++ b/db/migrate/20260705120007_add_date_index_to_offers.rb
@@ -1,0 +1,5 @@
+class AddDateIndexToOffers < ActiveRecord::Migration[8.1]
+  def change
+    add_index :offers, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_23_211332) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_05_120007) do
   create_table "acceptance_submissions", force: :cascade do |t|
     t.integer "attachment_id"
     t.datetime "created_at", null: false
@@ -89,6 +89,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_23_211332) do
     t.string "name", null: false
     t.boolean "receives_delivery_note_emails", default: false, null: false
     t.boolean "receives_invoice_emails", default: false, null: false
+    t.boolean "receives_offer_emails", default: false, null: false
     t.string "salutation_line"
     t.datetime "updated_at", null: false
     t.index ["customer_id"], name: "index_customer_contacts_on_customer_id"
@@ -128,6 +129,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_23_211332) do
     t.string "matchcode", null: false
     t.text "name"
     t.text "notes"
+    t.decimal "offer_milestone_split_threshold"
+    t.text "offer_milestone_templates_above"
+    t.text "offer_milestone_templates_below"
+    t.integer "offer_validity_days"
     t.integer "payment_terms_days", default: 30, null: false
     t.integer "sales_tax_customer_class_id"
     t.text "supplier_number"
@@ -304,6 +309,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_23_211332) do
     t.string "invoice_footer"
     t.string "legal_name"
     t.integer "money_decimal_places", default: 2, null: false
+    t.string "offer_footer"
+    t.integer "offer_validity_days", default: 30, null: false
     t.binary "pdf_logo"
     t.string "pdf_logo_height"
     t.string "pdf_logo_width"
@@ -323,6 +330,78 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_23_211332) do
     t.string "title", null: false
     t.datetime "updated_at", null: false
     t.index ["iso_code"], name: "index_languages_on_iso_code", unique: true
+  end
+
+  create_table "offer_milestones", force: :cascade do |t|
+    t.decimal "amount", null: false
+    t.datetime "created_at", null: false
+    t.integer "delivery_note_id"
+    t.text "description"
+    t.integer "invoice_id"
+    t.integer "offer_version_id", null: false
+    t.integer "position"
+    t.boolean "skip_delivery_note", default: false, null: false
+    t.string "title", null: false
+    t.string "trigger", default: "on_acceptance", null: false
+    t.date "trigger_date"
+    t.datetime "updated_at", null: false
+    t.index ["delivery_note_id"], name: "index_offer_milestones_on_delivery_note_id", unique: true, where: "delivery_note_id IS NOT NULL"
+    t.index ["invoice_id"], name: "index_offer_milestones_on_invoice_id", unique: true, where: "invoice_id IS NOT NULL"
+    t.index ["offer_version_id"], name: "index_offer_milestones_on_offer_version_id"
+  end
+
+  create_table "offer_versions", force: :cascade do |t|
+    t.integer "attachment_id"
+    t.datetime "created_at", null: false
+    t.text "customer_address"
+    t.string "customer_country_iso2", limit: 2
+    t.text "customer_name"
+    t.text "customer_supplier_number"
+    t.date "date"
+    t.date "delivery_date"
+    t.integer "offer_id", null: false
+    t.integer "payment_terms_days"
+    t.integer "sales_tax_product_class_id"
+    t.string "salutation_override"
+    t.datetime "sent_at"
+    t.string "subject"
+    t.decimal "sum_net", default: "0.0"
+    t.datetime "updated_at", null: false
+    t.integer "version_number", null: false
+    t.index ["attachment_id"], name: "index_offer_versions_on_attachment_id"
+    t.index ["offer_id", "version_number"], name: "index_offer_versions_on_offer_id_and_version_number", unique: true
+    t.index ["offer_id"], name: "index_offer_versions_on_offer_id"
+    t.index ["offer_id"], name: "index_offer_versions_one_draft_per_offer", unique: true, where: "sent_at IS NULL"
+    t.index ["sales_tax_product_class_id"], name: "index_offer_versions_on_sales_tax_product_class_id"
+  end
+
+  create_table "offers", force: :cascade do |t|
+    t.datetime "accepted_at"
+    t.bigint "accepted_version_id"
+    t.datetime "created_at", null: false
+    t.integer "customer_contact_id"
+    t.integer "customer_id", null: false
+    t.date "date"
+    t.string "document_number"
+    t.datetime "email_sent_at"
+    t.date "expires_at"
+    t.text "internal_reference"
+    t.integer "order_attachment_id"
+    t.text "order_number"
+    t.date "ordered_on"
+    t.integer "project_id", null: false
+    t.datetime "rejected_at"
+    t.datetime "reported_expired_at"
+    t.datetime "sent_at"
+    t.string "state", default: "draft", null: false
+    t.datetime "updated_at", null: false
+    t.index ["customer_contact_id"], name: "index_offers_on_customer_contact_id"
+    t.index ["customer_id"], name: "index_offers_on_customer_id"
+    t.index ["date"], name: "index_offers_on_date"
+    t.index ["document_number"], name: "index_offers_on_document_number", unique: true
+    t.index ["order_attachment_id"], name: "index_offers_on_order_attachment_id"
+    t.index ["project_id"], name: "index_offers_on_project_id"
+    t.index ["state"], name: "index_offers_on_state"
   end
 
   create_table "products", force: :cascade do |t|
@@ -505,6 +584,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_23_211332) do
   add_foreign_key "group_permissions", "groups"
   add_foreign_key "invoices", "customers"
   add_foreign_key "invoices", "projects"
+  add_foreign_key "offer_milestones", "delivery_notes"
+  add_foreign_key "offer_milestones", "invoices"
+  add_foreign_key "offer_milestones", "offer_versions"
+  add_foreign_key "offer_versions", "attachments"
+  add_foreign_key "offer_versions", "offers"
+  add_foreign_key "offer_versions", "sales_tax_product_classes"
+  add_foreign_key "offers", "attachments", column: "order_attachment_id"
+  add_foreign_key "offers", "customer_contacts"
+  add_foreign_key "offers", "customers"
+  add_foreign_key "offers", "offer_versions", column: "accepted_version_id"
+  add_foreign_key "offers", "projects"
   add_foreign_key "projects", "teams"
   add_foreign_key "team_memberships", "teams"
   add_foreign_key "team_memberships", "users"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -46,6 +46,14 @@ DocumentNumber.find_or_create_by(code: 'delivery_note') do |dn|
   dn.last_date = nil
 end
 
+# Document number configuration for offers
+DocumentNumber.find_or_create_by(code: 'offer') do |dn|
+  dn.format = '%{date}-%<number>02d'
+  dn.sequence = 0
+  dn.last_number = nil
+  dn.last_date = nil
+end
+
 # Sales tax customer classes (required for the system to work)
 national_class = SalesTaxCustomerClass.find_or_create_by(name: 'National') do |stcc|
   stcc.invoice_note = ''

--- a/docs/superpowers/plans/2026-07-05-offers.md
+++ b/docs/superpowers/plans/2026-07-05-offers.md
@@ -1,0 +1,2221 @@
+# Offers Feature Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Offers — sales quotes with versioning, a lifecycle (draft → sent → accepted/rejected/expired), an FOP-rendered PDF, offer emails, and milestone-to-invoice/delivery-note conversion — per issue #530.
+
+**Architecture:** Offer is a third document type next to Invoice and DeliveryNote, but with a richer shape: an `Offer` carries identity/lifecycle, `OfferVersion` carries the customer-facing content (frozen at send, re-branched as a new draft), and `OfferMilestone` rows are the line items that later convert 1:1 into draft Invoices/DeliveryNotes. Send/accept/reject/reopen are service- and model-level operations; the PDF pipeline reuses `FopRenderer` + `document_base.xsl` + `RichTextFoConverter`; email mirrors the DeliveryNote contact-opt-in pattern with a stored PDF like invoices.
+
+**Tech Stack:** Rails 8.1, HAML + Bootstrap 5, Stimulus (importmap), ActionText/Trix, Apache FOP + Saxon-B (XSLT 2.0), Solid Queue, minitest fixtures.
+
+## Global Constraints
+
+- Always `bundle exec rails ...` — bare `rails test` skips migrations.
+- HAML only, no ERB. No inline `style=` (strict CSP). Styles go in `app/assets/stylesheets/*.scss`.
+- Every page header is `breadcrumbs(...)`; edit/new pages put the submit in `action: save_button`; no Cancel buttons.
+- Every controller action must call `require_permission!` or opt out — `after_action :verify_permission_check_performed` raises otherwise, and `test/integration/permission_check_verification_test.rb` enforces it in CI.
+- Dates render `DD.MM.YYYY` via `l(date)`. Currency via `format_currency(amount)` — never hardcode a symbol.
+- Bootstrap JS is not bundled: modals/dropdowns need a Stimulus controller toggling classes manually.
+- Stimulus: bind in `connect()`, unbind in `disconnect()`; no relative import paths; no URL paths in JS (pass via data attributes). Run `npm run lint` after Stimulus changes.
+- Status badges: every lifecycle state gets a header badge; empty optional fields render nothing.
+- Comments: default to none; describe the present, not the history.
+- Run `pre-commit run --all-files` before every commit. Never `sudo`. Never commit screenshots.
+- Commit style: concise imperative subject, one functional sentence in the body.
+- Keep XML hardening in `bin/abt-fop`; don't introduce a second FOP launcher path.
+
+## Decisions locked in (from the spec + codebase)
+
+- **Document number**: own `DocumentNumber` row, `code: "offer"` (the "shared sequence" in the spec means the shared *mechanism*; each document type has its own row today). Assigned on first send inside the send transaction via `DocumentNumber.get_next_for("offer", date)`.
+- **No `PublishableDocument`** in the controller — offers have a real state machine, not a `published` boolean. Offer-specific guards instead. `ScopedThroughCustomer` *is* included (needs `customer_id`, `project_id`, `published`-free scopes it defines lazily, `document_number` — all satisfied; the concern's `published` scope is simply never called for offers).
+- **Draft version identity**: `offer_versions.sent_at IS NULL` marks the single in-progress draft (partial unique index). `Offer#draft_version` is a `has_one` with that scope so the form can use `fields_for :draft_version`.
+- **`offers.date` column** mirrors the latest sent version's document date so `YearFilterable` and the `ordered` scope work unchanged.
+- **Snapshot at send** (on the version): `customer_name`, `customer_address`, `customer_country_iso2`, `customer_supplier_number`, `payment_terms_days`, plus the boilerplate copied into the version's own rich text. Drafts render live from the customer.
+- **Preview** renders fully in-memory (no `prepare!`-style DB writes needed — offers snapshot at send, not at save), so no transaction-rollback dance: assign `date = Date.current` on the in-memory version and render.
+- **Email**: DeliveryNote pattern (contact opt-in via new `receives_offer_emails`), but attaches the **stored** version PDF like invoices (re-sends must be byte-identical). No bulk email (spec doesn't ask for it).
+- **`email_sent_at` stamping** happens in `config/initializers/mail_delivery_tracker.rb` — an `OfferMailer` case must be added there.
+- **Milestones are not `LineItem`s** — they have their own shape (trigger, amount, skip_delivery_note) and no type column. Their Stimulus controller subclasses `BaseLinesController` (add/remove/reorder/position machinery) with `openProductDropdown: false`.
+- **Action name for sending**: `send_offer` (a controller action literally named `send` would collide with `Object#send`).
+
+## Decisions resolved with the user
+
+- Offer document numbers use the format as planned: the migration copies the invoice row's format (falling back to `%{year}%<number>04d`), with an independent sequence under `code: "offer"`. No distinct prefix.
+
+- `ordered_on` is required at accept (HTML `required` on the dialog's date field *and* a guard in `Offer#accept!`), so it is always available later. Generated DeliveryNotes take `delivery_start_date` from it; the draft stays editable afterwards.
+- The spec UI section's "email auto" mention is a leftover — there is no invoice-style auto-email mode for offers. Offer email is contact opt-in only (`receives_offer_emails`); the customer form's offer section shows validity days, the milestone rule, and the boilerplate.
+
+## File map
+
+Create:
+- `db/migrate/*_create_offers.rb`, `*_create_offer_versions.rb`, `*_create_offer_milestones.rb`, `*_add_offer_fields_to_customers_and_contacts.rb`, `*_add_offer_settings_to_issuer_companies.rb`, `*_add_offer_document_number.rb`, `*_grant_offer_permissions_to_admin_group.rb`
+- `app/models/offer.rb`, `app/models/offer_version.rb`, `app/models/offer_milestone.rb`
+- `app/services/offer_sender.rb`, `app/services/offer_renderer.rb`, `app/services/offer_milestone_converter.rb`, `app/services/offer_milestone_scaffolder.rb`
+- `lib/foptemplate/offer.xsl`
+- `app/mailers/offer_mailer.rb`, `app/views/offer_mailer/customer_email.{html,text}.haml`
+- `app/mailers/expiring_offers_mailer.rb`, `app/views/expiring_offers_mailer/expiring_report.{html,text}.haml`
+- `app/jobs/expiring_offers_report_job.rb`
+- `app/controllers/offers_controller.rb`
+- `app/views/offers/` — `index`, `show`, `new`, `edit`, `_form`, `_milestone_fields`, `_accept_modal`, `_conversion_rows` (all `.html.haml`)
+- `app/javascript/controllers/offer_milestones_controller.js`, `app/javascript/controllers/modal_controller.js`
+- `test/models/offer_test.rb`, `test/models/offer_version_test.rb`, `test/models/offer_milestone_test.rb`, `test/services/offer_sender_test.rb`, `test/services/offer_renderer_test.rb`, `test/services/offer_milestone_converter_test.rb`, `test/services/offer_milestone_scaffolder_test.rb`, `test/mailers/offer_mailer_test.rb`, `test/jobs/expiring_offers_report_job_test.rb`, `test/controllers/offers_controller_test.rb`, `test/system/offer_form_test.rb`
+- `test/fixtures/offers.yml`, `test/fixtures/offer_versions.yml`, `test/fixtures/offer_milestones.yml`
+
+Modify:
+- `app/models/permission.rb`, `app/models/customer.rb`, `app/models/customer_contact.rb`, `app/models/project.rb`, `app/models/issuer_company.rb`
+- `app/controllers/attachments_controller.rb`, `app/controllers/customers_controller.rb`, `app/controllers/issuer_companies_controller.rb`
+- `config/routes.rb`, `config/recurring.yml`, `config/initializers/mail_delivery_tracker.rb`, `config/locales/*.yml`
+- `db/seeds.rb`, `test/fixtures/group_permissions.yml`, `test/fixtures/document_numbers.yml`, `test/fixtures/customer_contacts.yml`, `test/support/document_factories.rb`
+- Navbar layout (`app/views/layouts/` — the partial containing the Invoices/Delivery Notes links)
+- Customer show/form views, IssuerCompany show/form views
+- `CLAUDE.md` (add Offer to core models + pipeline notes)
+
+---
+
+### Task 1: Schema + permissions + document number plumbing
+
+**Files:**
+- Create: the seven migrations listed above
+- Modify: `app/models/permission.rb`, `db/seeds.rb`, `test/fixtures/document_numbers.yml`, `test/fixtures/group_permissions.yml`
+
+**Interfaces produced:** tables `offers`, `offer_versions`, `offer_milestones`; permission keys `offers.view`, `offers.edit`, `offers.convert`; `DocumentNumber` row `code: "offer"`.
+
+- [ ] **Step 1: Write the migrations.**
+
+`db/migrate/YYYYMMDDHHMMSS_create_offers.rb` (generate timestamps with `bundle exec rails generate migration ...` or hand-date sequentially):
+
+```ruby
+class CreateOffers < ActiveRecord::Migration[8.1]
+  def change
+    create_table :offers do |t|
+      t.references :customer, null: false, foreign_key: true
+      t.references :project, null: false, foreign_key: true
+      t.references :customer_contact, foreign_key: true
+      t.string :matchcode, null: false
+      t.string :state, null: false, default: "draft"
+      t.string :document_number
+      t.date :date
+      t.datetime :sent_at
+      t.datetime :accepted_at
+      t.datetime :rejected_at
+      t.date :expires_at
+      t.datetime :reported_expired_at
+      t.bigint :accepted_version_id
+      t.text :order_number
+      t.date :ordered_on
+      t.references :order_attachment, foreign_key: { to_table: :attachments }
+      t.text :internal_reference
+      t.datetime :email_sent_at
+      t.timestamps
+    end
+    add_index :offers, :document_number, unique: true
+    add_index :offers, "customer_id, LOWER(matchcode)", unique: true,
+              name: "index_offers_on_customer_and_lower_matchcode"
+    add_index :offers, :state
+  end
+end
+```
+
+`*_create_offer_versions.rb`:
+
+```ruby
+class CreateOfferVersions < ActiveRecord::Migration[8.1]
+  def change
+    create_table :offer_versions do |t|
+      t.references :offer, null: false, foreign_key: true
+      t.integer :version_number, null: false
+      t.string :subject
+      t.string :salutation_override
+      t.date :delivery_date
+      t.date :date
+      t.references :sales_tax_product_class, foreign_key: true
+      t.decimal :sum_net, default: "0.0"
+      t.datetime :sent_at
+      t.text :customer_name
+      t.text :customer_address
+      t.string :customer_country_iso2, limit: 2
+      t.text :customer_supplier_number
+      t.integer :payment_terms_days
+      t.references :attachment, foreign_key: true
+      t.timestamps
+    end
+    add_index :offer_versions, [:offer_id, :version_number], unique: true
+    add_index :offer_versions, :offer_id, unique: true, where: "sent_at IS NULL",
+              name: "index_offer_versions_one_draft_per_offer"
+  end
+end
+```
+
+Then `add_foreign_key :offers, :offer_versions, column: :accepted_version_id` in this migration (after `create_table`), since `offers` is created first.
+
+`*_create_offer_milestones.rb`:
+
+```ruby
+class CreateOfferMilestones < ActiveRecord::Migration[8.1]
+  def change
+    create_table :offer_milestones do |t|
+      t.references :offer_version, null: false, foreign_key: true
+      t.integer :position
+      t.string :title, null: false
+      t.text :description
+      t.string :trigger, null: false, default: "on_acceptance"
+      t.date :trigger_date
+      t.decimal :amount, null: false
+      t.boolean :skip_delivery_note, null: false, default: false
+      t.references :invoice, foreign_key: true, index: false
+      t.references :delivery_note, foreign_key: true, index: false
+      t.timestamps
+    end
+    add_index :offer_milestones, :invoice_id, unique: true, where: "invoice_id IS NOT NULL"
+    add_index :offer_milestones, :delivery_note_id, unique: true, where: "delivery_note_id IS NOT NULL"
+  end
+end
+```
+
+`*_add_offer_fields_to_customers_and_contacts.rb`:
+
+```ruby
+class AddOfferFieldsToCustomersAndContacts < ActiveRecord::Migration[8.1]
+  def change
+    add_column :customers, :offer_validity_days, :integer
+    add_column :customers, :offer_milestone_split_threshold, :decimal
+    add_column :customers, :offer_milestone_templates_below, :text
+    add_column :customers, :offer_milestone_templates_above, :text
+    add_column :customer_contacts, :receives_offer_emails, :boolean, null: false, default: false
+  end
+end
+```
+
+(`Customer#offer_boilerplate` and `Offer#internal_notes` are ActionText — no columns.)
+
+`*_add_offer_settings_to_issuer_companies.rb`:
+
+```ruby
+class AddOfferSettingsToIssuerCompanies < ActiveRecord::Migration[8.1]
+  def change
+    add_column :issuer_companies, :offer_validity_days, :integer, null: false, default: 30
+    add_column :issuer_companies, :offer_footer, :string
+  end
+end
+```
+
+`*_add_offer_document_number.rb` (self-contained AR stand-in per repo convention — see `db/migrate/20260623211331_backfill_prelude_rich_text.rb`):
+
+```ruby
+class AddOfferDocumentNumber < ActiveRecord::Migration[8.1]
+  class MigrationDocumentNumber < ActiveRecord::Base
+    self.table_name = "document_numbers"
+  end
+
+  def up
+    return if MigrationDocumentNumber.exists?(code: "offer")
+    invoice = MigrationDocumentNumber.find_by(code: "invoice")
+    MigrationDocumentNumber.create!(code: "offer", format: invoice&.format || "%{year}%<number>04d", sequence: 0)
+  end
+
+  def down
+    MigrationDocumentNumber.where(code: "offer").delete_all
+  end
+end
+```
+
+`*_grant_offer_permissions_to_admin_group.rb` (mirror `db/migrate/20260613120000_grant_review_acceptance_to_admin_group.rb` exactly, but loop):
+
+```ruby
+class GrantOfferPermissionsToAdminGroup < ActiveRecord::Migration[8.1]
+  PERMISSIONS = %w[offers.view offers.edit offers.convert].freeze
+
+  class MigrationGroup < ActiveRecord::Base
+    self.table_name = "groups"
+    has_many :group_permissions, class_name: "GrantOfferPermissionsToAdminGroup::MigrationGroupPermission", foreign_key: :group_id
+  end
+
+  class MigrationGroupPermission < ActiveRecord::Base
+    self.table_name = "group_permissions"
+  end
+
+  def up
+    admin = MigrationGroup.find_by(builtin: true, name: "Admin")
+    return unless admin
+    PERMISSIONS.each { |p| admin.group_permissions.find_or_create_by!(permission: p) }
+  end
+
+  def down; end
+end
+```
+
+- [ ] **Step 2: Add permission entries.** In `app/models/permission.rb`, after the `delivery_notes.review_acceptance` entry, add:
+
+```ruby
+Entry.new(key: "offers.view",    label: "View offers",                        category: "Operations"),
+Entry.new(key: "offers.edit",    label: "Create / send / accept offers",      category: "Operations"),
+Entry.new(key: "offers.convert", label: "Convert offer milestones to invoices", category: "Operations"),
+```
+
+- [ ] **Step 3: Seeds + fixtures.** In `db/seeds.rb`, next to the existing `DocumentNumber.find_or_create_by(code: 'delivery_note')` block, add the same for `code: 'offer'` (copy the invoice block's format). In `test/fixtures/document_numbers.yml` add:
+
+```yaml
+offer:
+  code: offer
+  format: '%{year}%<number>04d'
+  sequence: 0
+  last_number: nil
+  last_date: nil
+```
+
+In `test/fixtures/group_permissions.yml` add:
+
+```yaml
+admin_offers_view: { group: admin, permission: offers.view }
+admin_offers_edit: { group: admin, permission: offers.edit }
+admin_offers_convert: { group: admin, permission: offers.convert }
+```
+
+- [ ] **Step 4: Migrate and run the suite.**
+
+Run: `bundle exec rails db:migrate && bundle exec rails test`
+Expected: migrations apply cleanly; existing tests stay green (nothing consumes the new tables yet).
+
+- [ ] **Step 5: Commit.** `git add -A && pre-commit run --all-files && git commit -m "Add offers schema, permissions, and document number range"`
+
+---
+
+### Task 2: Models — Offer, OfferVersion, OfferMilestone
+
+**Files:**
+- Create: `app/models/offer.rb`, `app/models/offer_version.rb`, `app/models/offer_milestone.rb`, `test/models/offer_test.rb`, `test/models/offer_milestone_test.rb`, fixtures `offers.yml` / `offer_versions.yml` / `offer_milestones.yml`
+- Modify: `app/models/customer.rb`, `app/models/customer_contact.rb`, `app/models/project.rb`, `app/models/issuer_company.rb`, `test/support/document_factories.rb`
+
+**Interfaces produced (later tasks rely on these exact names):**
+- `Offer`: `STATES`, `draft?/sent?/accepted?/rejected?/expired?`, `draft_version`, `current_sent_version`, `accepted_version`, `versions`, `validity_days`, `send_problems`, `accept!(order_number:, ordered_on:, order_pdf: nil)`, `reject!`, `reopen!`, `email_recipients`, `email_cc_recipients` (returns `[]`), `email_salutation_contact`, `emailable?`, `status_badge`, `editable?`, `deletable?`
+- `OfferVersion`: `milestones`, `frozen?` (alias of `sent_at?`), `branch_draft!`, `recalculate_sum_net!`, rich texts `prelude` and `boilerplate`
+- `OfferMilestone`: `TRIGGERS`, `TRIGGER_LABELS`, `trigger_label`, `converted?`, `default_skip_delivery_note`
+
+- [ ] **Step 1: Write failing model tests** in `test/models/offer_test.rb`:
+
+```ruby
+require "test_helper"
+
+class OfferTest < ActiveSupport::TestCase
+  test "matchcode must be unique per customer case-insensitively" do
+    existing = offers(:draft_offer)
+    dup = Offer.new(customer: existing.customer, project: existing.project,
+                    matchcode: existing.matchcode.upcase)
+    assert_not dup.valid?
+    assert dup.errors[:matchcode].any?
+  end
+
+  test "same matchcode is allowed for a different customer" do
+    existing = offers(:draft_offer)
+    other = Offer.new(customer: customers(:good_national), project: projects(:two),
+                      matchcode: existing.matchcode)
+    other.valid?
+    assert_empty other.errors[:matchcode]
+  end
+
+  test "project is required" do
+    offer = Offer.new(customer: customers(:good_eu), matchcode: "NOPROJ")
+    assert_not offer.valid?
+    assert offer.errors[:project].any?
+  end
+
+  test "validity_days falls back from customer to issuer" do
+    offer = offers(:draft_offer)
+    offer.customer.update!(offer_validity_days: nil)
+    assert_equal IssuerCompany.get_the_issuer!.offer_validity_days, offer.validity_days
+    offer.customer.update!(offer_validity_days: 14)
+    assert_equal 14, offer.validity_days
+  end
+
+  test "send_problems requires a draft version with at least one milestone" do
+    offer = offers(:draft_offer)
+    offer.draft_version.milestones.destroy_all
+    assert_includes offer.send_problems.join, "milestone"
+  end
+
+  test "accept from sent stores order data and discards the draft version" do
+    offer = offers(:sent_offer)
+    draft_id = offer.draft_version.id
+    offer.accept!(order_number: "PO-100", ordered_on: Date.new(2026, 7, 1))
+    assert offer.accepted?
+    assert_equal "PO-100", offer.order_number
+    assert_equal offer.versions.where.not(sent_at: nil).order(:version_number).last.id,
+                 offer.accepted_version_id
+    assert_nil OfferVersion.find_by(id: draft_id)
+  end
+
+  test "accept refused unless sent" do
+    assert_raises(Offer::InvalidTransition) { offers(:draft_offer).accept!(order_number: "x", ordered_on: Date.current) }
+  end
+
+  test "accept requires an order date" do
+    assert_raises(Offer::InvalidTransition) { offers(:sent_offer).accept!(order_number: "x", ordered_on: nil) }
+    assert offers(:sent_offer).reload.sent?
+  end
+
+  test "reject stamps rejected_at" do
+    offer = offers(:sent_offer)
+    offer.reject!
+    assert offer.rejected?
+    assert_not_nil offer.rejected_at
+  end
+
+  test "reopen from rejected returns to sent" do
+    offer = offers(:sent_offer)
+    offer.reject!
+    offer.reopen!
+    assert offer.sent?
+    assert_nil offer.rejected_at
+  end
+
+  test "reopen from accepted branches a draft from the accepted version" do
+    offer = offers(:sent_offer)
+    offer.accept!(order_number: "PO-1", ordered_on: Date.current)
+    accepted_subject = offer.reload.accepted_version.subject
+    offer.reopen!
+    assert offer.sent?
+    assert_nil offer.accepted_version_id
+    assert_equal accepted_subject, offer.draft_version.subject
+  end
+
+  test "customer with offers cannot be deleted" do
+    customer = offers(:draft_offer).customer
+    assert_not customer.destroy
+    assert_includes customer.errors[:base].join, "offers"
+  end
+
+  test "deleting the addressed contact nullifies the reference" do
+    offer = offers(:draft_offer)
+    contact = customer_contacts(:eu_contact)
+    offer.update!(customer_contact: contact)
+    contact.destroy
+    assert_nil offer.reload.customer_contact_id
+  end
+
+  test "email_recipients uses offer-flagged contacts" do
+    offer = offers(:sent_offer)
+    assert_equal offer.customer.contacts_for_offer(offer).map(&:to_email_address),
+                 offer.email_recipients
+  end
+end
+```
+
+And `test/models/offer_milestone_test.rb`:
+
+```ruby
+require "test_helper"
+
+class OfferMilestoneTest < ActiveSupport::TestCase
+  test "trigger must be one of the known values" do
+    m = offer_milestones(:sent_ms_one)
+    m.trigger = "bogus"
+    assert_not m.valid?
+  end
+
+  test "on_date trigger requires a date" do
+    m = offer_milestones(:sent_ms_one)
+    m.trigger = "on_date"
+    m.trigger_date = nil
+    assert_not m.valid?
+  end
+
+  test "saving milestones updates the version sum_net" do
+    version = offer_versions(:draft_offer_v1)
+    version.milestones.create!(title: "Extra", amount: 100, trigger: "on_acceptance", position: 9)
+    assert_equal version.milestones.sum(:amount), version.reload.sum_net
+  end
+
+  test "default_skip_delivery_note true only for on_order" do
+    m = OfferMilestone.new(trigger: "on_order")
+    assert m.default_skip_delivery_note
+    m.trigger = "on_acceptance"
+    assert_not m.default_skip_delivery_note
+  end
+end
+```
+
+Fixtures — `test/fixtures/offers.yml`:
+
+```yaml
+draft_offer:
+  customer: good_eu
+  project: one
+  matchcode: OFFER-DRAFT
+  state: draft
+
+sent_offer:
+  customer: good_eu
+  project: one
+  matchcode: OFFER-SENT
+  state: sent
+  document_number: 20269001
+  date: 2026-06-01
+  sent_at: 2026-06-01 10:00:00
+  expires_at: 2026-07-01
+```
+
+`test/fixtures/offer_versions.yml`:
+
+```yaml
+draft_offer_v1:
+  offer: draft_offer
+  version_number: 1
+  subject: Draft offer subject
+
+sent_offer_v1:
+  offer: sent_offer
+  version_number: 1
+  subject: Sent offer subject
+  date: 2026-06-01
+  sent_at: 2026-06-01 10:00:00
+  sales_tax_product_class: standard
+  customer_name: Snapshot Name
+  customer_address: "Snapshot Street 1"
+  customer_country_iso2: DE
+  payment_terms_days: 30
+
+sent_offer_v2_draft:
+  offer: sent_offer
+  version_number: 2
+  subject: Sent offer subject
+  sales_tax_product_class: standard
+```
+
+`test/fixtures/offer_milestones.yml`:
+
+```yaml
+draft_ms_one:
+  offer_version: draft_offer_v1
+  position: 1
+  title: Concept
+  amount: 500
+  trigger: on_acceptance
+
+sent_ms_one:
+  offer_version: sent_offer_v1
+  position: 1
+  title: Setup
+  amount: 1000
+  trigger: on_order
+  skip_delivery_note: true
+
+sent_ms_two:
+  offer_version: sent_offer_v1
+  position: 2
+  title: Delivery
+  amount: 2000
+  trigger: on_acceptance
+
+sent_draft_ms_one:
+  offer_version: sent_offer_v2_draft
+  position: 1
+  title: Setup
+  amount: 1000
+  trigger: on_order
+  skip_delivery_note: true
+```
+
+Also add one offer-flagged contact in `test/fixtures/customer_contacts.yml` (set `receives_offer_emails: true` on an existing `good_eu` contact).
+
+- [ ] **Step 2: Run tests to verify they fail.**
+
+Run: `bundle exec rails test test/models/offer_test.rb test/models/offer_milestone_test.rb`
+Expected: FAIL — `NameError: uninitialized constant Offer`.
+
+- [ ] **Step 3: Implement the models.**
+
+`app/models/offer_milestone.rb`:
+
+```ruby
+class OfferMilestone < ApplicationRecord
+  TRIGGERS = %w[on_order on_acceptance on_date].freeze
+  TRIGGER_LABELS = {
+    "on_order" => "Upon order",
+    "on_acceptance" => "Upon acceptance",
+    "on_date" => "On date"
+  }.freeze
+
+  belongs_to :offer_version
+  belongs_to :invoice, optional: true
+  belongs_to :delivery_note, optional: true
+
+  validates :title, presence: true
+  validates :amount, presence: true, numericality: true
+  validates :trigger, presence: true, inclusion: { in: TRIGGERS }
+  validates :trigger_date, presence: true, if: -> { trigger == "on_date" }
+  validates :invoice_id, uniqueness: true, allow_nil: true
+  validates :delivery_note_id, uniqueness: true, allow_nil: true
+
+  after_save :refresh_version_sum
+  after_destroy :refresh_version_sum
+
+  def trigger_label
+    label = TRIGGER_LABELS.fetch(trigger, trigger)
+    trigger == "on_date" && trigger_date ? "#{label} #{I18n.l(trigger_date)}" : label
+  end
+
+  def converted?
+    invoice_id.present?
+  end
+
+  def default_skip_delivery_note
+    trigger == "on_order"
+  end
+
+  private
+
+  def refresh_version_sum
+    offer_version.recalculate_sum_net!
+  end
+end
+```
+
+`app/models/offer_version.rb`:
+
+```ruby
+class OfferVersion < ApplicationRecord
+  belongs_to :offer
+  belongs_to :sales_tax_product_class, optional: true
+  belongs_to :attachment, optional: true
+
+  has_many :milestones, -> { order(:position, :id) }, class_name: "OfferMilestone", dependent: :destroy
+  accepts_nested_attributes_for :milestones, allow_destroy: true, reject_if: :all_blank
+
+  has_rich_text :prelude
+  has_rich_text :boilerplate
+
+  validates :version_number, presence: true, uniqueness: { scope: :offer_id }
+
+  def frozen?
+    sent_at.present?
+  end
+
+  def recalculate_sum_net!
+    update_column(:sum_net, milestones.reload.sum(:amount))
+  end
+
+  # Copies customer-facing content into a new draft version. Frozen
+  # customer-derived values (snapshot, boilerplate) deliberately do NOT copy —
+  # drafts return to the live customer reference.
+  def branch_draft!
+    offer.versions.create!(
+      version_number: offer.versions.maximum(:version_number) + 1,
+      subject: subject,
+      salutation_override: salutation_override,
+      delivery_date: delivery_date,
+      sales_tax_product_class_id: sales_tax_product_class_id,
+      prelude: prelude.body
+    ).tap do |draft|
+      milestones.each do |m|
+        draft.milestones.create!(
+          position: m.position, title: m.title, description: m.description,
+          trigger: m.trigger, trigger_date: m.trigger_date,
+          amount: m.amount, skip_delivery_note: m.skip_delivery_note
+        )
+      end
+    end
+  end
+end
+```
+
+`app/models/offer.rb`:
+
+```ruby
+class Offer < ApplicationRecord
+  include YearFilterable
+  include ScopedThroughCustomer
+  include DocumentIdentity
+
+  class InvalidTransition < StandardError; end
+
+  STATES = %w[draft sent accepted rejected expired].freeze
+
+  belongs_to :customer
+  belongs_to :project
+  belongs_to :customer_contact, optional: true
+  belongs_to :accepted_version, class_name: "OfferVersion", optional: true
+  belongs_to :order_attachment, class_name: "Attachment", optional: true
+
+  has_many :versions, -> { order(:version_number) }, class_name: "OfferVersion", dependent: :destroy
+  has_one :draft_version, -> { where(sent_at: nil) }, class_name: "OfferVersion"
+  accepts_nested_attributes_for :draft_version
+
+  has_rich_text :internal_notes
+
+  validates :matchcode, presence: true, format: { with: /\A\S{2,}\z/ },
+            uniqueness: { scope: :customer_id, case_sensitive: false }
+  validates :state, inclusion: { in: STATES }
+
+  after_create :create_initial_version
+
+  STATES.each do |s|
+    define_method("#{s}?") { state == s }
+  end
+
+  def current_sent_version
+    return accepted_version if accepted_version
+    versions.where.not(sent_at: nil).order(:version_number).last
+  end
+
+  def validity_days
+    customer.offer_validity_days.presence || IssuerCompany.get_the_issuer!.offer_validity_days
+  end
+
+  def editable?
+    %w[draft sent expired].include?(state) && draft_version.present?
+  end
+
+  def deletable?
+    draft?
+  end
+
+  def send_problems
+    problems = []
+    problems << "No draft version to send." if draft_version.nil?
+    problems << "Add at least one milestone before sending." if draft_version && draft_version.milestones.none?
+    problems << "Offer is #{state}; reopen it before sending a revision." unless %w[draft sent expired].include?(state)
+    problems
+  end
+
+  def accept!(order_number:, ordered_on:, order_pdf: nil)
+    with_lock do
+      raise InvalidTransition, "accept requires state sent, was #{state}" unless sent?
+      raise InvalidTransition, "order date is required" if ordered_on.blank?
+      self.accepted_version = versions.where.not(sent_at: nil).order(:version_number).last
+      self.accepted_at = Time.current
+      self.order_number = order_number
+      self.ordered_on = ordered_on
+      attach_order_pdf(order_pdf) if order_pdf
+      self.state = "accepted"
+      draft_version&.destroy
+      save!
+    end
+  end
+
+  def reject!
+    with_lock do
+      raise InvalidTransition, "reject requires sent or expired, was #{state}" unless sent? || expired?
+      update!(state: "rejected", rejected_at: Time.current)
+    end
+  end
+
+  def reopen!
+    with_lock do
+      case state
+      when "accepted"
+        source = accepted_version
+        assign_attributes(state: "sent", accepted_at: nil, accepted_version: nil)
+        save!
+        source.branch_draft! if draft_version.nil?
+      when "rejected"
+        update!(state: "sent", rejected_at: nil)
+      else
+        raise InvalidTransition, "reopen requires accepted or rejected, was #{state}"
+      end
+    end
+  end
+
+  def email_recipients
+    customer.contacts_for_offer(self).map(&:to_email_address)
+  end
+
+  def email_cc_recipients
+    []
+  end
+
+  def email_salutation_contact
+    contacts = customer.contacts_for_offer(self)
+    contacts.size == 1 ? contacts.first : nil
+  end
+
+  def emailable?
+    current_sent_version&.attachment.present? && email_recipients.any?
+  end
+
+  def status_badge
+    { "draft" => ["Draft", "bg-secondary"],
+      "sent" => ["Sent", "bg-info text-dark"],
+      "accepted" => ["Accepted", "bg-success"],
+      "rejected" => ["Rejected", "bg-danger"],
+      "expired" => ["Expired", "bg-warning text-dark"] }.fetch(state)
+  end
+
+  def attach_order_pdf(uploaded_file)
+    attachment = order_attachment || Attachment.new
+    attachment.set_data(uploaded_file.read, "application/pdf")
+    attachment.filename = "Order-#{display_label}.pdf"
+    attachment.title = "Customer order for #{display_name}"
+    attachment.save!
+    self.order_attachment = attachment
+  end
+
+  private
+
+  def create_initial_version
+    versions.create!(version_number: 1)
+  end
+end
+```
+
+Model extensions:
+
+- `app/models/customer.rb`: add `has_many :offers`, `has_rich_text :offer_boilerplate`, `def contacts_for_offer(offer) = customer_contacts.for_offers.select { |c| c.applies_to_project?(offer.project) }`, extend `deletion_blocker` with an `offers` branch (`return "offers" if offers.exists?` — put it after invoices/delivery notes), and `validates :offer_validity_days, numericality: { greater_than: 0, allow_nil: true }`.
+- `app/models/customer_contact.rb`: add `scope :for_offers, -> { where(receives_offer_emails: true) }` and `has_many :offers, dependent: :nullify`.
+- `app/models/project.rb`: add `has_many :offers` and the same `deletion_blocker` branch.
+- `app/models/issuer_company.rb`: `validates :offer_validity_days, numericality: { greater_than: 0 }`.
+
+Factories — in `test/support/document_factories.rb` add:
+
+```ruby
+def create_draft_offer(customer: customers(:good_eu), project: projects(:one), matchcode: "OF-#{SecureRandom.hex(3)}")
+  Offer.create!(customer: customer, project: project, matchcode: matchcode)
+end
+
+def create_offer_with_milestone(**kwargs)
+  offer = create_draft_offer(**kwargs)
+  offer.draft_version.milestones.create!(title: "Milestone", amount: 1000, trigger: "on_acceptance", position: 1)
+  offer
+end
+```
+
+- [ ] **Step 4: Run the model tests, then the whole suite.**
+
+Run: `bundle exec rails test test/models/offer_test.rb test/models/offer_milestone_test.rb && bundle exec rails test`
+Expected: PASS. (Watch for existing customer/project deletion tests — the new blocker branch must not change their messages for invoice/DN cases.)
+
+- [ ] **Step 5: Commit.** `pre-commit run --all-files && git commit -m "Add Offer, OfferVersion, and OfferMilestone models"`
+
+---
+
+### Task 3: Send flow — OfferSender service
+
+**Files:**
+- Create: `app/services/offer_sender.rb`, `test/services/offer_sender_test.rb`
+
+**Interfaces:**
+- Consumes: `Offer#send_problems`, `OfferVersion#branch_draft!`, `DocumentNumber.get_next_for("offer", date)`, `OfferRenderer` (stubbed until Task 4 — see Step 3).
+- Produces: `OfferSender.new(offer, issuer).send! → true/false`, `#log` (String), same shape as `InvoicePublisher`.
+
+- [ ] **Step 1: Write failing tests** in `test/services/offer_sender_test.rb`:
+
+```ruby
+require "test_helper"
+
+class OfferSenderTest < ActiveSupport::TestCase
+  setup do
+    @issuer = IssuerCompany.get_the_issuer!
+  end
+
+  # Renderer stubbed per test via OfferRenderer.stub(:new, ...) so these tests
+  # don't need FOP. InvoicePublisher's test file uses the same technique
+  # (with_failing_renderer) — mirror its style.
+
+  test "first send assigns a document number, freezes the version, and branches a new draft" do
+    offer = create_offer_with_milestone
+    sender = OfferSender.new(offer, @issuer)
+    fake = Minitest::Mock.new
+    fake.expect(:render, "%PDF-fake")
+    OfferRenderer.stub(:new, ->(*_) { fake }) do
+      assert sender.send!, sender.log
+    end
+    offer.reload
+    assert offer.sent?
+    assert_match(/\A2026/, offer.document_number)
+    frozen = offer.versions.find_by(version_number: 1)
+    assert frozen.frozen?
+    assert_equal Date.current, frozen.date
+    assert_equal offer.customer.name, frozen.customer_name
+    assert_equal offer.customer.payment_terms_days, frozen.payment_terms_days
+    assert frozen.attachment&.data&.start_with?("%PDF")
+    draft = offer.draft_version
+    assert_equal 2, draft.version_number
+    assert_equal frozen.milestones.count, draft.milestones.count
+    assert_equal Date.current + offer.validity_days, offer.expires_at
+  end
+
+  test "second send keeps the document number and supersedes the prior version" do
+    offer = create_offer_with_milestone
+    numbers = []
+    2.times do
+      fake = Minitest::Mock.new
+      fake.expect(:render, "%PDF-fake")
+      OfferRenderer.stub(:new, ->(*_) { fake }) { assert OfferSender.new(offer.reload, @issuer).send! }
+      numbers << offer.reload.document_number
+    end
+    assert_equal numbers.first, numbers.last
+    assert_equal 2, offer.versions.where.not(sent_at: nil).count
+    assert_equal 3, offer.versions.maximum(:version_number)
+  end
+
+  test "send from expired re-enters sent with a fresh validity window" do
+    offer = create_offer_with_milestone
+    fake = Minitest::Mock.new
+    fake.expect(:render, "%PDF-fake")
+    OfferRenderer.stub(:new, ->(*_) { fake }) { assert OfferSender.new(offer, @issuer).send! }
+    offer.reload.update!(state: "expired", expires_at: 1.week.ago.to_date, reported_expired_at: Time.current)
+    fake2 = Minitest::Mock.new
+    fake2.expect(:render, "%PDF-fake")
+    OfferRenderer.stub(:new, ->(*_) { fake2 }) { assert OfferSender.new(offer.reload, @issuer).send! }
+    offer.reload
+    assert offer.sent?
+    assert_operator offer.expires_at, :>, Date.current
+    assert_nil offer.reported_expired_at
+  end
+
+  test "send refused without milestones" do
+    offer = create_draft_offer
+    sender = OfferSender.new(offer, @issuer)
+    assert_not sender.send!
+    assert offer.reload.draft?
+  end
+
+  test "boilerplate is frozen onto the version at send" do
+    offer = create_offer_with_milestone
+    offer.customer.update!(offer_boilerplate: "<p>Standing terms</p>")
+    fake = Minitest::Mock.new
+    fake.expect(:render, "%PDF-fake")
+    OfferRenderer.stub(:new, ->(*_) { fake }) { assert OfferSender.new(offer, @issuer).send! }
+    frozen = offer.reload.versions.find_by(version_number: 1)
+    assert_includes frozen.boilerplate.body.to_html, "Standing terms"
+    offer.customer.update!(offer_boilerplate: "<p>Changed later</p>")
+    assert_includes frozen.reload.boilerplate.body.to_html, "Standing terms"
+  end
+
+  test "nothing persists when PDF rendering fails" do
+    offer = create_offer_with_milestone
+    failing = Object.new
+    def failing.render = raise("FOP exploded")
+    OfferRenderer.stub(:new, ->(*_) { failing }) do
+      assert_raises(RuntimeError) { OfferSender.new(offer, @issuer).send! }
+    end
+    offer.reload
+    assert offer.draft?
+    assert_nil offer.document_number
+    assert_nil offer.versions.find_by(version_number: 1).sent_at
+  end
+end
+```
+
+(Clean up the stray `send_offer` helper sketch at the top — the per-test `Minitest::Mock` + `OfferRenderer.stub(:new, ...)` pattern is the real one; `InvoicePublisher`'s test uses an equivalent `with_failing_renderer` — read `test/services/invoice_publisher_test.rb` and mirror its stubbing style.)
+
+- [ ] **Step 2: Run to verify failure.**
+
+Run: `bundle exec rails test test/services/offer_sender_test.rb`
+Expected: FAIL — `uninitialized constant OfferSender`.
+
+- [ ] **Step 3: Implement** `app/services/offer_sender.rb` (also create a placeholder `app/services/offer_renderer.rb` so the constant exists for stubbing; the real renderer is Task 4):
+
+```ruby
+class OfferSender
+  attr_reader :log
+
+  def initialize(offer, issuer)
+    @offer = offer
+    @issuer = issuer
+    @log = ""
+  end
+
+  def send!
+    @offer.with_lock { send_locked! }
+  end
+
+  private
+
+  def send_locked!
+    problems = @offer.send_problems
+    if problems.any?
+      problems.each { |p| @log += "E: #{p}\n" }
+      return false
+    end
+
+    version = @offer.draft_version
+    today = Date.current
+    customer = @offer.customer
+
+    @offer.document_number ||= DocumentNumber.get_next_for("offer", today)
+
+    version.assign_attributes(
+      date: today,
+      sent_at: Time.current,
+      customer_name: customer.name,
+      customer_address: customer.address,
+      customer_country_iso2: customer.country_iso2,
+      customer_supplier_number: customer.supplier_number,
+      payment_terms_days: customer.payment_terms_days
+    )
+    version.boilerplate = customer.offer_boilerplate.body if customer.offer_boilerplate.present?
+    version.save!
+
+    pdf = OfferRenderer.new(version, @issuer).render
+    version.attachment ||= Attachment.new
+    version.attachment.set_data(pdf, "application/pdf")
+    version.attachment.filename = "#{@issuer.short_name}-Offer-#{@offer.document_number}-v#{version.version_number}.pdf"
+    version.attachment.title = "#{@issuer.short_name} Offer #{@offer.document_number} (version #{version.version_number})"
+    version.attachment.save!
+    version.save!
+
+    @offer.assign_attributes(
+      state: "sent",
+      date: today,
+      sent_at: Time.current,
+      expires_at: today + @offer.validity_days,
+      reported_expired_at: nil
+    )
+    @offer.save!
+
+    version.branch_draft!
+    @log += "I: sent version #{version.version_number} as #{@offer.document_number}\n"
+    true
+  end
+end
+```
+
+Placeholder `app/services/offer_renderer.rb` for this task only:
+
+```ruby
+class OfferRenderer
+  def initialize(version, issuer)
+    @version = version
+    @issuer = issuer
+  end
+
+  def render
+    raise NotImplementedError
+  end
+end
+```
+
+Note: `with_lock` opens the transaction — a renderer failure rolls everything back, matching `InvoicePublisher`.
+
+- [ ] **Step 4: Run tests.**
+
+Run: `bundle exec rails test test/services/offer_sender_test.rb`
+Expected: PASS.
+
+- [ ] **Step 5: Commit.** `pre-commit run --all-files && git commit -m "Add OfferSender send/freeze/branch flow"`
+
+---
+
+### Task 4: PDF — OfferRenderer + offer.xsl
+
+**Files:**
+- Modify: `app/services/offer_renderer.rb`
+- Create: `lib/foptemplate/offer.xsl`, `test/services/offer_renderer_test.rb`
+
+**Interfaces:**
+- Consumes: `FopRenderer#render_pdf_with_logo("offer.xsl", logo_data) { |logo_path| xml }`, `RichTextFoConverter`, `AddressFormatter.build`, version snapshot columns.
+- Produces: `OfferRenderer.new(version, issuer)` with `#emit_xml(logo_file_path)` and `#render → pdf bytes`. Draft versions render live customer data, `<number>` empty, valid-until from today; frozen versions render the snapshot and the offer's real number/expiry.
+
+- [ ] **Step 1: Write failing tests** in `test/services/offer_renderer_test.rb` (mirror `test/services/invoice_renderer_test.rb`'s structure — XML assertions via `emit_xml(nil)` plus one FOP smoke test):
+
+```ruby
+require "test_helper"
+
+class OfferRendererTest < ActiveSupport::TestCase
+  setup { @issuer = IssuerCompany.get_the_issuer! }
+
+  test "frozen version emits snapshot recipient, number, version and valid-until" do
+    version = offer_versions(:sent_offer_v1)
+    xml = OfferRenderer.new(version, @issuer).emit_xml(nil)
+    assert_match "Snapshot Name", xml
+    assert_match "<number>20269001</number>", xml
+    assert_match "<valid-until>", xml
+    assert_no_match(/<version-number>/, xml) # version row only from v2 onward
+  end
+
+  test "second and later versions emit a version-number element" do
+    v1 = offer_versions(:sent_offer_v1)
+    v2 = v1.offer.versions.find_by(version_number: 2)
+    v2.update!(sent_at: Time.current, date: Date.current,
+               customer_name: "Snap", customer_address: "A", customer_country_iso2: "DE",
+               payment_terms_days: 30)
+    xml = OfferRenderer.new(v2, @issuer).emit_xml(nil)
+    assert_match "<version-number>2</version-number>", xml
+  end
+
+  test "draft version renders live customer data without a number" do
+    version = offer_versions(:draft_offer_v1)
+    xml = OfferRenderer.new(version, @issuer).emit_xml(nil)
+    assert_match version.offer.customer.name, xml
+    assert_no_match(/<number>\S/, xml) # element present but empty for drafts
+  end
+
+  test "no VAT ids and no totals appear in the XML" do
+    xml = OfferRenderer.new(offer_versions(:sent_offer_v1), @issuer).emit_xml(nil)
+    assert_no_match(/vat-id/, xml)
+    assert_no_match(/<sums>/, xml)
+  end
+
+  test "milestones carry trigger and formatted amount data" do
+    xml = OfferRenderer.new(offer_versions(:sent_offer_v1), @issuer).emit_xml(nil)
+    assert_match "<trigger>on_order</trigger>", xml
+    assert_match "Setup", xml
+  end
+
+  test "prelude and boilerplate are embedded as FO fragments" do
+    version = offer_versions(:sent_offer_v1)
+    version.update!(prelude: "<p>Dear customer</p>", boilerplate: "<h1>Terms</h1>")
+    xml = OfferRenderer.new(version.reload, @issuer).emit_xml(nil)
+    assert_match "Dear customer", xml
+    assert_match "Terms", xml
+  end
+
+  test "FOP smoke: renders a real PDF" do
+    version = offer_versions(:sent_offer_v1)
+    pdf = OfferRenderer.new(version, @issuer).render
+    assert pdf.start_with?("%PDF"), "expected a PDF, got: #{pdf[0, 20].inspect}"
+  end
+end
+```
+
+- [ ] **Step 2: Run to verify failure.** `bundle exec rails test test/services/offer_renderer_test.rb` — FAIL (`NotImplementedError` / missing `emit_xml`).
+
+- [ ] **Step 3: Implement the renderer.** Replace `app/services/offer_renderer.rb` (read `app/services/invoice_renderer.rb` first and keep its Builder/AddressFormatter idioms exactly):
+
+```ruby
+class OfferRenderer
+  def initialize(version, issuer)
+    @version = version
+    @offer = version.offer
+    @issuer = issuer
+  end
+
+  def render
+    logo_data = @issuer.pdf_logo.presence
+    FopRenderer.new.render_pdf_with_logo("offer.xsl", logo_data) do |logo_file_path|
+      emit_xml(logo_file_path)
+    end
+  end
+
+  def emit_xml(logo_file_path)
+    frozen = @version.frozen?
+    customer = @offer.customer
+    recipient_name = frozen ? @version.customer_name : customer.name
+    recipient_address = frozen ? @version.customer_address : customer.address
+    recipient_country = frozen ? @version.customer_country_iso2 : customer.country_iso2
+    supplier_number = frozen ? @version.customer_supplier_number : customer.supplier_number
+    payment_terms = frozen ? @version.payment_terms_days : customer.payment_terms_days
+    boilerplate_html =
+      if frozen
+        @version.boilerplate.presence&.body&.to_html
+      else
+        customer.offer_boilerplate.presence&.body&.to_html
+      end
+    date = @version.date || Date.current
+    valid_until = frozen ? @offer.expires_at : Date.current + @offer.validity_days
+
+    xml = Builder::XmlMarkup.new(indent: 2)
+    xml.instruct!
+    xml.document(class: "offer", "xmlns:fo" => "http://www.w3.org/1999/XSL/Format") do |doc|
+      doc.language customer.language&.iso_code || "en"
+      doc.tag!("accent-color", @issuer.document_accent_color)
+      doc.footer @issuer.offer_footer
+      if logo_file_path
+        doc.tag!("logo-path", logo_file_path)
+        doc.tag!("logo-width", @issuer.pdf_logo_width)
+        doc.tag!("logo-height", @issuer.pdf_logo_height)
+      end
+      doc.issuer do |issuer_xml|
+        issuer_xml.address AddressFormatter.build(name: @issuer.legal_name, address: @issuer.address,
+                                                  self_country: @issuer.country_iso2,
+                                                  other_country: recipient_country, locale: :en)
+        issuer_xml.tag!("short-name", @issuer.short_name)
+        issuer_xml.tag!("legal-name", @issuer.legal_name)
+        issuer_xml.tag!("contact-line1", @issuer.document_contact_line1)
+        issuer_xml.tag!("contact-line2", @issuer.document_contact_line2)
+      end
+      doc.recipient do |r|
+        r.address AddressFormatter.build(name: recipient_name, address: recipient_address,
+                                         self_country: recipient_country,
+                                         other_country: @issuer.country_iso2, locale: :en)
+        r.tag!("supplier-no", supplier_number)
+      end
+      doc.currency @issuer.currency
+      doc.tag!("money-decimal-places", @issuer.money_decimal_places)
+      doc.subject @version.subject
+      doc.number @offer.document_number
+      doc.tag!("issue-date", date.iso8601)
+      doc.tag!("valid-until", valid_until.iso8601)
+      doc.tag!("version-number", @version.version_number) if @version.version_number >= 2
+      doc.tag!("delivery-date", @version.delivery_date&.iso8601)
+      doc.tag!("payment-terms-days", payment_terms)
+      doc.prelude do |p|
+        p << RichTextFoConverter.new(@version.prelude.body.to_html).to_fo_fragment if @version.prelude.present?
+      end
+      doc.boilerplate do |b|
+        b << RichTextFoConverter.new(boilerplate_html).to_fo_fragment if boilerplate_html
+      end
+      doc.milestones do |ms|
+        @version.milestones.each do |m|
+          ms.milestone do |mx|
+            mx.title m.title
+            mx.description m.description
+            mx.trigger m.trigger
+            mx.tag!("trigger-date", m.trigger_date&.iso8601)
+            mx.amount m.amount
+          end
+        end
+      end
+    end
+    xml.target!
+  end
+end
+```
+
+Adjust element names/`AddressFormatter` arguments to whatever `InvoiceRenderer` actually does (copy its calls verbatim — the sketch above must be reconciled against `app/services/invoice_renderer.rb` and the assertions updated to match; the *element names for offer-specific content* — `subject`, `valid-until`, `version-number`, `boilerplate`, `milestones/milestone/trigger` — are the contract for the XSL below).
+
+- [ ] **Step 4: Write `lib/foptemplate/offer.xsl`.** Start from a copy of `invoice.xsl`; keep `<xsl:import href="document_base.xsl"/>` and the overall page structure. Required deltas:
+
+1. `pdf-metadata` call: `document-type` param → `Offer`.
+2. Title block: `Angebot`/`Offer` (choose by `/document/language` like invoice.xsl does for its labels).
+3. Info box rows: Belegnummer/Document No (hide the row entirely when `/document/number` is empty — draft preview), Belegdatum/Date, `Gültig bis`/`Valid until` from `/document/valid-until`, and — only when `/document/version-number` exists — `Version`. **Delete** the VAT-ID rows (`Ihre USt-IdNr.`, `Unsere USt-IdNr.`) and reference rows; keep Kreditorennr/supplier-no only if `/document/recipient/supplier-no` is non-empty.
+4. Body flow order: subject line (bold, InterDisplay, below the title area) → prelude `<xsl:copy-of select="/document/prelude/*"/>` → boilerplate `<xsl:copy-of select="/document/boilerplate/*"/>` (same `fo:block-container space-after="18pt"` wrapper, guarded by `test="/document/boilerplate/*"`) → milestone table.
+5. Milestone table (replaces the invoice 5-col line table): columns Title+description (wide), Trigger, Amount. Template:
+
+```xml
+<xsl:template match="/document/milestones/milestone">
+  <fo:table-row>
+    <fo:table-cell padding="2pt"><fo:block font-weight="600"><xsl:value-of select="title"/></fo:block>
+      <xsl:if test="abt:strip-space(description) != ''">
+        <fo:block margin-left="4mm" font-size="9pt"><xsl:value-of select="description"/></fo:block>
+      </xsl:if>
+    </fo:table-cell>
+    <fo:table-cell padding="2pt"><fo:block>
+      <xsl:choose>
+        <xsl:when test="trigger = 'on_order'"><xsl:text>Bei Auftrag / Upon order</xsl:text></xsl:when>
+        <xsl:when test="trigger = 'on_acceptance'"><xsl:text>Bei Abnahme / Upon acceptance</xsl:text></xsl:when>
+        <xsl:otherwise><xsl:value-of select="abt:format-date(trigger-date, /document/language)"/></xsl:otherwise>
+      </xsl:choose>
+    </fo:block></fo:table-cell>
+    <fo:table-cell padding="2pt" text-align="right"><fo:block>
+      <xsl:value-of select="/document/currency"/><xsl:text> </xsl:text>
+      <xsl:value-of select="abt:format-amount(amount)"/>
+    </fo:block></fo:table-cell>
+  </fo:table-row>
+</xsl:template>
+```
+
+(Reuse invoice.xsl's German-vs-English label technique instead of the slash-pairs if that's what it does — match the existing convention.)
+
+6. **No sums block, no tax-class rows, no payment/bank box.** Replace the payment box with a bordered terms box containing: delivery date (`Liefertermin`/`Delivery date`, when present), payment terms (`Zahlungsziel: N Tage`/`Payment terms: N days`), the fixed sentence "Alle Beträge netto; gesetzliche USt. wird bei Rechnungslegung aufgeschlagen." / "All amounts are net; statutory VAT is added on invoicing.", and "Dieses Angebot ist gültig bis …" / "This offer is valid until …" with `abt:format-date(/document/valid-until, ...)`.
+7. Footer block reads `/document/footer` (now fed by `offer_footer`) — unchanged mechanics.
+
+- [ ] **Step 5: Run tests including the FOP smoke test.**
+
+Run: `bundle exec rails test test/services/offer_renderer_test.rb`
+Expected: PASS, including `%PDF` smoke. If FOP errors, run the failing transform manually per `lib/foptemplate/NOTE.md` and fix the XSL (typical: leftover invoice XPath like `/document/sums`).
+
+- [ ] **Step 6: Also re-run the sender tests** (`bundle exec rails test test/services/offer_sender_test.rb`) — they stub the renderer and must stay green.
+
+- [ ] **Step 7: Commit.** `pre-commit run --all-files && git commit -m "Add offer PDF renderer and FOP template"`
+
+---
+
+### Task 5: Milestone conversion + scaffolding services
+
+**Files:**
+- Create: `app/services/offer_milestone_converter.rb`, `app/services/offer_milestone_scaffolder.rb`, `test/services/offer_milestone_converter_test.rb`, `test/services/offer_milestone_scaffolder_test.rb`
+
+**Interfaces:**
+- Produces: `OfferMilestoneConverter.new(milestone).convert! → Invoice` (creates draft Invoice + optional draft DeliveryNote, links them on the milestone; raises `OfferMilestoneConverter::NotConvertible` when the offer isn't accepted or the milestone is already linked); `OfferMilestone#reopen_link!` (clears both links); `OfferMilestoneScaffolder.new(customer, total).apply_to(version) → Array<OfferMilestone>` (raises `OfferMilestoneScaffolder::MilestonesPresent` when the version already has milestones).
+
+- [ ] **Step 1: Write failing converter tests:**
+
+```ruby
+require "test_helper"
+
+class OfferMilestoneConverterTest < ActiveSupport::TestCase
+  setup do
+    @offer = offers(:sent_offer)
+    @offer.accept!(order_number: "PO-77", ordered_on: Date.new(2026, 6, 15))
+  end
+
+  test "converts a milestone into a draft invoice and delivery note" do
+    milestone = offer_milestones(:sent_ms_two) # on_acceptance, no skip
+    invoice = OfferMilestoneConverter.new(milestone).convert!
+    assert_not invoice.published
+    assert_equal @offer.customer, invoice.customer
+    assert_equal @offer.project, invoice.project
+    assert_equal "PO-77", invoice.cust_order
+    line = invoice.invoice_lines.first
+    assert_equal "item", line.type
+    assert_equal milestone.title, line.title
+    assert_equal 1, line.quantity
+    assert_equal milestone.amount, line.rate
+    assert_equal @offer.accepted_version.sales_tax_product_class_id, line.sales_tax_product_class_id
+    assert_includes invoice.prelude.body.to_html, @offer.document_number
+    milestone.reload
+    assert_equal invoice.id, milestone.invoice_id
+    dn = milestone.delivery_note
+    assert dn.present?
+    assert_equal invoice, dn.invoice
+    assert_equal milestone.title, dn.delivery_note_lines.first.title
+    assert_equal @offer.ordered_on, dn.delivery_start_date
+  end
+
+  test "skip_delivery_note produces only an invoice" do
+    milestone = offer_milestones(:sent_ms_one) # on_order, skip
+    OfferMilestoneConverter.new(milestone).convert!
+    assert_nil milestone.reload.delivery_note_id
+  end
+
+  test "conversion requires an accepted offer" do
+    other = offers(:draft_offer)
+    milestone = other.draft_version.milestones.first
+    assert_raises(OfferMilestoneConverter::NotConvertible) { OfferMilestoneConverter.new(milestone).convert! }
+  end
+
+  test "a converted milestone cannot convert twice, and reopen_link! clears it" do
+    milestone = offer_milestones(:sent_ms_two)
+    OfferMilestoneConverter.new(milestone).convert!
+    assert_raises(OfferMilestoneConverter::NotConvertible) { OfferMilestoneConverter.new(milestone.reload).convert! }
+    milestone.reopen_link!
+    assert_nil milestone.reload.invoice_id
+    assert_nil milestone.delivery_note_id
+  end
+
+  test "version prelude is appended to the invoice prelude" do
+    @offer.accepted_version.update!(prelude: "<p>Original offer prelude</p>")
+    invoice = OfferMilestoneConverter.new(offer_milestones(:sent_ms_two)).convert!
+    assert_includes invoice.prelude.body.to_html, "Original offer prelude"
+  end
+end
+```
+
+And scaffolder tests:
+
+```ruby
+require "test_helper"
+
+class OfferMilestoneScaffolderTest < ActiveSupport::TestCase
+  setup do
+    @customer = customers(:good_eu)
+    @customer.update!(
+      offer_milestone_split_threshold: 10_000,
+      offer_milestone_templates_below: "Full amount|on_acceptance|1.0",
+      offer_milestone_templates_above: "Deposit|on_order|0.3\nDelivery|on_acceptance|0.7"
+    )
+    @version = create_draft_offer(customer: @customer).draft_version
+  end
+
+  test "below threshold uses the below list" do
+    rows = OfferMilestoneScaffolder.new(@customer, 5000).apply_to(@version)
+    assert_equal ["Full amount"], rows.map(&:title)
+    assert_equal [5000], rows.map(&:amount)
+  end
+
+  test "above threshold distributes proportionally with the last row absorbing rounding" do
+    rows = OfferMilestoneScaffolder.new(@customer, 10_001).apply_to(@version)
+    assert_equal %w[Deposit Delivery], rows.map(&:title)
+    assert_equal 10_001, rows.sum(&:amount)
+    assert_equal (10_001 * 0.3).round(2), rows.first.amount
+  end
+
+  test "on_order rows default to skipping the delivery note" do
+    rows = OfferMilestoneScaffolder.new(@customer, 20_000).apply_to(@version)
+    assert rows.first.skip_delivery_note
+    assert_not rows.last.skip_delivery_note
+  end
+
+  test "malformed lines are skipped; nothing parseable falls back to a single placeholder" do
+    @customer.update!(offer_milestone_templates_below: "garbage-without-pipes\nAlso|bad")
+    rows = OfferMilestoneScaffolder.new(@customer, 100).apply_to(@version)
+    assert_equal ["Milestone"], rows.map(&:title)
+    assert_equal [100], rows.map(&:amount)
+  end
+
+  test "unconfigured rule falls back to a single placeholder" do
+    @customer.update!(offer_milestone_split_threshold: nil)
+    rows = OfferMilestoneScaffolder.new(@customer, 100).apply_to(@version)
+    assert_equal ["Milestone"], rows.map(&:title)
+  end
+
+  test "refuses when the draft already has milestones" do
+    @version.milestones.create!(title: "Existing", amount: 1, trigger: "on_acceptance", position: 1)
+    assert_raises(OfferMilestoneScaffolder::MilestonesPresent) do
+      OfferMilestoneScaffolder.new(@customer, 100).apply_to(@version)
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run to verify failure.** `bundle exec rails test test/services/offer_milestone_converter_test.rb test/services/offer_milestone_scaffolder_test.rb` — FAIL (uninitialized constants).
+
+- [ ] **Step 3: Implement.**
+
+`app/services/offer_milestone_converter.rb`:
+
+```ruby
+class OfferMilestoneConverter
+  class NotConvertible < StandardError; end
+
+  def initialize(milestone)
+    @milestone = milestone
+    @version = milestone.offer_version
+    @offer = @version.offer
+  end
+
+  def convert!
+    raise NotConvertible, "offer is not accepted" unless @offer.accepted?
+    raise NotConvertible, "milestone belongs to a non-accepted version" unless @version.id == @offer.accepted_version_id
+    raise NotConvertible, "milestone already converted" if @milestone.converted?
+
+    ActiveRecord::Base.transaction do
+      invoice = build_invoice
+      invoice.save!
+      delivery_note = @milestone.skip_delivery_note? ? nil : build_delivery_note(invoice).tap(&:save!)
+      @milestone.update!(invoice: invoice, delivery_note: delivery_note)
+      invoice
+    end
+  end
+
+  private
+
+  def reference_html
+    subject = @version.subject.presence
+    text = "Based on offer #{@offer.document_number}#{subject ? " (#{subject})" : ""}"
+    "<p>#{ERB::Util.html_escape(text)}</p>"
+  end
+
+  def prelude_html
+    html = reference_html
+    html += @version.prelude.body.to_html if @version.prelude.present?
+    html
+  end
+
+  def build_invoice
+    invoice = Invoice.new(customer: @offer.customer, project: @offer.project,
+                          cust_order: @offer.order_number)
+    invoice.prelude = prelude_html
+    invoice.invoice_lines.build(type: "item", position: 1, title: @milestone.title,
+                                description: @milestone.description, quantity: 1,
+                                rate: @milestone.amount,
+                                sales_tax_product_class_id: @version.sales_tax_product_class_id)
+    invoice
+  end
+
+  def build_delivery_note(invoice)
+    dn = DeliveryNote.new(customer: @offer.customer, project: @offer.project,
+                          invoice: invoice, cust_order: @offer.order_number,
+                          delivery_start_date: @offer.ordered_on)
+    dn.prelude = reference_html
+    dn.delivery_note_lines.build(type: "item", position: 1, title: @milestone.title,
+                                 description: @milestone.description, quantity: 1)
+    dn
+  end
+end
+```
+
+Add to `app/models/offer_milestone.rb`:
+
+```ruby
+def reopen_link!
+  update!(invoice: nil, delivery_note: nil)
+end
+```
+
+`app/services/offer_milestone_scaffolder.rb`:
+
+```ruby
+class OfferMilestoneScaffolder
+  class MilestonesPresent < StandardError; end
+
+  Row = Struct.new(:title, :trigger, :ratio)
+
+  def initialize(customer, total)
+    @customer = customer
+    @total = BigDecimal(total.to_s)
+  end
+
+  def apply_to(version)
+    raise MilestonesPresent if version.milestones.any?
+
+    rows = parse_rows
+    places = IssuerCompany.get_the_issuer!.money_decimal_places
+    milestones =
+      if rows.empty?
+        [version.milestones.create!(position: 1, title: "Milestone", trigger: "on_acceptance",
+                                    amount: @total.round(places))]
+      else
+        amounts = rows[0..-2].map { |r| (@total * r.ratio).round(places) }
+        amounts << @total - amounts.sum
+        rows.each_with_index.map do |row, i|
+          version.milestones.create!(position: i + 1, title: row.title, trigger: row.trigger,
+                                     trigger_date: (Date.current if row.trigger == "on_date"),
+                                     amount: amounts[i],
+                                     skip_delivery_note: row.trigger == "on_order")
+        end
+      end
+    milestones
+  end
+
+  private
+
+  def configured?
+    @customer.offer_milestone_split_threshold.present? &&
+      (@customer.offer_milestone_templates_below.present? || @customer.offer_milestone_templates_above.present?)
+  end
+
+  def parse_rows
+    return [] unless configured?
+    source = @total < @customer.offer_milestone_split_threshold ?
+      @customer.offer_milestone_templates_below : @customer.offer_milestone_templates_above
+    source.to_s.each_line.filter_map do |line|
+      title, trigger, ratio = line.strip.split("|").map(&:strip)
+      next if title.blank? || !OfferMilestone::TRIGGERS.include?(trigger)
+      ratio = Float(ratio, exception: false)
+      next if ratio.nil? || ratio <= 0
+      Row.new(title, trigger, BigDecimal(ratio.to_s))
+    end
+  end
+end
+```
+
+(`on_date` template rows keep their trigger and scaffold with `trigger_date: Date.current` as an editable placeholder — a nil date would fail the model validation. Add a test asserting an `on_date` template row scaffolds with today's date.)
+
+- [ ] **Step 4: Run tests.** `bundle exec rails test test/services/offer_milestone_converter_test.rb test/services/offer_milestone_scaffolder_test.rb` — PASS.
+
+- [ ] **Step 5: Commit.** `pre-commit run --all-files && git commit -m "Add offer milestone conversion and scaffolding services"`
+
+---
+
+### Task 6: Email — OfferMailer + delivery tracking
+
+**Files:**
+- Create: `app/mailers/offer_mailer.rb`, `app/views/offer_mailer/customer_email.html.haml`, `app/views/offer_mailer/customer_email.text.haml`, `test/mailers/offer_mailer_test.rb`
+- Modify: `config/initializers/mail_delivery_tracker.rb`, `config/locales/en.yml` (and `de.yml` if the invoice subject key exists there)
+
+**Interfaces:**
+- Produces: `OfferMailer.with(offer: offer).customer_email` — attaches `offer.current_sent_version.attachment` (the stored PDF, byte-identical on re-send), salutation = version `salutation_override` presence, else contact `salutation_line`.
+
+- [ ] **Step 1: Write failing tests** in `test/mailers/offer_mailer_test.rb` (mirror `test/mailers/delivery_note_mailer_test.rb`'s structure):
+
+```ruby
+require "test_helper"
+
+class OfferMailerTest < ActionMailer::TestCase
+  setup do
+    @offer = offers(:sent_offer)
+    version = @offer.versions.find_by(version_number: 1)
+    attachment = Attachment.new(title: "Offer PDF")
+    attachment.set_data("%PDF-stored", "application/pdf")
+    attachment.filename = "offer.pdf"
+    attachment.save!
+    version.update!(attachment: attachment)
+  end
+
+  test "sends to offer-flagged contacts with the stored PDF attached" do
+    mail = OfferMailer.with(offer: @offer).customer_email
+    assert_equal @offer.email_recipients, mail.to
+    assert_equal 1, mail.attachments.size
+    assert_equal "%PDF-stored", mail.attachments.first.body.raw_source
+  end
+
+  test "salutation override on the sent version wins over the contact salutation" do
+    @offer.current_sent_version.update!(salutation_override: "Dear override,")
+    mail = OfferMailer.with(offer: @offer).customer_email
+    assert_includes mail.text_part.body.to_s, "Dear override,"
+  end
+
+  test "no-op when no contact opted in" do
+    @offer.customer.customer_contacts.update_all(receives_offer_emails: false)
+    mail = OfferMailer.with(offer: @offer).customer_email
+    assert_nil mail.to
+  end
+end
+```
+
+- [ ] **Step 2: Run to verify failure.** `bundle exec rails test test/mailers/offer_mailer_test.rb` — FAIL.
+
+- [ ] **Step 3: Implement.** `app/mailers/offer_mailer.rb`:
+
+```ruby
+class OfferMailer < ApplicationMailer
+  def customer_email
+    @offer = params[:offer]
+    @version = @offer.current_sent_version
+    @salutation = @version&.salutation_override.presence ||
+                  @offer.email_salutation_contact&.salutation_line.presence
+
+    unless params[:skip_attachments]
+      pdf = @version&.attachment
+      attachments[pdf.filename] = { mime_type: pdf.safe_content_type, content: pdf.data } if pdf
+    end
+
+    with_customer_locale(@offer.customer) do
+      document_mail(to: @offer.email_recipients,
+                    subject: I18n.t("mailers.offer.subject",
+                                    issuer: @issuer.short_name,
+                                    number: @offer.document_number))
+    end
+  end
+end
+```
+
+(Reconcile helper usage against `app/mailers/invoice_mailer.rb` / `delivery_note_mailer.rb` — attachment API, `with_customer_locale` signature, and view instance variables must match the existing mailers exactly.) Views: copy `app/views/delivery_note_mailer/customer_email.{html,text}.haml` and strip the acceptance-upload paragraph; reference the offer number/subject. Locale key `mailers.offer.subject` — copy the shape of `mailers.invoice.subject` into the same locale files.
+
+Delivery tracking — in `config/initializers/mail_delivery_tracker.rb`, add alongside the `InvoiceMailer` case:
+
+```ruby
+when "OfferMailer"
+  offer = job_params[:offer]
+  offer&.update_column(:email_sent_at, Time.current)
+```
+
+(match the file's actual local-variable names).
+
+- [ ] **Step 4: Run tests.** `bundle exec rails test test/mailers/offer_mailer_test.rb` — PASS.
+
+- [ ] **Step 5: Commit.** `pre-commit run --all-files && git commit -m "Add OfferMailer with stored-PDF attachment and sent tracking"`
+
+---
+
+### Task 7: Expiry job
+
+**Files:**
+- Create: `app/jobs/expiring_offers_report_job.rb`, `app/mailers/expiring_offers_mailer.rb`, `app/views/expiring_offers_mailer/expiring_report.{html,text}.haml`, `test/jobs/expiring_offers_report_job_test.rb`
+- Modify: `config/recurring.yml`, locales
+
+- [ ] **Step 1: Write failing tests** (mirror `test/jobs/overdue_invoices_report_job_test.rb`):
+
+```ruby
+require "test_helper"
+
+class ExpiringOffersReportJobTest < ActiveJob::TestCase
+  test "expires past-validity sent offers and sends one digest" do
+    offer = offers(:sent_offer)
+    offer.update!(expires_at: Date.yesterday)
+    assert_emails 1 do
+      ExpiringOffersReportJob.perform_now
+    end
+    offer.reload
+    assert offer.expired?
+    assert_not_nil offer.reported_expired_at
+  end
+
+  test "no-op when nothing expired" do
+    offers(:sent_offer).update!(expires_at: Date.tomorrow)
+    assert_emails 0 do
+      ExpiringOffersReportJob.perform_now
+    end
+  end
+
+  test "already-reported offers are not re-reported" do
+    offer = offers(:sent_offer)
+    offer.update!(state: "expired", expires_at: Date.yesterday, reported_expired_at: Time.current)
+    assert_emails 0 do
+      ExpiringOffersReportJob.perform_now
+    end
+  end
+
+  test "drafts and accepted offers are untouched" do
+    offers(:sent_offer).accept!(order_number: "PO", ordered_on: Date.current)
+    offers(:sent_offer).update!(expires_at: Date.yesterday)
+    assert_emails 0 do
+      ExpiringOffersReportJob.perform_now
+    end
+    assert offers(:sent_offer).reload.accepted?
+  end
+end
+```
+
+- [ ] **Step 2: Run to verify failure.** — FAIL.
+
+- [ ] **Step 3: Implement.**
+
+```ruby
+class ExpiringOffersReportJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    offers = Offer.where(state: "sent", reported_expired_at: nil)
+                  .where(expires_at: ...Date.current)
+                  .includes(:customer).order(:expires_at).to_a
+    return if offers.empty?
+
+    Offer.where(id: offers.map(&:id)).update_all(state: "expired", reported_expired_at: Time.current)
+    ExpiringOffersMailer.with(offers: offers).expiring_report.deliver_now
+  end
+end
+```
+
+Mailer mirrors `OverdueInvoicesMailer` (to `@issuer.reporting_email`, `I18n.default_locale`, subject `mailers.expiring_offers.subject` with count); views mirror `overdue_report.{html,text}.haml` listing number, customer, matchcode, expired-on date, milestone total. Add to `config/recurring.yml` under `production:`:
+
+```yaml
+expiring_offers_report:
+  class: ExpiringOffersReportJob
+  queue: default
+  schedule: every day at 07:30
+```
+
+- [ ] **Step 4: Run tests.** — PASS. **Step 5: Commit.** `git commit -m "Add expiring offers job and digest mailer"`
+
+---
+
+### Task 8: Controller + routes + attachment authorization
+
+**Files:**
+- Create: `app/controllers/offers_controller.rb`, `test/controllers/offers_controller_test.rb`
+- Modify: `config/routes.rb`, `app/controllers/attachments_controller.rb`
+
+**Interfaces produced:** routes `offers` + members `preview`, `send_offer`, `accept`, `reject`, `reopen`, `scaffold_milestones`, `update_internal_notes`, `upload_order_pdf`, `preview_email`, `preview_email_html`, `send_email`, `milestones/:milestone_id/convert`, `milestones/:milestone_id/reopen_link`.
+
+- [ ] **Step 1: Routes.** In `config/routes.rb` next to the invoices block:
+
+```ruby
+resources :offers do
+  member do
+    get "preview"
+    get "preview_email"
+    get "preview_email_html"
+    post "send_offer"
+    post "accept"
+    post "reject"
+    post "reopen"
+    post "scaffold_milestones"
+    patch "update_internal_notes"
+    post "upload_order_pdf"
+    post "send_email"
+    post "milestones/:milestone_id/convert", action: :convert_milestone, as: :convert_milestone
+    post "milestones/:milestone_id/reopen_link", action: :reopen_milestone_link, as: :reopen_milestone_link
+  end
+end
+```
+
+- [ ] **Step 2: Write failing controller tests** in `test/controllers/offers_controller_test.rb` (style: `ActionDispatch::IntegrationTest`; default sign-in is admin `users(:alice)`; use `users(:bob)` for denial cases — bob's `sales` group has no offer permissions):
+
+```ruby
+require "test_helper"
+
+class OffersControllerTest < ActionDispatch::IntegrationTest
+  test "index lists offers with state filter" do
+    get offers_url
+    assert_response :success
+    get offers_url(state: "sent", year: "all")
+    assert_response :success
+    assert_select "td", text: offers(:sent_offer).document_number
+  end
+
+  test "index denied without offers.view" do
+    sign_in_as users(:bob)
+    get offers_url
+    assert_redirected_to root_path
+  end
+
+  test "create redirects to edit with starter milestone flash" do
+    assert_difference("Offer.count") do
+      post offers_url, params: { offer: { customer_id: customers(:good_eu).id,
+                                          project_id: projects(:one).id,
+                                          matchcode: "NEW-OFFER" } }
+    end
+    assert_redirected_to edit_offer_url(Offer.order(:id).last)
+  end
+
+  test "update edits offer and draft version fields" do
+    offer = offers(:draft_offer)
+    patch offer_url(offer), params: { offer: {
+      internal_reference: "internal-x",
+      draft_version_attributes: { id: offer.draft_version.id, subject: "New subject" }
+    } }
+    assert_redirected_to offer_url(offer)
+    assert_equal "New subject", offer.reload.draft_version.subject
+  end
+
+  test "destroy only in draft" do
+    assert_difference("Offer.count", -1) { delete offer_url(offers(:draft_offer)) }
+    assert_no_difference("Offer.count") { delete offer_url(offers(:sent_offer)) }
+    assert_redirected_to offer_url(offers(:sent_offer))
+  end
+
+  test "send_offer transitions to sent" do
+    offer = create_offer_with_milestone
+    fake = Minitest::Mock.new
+    fake.expect(:render, "%PDF-fake")
+    OfferRenderer.stub(:new, ->(*_) { fake }) do
+      post send_offer_offer_url(offer)
+    end
+    assert_redirected_to offer_url(offer)
+    assert offer.reload.sent?
+  end
+
+  test "accept collects order data and order pdf" do
+    offer = offers(:sent_offer)
+    pdf = fixture_file_upload("acceptance.pdf", "application/pdf")
+    post accept_offer_url(offer), params: { order_number: "PO-1", ordered_on: "2026-07-01", order_pdf: pdf }
+    assert_redirected_to offer_url(offer)
+    offer.reload
+    assert offer.accepted?
+    assert offer.order_attachment.present?
+  end
+
+  test "convert_milestone requires offers.convert and links documents" do
+    offer = offers(:sent_offer)
+    offer.accept!(order_number: "PO", ordered_on: Date.current)
+    milestone = offer_milestones(:sent_ms_two)
+    assert_difference(["Invoice.count", "DeliveryNote.count"]) do
+      post convert_milestone_offer_url(offer, milestone_id: milestone.id)
+    end
+    assert milestone.reload.converted?
+  end
+
+  test "update_internal_notes works even when accepted" do
+    offer = offers(:sent_offer)
+    offer.accept!(order_number: "PO", ordered_on: Date.current)
+    patch update_internal_notes_offer_url(offer), params: { offer: { internal_notes: "<p>note</p>" } }
+    assert_redirected_to offer_url(offer)
+    assert_includes offer.reload.internal_notes.body.to_html, "note"
+  end
+
+  test "scaffold refuses when milestones exist" do
+    offer = create_offer_with_milestone
+    post scaffold_milestones_offer_url(offer), params: { total: "1000" }
+    assert_redirected_to edit_offer_url(offer)
+    assert_match(/remove/i, flash[:alert])
+  end
+
+  test "edit blocked once accepted" do
+    offer = offers(:sent_offer)
+    offer.accept!(order_number: "PO", ordered_on: Date.current)
+    get edit_offer_url(offer)
+    assert_redirected_to offer_url(offer)
+  end
+end
+```
+
+- [ ] **Step 3: Run to verify failure**, then implement `app/controllers/offers_controller.rb`:
+
+```ruby
+class OffersController < ApplicationController
+  include EmailableDocument
+
+  before_action -> { require_permission!("offers.view") },
+                only: %i[index show preview preview_email preview_email_html]
+  before_action -> { require_permission!("offers.edit") },
+                only: %i[new create edit update destroy send_offer accept reject reopen
+                         scaffold_milestones update_internal_notes upload_order_pdf send_email]
+  before_action -> { require_permission!("offers.convert") },
+                only: %i[convert_milestone reopen_milestone_link]
+  before_action :set_offer, except: %i[index new create]
+  before_action :require_editable, only: %i[edit update preview scaffold_milestones]
+  before_action :require_deletable, only: %i[destroy]
+
+  def index
+    @selected_year = params[:year] == "all" ? "all" : (params[:year].presence || Date.current.year).to_i
+    @state_filter = params[:state].presence_in(Offer::STATES) || "all"
+    @selected_customer_id = params[:customer_id].presence
+
+    scope = Offer.visible_to(current_user).ordered.includes(:customer, :project)
+    scope = scope.in_year(@selected_year, include_drafts: @selected_year == Date.current.year) unless @selected_year == "all"
+    scope = scope.where(state: @state_filter) unless @state_filter == "all"
+    scope = scope.where(customer_id: @selected_customer_id) if @selected_customer_id
+    @offers = scope
+    @available_years = Offer.visible_to(current_user).available_years
+    @available_customers = Offer.available_customers(current_user, including: nil)
+  end
+
+  def show; end
+
+  def new
+    @offer = Offer.new(customer_id: params[:customer_id].presence)
+  end
+
+  def create
+    @offer = Offer.new(offer_params)
+    if @offer.save
+      redirect_to edit_offer_path(@offer), flash: { notice: "Offer created.", build_starter_milestone: true }
+    else
+      render :new, status: :unprocessable_content
+    end
+  end
+
+  def edit
+    @autofocus_first_milestone = flash[:build_starter_milestone].present?
+  end
+
+  def update
+    if @offer.update(offer_params)
+      redirect_to @offer, notice: "Offer updated."
+    else
+      render :edit, status: :unprocessable_content
+    end
+  end
+
+  def destroy
+    @offer.destroy
+    redirect_to offers_path, notice: "Offer deleted."
+  end
+
+  def preview
+    version = @offer.draft_version
+    version.date = Date.current
+    pdf = OfferRenderer.new(version, IssuerCompany.get_the_issuer!).render
+    send_data pdf, type: "application/pdf", disposition: "inline",
+              filename: "offer-draft-#{@offer.id}.pdf"
+  end
+
+  def send_offer
+    sender = OfferSender.new(@offer, IssuerCompany.get_the_issuer!)
+    if sender.send!
+      redirect_to @offer, notice: "Offer sent version #{@offer.reload.current_sent_version.version_number}."
+    else
+      redirect_to @offer, alert: sender.log.presence || "Offer could not be sent."
+    end
+  end
+
+  def accept
+    order_pdf = params[:order_pdf]
+    if order_pdf.present? && Attachment.detect_content_type(order_pdf.tempfile) != "application/pdf"
+      return redirect_to @offer, alert: "Order document must be a PDF."
+    end
+    @offer.accept!(order_number: params[:order_number], ordered_on: params[:ordered_on],
+                   order_pdf: order_pdf)
+    redirect_to @offer, notice: "Offer accepted."
+  rescue Offer::InvalidTransition => e
+    redirect_to @offer, alert: e.message
+  end
+
+  def reject
+    @offer.reject!
+    redirect_to @offer, notice: "Offer rejected."
+  rescue Offer::InvalidTransition => e
+    redirect_to @offer, alert: e.message
+  end
+
+  def reopen
+    @offer.reopen!
+    redirect_to @offer, notice: "Offer reopened."
+  rescue Offer::InvalidTransition => e
+    redirect_to @offer, alert: e.message
+  end
+
+  def scaffold_milestones
+    OfferMilestoneScaffolder.new(@offer.customer, params[:total].to_d).apply_to(@offer.draft_version)
+    redirect_to edit_offer_path(@offer), notice: "Milestones scaffolded."
+  rescue OfferMilestoneScaffolder::MilestonesPresent
+    redirect_to edit_offer_path(@offer), alert: "Remove the existing milestones first."
+  end
+
+  def update_internal_notes
+    @offer.update!(internal_notes: params.require(:offer)[:internal_notes])
+    redirect_to @offer, notice: "Internal notes saved."
+  end
+
+  def upload_order_pdf
+    uploaded = params[:order_pdf]
+    if uploaded.blank? || Attachment.detect_content_type(uploaded.tempfile) != "application/pdf"
+      return redirect_to @offer, alert: "Order document must be a PDF."
+    end
+    @offer.attach_order_pdf(uploaded)
+    @offer.save!
+    redirect_to @offer, notice: "Order document stored."
+  end
+
+  def convert_milestone
+    milestone = accepted_milestone!
+    invoice = OfferMilestoneConverter.new(milestone).convert!
+    redirect_to @offer, notice: "Milestone converted to #{invoice.display_name}."
+  rescue OfferMilestoneConverter::NotConvertible => e
+    redirect_to @offer, alert: e.message
+  end
+
+  def reopen_milestone_link
+    milestone = accepted_milestone!
+    milestone.reopen_link!
+    redirect_to @offer, notice: "Milestone link cleared."
+  end
+
+  private
+
+  def set_offer
+    @offer = Offer.visible_to(current_user).find(params[:id])
+  end
+
+  def require_editable
+    redirect_to @offer, alert: "This offer can no longer be edited." unless @offer.editable?
+  end
+
+  def require_deletable
+    redirect_to @offer, alert: "Only draft offers can be deleted." unless @offer.deletable?
+  end
+
+  def accepted_milestone!
+    @offer.accepted_version.milestones.find(params[:milestone_id])
+  end
+
+  def offer_params
+    params.require(:offer).permit(
+      :customer_id, :project_id, :customer_contact_id, :matchcode, :internal_reference,
+      draft_version_attributes: [
+        :id, :subject, :prelude, :salutation_override, :delivery_date, :sales_tax_product_class_id,
+        milestones_attributes: [
+          :id, :position, :title, :description, :trigger, :trigger_date,
+          :amount, :skip_delivery_note, :_destroy
+        ]
+      ]
+    )
+  end
+
+  # EmailableDocument hooks
+  def email_preview_document = @offer
+  def email_preview_mail = OfferMailer.with(offer: @offer, skip_attachments: true).customer_email
+  def email_preview_html_mail = OfferMailer.with(offer: @offer, skip_attachments: true).customer_email
+  def email_for_sending = OfferMailer.with(offer: @offer).customer_email
+end
+```
+
+(Reconcile the `EmailableDocument` hook names/signatures against `app/controllers/concerns/emailable_document.rb` and how `InvoicesController` implements them — including any `build_customer_email(skip_attachments:)` hook — and guard `send_email` so it requires `@offer.current_sent_version` present: add `before_action` raising a redirect for state `draft`.)
+
+- [ ] **Step 4: Attachment authorization.** In `app/controllers/attachments_controller.rb#authorize_attachment!`, add branches following the existing invoice one:
+
+```ruby
+return if OfferVersion.joins(:offer).where(attachment_id: @attachment.id)
+                      .merge(Offer.visible_to(current_user)).exists?
+return if Offer.visible_to(current_user).where(order_attachment_id: @attachment.id).exists?
+```
+
+Add a test in the existing attachments controller test file: an offer-version PDF is downloadable by alice and denied to a user whose team can't see the customer.
+
+- [ ] **Step 5: Run tests.** `bundle exec rails test test/controllers/offers_controller_test.rb test/integration/permission_check_verification_test.rb` — PASS (the integration test proves every new action gates).
+
+- [ ] **Step 6: Commit.** `git commit -m "Add OffersController, routes, and attachment authorization"`
+
+---
+
+### Task 9: Views + Stimulus
+
+**Files:**
+- Create: `app/views/offers/index.html.haml`, `show.html.haml`, `new.html.haml`, `edit.html.haml`, `_form.html.haml`, `_milestone_fields.html.haml`, `_accept_modal.html.haml`, `_conversion_rows.html.haml`, `app/javascript/controllers/offer_milestones_controller.js`, `app/javascript/controllers/modal_controller.js`, `test/system/offer_form_test.rb`
+- Modify: navbar layout partial (add Offers link), `app/helpers/action_buttons_helper.rb` (only if a new verb helper is needed — send uses glyph+text per the established table: `✉️ Send` is a status-row verb; the breadcrumb send action for offers is `🚀 Send` — reuse 🚀 "promote forward")
+
+Read `app/views/invoices/{index,show,_form}.html.haml`, `app/views/invoices/_invoice_line_fields.html.haml`, and `app/views/delivery_notes/show.html.haml` first; copy their structure. Offer-specific content below.
+
+- [ ] **Step 1: `index.html.haml`.** Copy the invoice index. Changes: breadcrumb title `Offers`; `+ New` → `new_offer_path`, permission `offers.edit`; the filter btn-group iterates `[["all", "All"]] + Offer::STATES.map { |s| [s, s.capitalize] }` linking `offers_path(state: s, year: @selected_year, customer_id: @selected_customer_id)`; table columns: Number (`offer.display_label` linked), Matchcode, Customer (customer matchcode), Project (project matchcode), Subject (current draft or sent version), State badge (`status_badge` pair rendered as `%span.badge{class: badge_class}= label` — hide the column when `@state_filter != "all"` per the style guide), Total net (`format_currency(version.sum_net)`), Valid until (`l(offer.expires_at)` when present). No bulk-email checkboxes. Keep `shared/customer_filter` + year pagination exactly as invoices do.
+
+- [ ] **Step 2: `show.html.haml`.** Structure:
+
+```haml
+- content_for :title, @offer.display_name
+- edit_action = action_button('Edit', edit_offer_path(@offer), permission: 'offers.edit') if @offer.editable?
+- workflow_actions = [
+-   (@offer.draft_version && @offer.draft_version.milestones.any? ? preview_button(preview_offer_path(@offer), permission: 'offers.view') : nil),
+-   (delete_button(@offer) if @offer.deletable? && can?('offers.edit')),
+- ]
+= breadcrumbs ['Offers', offers_path], @offer.display_label, actions: workflow_actions, action: edit_action do
+  - label, badge_class = @offer.status_badge
+  %span.badge{class: badge_class}= label
+```
+
+Cards, in order:
+
+1. **Details card** — customer (link), project, matchcode, addressed contact, internal reference, document number (or "(assigned at first send)"), document date (or "(assigned at first send)"), valid-until, delivery date, tax class.
+2. **Send row** (visible when `@offer.editable?`): a `button_to '🚀 Send', send_offer_offer_path(@offer)` — disabled with a wrapping `%span` + `title` when `@offer.send_problems.any?` (belt-and-suspenders: milestone-less drafts can't send). Style per "Status-row action buttons" (`ms-auto` on the `button_to` form).
+3. **Sent-version card** (when `current_sent_version`): version number, sent date, `📄` `pdf_button(attachment_path(version.attachment))`, `✉️ Send` email action + `shared/email_preview_modal` (copy the invoice show wiring), `email_sent_at` display. Accept/Reject buttons when `sent?`: Accept opens the accept modal (Step 5), Reject is a `button_to` with `turbo-confirm`. `Reopen` button when `accepted?` or `rejected?` (confirm text explains a fresh draft branches from the accepted version).
+4. **Order card** (when `accepted?`): accepted date + accepted version number, order number, ordered-on, order-PDF link (`attachment_path(@offer.order_attachment)`) or the upload form (`upload_order_pdf`, copy the DN acceptance-upload form incl. `file-upload-validation` controller).
+5. **Milestones / conversion card**: render `_conversion_rows` when `accepted?` (each accepted-version milestone: title, trigger label, `format_currency(amount)`, then per-row: link to `milestone.invoice`/`milestone.delivery_note` when converted, else `button_to '🚀 Convert', convert_milestone_offer_path(@offer, milestone_id: milestone.id)` gated `can?('offers.convert')`, plus `button_to 'Reopen link', reopen_milestone_link_offer_path(...)` with `turbo-confirm` when converted). Otherwise a read-only milestone table of the relevant version (draft while editable, sent version otherwise).
+6. **Internal notes card** (all states): `form_with url: update_internal_notes_offer_path(@offer), method: :patch` around `rich_text_area :internal_notes` + save button, gated `can?('offers.edit')`.
+7. **Prelude / boilerplate**: render `@version.prelude` and (frozen ? version boilerplate : customer live boilerplate) read-only.
+
+- [ ] **Step 3: `_form.html.haml` + `_milestone_fields.html.haml`.** Copy the invoice form skeleton (`form_with model: @offer, id: ActionButtonsHelper::PAGE_FORM_ID`, `auto-resize-form` wrapper). Fields:
+
+- Customer + project searchable dropdowns — copy from the invoice form, hidden-field ids `offer_customer_id` / `offer_project_id`, dependent selector `#offer_customer_id`.
+- `matchcode`, `internal_reference`, `customer_contact_id` (plain `f.collection_select` over `@offer.customer&.customer_contacts`, include_blank).
+- Read-only info rows: "Document number: (assigned at first send)" when blank.
+- `fields_for :draft_version, @offer.draft_version do |vf|`: `vf.text_field :subject`, `vf.rich_text_area :prelude, data: { controller: 'rich-text' }`, `vf.text_field :salutation_override`, `vf.date_field :delivery_date`, `vf.collection_select :sales_tax_product_class_id`.
+- **Boilerplate preview card**: read-only `= @offer.customer.offer_boilerplate` with the caption `live in drafts · frozen on send` and `link_to 'Edit on customer', edit_customer_path(@offer.customer)` — only when customer present.
+- **Total Net card**: `#offer-total-net` showing `format_currency(@offer.draft_version.milestones.sum(:amount))`, plus the scaffold control: a `number_field_tag :total` + `button_to 'Apply milestone rule', scaffold_milestones_offer_path(@offer), params: {...}` — **this must live OUTSIDE the main form** (nested-form trap from the spec). Place the scaffold control before/after the `form_with` block, not inside. Only render when `@offer.persisted? && @offer.draft_version.milestones.none? && @offer.customer`.
+- Milestones block inside the version `fields_for`:
+
+```haml
+%div{data: { controller: 'offer-milestones' }}
+  %div{data: { offer_milestones_target: 'container' }}
+    = vf.fields_for :milestones do |mf|
+      = render 'milestone_fields', f: mf
+  %template{data: { offer_milestones_target: 'template' }}
+    = vf.fields_for :milestones, OfferMilestone.new, child_index: 'NEW_RECORD' do |mf|
+      = render 'milestone_fields', f: mf
+  %button.btn.btn-outline-primary{type: 'button', data: { action: 'click->offer-milestones#addLine' }} + Add Milestone
+```
+
+`_milestone_fields.html.haml` — a `.card{data: { line_index: f.index }}` mirroring `_invoice_line_fields.html.haml`'s chrome (hidden `:id`, hidden `:position`, ▲/▼/🗑 buttons wired to `offer-milestones#moveLineUp/moveLineDown/removeLine`) with fields: `f.text_field :title`, `f.text_area :description, rows: 2`, `f.select :trigger, OfferMilestone::TRIGGER_LABELS.invert.to_a, {}, data: { action: 'change->offer-milestones#triggerChanged' }`, `f.date_field :trigger_date` (wrapped in a div the controller shows only for `on_date`), `f.number_field :amount, step: :any, data: { action: 'change->offer-milestones#updateTotal' }`, `f.check_box :skip_delivery_note`. **No nested `<form>`, no `button_to` anywhere in the row** — delete is the JS `removeLine`, exactly like invoice lines.
+
+- [ ] **Step 4: `offer_milestones_controller.js`.**
+
+```javascript
+import BaseLinesController from "controllers/base_lines_controller"
+
+export default class extends BaseLinesController {
+  static values = { currencySymbol: String, moneyDecimalPlaces: Number }
+
+  addLine() {
+    const line = this.appendLineFromTemplate({ openProductDropdown: false })
+    if (line) this.syncTriggerFields(line)
+  }
+
+  connect() {
+    super.connect()
+    this.containerTarget.querySelectorAll('[data-line-index]').forEach(line => this.syncTriggerFields(line))
+  }
+
+  triggerChanged(event) {
+    const line = event.target.closest('[data-line-index]')
+    this.syncTriggerFields(line, { applyDefaultSkip: true })
+  }
+
+  syncTriggerFields(line, { applyDefaultSkip = false } = {}) {
+    const trigger = line.querySelector('select[name*="[trigger]"]').value
+    const dateWrap = line.querySelector('[data-trigger-date-wrap]')
+    if (dateWrap) dateWrap.classList.toggle('d-none', trigger !== 'on_date')
+    if (applyDefaultSkip) {
+      const skip = line.querySelector('input[type="checkbox"][name*="[skip_delivery_note]"]')
+      if (skip) skip.checked = (trigger === 'on_order')
+    }
+  }
+
+  getLineType() { return 'offer_milestones' }
+  getIdPrefix() { return 'offer_draft_version_attributes_milestones_attributes_' }
+}
+```
+
+Two base-class caveats verified against `base_lines_controller.js`: milestones have no `select[name*="[type]"]`, so `initializeFieldVisibility`/`updateFieldVisibility` are skipped automatically; and `appendLineFromTemplate` must be called with `openProductDropdown: false` because there is no product dropdown in the row (the base method would crash on `dropdown.classList`). Add an `updateTotal()` that sums `input[name*="[amount]"]` over non-hidden rows into `#offer-total-net` (copy the formatting approach from `invoice_lines_controller.js`).
+
+- [ ] **Step 5: Accept modal.** `_accept_modal.html.haml` + generic `modal_controller.js` (Bootstrap JS isn't bundled — toggle classes manually):
+
+```javascript
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["dialog"]
+
+  open() {
+    this.dialogTarget.classList.add("show", "d-block")
+    document.body.classList.add("modal-open")
+  }
+
+  close() {
+    this.dialogTarget.classList.remove("show", "d-block")
+    document.body.classList.remove("modal-open")
+  }
+}
+```
+
+Modal body: a `form_with url: accept_offer_path(@offer), method: :post, multipart: true` with `order_number` text field, `ordered_on` date field (`required: true` — `accept!` also enforces it server-side so `ordered_on` is always available for later milestone conversion), `order_pdf` file field (`accept: 'application/pdf'`, `file-upload-validation` controller), and warning copy: "Version N (sent DATE) becomes the accepted version. The in-progress draft version N+1 will be discarded." (interpolate `@offer.current_sent_version.version_number` and `@offer.draft_version&.version_number`). The Accept button on the show page has `data: { action: 'click->modal#open' }`.
+
+- [ ] **Step 6: New/edit pages** (3-liners copying `invoices/edit.html.haml`), navbar link (`Offers` between Invoices and Delivery Notes, gated `can?('offers.view')` — copy the exact `nav_link_to` idiom used for Invoices), and locale keys if the navbar uses them.
+
+- [ ] **Step 7: System test** `test/system/offer_form_test.rb`:
+
+```ruby
+require "application_system_test_case"
+
+class OfferFormTest < ApplicationSystemTestCase
+  test "adding, reordering, and removing milestones survives submit" do
+    visit edit_offer_path(offers(:draft_offer))
+    click_on "+ Add Milestone"
+    within all("[data-line-index]").last do
+      fill_in "Title", with: "Second milestone"
+      fill_in "Amount", with: "250"
+    end
+    click_on "Save"
+    assert_text "Offer updated"
+    offer = offers(:draft_offer).reload
+    assert_equal ["Concept", "Second milestone"], offer.draft_version.milestones.map(&:title)
+  end
+
+  test "milestone description and skip flag are not dropped on submit" do
+    visit edit_offer_path(offers(:draft_offer))
+    within first("[data-line-index]") do
+      fill_in "Description", with: "Detailed scope"
+      select "Upon order", from: "Trigger"
+    end
+    click_on "Save"
+    milestone = offers(:draft_offer).reload.draft_version.milestones.first
+    assert_equal "Detailed scope", milestone.description
+    assert milestone.skip_delivery_note
+  end
+
+  test "send button disabled without milestones" do
+    offer = create_draft_offer
+    visit offer_path(offer)
+    assert_selector "button[disabled]", text: /Send/
+  end
+end
+```
+
+(The second test is the spec's required regression for the nested-form/`button_to` truncation trap.)
+
+- [ ] **Step 8: Run.** `bundle exec rails test test/system/offer_form_test.rb && npm run lint && bundle exec rails test` — all green.
+
+- [ ] **Step 9: Commit.** `git commit -m "Add offer views, milestone form Stimulus, and accept dialog"`
+
+---
+
+### Task 10: Customer + IssuerCompany settings UI
+
+**Files:**
+- Modify: `app/views/customers/_form.html.haml`, `app/views/customers/show.html.haml`, `app/controllers/customers_controller.rb` (permit new params), customer-contact form/views (add `receives_offer_emails` checkbox wherever `receives_delivery_note_emails` appears), `app/views/issuer_companies/_form.html.haml` + `show.html.haml`, `app/controllers/issuer_companies_controller.rb` (permit `:offer_validity_days, :offer_footer`), `test/controllers/customers_controller_test.rb`, `test/controllers/issuer_companies_controller_test.rb`
+
+- [ ] **Step 1: Failing tests** — extend the existing customers controller test with a round-trip of the new fields:
+
+```ruby
+test "offer settings round-trip" do
+  customer = customers(:good_eu)
+  patch customer_url(customer), params: { customer: {
+    offer_validity_days: 21,
+    offer_milestone_split_threshold: 5000,
+    offer_milestone_templates_below: "Full|on_acceptance|1.0",
+    offer_milestone_templates_above: "Deposit|on_order|0.5\nRest|on_acceptance|0.5",
+    offer_boilerplate: "<p>Standing offer terms</p>"
+  } }
+  assert_redirected_to customer_url(customer)
+  customer.reload
+  assert_equal 21, customer.offer_validity_days
+  assert_includes customer.offer_boilerplate.body.to_html, "Standing offer terms"
+end
+```
+
+Same shape for issuer (`offer_validity_days: 45, offer_footer: "Offer footer"`).
+
+- [ ] **Step 2: Implement.** Permit params; add a dedicated "Offer settings" card to the customer form mirroring the invoice-settings section: `offer_validity_days` (number field, placeholder showing the issuer default), `offer_milestone_split_threshold`, both template textareas (help text: one per line, `Title|trigger|ratio`, triggers `on_order`/`on_acceptance`/`on_date`), `rich_text_area :offer_boilerplate`. Surface the same read-only on customer show. Contact rows gain the `receives_offer_emails` checkbox. IssuerCompany form/show gain `offer_validity_days` + `offer_footer` next to `invoice_footer`.
+
+- [ ] **Step 3: Run + commit.** `bundle exec rails test && git commit -m "Surface offer settings on customer and issuer company"`
+
+---
+
+### Task 11: Docs, seeds polish, final sweep
+
+**Files:**
+- Modify: `CLAUDE.md`, `db/seeds.rb` (optional demo offer in the demo-data section), `docs/` (nothing new needed — this plan file is the spec record)
+
+- [ ] **Step 1: CLAUDE.md.** Add `Offer` (+ `OfferVersion`, `OfferMilestone`) to Core Models; note the send/accept lifecycle, `OfferSender`/`OfferRenderer`/`offer.xsl`, `offers.view/edit/convert` permissions, and `ExpiringOffersReportJob` in the recurring-jobs line. Add key files: `app/services/offer_sender.rb`, `lib/foptemplate/offer.xsl`, `app/controllers/offers_controller.rb`.
+- [ ] **Step 2: Full verification.**
+
+Run, in order — all must pass:
+1. `bundle exec rails test`
+2. `bundle exec rails test test/system/`
+3. `npm run lint`
+4. `pre-commit run --all-files`
+5. `./bin/postgres-dev test` (partial indexes + `NULLS FIRST` ordering must hold on PostgreSQL, not just SQLite)
+
+- [ ] **Step 3: Manual eyeball on the dev server** (`bundle exec rails server`): create an offer → scaffold milestones → preview PDF → send → check the versioned PDF and info box → edit draft v2 → send again → accept with an order PDF → convert one milestone → verify draft invoice + delivery note contents → reopen → reject → expiry job via `ExpiringOffersReportJob.perform_now` in the console.
+- [ ] **Step 4: Commit.** `git commit -m "Document offers feature"`
+
+---
+
+## Self-review against issue #530
+
+| Spec section | Covered by |
+|---|---|
+| Domain model (Offer/OfferVersion/OfferMilestone, matchcode, contact nullify, order data) | Tasks 1–2 |
+| Deletion blockers (customer/project) | Task 2 |
+| Customer boilerplate (live draft / frozen at send) | Tasks 2–4 (model + sender + renderer + form card) |
+| Rich text boundaries (prelude/boilerplate/internal notes rich; subject/salutation/milestones/footer plain) | Tasks 1–2 (schema types), 9 (form controls) |
+| Lifecycle incl. expired→sent re-send, reopen branching | Tasks 2–3, 7 |
+| Offer PDF (no VAT/totals, version row, terms box, offer_footer) | Task 4 |
+| Preview without number, valid-until from today | Tasks 4, 8 |
+| Milestones→invoices/DNs, skip defaults, reopen-link, partial unique indexes | Tasks 1, 5, 8–9 |
+| Scaffolding rule (threshold, ratios, last-row remainder, non-destructive) | Task 5 |
+| Email (contact opt-in, stored PDF, email_sent_at) | Task 6 |
+| Issuer defaults (validity 30, offer_footer) | Tasks 1, 10 |
+| Expiring job + digest | Task 7 |
+| Permissions (three keys, Admin grant migration) | Task 1, enforcement Task 8 |
+| UI (searchable dropdowns, year+state filters, labels not enum names, Total Net card, no nested form, disabled Send, accept dialog, order card, internal notes) | Task 9 |
+| Customer/Issuer settings sections | Task 10 |
+| Explicitly rejected items | none implemented — no `cust_reference` analog, single delivery date, plain-text footer, no tax on PDF |

--- a/lib/foptemplate/document_base.xsl
+++ b/lib/foptemplate/document_base.xsl
@@ -93,6 +93,7 @@
 
     <!-- Page master templates -->
     <xsl:template name="standard-page-masters">
+        <xsl:param name="first-body-margin-top" select="'8.5cm'" />
         <fo:simple-page-master master-name="first"
                                margin-left="2.25cm"
                                margin-top="1.5cm"
@@ -100,7 +101,7 @@
                                margin-bottom="1.5cm"
                                page-width="21cm"
                                page-height="29.7cm">
-            <fo:region-body region-name="body" margin-top="8.5cm" margin-bottom="0.2cm" />
+            <fo:region-body region-name="body" margin-top="{$first-body-margin-top}" margin-bottom="0.2cm" />
             <fo:region-before region-name="first-page-header" />
             <fo:region-after region-name="any-page-footer" />
         </fo:simple-page-master>

--- a/lib/foptemplate/offer.xsl
+++ b/lib/foptemplate/offer.xsl
@@ -1,0 +1,297 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="2.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:fo="http://www.w3.org/1999/XSL/Format"
+                xmlns:abt="http://deduktiva.com/Namespace/ABT/XSLT">
+
+    <xsl:import href="document_base.xsl"/>
+
+
+    <!-- Milestone table templates -->
+    <xsl:template match="/document/milestones">
+        <fo:table-body>
+            <xsl:apply-templates select="milestone" />
+        </fo:table-body>
+    </xsl:template>
+
+    <xsl:template match="/document/milestones/milestone">
+        <fo:table-row keep-together.within-page="always">
+            <fo:table-cell padding-before="2mm">
+                <fo:block text-align="start" font-weight="600">
+                    <xsl:if test="count(/document/milestones/milestone) &gt; 1">
+                        <xsl:text>Position </xsl:text>
+                        <xsl:value-of select="position()" />
+                        <xsl:text>: </xsl:text>
+                    </xsl:if>
+                    <xsl:value-of select="abt:strip-space(title)" />
+                </fo:block>
+                <xsl:if test="abt:strip-space(description) != ''">
+                    <fo:block margin-left="4mm" font-size="9pt" linefeed-treatment="preserve"><xsl:value-of select="abt:strip-space(description)" /></fo:block>
+                </xsl:if>
+            </fo:table-cell>
+            <fo:table-cell padding-before="2mm">
+                <fo:block text-align="start">
+                    <xsl:choose>
+                        <xsl:when test="trigger = 'on_order'">
+                            <xsl:choose>
+                                <xsl:when test="/document/language = 'de'">Bei Auftrag</xsl:when>
+                                <xsl:otherwise>Upon order</xsl:otherwise>
+                            </xsl:choose>
+                        </xsl:when>
+                        <xsl:when test="trigger = 'on_acceptance'">
+                            <xsl:choose>
+                                <xsl:when test="/document/language = 'de'">Bei Abnahme</xsl:when>
+                                <xsl:otherwise>Upon acceptance</xsl:otherwise>
+                            </xsl:choose>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:value-of select="abt:format-date(trigger-date, /document/language)" />
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </fo:block>
+            </fo:table-cell>
+            <fo:table-cell padding-before="2mm">
+                <fo:block text-align="end">
+                    <xsl:value-of select="/document/currency" />
+                    <xsl:text> </xsl:text>
+                    <xsl:value-of select="abt:format-amount(amount)" />
+                </fo:block>
+            </fo:table-cell>
+        </fo:table-row>
+    </xsl:template>
+
+    <!-- Offer document -->
+    <xsl:template match="/">
+        <fo:root font-family="{$font-name-normal}">
+            <fo:layout-master-set>
+                <xsl:call-template name="standard-page-masters">
+                    <xsl:with-param name="first-body-margin-top" select="'6.5cm'" />
+                </xsl:call-template>
+            </fo:layout-master-set>
+
+            <xsl:call-template name="pdf-metadata">
+                <xsl:with-param name="document-type">Offer</xsl:with-param>
+                <xsl:with-param name="document-number" select="/document/number" />
+            </xsl:call-template>
+
+            <fo:page-sequence master-reference="abt-document-master" id="document-sequence" font-family="{$font-name-normal}" font-weight="200" font-size="11pt" line-height="12pt">
+                <fo:static-content flow-name="first-page-header">
+                    <!-- Address blocks -->
+                    <xsl:call-template name="sender-address-block" />
+                    <xsl:call-template name="recipient-address-block" />
+
+                    <!-- Right column: logo, document type, info boxes -->
+                    <fo:block-container top="0cm" left="8.75cm" position="absolute">
+                        <xsl:call-template name="company-header-block" />
+
+                        <!-- Document type header -->
+                        <fo:block-container height="1cm" width="8cm" top="3.25cm" position="absolute">
+                            <fo:block text-align="start" font-family="{$font-name-display}" font-size="28pt" font-weight="700">
+                                <xsl:choose>
+                                    <xsl:when test="/document/language = 'de'">Angebot</xsl:when>
+                                    <xsl:otherwise>Offer</xsl:otherwise>
+                                </xsl:choose>
+                            </fo:block>
+                        </fo:block-container>
+
+                        <!-- Document key info -->
+                        <fo:block-container top="4.25cm" position="absolute">
+
+                            <fo:table table-layout="fixed" padding="0mm" margin="0mm">
+                                <fo:table-column column-width="3cm"/>
+                                <fo:table-column column-width="5cm"/>
+
+                                <fo:table-body>
+                                    <xsl:if test="normalize-space(/document/number) != ''">
+                                        <fo:table-row line-height="130%">
+                                            <fo:table-cell>
+                                                <fo:block font-family="{$font-name-display}" xsl:use-attribute-sets="accent-color">
+                                                    <xsl:choose>
+                                                        <xsl:when test="/document/language = 'de'">Nummer:</xsl:when>
+                                                        <xsl:otherwise>Document No:</xsl:otherwise>
+                                                    </xsl:choose>
+                                                </fo:block>
+                                            </fo:table-cell>
+                                            <fo:table-cell>
+                                                <fo:block>
+                                                    <xsl:value-of select="/document/number" />
+                                                    <xsl:if test="/document/version-number">
+                                                        <xsl:text> v</xsl:text>
+                                                        <xsl:value-of select="/document/version-number" />
+                                                    </xsl:if>
+                                                </fo:block>
+                                            </fo:table-cell>
+                                        </fo:table-row>
+                                    </xsl:if>
+                                    <fo:table-row line-height="130%">
+                                        <fo:table-cell>
+                                            <fo:block font-family="{$font-name-display}" xsl:use-attribute-sets="accent-color">
+                                                <xsl:choose>
+                                                    <xsl:when test="/document/language = 'de'">Angebotsdatum:</xsl:when>
+                                                    <xsl:otherwise>Date:</xsl:otherwise>
+                                                </xsl:choose>
+                                            </fo:block>
+                                        </fo:table-cell>
+                                        <fo:table-cell>
+                                            <fo:block>
+                                                <xsl:value-of select="abt:format-date(/document/issue-date, /document/language)"/>
+                                            </fo:block>
+                                        </fo:table-cell>
+                                    </fo:table-row>
+                                    <fo:table-row line-height="130%">
+                                        <fo:table-cell>
+                                            <fo:block font-family="{$font-name-display}" xsl:use-attribute-sets="accent-color">
+                                                <xsl:choose>
+                                                    <xsl:when test="/document/language = 'de'">Gültig bis:</xsl:when>
+                                                    <xsl:otherwise>Valid until:</xsl:otherwise>
+                                                </xsl:choose>
+                                            </fo:block>
+                                        </fo:table-cell>
+                                        <fo:table-cell>
+                                            <fo:block>
+                                                <xsl:value-of select="abt:format-date(/document/valid-until, /document/language)"/>
+                                            </fo:block>
+                                        </fo:table-cell>
+                                    </fo:table-row>
+                                    <xsl:if test="normalize-space(/document/delivery-date) != ''">
+                                        <fo:table-row line-height="130%">
+                                            <fo:table-cell>
+                                                <fo:block font-family="{$font-name-display}" xsl:use-attribute-sets="accent-color">
+                                                    <xsl:choose>
+                                                        <xsl:when test="/document/language = 'de'">Liefertermin:</xsl:when>
+                                                        <xsl:otherwise>Delivery date:</xsl:otherwise>
+                                                    </xsl:choose>
+                                                </fo:block>
+                                            </fo:table-cell>
+                                            <fo:table-cell>
+                                                <fo:block>
+                                                    <xsl:value-of select="abt:format-date(/document/delivery-date, /document/language)"/>
+                                                </fo:block>
+                                            </fo:table-cell>
+                                        </fo:table-row>
+                                    </xsl:if>
+                                    <xsl:if test="normalize-space(/document/recipient/supplier-no) != ''">
+                                        <fo:table-row line-height="130%">
+                                            <fo:table-cell>
+                                                <fo:block font-family="{$font-name-display}" xsl:use-attribute-sets="accent-color">
+                                                    <xsl:choose>
+                                                        <xsl:when test="/document/language = 'de'">Kreditorennr.:</xsl:when>
+                                                        <xsl:otherwise>Supplier No.:</xsl:otherwise>
+                                                    </xsl:choose>
+                                                </fo:block>
+                                            </fo:table-cell>
+                                            <fo:table-cell>
+                                                <fo:block>
+                                                    <xsl:value-of select="/document/recipient/supplier-no" />
+                                                </fo:block>
+                                            </fo:table-cell>
+                                        </fo:table-row>
+                                    </xsl:if>
+                                </fo:table-body>
+                            </fo:table>
+
+                        </fo:block-container>
+                    </fo:block-container>
+
+                </fo:static-content>
+
+                <fo:static-content flow-name="rest-page-header">
+                    <!-- logo -->
+                    <xsl:call-template name="company-logo-block"/>
+
+                    <fo:block-container top="0cm" left="8.75cm" position="absolute">
+                        <fo:block text-align="start" font-weight="100" font-size="8pt">
+                            <xsl:choose>
+                                <xsl:when test="/document/language = 'de'">Angebot</xsl:when>
+                                <xsl:otherwise>Offer</xsl:otherwise>
+                            </xsl:choose>
+                            <xsl:text> </xsl:text><xsl:value-of select="/document/number" />
+                        </fo:block>
+                    </fo:block-container>
+
+                    <fo:block-container top="0cm" right="0cm" text-align="end" position="absolute">
+                        <xsl:call-template name="page-x-of-y-text" />
+                    </fo:block-container>
+                </fo:static-content>
+
+                <fo:static-content flow-name="any-page-footer">
+                    <xsl:call-template name="folding-marks" />
+
+                    <fo:block-container text-align="end">
+                        <xsl:call-template name="page-x-of-y-text" />
+                    </fo:block-container>
+                </fo:static-content>
+
+                <!-- Actual offer content -->
+                <fo:flow flow-name="body">
+                    <!-- Subject line -->
+                    <xsl:if test="abt:strip-space(/document/subject) != ''">
+                        <fo:block-container space-after="12pt">
+                            <fo:block font-family="{$font-name-display}" font-size="13pt" font-weight="600">
+                                <xsl:value-of select="abt:strip-space(/document/subject)" />
+                            </fo:block>
+                        </fo:block-container>
+                    </xsl:if>
+
+                    <xsl:if test="/document/prelude/*">
+                        <!-- 12pt = one body line, so the gap reads as a single empty line -->
+                        <fo:block-container space-after="12pt">
+                            <xsl:copy-of select="/document/prelude/*" />
+                        </fo:block-container>
+                    </xsl:if>
+
+                    <xsl:if test="/document/boilerplate/*">
+                        <fo:block-container space-after="18pt">
+                            <xsl:copy-of select="/document/boilerplate/*" />
+                        </fo:block-container>
+                    </xsl:if>
+
+                    <!-- Milestone table -->
+                    <fo:table table-layout="fixed" width="100%" padding="0mm" margin="0mm">
+                        <fo:table-column column-width="11cm"/>
+                        <fo:table-column column-width="3.25cm"/>
+                        <fo:table-column column-width="3cm"/>
+                        <fo:table-header>
+                            <fo:table-row xsl:use-attribute-sets="accent-color">
+                                <fo:table-cell>
+                                    <fo:block text-align="start">
+                                        <xsl:if test="count(/document/milestones/milestone) &gt; 1">
+                                            <xsl:choose>
+                                                <xsl:when test="/document/language = 'de'">Meilensteine</xsl:when>
+                                                <xsl:otherwise>Milestones</xsl:otherwise>
+                                            </xsl:choose>
+                                        </xsl:if>
+                                    </fo:block>
+                                </fo:table-cell>
+                                <fo:table-cell>
+                                    <fo:block text-align="start">
+                                        <xsl:choose>
+                                            <xsl:when test="/document/language = 'de'">Fällig</xsl:when>
+                                            <xsl:otherwise>Payment Due</xsl:otherwise>
+                                        </xsl:choose>
+                                    </fo:block>
+                                </fo:table-cell>
+                                <fo:table-cell>
+                                    <fo:block text-align="end">
+                                        <xsl:choose>
+                                            <xsl:when test="/document/language = 'de'">Betrag Netto</xsl:when>
+                                            <xsl:otherwise>Amount Netto</xsl:otherwise>
+                                        </xsl:choose>
+                                    </fo:block>
+                                </fo:table-cell>
+                            </fo:table-row>
+                        </fo:table-header>
+
+                        <xsl:apply-templates select="/document/milestones" />
+
+                    </fo:table>
+
+                    <fo:block space-before.optimum="0.5cm" space-before.minimum="0.5cm" space-before.maximum="1cm" text-align="justify" font-size="8pt" line-height="10pt">
+                        <xsl:value-of select="/document/footer" />
+                    </fo:block>
+                </fo:flow>
+            </fo:page-sequence>
+        </fo:root>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/test/controllers/attachments_controller_test.rb
+++ b/test/controllers/attachments_controller_test.rb
@@ -60,4 +60,50 @@ class AttachmentsControllerTest < ActionDispatch::IntegrationTest
     get attachment_url(outside_attachment)
     assert_redirected_to root_path
   end
+
+  test "show serves an offer-version PDF to alice" do
+    offer = offers(:sent_offer)
+    version = offer.versions.find_by(version_number: 1)
+    attachment = Attachment.create!(
+      title: "Offer PDF",
+      filename: "offer.pdf",
+      content_type: "application/pdf",
+      data: "%PDF-fake"
+    )
+    version.update!(attachment: attachment)
+
+    get attachment_url(attachment)
+    assert_response :success
+    assert_equal "application/pdf", response.media_type
+  end
+
+  test "show denies an offer-version PDF whose customer belongs to another team" do
+    other_team = Team.create!(name: "OutsideOffersTeam")
+    outside_customer = Customer.create!(
+      matchcode: "OUTOFF",
+      name: "Outside Offers Co.",
+      vat_id: "EU161616161",
+      country_iso2: "NL",
+      sales_tax_customer_class: sales_tax_customer_classes(:eu),
+      language: languages(:english),
+      team: other_team
+    )
+    outside_offer = Offer.create!(customer: outside_customer, project: projects(:reusable_project))
+    outside_attachment = Attachment.create!(
+      title: "secret offer",
+      filename: "secret.pdf",
+      content_type: "application/pdf",
+      data: "secret"
+    )
+    outside_offer.draft_version.update!(attachment: outside_attachment)
+
+    offers_viewer = Group.create!(name: "OffersViewerOnly")
+    GroupPermission.create!(group: offers_viewer, permission: "offers.view")
+    bob = users(:bob)
+    bob.groups << offers_viewer # offers.view, but bob's teams don't include OutsideOffersTeam
+    sign_in_as(bob)
+
+    get attachment_url(outside_attachment)
+    assert_redirected_to root_path
+  end
 end

--- a/test/controllers/customer_contacts_controller_test.rb
+++ b/test/controllers/customer_contacts_controller_test.rb
@@ -56,6 +56,14 @@ class CustomerContactsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Renamed Acct", @contact.reload.name
   end
 
+  test "update permits receives_offer_emails" do
+    patch customer_contact_path(@contact),
+          params: { customer_contact: { receives_offer_emails: true } }
+
+    assert_response :success
+    assert @contact.reload.receives_offer_emails?
+  end
+
   test "update on validation failure returns 422 with the frame" do
     patch customer_contact_path(@contact),
           params: { customer_contact: { name: "", email: "bad" } }

--- a/test/controllers/customers_controller_test.rb
+++ b/test/controllers/customers_controller_test.rb
@@ -210,4 +210,22 @@ class CustomersControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to customer_url(@customer)
     assert_match(/no VAT ID to verify/, flash[:alert])
   end
+
+  test "offer settings round-trip" do
+    patch customer_url(@customer), params: { customer: {
+      offer_validity_days: 21,
+      offer_milestone_split_threshold: 5000,
+      offer_milestone_templates_below: "Full|on_acceptance|100",
+      offer_milestone_templates_above: "Deposit|on_order|50\nRest|on_acceptance|50",
+      offer_boilerplate: "<p>Standing offer terms</p>"
+    } }
+    assert_redirected_to customer_url(@customer)
+
+    @customer.reload
+    assert_equal 21, @customer.offer_validity_days
+    assert_equal 5000, @customer.offer_milestone_split_threshold
+    assert_equal "Full|on_acceptance|100", @customer.offer_milestone_templates_below
+    assert_equal "Deposit|on_order|50\nRest|on_acceptance|50", @customer.offer_milestone_templates_above
+    assert_includes @customer.offer_boilerplate.body.to_html, "Standing offer terms"
+  end
 end

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -11,7 +11,11 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should display setup warning when not configured" do
-    # Clear existing tax configuration
+    # Clear existing tax configuration. Offers must go first: OfferVersion has
+    # a DB-level foreign key to sales_tax_product_classes (unlike invoice
+    # lines/tax classes, which have none), so any fixture referencing a
+    # product class blocks its deletion until the referencing offer is gone.
+    Offer.destroy_all
     SalesTaxRate.delete_all
     SalesTaxCustomerClass.delete_all
     SalesTaxProductClass.delete_all

--- a/test/controllers/issuer_companies_controller_test.rb
+++ b/test/controllers/issuer_companies_controller_test.rb
@@ -139,6 +139,16 @@ class IssuerCompaniesControllerTest < ActionDispatch::IntegrationTest
     assert_equal original, @issuer_company.reload.vat_id_recheck_days
   end
 
+  test "offer settings round-trip" do
+    patch issuer_company_url, params: {
+      issuer_company: { offer_validity_days: 45, offer_footer: "Offer footer" }
+    }
+    assert_redirected_to issuer_company_url
+    @issuer_company.reload
+    assert_equal 45, @issuer_company.offer_validity_days
+    assert_equal "Offer footer", @issuer_company.offer_footer
+  end
+
   test "should preserve whitespace in contact lines on show page" do
     # Update the fixture to have explicit whitespace
     @issuer_company.update!(

--- a/test/controllers/offers_controller_test.rb
+++ b/test/controllers/offers_controller_test.rb
@@ -1,0 +1,200 @@
+require "test_helper"
+
+class OffersControllerTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
+  test "index lists offers with state filter" do
+    get offers_url
+    assert_response :success
+    get offers_url(state: "sent", year: "all")
+    assert_response :success
+    assert_select "td", text: offers(:sent_offer).document_number
+  end
+
+  test "index denied without offers.view" do
+    sign_in_as users(:bob)
+    get offers_url
+    assert_redirected_to root_path
+  end
+
+  test "create redirects to edit with starter milestone flash" do
+    assert_difference("Offer.count") do
+      post offers_url, params: { offer: { customer_id: customers(:good_eu).id,
+                                          project_id: projects(:one).id } }
+    end
+    assert_redirected_to edit_offer_url(Offer.order(:id).last)
+  end
+
+  test "update edits offer and draft version fields" do
+    offer = offers(:draft_offer)
+    patch offer_url(offer), params: { offer: {
+      internal_reference: "internal-x",
+      draft_version_attributes: { id: offer.draft_version.id, subject: "New subject" }
+    } }
+    assert_redirected_to offer_url(offer)
+    assert_equal "New subject", offer.reload.draft_version.subject
+  end
+
+  test "destroy only in draft" do
+    assert_difference("Offer.count", -1) { delete offer_url(offers(:draft_offer)) }
+    assert_no_difference("Offer.count") { delete offer_url(offers(:sent_offer)) }
+    assert_redirected_to offer_url(offers(:sent_offer))
+  end
+
+  test "send_offer transitions to sent" do
+    offer = create_offer_with_milestone
+    post send_offer_offer_url(offer)
+    assert_redirected_to offer_url(offer)
+    assert offer.reload.sent?
+  end
+
+  test "send_offer failure path alerts from sender log" do
+    offer = create_draft_offer
+    post send_offer_offer_url(offer)
+    assert_redirected_to offer_url(offer)
+    assert_match(/milestone/i, flash[:alert])
+    assert offer.reload.draft?
+  end
+
+  test "preview redirects with alert for a draft with no milestones" do
+    offer = create_draft_offer
+    get preview_offer_url(offer)
+    assert_redirected_to offer_url(offer)
+    assert_match(/milestone/i, flash[:alert])
+  end
+
+  test "accept collects order data and order pdf" do
+    offer = offers(:sent_offer)
+    pdf = fixture_file_upload("acceptance.pdf", "application/pdf")
+    post accept_offer_url(offer), params: { order_number: "PO-1", ordered_on: "2026-07-01", order_pdf: pdf }
+    assert_redirected_to offer_url(offer)
+    offer.reload
+    assert offer.accepted?
+    assert offer.order_attachment.present?
+  end
+
+  test "convert_milestone requires offers.convert and links documents" do
+    offer = offers(:sent_offer)
+    offer.accept!(order_number: "PO", ordered_on: Date.current)
+    milestone = offer_milestones(:sent_ms_two)
+    assert_difference([ "Invoice.count", "DeliveryNote.count" ]) do
+      post convert_milestone_offer_url(offer, milestone_id: milestone.id)
+    end
+    milestone.reload
+    assert milestone.converted?
+    assert_equal "Milestone converted to #{milestone.invoice.display_name} and #{milestone.delivery_note.display_name}.",
+                 flash[:notice]
+  end
+
+  test "convert_milestone flash names only the invoice when the delivery note is skipped" do
+    offer = offers(:sent_offer)
+    offer.accept!(order_number: "PO", ordered_on: Date.current)
+    milestone = offer_milestones(:sent_ms_one)
+    post convert_milestone_offer_url(offer, milestone_id: milestone.id)
+    assert_equal "Milestone converted to #{milestone.reload.invoice.display_name}.", flash[:notice]
+  end
+
+  test "convert_milestone redirects with alert when offer isn't accepted" do
+    offer = offers(:sent_offer)
+    milestone = offer_milestones(:sent_ms_two)
+    assert_no_difference([ "Invoice.count", "DeliveryNote.count" ]) do
+      post convert_milestone_offer_url(offer, milestone_id: milestone.id)
+    end
+    assert_redirected_to offer_url(offer)
+    assert flash[:alert].present?
+    assert_not milestone.reload.converted?
+  end
+
+  test "reopen_milestone_link redirects with alert when offer isn't accepted" do
+    offer = offers(:sent_offer)
+    milestone = offer_milestones(:sent_ms_two)
+    post reopen_milestone_link_offer_url(offer, milestone_id: milestone.id)
+    assert_redirected_to offer_url(offer)
+    assert flash[:alert].present?
+  end
+
+  test "convert_milestone denied without offers.convert" do
+    offer = offers(:sent_offer)
+    offer.accept!(order_number: "PO", ordered_on: Date.current)
+    milestone = offer_milestones(:sent_ms_two)
+
+    sales = users(:bob)
+    sales.groups << groups(:sales) # customers/invoices only, no offers.* perms
+    sign_in_as(sales)
+
+    post convert_milestone_offer_url(offer, milestone_id: milestone.id)
+    assert_redirected_to root_path
+  end
+
+  test "update_internal_notes works even when accepted" do
+    offer = offers(:sent_offer)
+    offer.accept!(order_number: "PO", ordered_on: Date.current)
+    patch update_internal_notes_offer_url(offer), params: { offer: { internal_notes: "<p>note</p>" } }
+    assert_redirected_to offer_url(offer)
+    assert_includes offer.reload.internal_notes.body.to_html, "note"
+  end
+
+  test "scaffold_milestones saves pending offer edits before scaffolding" do
+    offer = create_draft_offer
+    post scaffold_milestones_offer_url(offer), params: {
+      total: "1000",
+      offer: { internal_reference: "edited-ref",
+               draft_version_attributes: { id: offer.draft_version.id, subject: "Edited subject" } }
+    }
+    assert_redirected_to edit_offer_url(offer)
+    offer.reload
+    assert_equal "edited-ref", offer.internal_reference
+    assert_equal "Edited subject", offer.draft_version.subject
+    assert_equal [ "Milestone" ], offer.draft_version.milestones.map(&:title)
+  end
+
+  test "scaffold refuses when milestones exist" do
+    offer = create_offer_with_milestone
+    post scaffold_milestones_offer_url(offer), params: { total: "1000" }
+    assert_redirected_to edit_offer_url(offer)
+    assert_match(/remove/i, flash[:alert])
+  end
+
+  test "edit blocked once accepted" do
+    offer = offers(:sent_offer)
+    offer.accept!(order_number: "PO", ordered_on: Date.current)
+    get edit_offer_url(offer)
+    assert_redirected_to offer_url(offer)
+  end
+
+  # Carry-forward obligation: the OfferMailer branch of the mail_delivery_tracker
+  # initializer (config/initializers/mail_delivery_tracker.rb) stamps
+  # email_sent_at on successful delivery. Untested since Task 6.
+  test "send_email stamps email_sent_at once delivered" do
+    ActionMailer::Base.deliveries.clear
+    offer = offers(:sent_offer)
+    attach_pdf_to(offer.versions.find_by(version_number: 1))
+
+    assert_enqueued_emails 1 do
+      post send_email_offer_url(offer)
+    end
+    assert_redirected_to offer_url(offer)
+
+    perform_enqueued_jobs
+
+    assert_equal 1, ActionMailer::Base.deliveries.size
+    offer.reload
+    assert_not_nil offer.email_sent_at
+  end
+
+  test "send_email refuses when the offer has never been sent" do
+    offer = create_draft_offer
+    post send_email_offer_url(offer)
+    assert_redirected_to offer_url(offer)
+    assert_nil offer.reload.email_sent_at
+  end
+
+  private
+
+  def attach_pdf_to(version)
+    attachment = Attachment.new(title: "Offer PDF", filename: "offer.pdf")
+    attachment.set_data("%PDF-fake", "application/pdf")
+    attachment.save!
+    version.update!(attachment: attachment)
+  end
+end

--- a/test/controllers/offers_controller_test.rb
+++ b/test/controllers/offers_controller_test.rb
@@ -86,6 +86,19 @@ class OffersControllerTest < ActionDispatch::IntegrationTest
                  flash[:notice]
   end
 
+  test "deleting a converted invoice redirects with an alert and keeps it" do
+    offer = offers(:sent_offer)
+    offer.accept!(order_number: "PO", ordered_on: Date.current)
+    milestone = offer_milestones(:sent_ms_two)
+    post convert_milestone_offer_url(offer, milestone_id: milestone.id)
+    invoice = milestone.reload.invoice
+    assert_no_difference("Invoice.count") do
+      delete invoice_url(invoice)
+    end
+    assert_redirected_to invoice_url(invoice)
+    assert_match(/converted from/, flash[:alert])
+  end
+
   test "convert_milestone flash names only the invoice when the delivery note is skipped" do
     offer = offers(:sent_offer)
     offer.accept!(order_number: "PO", ordered_on: Date.current)

--- a/test/fixtures/customer_contacts.yml
+++ b/test/fixtures/customer_contacts.yml
@@ -25,3 +25,9 @@ auto_email_contact:
   email: backup@autoemail.com
   receives_invoice_emails: true
   receives_delivery_note_emails: false
+
+eu_contact:
+  customer: good_eu
+  name: GOOD Offers
+  email: offers@good-company.co.uk
+  receives_offer_emails: true

--- a/test/fixtures/customers.yml
+++ b/test/fixtures/customers.yml
@@ -55,3 +55,19 @@ no_email_customer:
   language: english
   active: true
   team: default
+
+# Deliberately untouched by any invoice/delivery-note fixture, so the
+# offers-only deletion-blocker branch can be exercised in isolation (see
+# OfferTest#test_customer_with_offers_cannot_be_deleted).
+offer_only_customer:
+  matchcode: OFFERONLY
+  name: Offer Only Customer Ltd
+  address: |
+    1 Offer Street
+    10000 Offer City
+  country_iso2: DE
+  vat_id: OFFERONLY789
+  sales_tax_customer_class: eu
+  language: english
+  active: true
+  team: default

--- a/test/fixtures/document_numbers.yml
+++ b/test/fixtures/document_numbers.yml
@@ -32,3 +32,10 @@ delivery_note:
   sequence: 0
   last_number: nil
   last_date: nil
+
+offer:
+  code: offer
+  format: '%{date}-%<number>02d'
+  sequence: 0
+  last_number: nil
+  last_date: nil

--- a/test/fixtures/group_permissions.yml
+++ b/test/fixtures/group_permissions.yml
@@ -25,6 +25,15 @@ admin_delivery_notes_edit:
 admin_delivery_notes_review_acceptance:
   group: admin
   permission: delivery_notes.review_acceptance
+admin_offers_view:
+  group: admin
+  permission: offers.view
+admin_offers_edit:
+  group: admin
+  permission: offers.edit
+admin_offers_convert:
+  group: admin
+  permission: offers.convert
 admin_products_view:
   group: admin
   permission: products.view

--- a/test/fixtures/offer_milestones.yml
+++ b/test/fixtures/offer_milestones.yml
@@ -1,0 +1,29 @@
+draft_ms_one:
+  offer_version: draft_offer_v1
+  position: 1
+  title: Concept
+  amount: 500
+  trigger: on_acceptance
+
+sent_ms_one:
+  offer_version: sent_offer_v1
+  position: 1
+  title: Setup
+  amount: 1000
+  trigger: on_order
+  skip_delivery_note: true
+
+sent_ms_two:
+  offer_version: sent_offer_v1
+  position: 2
+  title: Delivery
+  amount: 2000
+  trigger: on_acceptance
+
+sent_draft_ms_one:
+  offer_version: sent_offer_v2_draft
+  position: 1
+  title: Setup
+  amount: 1000
+  trigger: on_order
+  skip_delivery_note: true

--- a/test/fixtures/offer_versions.yml
+++ b/test/fixtures/offer_versions.yml
@@ -1,0 +1,22 @@
+draft_offer_v1:
+  offer: draft_offer
+  version_number: 1
+  subject: Draft offer subject
+
+sent_offer_v1:
+  offer: sent_offer
+  version_number: 1
+  subject: Sent offer subject
+  date: 2026-06-01
+  sent_at: 2026-06-01 10:00:00
+  sales_tax_product_class: standard
+  customer_name: Snapshot Name
+  customer_address: "Snapshot Street 1"
+  customer_country_iso2: DE
+  payment_terms_days: 30
+
+sent_offer_v2_draft:
+  offer: sent_offer
+  version_number: 2
+  subject: Sent offer subject
+  sales_tax_product_class: standard

--- a/test/fixtures/offer_versions.yml
+++ b/test/fixtures/offer_versions.yml
@@ -14,6 +14,7 @@ sent_offer_v1:
   customer_address: "Snapshot Street 1"
   customer_country_iso2: DE
   payment_terms_days: 30
+  sum_net: 3000
 
 sent_offer_v2_draft:
   offer: sent_offer

--- a/test/fixtures/offers.yml
+++ b/test/fixtures/offers.yml
@@ -1,0 +1,13 @@
+draft_offer:
+  customer: offer_only_customer
+  project: one
+  state: draft
+
+sent_offer:
+  customer: good_eu
+  project: one
+  state: sent
+  document_number: 20260601-01
+  date: 2026-06-01
+  sent_at: 2026-06-01 10:00:00
+  expires_at: 2026-07-01

--- a/test/fixtures/offers.yml
+++ b/test/fixtures/offers.yml
@@ -1,6 +1,6 @@
 draft_offer:
   customer: offer_only_customer
-  project: one
+  project: offer_only_project
   state: draft
 
 sent_offer:

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -12,6 +12,13 @@ two:
   active: true
   team: default
 
+offer_only_project:
+  matchcode: PROJOFFER
+  description: Project for the offer-only customer
+  bill_to_customer: offer_only_customer
+  active: true
+  team: default
+
 test_project:
   matchcode: TEST
   description: Test project for PDF generation tests

--- a/test/jobs/expiring_offers_report_job_test.rb
+++ b/test/jobs/expiring_offers_report_job_test.rb
@@ -1,0 +1,98 @@
+require "test_helper"
+
+class ExpiringOffersReportJobTest < ActiveJob::TestCase
+  include ActiveJob::TestHelper
+  include ActionMailer::TestHelper
+
+  test "expires past-validity sent offers and sends one digest" do
+    offer = offers(:sent_offer)
+    offer.update!(expires_at: Date.yesterday)
+    assert_emails 1 do
+      ExpiringOffersReportJob.perform_now
+    end
+    offer.reload
+    assert offer.expired?
+    assert_not_nil offer.reported_expired_at
+  end
+
+  test "digest covers multiple expiring offers in a single email with full content" do
+    offer1 = offers(:sent_offer)
+    offer1.update!(expires_at: Date.yesterday)
+
+    offer2 = create_offer_with_milestone(customer: customers(:good_national))
+    version2 = offer2.draft_version
+    version2.update!(
+      sent_at: Time.current,
+      date: Date.current,
+      customer_name: offer2.customer.name,
+      customer_address: offer2.customer.address,
+      customer_country_iso2: offer2.customer.country_iso2,
+      payment_terms_days: offer2.customer.payment_terms_days
+    )
+    offer2.update!(state: "sent", document_number: "20269002", expires_at: Date.yesterday)
+
+    assert_emails 1 do
+      ExpiringOffersReportJob.perform_now
+    end
+
+    issuer = issuer_companies(:one)
+    delivered = ActionMailer::Base.deliveries.last
+    assert_equal [ issuer.reporting_email ], delivered.to
+    assert_equal I18n.t("mailers.expiring_offers.subject", issuer_name: issuer.short_name, count: 2), delivered.subject
+
+    html = delivered.html_part.body.to_s
+    text = delivered.text_part.body.to_s
+
+    [ offer1, offer2 ].each do |offer|
+      offer.reload
+      version = offer.current_sent_version
+      [ html, text ].each do |body|
+        assert_match offer.document_number, body
+        assert_match offer.customer.name, body
+        assert_match offer.expires_at.strftime("%d.%m.%Y"), body
+        assert_match sprintf("%.2f", version.sum_net), body
+      end
+      assert offer.expired?
+    end
+  end
+
+  test "no-op when nothing expired" do
+    offer = offers(:sent_offer)
+    offer.update!(expires_at: Date.tomorrow)
+    assert_emails 0 do
+      ExpiringOffersReportJob.perform_now
+    end
+    offer.reload
+    assert offer.sent?
+    assert_nil offer.reported_expired_at
+  end
+
+  test "already-reported offers are not re-reported" do
+    offer = offers(:sent_offer)
+    offer.update!(state: "expired", expires_at: Date.yesterday, reported_expired_at: Time.current)
+    assert_emails 0 do
+      ExpiringOffersReportJob.perform_now
+    end
+  end
+
+  test "re-expires an offer that was rejected and reopened after auto-expiry" do
+    offer = offers(:sent_offer)
+    offer.update!(state: "expired", expires_at: Date.yesterday, reported_expired_at: Time.current)
+    offer.reject!
+    offer.reopen!
+
+    assert_emails 1 do
+      ExpiringOffersReportJob.perform_now
+    end
+    assert offer.reload.expired?
+  end
+
+  test "drafts and accepted offers are untouched" do
+    offers(:sent_offer).accept!(order_number: "PO", ordered_on: Date.current)
+    offers(:sent_offer).update!(expires_at: Date.yesterday)
+    assert_emails 0 do
+      ExpiringOffersReportJob.perform_now
+    end
+    assert offers(:sent_offer).reload.accepted?
+  end
+end

--- a/test/mailers/offer_mailer_test.rb
+++ b/test/mailers/offer_mailer_test.rb
@@ -1,0 +1,67 @@
+require "test_helper"
+
+class OfferMailerTest < ActionMailer::TestCase
+  setup do
+    ActionMailer::Base.deliveries.clear
+    @offer = offers(:sent_offer)
+    version = @offer.versions.find_by(version_number: 1)
+    attachment = Attachment.new(title: "Offer PDF")
+    attachment.set_data("%PDF-stored", "application/pdf")
+    attachment.filename = "offer.pdf"
+    attachment.save!
+    version.update!(attachment: attachment)
+  end
+
+  test "sends to offer-flagged contacts with the stored PDF attached" do
+    mail = OfferMailer.with(offer: @offer).customer_email
+
+    # good_eu's only offer-flagged contact is eu_contact (offers@good-company.co.uk).
+    assert_equal [ "offers@good-company.co.uk" ], mail.to
+    assert_equal 1, mail.attachments.size
+    assert_equal "offer.pdf", mail.attachments.first.filename
+    assert_equal "%PDF-stored", mail.attachments.first.body.raw_source
+  end
+
+  test "customer_email skips attaching the stored PDF when skip_attachments is set" do
+    mail = OfferMailer.with(offer: @offer, skip_attachments: true).customer_email
+
+    assert_equal 0, mail.attachments.size
+  end
+
+  test "salutation override on the sent version wins over the contact salutation" do
+    @offer.current_sent_version.update!(salutation_override: "Dear override,")
+    mail = OfferMailer.with(offer: @offer).customer_email
+
+    assert_includes mail.text_part.body.to_s, "Dear override,"
+    assert_includes mail.html_part.body.to_s, "Dear override,"
+  end
+
+  test "customer_email falls back to greeting when the contact has no salutation_line" do
+    mail = OfferMailer.with(offer: @offer).customer_email
+
+    assert_match "Dear A Good Company B.V.,", mail.text_part.body.to_s
+    assert_match "Dear A Good Company B.V.,", mail.html_part.body.to_s
+  end
+
+  test "no-op when no contact opted in" do
+    @offer.customer.customer_contacts.update_all(receives_offer_emails: false)
+    mail = OfferMailer.with(offer: @offer).customer_email
+
+    assert_nil mail.to
+    assert_instance_of ActionMailer::Base::NullMail, mail.message
+  end
+
+  test "customer_email subject includes the issuer and offer document number" do
+    mail = OfferMailer.with(offer: @offer).customer_email
+
+    assert_equal "My Example Offer #{@offer.document_number}", mail.subject
+  end
+
+  test "customer_email HTML and text templates include the offer subject line" do
+    @offer.current_sent_version.update!(subject: "Website redesign proposal")
+    mail = OfferMailer.with(offer: @offer).customer_email
+
+    assert_match "Website redesign proposal", mail.html_part.body.to_s
+    assert_match "Website redesign proposal", mail.text_part.body.to_s
+  end
+end

--- a/test/models/document_number_test.rb
+++ b/test/models/document_number_test.rb
@@ -53,4 +53,10 @@ class DocumentNumberTest < ActiveSupport::TestCase
     assert_equal 1, dn.sequence
     assert_equal Date.new(2026, 1, 1), dn.last_date
   end
+  test "date format resets the sequence each day and zero-pads" do
+    dn = DocumentNumber.create!(code: "daily", format: "%{date}-%<number>02d", sequence: 0)
+    assert_equal "20260705-01", dn.get_next(Date.new(2026, 7, 5))
+    assert_equal "20260705-02", dn.get_next(Date.new(2026, 7, 5))
+    assert_equal "20260706-01", dn.get_next(Date.new(2026, 7, 6))
+  end
 end

--- a/test/models/offer_milestone_test.rb
+++ b/test/models/offer_milestone_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+class OfferMilestoneTest < ActiveSupport::TestCase
+  test "trigger must be one of the known values" do
+    m = offer_milestones(:sent_ms_one)
+    m.trigger = "bogus"
+    assert_not m.valid?
+  end
+
+  test "on_date trigger requires a date" do
+    m = offer_milestones(:sent_ms_one)
+    m.trigger = "on_date"
+    m.trigger_date = nil
+    assert_not m.valid?
+  end
+
+  test "saving milestones updates the version sum_net" do
+    version = offer_versions(:draft_offer_v1)
+    version.milestones.create!(title: "Extra", amount: 100, trigger: "on_acceptance", position: 9)
+    assert_equal version.milestones.sum(:amount), version.reload.sum_net
+  end
+
+  test "default_skip_delivery_note true only for on_order" do
+    m = OfferMilestone.new(trigger: "on_order")
+    assert m.default_skip_delivery_note
+    m.trigger = "on_acceptance"
+    assert_not m.default_skip_delivery_note
+  end
+end

--- a/test/models/offer_test.rb
+++ b/test/models/offer_test.rb
@@ -1,0 +1,141 @@
+require "test_helper"
+
+class OfferTest < ActiveSupport::TestCase
+  test "project is required" do
+    offer = Offer.new(customer: customers(:good_eu))
+    assert_not offer.valid?
+    assert offer.errors[:project].any?
+  end
+
+  test "validity_days falls back from customer to issuer" do
+    offer = offers(:draft_offer)
+    offer.customer.update!(offer_validity_days: nil)
+    assert_equal IssuerCompany.get_the_issuer!.offer_validity_days, offer.validity_days
+    offer.customer.update!(offer_validity_days: 14)
+    assert_equal 14, offer.validity_days
+  end
+
+  test "send_problems requires a draft version with at least one milestone" do
+    offer = offers(:draft_offer)
+    offer.draft_version.milestones.destroy_all
+    assert_includes offer.send_problems.join, "milestone"
+  end
+
+  test "accept from sent stores order data and discards the draft version" do
+    offer = offers(:sent_offer)
+    draft_id = offer.draft_version.id
+    offer.accept!(order_number: "PO-100", ordered_on: Date.new(2026, 7, 1))
+    assert offer.accepted?
+    assert_equal "PO-100", offer.order_number
+    assert_equal offer.versions.where.not(sent_at: nil).order(:version_number).last.id,
+                 offer.accepted_version_id
+    assert_nil OfferVersion.find_by(id: draft_id)
+  end
+
+  test "accept refused unless sent" do
+    assert_raises(Offer::InvalidTransition) { offers(:draft_offer).accept!(order_number: "x", ordered_on: Date.current) }
+  end
+
+  test "accept requires an order date" do
+    assert_raises(Offer::InvalidTransition) { offers(:sent_offer).accept!(order_number: "x", ordered_on: nil) }
+    assert offers(:sent_offer).reload.sent?
+  end
+
+  test "reject stamps rejected_at" do
+    offer = offers(:sent_offer)
+    offer.reject!
+    assert offer.rejected?
+    assert_not_nil offer.rejected_at
+  end
+
+  test "reopen from rejected returns to sent" do
+    offer = offers(:sent_offer)
+    offer.reject!
+    offer.reopen!
+    assert offer.sent?
+    assert_nil offer.rejected_at
+  end
+
+  test "reopen clears a stale reported_expired_at from a prior auto-expiry" do
+    offer = offers(:sent_offer)
+    # Mirror what ExpiringOffersReportJob does to an overdue sent offer.
+    offer.update!(state: "expired", reported_expired_at: Time.current)
+    offer.reject!
+    offer.reopen!
+    assert offer.sent?
+    assert_nil offer.reported_expired_at
+  end
+
+  test "reopen from accepted branches a draft from the accepted version" do
+    offer = offers(:sent_offer)
+    offer.accept!(order_number: "PO-1", ordered_on: Date.current)
+    accepted_subject = offer.reload.accepted_version.subject
+    offer.reopen!
+    assert offer.sent?
+    assert_nil offer.accepted_version_id
+    assert_equal accepted_subject, offer.draft_version.subject
+  end
+
+  test "customer with offers cannot be deleted" do
+    customer = offers(:draft_offer).customer
+    assert_not customer.destroy
+    assert_includes customer.errors[:base].join, "offers"
+  end
+
+  test "deleting the addressed contact nullifies the reference" do
+    offer = offers(:draft_offer)
+    contact = CustomerContact.create!(
+      customer: offer.customer,
+      name: "Test Contact to Delete",
+      email: "delete-me@example.com"
+    )
+    offer.update!(customer_contact: contact)
+    contact.destroy
+    assert_nil offer.reload.customer_contact_id
+  end
+
+  test "customer_contact must belong to the offer's customer" do
+    offer = offers(:draft_offer)
+    contact_from_different_customer = customer_contacts(:eu_contact) # belongs to good_eu, not offer_only_customer
+    offer.customer_contact = contact_from_different_customer
+    assert_not offer.valid?
+    assert_includes offer.errors[:customer_contact], "must belong to the offer's customer"
+  end
+
+  test "customer_contact can be assigned if it belongs to the offer's customer" do
+    offer = offers(:draft_offer)
+    contact = CustomerContact.create!(
+      customer: offer.customer,
+      name: "Test Contact",
+      email: "test@example.com"
+    )
+    offer.customer_contact = contact
+    assert offer.valid?
+    assert_empty offer.errors[:customer_contact]
+  end
+
+  test "new offer preselects the tax class when the customer has exactly one" do
+    offer = create_draft_offer
+    assert_equal sales_tax_product_classes(:standard), offer.draft_version.sales_tax_product_class
+  end
+
+  test "new offer preselects no tax class when the customer has several" do
+    customer = customers(:good_eu)
+    reduced = SalesTaxProductClass.create!(name: "Reduced Goods", indicator_code: "RED")
+    SalesTaxRate.create!(sales_tax_customer_class: customer.sales_tax_customer_class,
+                         sales_tax_product_class: reduced, rate: 10)
+    offer = create_draft_offer(customer: customer)
+    assert_nil offer.draft_version.sales_tax_product_class_id
+  end
+  test "rich text preludes lose leading and trailing blank lines on save" do
+    version = offers(:draft_offer).draft_version
+    version.update!(prelude: "<div><br></div><div><br>First line<br>Second<br><br></div><div><br></div>")
+    assert_equal "<div>First line<br>Second</div>", version.reload.prelude.body.to_html
+  end
+
+  test "internal notes keep interior breaks while edges are stripped" do
+    offer = offers(:draft_offer)
+    offer.update!(internal_notes: "<div>keep<br><br>this</div><p><br></p>")
+    assert_equal "<div>keep<br><br>this</div>", offer.reload.internal_notes.body.to_html
+  end
+end

--- a/test/services/offer_milestone_converter_test.rb
+++ b/test/services/offer_milestone_converter_test.rb
@@ -131,4 +131,15 @@ class OfferMilestoneConverterTest < ActiveSupport::TestCase
     invoice = OfferMilestoneConverter.new(offer_milestones(:sent_ms_two)).convert!
     assert_equal "2", invoice.internal_reference
   end
+  test "converted documents cannot be deleted while the milestone link is set" do
+    milestone = offer_milestones(:sent_ms_two)
+    invoice = OfferMilestoneConverter.new(milestone).convert!
+    dn = milestone.reload.delivery_note
+    assert_not invoice.destroy
+    assert_includes invoice.errors[:base].join, @offer.display_name
+    assert_not dn.destroy
+    milestone.reopen_link!
+    assert dn.reload.destroy
+    assert invoice.reload.destroy
+  end
 end

--- a/test/services/offer_milestone_converter_test.rb
+++ b/test/services/offer_milestone_converter_test.rb
@@ -1,0 +1,134 @@
+require "test_helper"
+
+class OfferMilestoneConverterTest < ActiveSupport::TestCase
+  setup do
+    @offer = offers(:sent_offer)
+    @offer.accept!(order_number: "PO-77", ordered_on: Date.new(2026, 6, 15))
+  end
+
+  test "converts a milestone into a draft invoice and delivery note" do
+    milestone = offer_milestones(:sent_ms_two) # on_acceptance, no skip
+    invoice = OfferMilestoneConverter.new(milestone).convert!
+    assert_not invoice.published
+    assert_equal @offer.customer, invoice.customer
+    assert_equal @offer.project, invoice.project
+    assert_equal "PO-77", invoice.cust_order
+    line = invoice.invoice_lines.first
+    assert_equal "item", line.type
+    assert_equal @offer.accepted_version.subject, line.title
+    assert_equal "#{milestone.title}\nOffer #{@offer.document_number} v#{@offer.accepted_version.version_number}",
+                 line.description
+    assert_equal 1, line.quantity
+    assert_equal milestone.amount, line.rate
+    assert_equal @offer.accepted_version.sales_tax_product_class_id, line.sales_tax_product_class_id
+    assert_nil invoice.prelude.body
+    milestone.reload
+    assert_equal invoice.id, milestone.invoice_id
+    dn = milestone.delivery_note
+    assert dn.present?
+    assert_equal invoice, dn.invoice
+    line = dn.delivery_note_lines.first
+    assert_equal @offer.accepted_version.subject, line.title
+    assert_equal "#{milestone.title}\nOffer #{@offer.document_number} v#{@offer.accepted_version.version_number}",
+                 line.description
+    assert_nil dn.prelude.body
+    assert_equal @offer.ordered_on, dn.delivery_start_date
+  end
+
+  test "delivery note range runs from order date to the version delivery date" do
+    @offer.accepted_version.update!(delivery_date: Date.new(2026, 9, 30))
+    dn = OfferMilestoneConverter.new(offer_milestones(:sent_ms_two)).convert!
+                                .then { offer_milestones(:sent_ms_two).reload.delivery_note }
+    assert_equal @offer.ordered_on, dn.delivery_start_date
+    assert_equal Date.new(2026, 9, 30), dn.delivery_end_date
+  end
+
+  test "delivery date before the order date leaves the range open-ended" do
+    @offer.accepted_version.update!(delivery_date: @offer.ordered_on - 1.day)
+    OfferMilestoneConverter.new(offer_milestones(:sent_ms_two)).convert!
+    assert_nil offer_milestones(:sent_ms_two).reload.delivery_note.delivery_end_date
+  end
+
+  test "skip_delivery_note produces only an invoice" do
+    milestone = offer_milestones(:sent_ms_one) # on_order, skip
+    OfferMilestoneConverter.new(milestone).convert!
+    assert_nil milestone.reload.delivery_note_id
+  end
+
+  test "conversion requires an accepted offer" do
+    other = offers(:draft_offer)
+    milestone = other.draft_version.milestones.first
+    assert_raises(OfferMilestoneConverter::NotConvertible) { OfferMilestoneConverter.new(milestone).convert! }
+  end
+
+  test "a converted milestone cannot convert twice, and reopen_link! clears it" do
+    milestone = offer_milestones(:sent_ms_two)
+    OfferMilestoneConverter.new(milestone).convert!
+    assert_raises(OfferMilestoneConverter::NotConvertible) { OfferMilestoneConverter.new(milestone.reload).convert! }
+    milestone.reopen_link!
+    assert_nil milestone.reload.invoice_id
+    assert_nil milestone.delivery_note_id
+  end
+
+  test "milestone description lands after the reference in the line description" do
+    milestone = offer_milestones(:sent_ms_two)
+    milestone.update!(description: "Detailed scope")
+    invoice = OfferMilestoneConverter.new(milestone).convert!
+    expected = "#{milestone.title}\nOffer #{@offer.document_number} v#{@offer.accepted_version.version_number}\nDetailed scope"
+    assert_equal expected, invoice.invoice_lines.first.description
+    assert_equal expected, milestone.reload.delivery_note.delivery_note_lines.first.description
+  end
+
+  test "version prelude becomes the invoice prelude" do
+    @offer.accepted_version.update!(prelude: "<p>Original offer prelude</p>")
+    invoice = OfferMilestoneConverter.new(offer_milestones(:sent_ms_two)).convert!
+    assert_includes invoice.prelude.body.to_html, "Original offer prelude"
+  end
+
+  test "conversion refused for a milestone on a non-accepted version" do
+    # Create a new non-accepted version on the already-accepted offer
+    non_accepted_version = @offer.versions.create!(
+      version_number: 99,
+      sent_at: Time.current,
+      date: Date.current,
+      customer_name: "Test Customer",
+      customer_address: "Test Address",
+      customer_country_iso2: "DE",
+      payment_terms_days: 30
+    )
+    milestone = non_accepted_version.milestones.create!(
+      position: 1,
+      title: "Non-Accepted Milestone",
+      amount: 1000,
+      trigger: "on_acceptance"
+    )
+
+    assert_raises(OfferMilestoneConverter::NotConvertible) do
+      OfferMilestoneConverter.new(milestone).convert!
+    end
+    assert_nil milestone.reload.invoice_id
+  end
+  test "internal reference carries over with the milestone ordinal when several milestones exist" do
+    @offer.update!(internal_reference: "PROJ-REF")
+    first = offer_milestones(:sent_ms_one)
+    second = offer_milestones(:sent_ms_two)
+    invoice_one = OfferMilestoneConverter.new(first).convert!
+    invoice_two = OfferMilestoneConverter.new(second).convert!
+    assert_equal "PROJ-REF 1", invoice_one.internal_reference
+    assert_equal "PROJ-REF 2", invoice_two.internal_reference
+    assert_equal "PROJ-REF 2", second.reload.delivery_note.internal_reference
+  end
+
+  test "internal reference carries over without ordinal for a sole milestone" do
+    @offer.update!(internal_reference: "PROJ-REF")
+    version = @offer.accepted_version
+    version.milestones.where.not(id: offer_milestones(:sent_ms_two).id).destroy_all
+    invoice = OfferMilestoneConverter.new(offer_milestones(:sent_ms_two)).convert!
+    assert_equal "PROJ-REF", invoice.internal_reference
+  end
+
+  test "blank internal reference converts with just the ordinal" do
+    invoice = OfferMilestoneConverter.new(offer_milestones(:sent_ms_two)).convert!
+    assert_equal "2", invoice.internal_reference
+  end
+end

--- a/test/services/offer_milestone_scaffolder_test.rb
+++ b/test/services/offer_milestone_scaffolder_test.rb
@@ -1,0 +1,84 @@
+require "test_helper"
+
+class OfferMilestoneScaffolderTest < ActiveSupport::TestCase
+  setup do
+    @customer = customers(:good_eu)
+    @customer.update!(
+      offer_milestone_split_threshold: 10_000,
+      offer_milestone_templates_below: "Full amount|on_acceptance|100",
+      offer_milestone_templates_above: "Deposit|on_order|30\nDelivery|on_acceptance|70"
+    )
+    @version = create_draft_offer(customer: @customer).draft_version
+  end
+
+  test "below threshold uses the below list" do
+    rows = OfferMilestoneScaffolder.new(@customer, 5000).apply_to(@version)
+    assert_equal [ "Full amount" ], rows.map(&:title)
+    assert_equal [ 5000 ], rows.map(&:amount)
+  end
+
+  test "above threshold distributes proportionally with the last row absorbing rounding" do
+    rows = OfferMilestoneScaffolder.new(@customer, 10_001).apply_to(@version)
+    assert_equal %w[Deposit Delivery], rows.map(&:title)
+    assert_equal 10_001, rows.sum(&:amount)
+    assert_equal (10_001 * 0.3).round(2), rows.first.amount
+  end
+
+  test "on_order rows default to skipping the delivery note" do
+    rows = OfferMilestoneScaffolder.new(@customer, 20_000).apply_to(@version)
+    assert rows.first.skip_delivery_note
+    assert_not rows.last.skip_delivery_note
+  end
+
+  test "malformed lines are skipped; nothing parseable falls back to a single placeholder" do
+    @customer.update!(offer_milestone_templates_below: "garbage-without-pipes\nAlso|bad")
+    rows = OfferMilestoneScaffolder.new(@customer, 100).apply_to(@version)
+    assert_equal [ "Milestone" ], rows.map(&:title)
+    assert_equal [ 100 ], rows.map(&:amount)
+  end
+
+  test "no threshold always uses the below list" do
+    @customer.update!(offer_milestone_split_threshold: nil)
+    rows = OfferMilestoneScaffolder.new(@customer, 50_000).apply_to(@version)
+    assert_equal [ "Full amount" ], rows.map(&:title)
+    assert_equal [ 50_000 ], rows.map(&:amount)
+  end
+
+  test "blank templates fall back to a single placeholder" do
+    @customer.update!(offer_milestone_split_threshold: nil,
+                      offer_milestone_templates_below: "",
+                      offer_milestone_templates_above: "")
+    rows = OfferMilestoneScaffolder.new(@customer, 100).apply_to(@version)
+    assert_equal [ "Milestone" ], rows.map(&:title)
+  end
+
+  test "refuses when the draft already has milestones" do
+    @version.milestones.create!(title: "Existing", amount: 1, trigger: "on_acceptance", position: 1)
+    assert_raises(OfferMilestoneScaffolder::MilestonesPresent) do
+      OfferMilestoneScaffolder.new(@customer, 100).apply_to(@version)
+    end
+  end
+
+  test "on_date template rows scaffold with today's date as an editable placeholder" do
+    @customer.update!(
+      offer_milestone_templates_below: "Kickoff|on_date|100"
+    )
+    rows = OfferMilestoneScaffolder.new(@customer, 100).apply_to(@version)
+    assert_equal [ "on_date" ], rows.map(&:trigger)
+    assert_equal Date.current, rows.first.trigger_date
+  end
+
+  test "three-row template distributes proportionally and the last row absorbs rounding" do
+    @customer.update!(
+      offer_milestone_templates_above: "A|on_acceptance|33.3\nB|on_acceptance|33.3\nC|on_acceptance|33.4"
+    )
+    rows = OfferMilestoneScaffolder.new(@customer, 10_000).apply_to(@version)
+    assert_equal 3, rows.length
+    assert_equal %w[A B C], rows.map(&:title)
+    assert_equal 10_000, rows.sum(&:amount)
+    expected_first_two = (BigDecimal("10000") * BigDecimal("33.3") / 100).round(2)
+    assert_equal expected_first_two, rows[0].amount
+    assert_equal expected_first_two, rows[1].amount
+    assert_equal 10_000 - expected_first_two - expected_first_two, rows[2].amount
+  end
+end

--- a/test/services/offer_renderer_test.rb
+++ b/test/services/offer_renderer_test.rb
@@ -1,0 +1,65 @@
+require "test_helper"
+
+class OfferRendererTest < ActiveSupport::TestCase
+  setup { @issuer = IssuerCompany.get_the_issuer! }
+
+  test "frozen version emits snapshot recipient, number, and valid-until" do
+    version = offer_versions(:sent_offer_v1)
+    xml = OfferRenderer.new(version, @issuer).emit_xml(nil)
+    assert_match "Snapshot Name", xml
+    assert_match "<number>20260601-01</number>", xml
+    assert_match "<valid-until>", xml
+    assert_no_match(/<version-number>/, xml) # version row only from v2 onward
+  end
+
+  test "second and later versions emit a version-number element" do
+    v1 = offer_versions(:sent_offer_v1)
+    v2 = v1.offer.versions.find_by(version_number: 2)
+    v2.update!(sent_at: Time.current, date: Date.current,
+               customer_name: "Snap", customer_address: "A", customer_country_iso2: "DE",
+               payment_terms_days: 30)
+    xml = OfferRenderer.new(v2, @issuer).emit_xml(nil)
+    assert_match "<version-number>2</version-number>", xml
+  end
+
+  test "draft version renders live customer data with a DRAFT number" do
+    version = offer_versions(:draft_offer_v1)
+    xml = OfferRenderer.new(version, @issuer).emit_xml(nil)
+    assert_match version.offer.customer.name, xml
+    assert_match "<number>DRAFT</number>", xml
+  end
+
+  test "no VAT ids and no totals appear in the XML" do
+    xml = OfferRenderer.new(offer_versions(:sent_offer_v1), @issuer).emit_xml(nil)
+    assert_no_match(/vat-id/, xml)
+    assert_no_match(/<sums>/, xml)
+  end
+
+  test "milestones carry trigger and formatted amount data" do
+    xml = OfferRenderer.new(offer_versions(:sent_offer_v1), @issuer).emit_xml(nil)
+    assert_match "<trigger>on_order</trigger>", xml
+    assert_match "Setup", xml
+  end
+
+  test "draft valid-until is computed from today plus validity days" do
+    version = offer_versions(:draft_offer_v1)
+    xml = OfferRenderer.new(version, @issuer).emit_xml(nil)
+    expected = (Date.current + version.offer.validity_days).iso8601
+    assert_match "<valid-until>#{expected}</valid-until>", xml
+  end
+
+  test "prelude and boilerplate are embedded as FO fragments" do
+    version = offer_versions(:sent_offer_v1)
+    version.update!(prelude: "<p>Dear customer</p>", boilerplate: "<h1>Terms</h1>")
+    xml = OfferRenderer.new(version.reload, @issuer).emit_xml(nil)
+    assert_match "Dear customer", xml
+    assert_match "Terms", xml
+    assert_includes xml, %(xmlns:fo="http://www.w3.org/1999/XSL/Format")
+  end
+
+  test "FOP smoke: renders a real PDF" do
+    version = offer_versions(:sent_offer_v1)
+    pdf = OfferRenderer.new(version, @issuer).render
+    assert pdf.start_with?("%PDF"), "expected a PDF, got: #{pdf[0, 20].inspect}"
+  end
+end

--- a/test/services/offer_sender_test.rb
+++ b/test/services/offer_sender_test.rb
@@ -1,0 +1,102 @@
+require "test_helper"
+
+class OfferSenderTest < ActiveSupport::TestCase
+  setup do
+    @issuer = IssuerCompany.get_the_issuer!
+  end
+
+  # Renderer stubbed per test via stub_offer_renderer, mirroring the plain
+  # singleton-method technique InvoicePublisher's test uses in
+  # with_failing_renderer (Minitest::Mock's `expect`/`stub` API isn't
+  # available in this app's pinned minitest, which no longer ships
+  # minitest/mock).
+
+  test "first send assigns a document number, freezes the version, and branches a new draft" do
+    offer = create_offer_with_milestone
+    sender = OfferSender.new(offer, @issuer)
+    stub_offer_renderer(render_stub("%PDF-fake")) do
+      assert sender.send!, sender.log
+    end
+    offer.reload
+    assert offer.sent?
+    assert_equal "#{Date.current.strftime("%Y%m%d")}-01", offer.document_number
+    frozen = offer.versions.find_by(version_number: 1)
+    assert frozen.frozen?
+    assert_equal Date.current, frozen.date
+    assert_equal offer.customer.name, frozen.customer_name
+    assert_equal offer.customer.payment_terms_days, frozen.payment_terms_days
+    assert frozen.attachment&.data&.start_with?("%PDF")
+    draft = offer.draft_version
+    assert_equal 2, draft.version_number
+    assert_equal frozen.milestones.count, draft.milestones.count
+    assert_equal Date.current + offer.validity_days, offer.expires_at
+  end
+
+  test "second send keeps the document number and supersedes the prior version" do
+    offer = create_offer_with_milestone
+    numbers = []
+    2.times do
+      stub_offer_renderer(render_stub("%PDF-fake")) { assert OfferSender.new(offer.reload, @issuer).send! }
+      numbers << offer.reload.document_number
+    end
+    assert_equal numbers.first, numbers.last
+    assert_equal 2, offer.versions.where.not(sent_at: nil).count
+    assert_equal 3, offer.versions.maximum(:version_number)
+  end
+
+  test "send from expired re-enters sent with a fresh validity window" do
+    offer = create_offer_with_milestone
+    stub_offer_renderer(render_stub("%PDF-fake")) { assert OfferSender.new(offer, @issuer).send! }
+    offer.reload.update!(state: "expired", expires_at: 1.week.ago.to_date, reported_expired_at: Time.current)
+    stub_offer_renderer(render_stub("%PDF-fake")) { assert OfferSender.new(offer.reload, @issuer).send! }
+    offer.reload
+    assert offer.sent?
+    assert_operator offer.expires_at, :>, Date.current
+    assert_nil offer.reported_expired_at
+  end
+
+  test "send refused without milestones" do
+    offer = create_draft_offer
+    sender = OfferSender.new(offer, @issuer)
+    assert_not sender.send!
+    assert offer.reload.draft?
+  end
+
+  test "boilerplate is frozen onto the version at send" do
+    offer = create_offer_with_milestone
+    offer.customer.update!(offer_boilerplate: "<p>Standing terms</p>")
+    stub_offer_renderer(render_stub("%PDF-fake")) { assert OfferSender.new(offer, @issuer).send! }
+    frozen = offer.reload.versions.find_by(version_number: 1)
+    assert_includes frozen.boilerplate.body.to_html, "Standing terms"
+    offer.customer.update!(offer_boilerplate: "<p>Changed later</p>")
+    assert_includes frozen.reload.boilerplate.body.to_html, "Standing terms"
+  end
+
+  test "nothing persists when PDF rendering fails" do
+    offer = create_offer_with_milestone
+    sequence_before = DocumentNumber.find_by!(code: "offer").sequence
+    failing = Object.new
+    def failing.render = raise("FOP exploded")
+    stub_offer_renderer(failing) do
+      assert_raises(RuntimeError) { OfferSender.new(offer, @issuer).send! }
+    end
+    offer.reload
+    assert offer.draft?
+    assert_nil offer.document_number
+    assert_nil offer.versions.find_by(version_number: 1).sent_at
+    assert_equal sequence_before, DocumentNumber.find_by!(code: "offer").sequence
+  end
+
+  private
+
+  def render_stub(pdf_data)
+    Object.new.tap { |stub| stub.define_singleton_method(:render) { pdf_data } }
+  end
+
+  def stub_offer_renderer(fake)
+    OfferRenderer.define_singleton_method(:new) { |*| fake }
+    yield
+  ensure
+    OfferRenderer.singleton_class.send(:remove_method, :new)
+  end
+end

--- a/test/services/rich_text_fo_converter_test.rb
+++ b/test/services/rich_text_fo_converter_test.rb
@@ -32,10 +32,15 @@ class RichTextFoConverterTest < ActiveSupport::TestCase
     assert_includes fo("<div><em>y</em></div>"), %(<fo:inline font-style="italic">y</fo:inline>)
   end
 
-  test "h1 becomes a styled fo:block" do
+  test "h1 becomes a spaced fo:block at body size" do
     out = fo("<h1>Title</h1>")
-    assert_includes out, %(font-weight="bold")
-    assert_includes out, "Title"
+    assert_includes out, %(<fo:block space-after="4pt">Title</fo:block>)
+    assert_not_includes out, "font-weight"
+  end
+
+  test "h1 carries the heading color when one is given" do
+    out = RichTextFoConverter.new("<h1>Title</h1>", heading_color: "#123456").to_fo_fragment
+    assert_includes out, %(color="#123456")
   end
 
   test "bullet list emits fo:list-block with bullet labels" do

--- a/test/services/rich_text_fo_converter_test.rb
+++ b/test/services/rich_text_fo_converter_test.rb
@@ -38,6 +38,12 @@ class RichTextFoConverterTest < ActiveSupport::TestCase
     assert_not_includes out, "font-weight"
   end
 
+  test "an empty div renders as a single blank line" do
+    out = fo("<div>a</div><div><br></div><div>b</div>")
+    assert_includes out, "<fo:block>\u00A0</fo:block>"
+    assert_not_includes out, "<fo:block>\u2028</fo:block>"
+  end
+
   test "h1 carries the heading color when one is given" do
     out = RichTextFoConverter.new("<h1>Title</h1>", heading_color: "#123456").to_fo_fragment
     assert_includes out, %(color="#123456")

--- a/test/support/document_factories.rb
+++ b/test/support/document_factories.rb
@@ -51,6 +51,16 @@ module DocumentFactories
     note
   end
 
+  def create_draft_offer(customer: customers(:good_eu), project: projects(:one))
+    Offer.create!(customer: customer, project: project)
+  end
+
+  def create_offer_with_milestone(**kwargs)
+    offer = create_draft_offer(**kwargs)
+    offer.draft_version.milestones.create!(title: "Milestone", amount: 1000, trigger: "on_acceptance", position: 1)
+    offer
+  end
+
   def create_published_delivery_note(customer: customers(:good_eu), document_number:, cust_reference:,
                                      project: projects(:one), **overrides)
     DeliveryNote.new({

--- a/test/system/offer_form_test.rb
+++ b/test/system/offer_form_test.rb
@@ -1,0 +1,83 @@
+require "application_system_test_case"
+
+class OfferFormTest < ApplicationSystemTestCase
+  test "adding a milestone survives submit" do
+    visit edit_offer_path(offers(:draft_offer))
+    click_on "+ Add Milestone"
+    within all("[data-line-index]").last do
+      fill_in "Title", with: "Second milestone"
+      fill_in "Amount", with: "250"
+    end
+    click_on "Save"
+    assert_text "Offer updated"
+    offer = offers(:draft_offer).reload
+    assert_equal [ "Concept", "Second milestone" ], offer.draft_version.milestones.map(&:title)
+  end
+
+  test "reordering and removing milestones survives submit" do
+    version = offers(:draft_offer).draft_version
+    version.milestones.create!(position: 2, title: "Middle", amount: 100, trigger: "on_acceptance")
+    version.milestones.create!(position: 3, title: "Last", amount: 200, trigger: "on_acceptance")
+    visit edit_offer_path(offers(:draft_offer))
+    within all("[data-line-index]")[2] do
+      click_on "▲"
+    end
+    within all("[data-line-index]")[2] do
+      click_on "🗑"
+    end
+    click_on "Save"
+    assert_text "Offer updated"
+    milestones = offers(:draft_offer).reload.draft_version.milestones
+    assert_equal [ "Concept", "Last" ], milestones.map(&:title)
+    assert_equal [ 1, 2 ], milestones.map(&:position)
+  end
+
+  test "milestone description and skip flag are not dropped on submit" do
+    visit edit_offer_path(offers(:draft_offer))
+    within first("[data-line-index]") do
+      fill_in "Description", with: "Detailed scope"
+      select "Upon order", from: "Trigger"
+    end
+    click_on "Save"
+    assert_text "Offer updated"
+    milestone = offers(:draft_offer).reload.draft_version.milestones.first
+    assert_equal "Detailed scope", milestone.description
+    assert milestone.skip_delivery_note
+  end
+
+  test "send button disabled without milestones" do
+    offer = create_draft_offer
+    visit offer_path(offer)
+    assert_selector "button[disabled]", text: /Send/
+  end
+
+  test "accepting without an order document succeeds" do
+    offer = offers(:sent_offer)
+    visit offer_path(offer)
+
+    click_on "Accept…"
+    assert_selector ".accept-order-modal", visible: :visible
+
+    within ".accept-order-modal" do
+      fill_in "order_number", with: "PO-NOFILE"
+      fill_in "ordered_on", with: Date.new(2026, 7, 1).strftime("%Y-%m-%d")
+      click_on "Accept offer"
+    end
+
+    assert_text "Offer accepted"
+    offer.reload
+    assert offer.accepted?
+    assert_nil offer.order_attachment_id
+  end
+  test "applying the milestone rule keeps unsaved form edits" do
+    offer = create_draft_offer
+    visit edit_offer_path(offer)
+    fill_in "Subject", with: "Kept subject"
+    fill_in "Target total net", with: "2500"
+    click_on "Apply milestone rule"
+    assert_text "Milestones scaffolded"
+    offer.reload
+    assert_equal "Kept subject", offer.draft_version.subject
+    assert_equal [ 2500 ], offer.draft_version.milestones.map(&:amount)
+  end
+end


### PR DESCRIPTION
Implements the offers feature per the refined requirements in #530 (plan: docs/superpowers/plans/2026-07-05-offers.md).

## What
- **Offer / OfferVersion / OfferMilestone**: quotes parallel to invoices & delivery notes. Sending freezes the current version (customer snapshot, boilerplate copy, stored PDF) and branches a fresh draft; lifecycle `draft → sent → accepted/rejected/expired` with reopen back-edges.
- **Document numbers**: new `YYYYMMDD-NN` range with a daily-resetting sequence (`DocumentNumber` gained a `date` format token), assigned on first send.
- **PDF** via FOP (`offer.xsl` on the shared base): subject → prelude → customer boilerplate → numbered milestone table; no VAT IDs, totals, or tax anywhere; validity/delivery dates in the info box; `DRAFT` number on previews.
- **Conversion**: accepted-offer milestones convert to a draft invoice (+ optional delivery note) — subject as line title, milestone + offer reference + description as line description, internal reference with per-milestone ordinal, delivery range `ordered_on → version delivery date`. Converted documents can't be deleted while linked and show their source offer.
- **Scaffolding**: per-customer milestone templates (`Title|trigger|percent`, below/above a total-net threshold; below applies when no threshold is set).
- **Email**: contact opt-in (`receives_offer_emails`), attaches the frozen version's stored PDF, `email_sent_at` tracking.
- **Expiry**: daily job auto-expires overdue sent offers and mails one digest.
- **Permissions**: `offers.view` / `offers.edit` / `offers.convert`, granted to Admin by migration.
- Shared polish: rich-text headings render in the document accent color (all document types), Trix empty lines render single-height.

## Testing
- 979 unit + 64 system tests green locally (SQLite); PostgreSQL covered by CI.
- Built task-by-task with per-task adversarial code review, a whole-branch review, and a security review (no findings; contact-assignment hardening included).

Closes #530.

🤖 Generated with [Claude Code](https://claude.com/claude-code)