### PR TITLE
Report accepted offers nearing delivery with open invoicing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ For testing against PostgreSQL (matches production environment):
 - Permissions: `offers.view`, `offers.edit` (create/send/accept/reject/reopen), `offers.convert` (milestone → invoice/delivery-note)
 
 ### Background Jobs
-- Solid Queue (`bin/jobs` worker, `solid_queue` gem). Schedule lives in `config/recurring.yml` — currently `OverdueInvoicesReportJob` (every other day at 08:00), `ExpiringOffersReportJob` (daily at 07:30), `RefreshStaleVatVerificationsJob` (daily at 04:00), `VatVerificationsReportJob` (daily at 11:00), and finished-job cleanup.
+- Solid Queue (`bin/jobs` worker, `solid_queue` gem). Schedule lives in `config/recurring.yml` — currently `OverdueInvoicesReportJob` (every other day at 08:00), `ExpiringOffersReportJob` (daily at 07:30), `UpcomingOfferDeliveriesReportJob` (daily at 07:45), `RefreshStaleVatVerificationsJob` (daily at 04:00), `VatVerificationsReportJob` (daily at 11:00), and finished-job cleanup.
 - Worker status surfaced under **Configuration → Background Jobs** (`JobsStatusController`).
 
 ### Authentication

--- a/app/jobs/upcoming_offer_deliveries_report_job.rb
+++ b/app/jobs/upcoming_offer_deliveries_report_job.rb
@@ -1,0 +1,37 @@
+class UpcomingOfferDeliveriesReportJob < ApplicationJob
+  queue_as :default
+
+  DELIVERY_WINDOW = 5.days
+
+  def perform
+    offers = Offer.where(state: "accepted")
+                  .joins(:accepted_version)
+                  .where(offer_versions: { delivery_date: ..(Date.current + DELIVERY_WINDOW) })
+                  .includes(:customer, accepted_version: { milestones: :invoice })
+                  .order("offer_versions.delivery_date")
+
+    entries = offers.filter_map do |offer|
+      missing = missing_statuses(offer)
+      { offer: offer, missing: missing } if missing.any?
+    end
+    return if entries.empty?
+
+    UpcomingOfferDeliveriesMailer.with(entries: entries).upcoming_report.deliver_now
+  end
+
+  private
+
+  # What still stands between this offer's milestones and fully booked, sent
+  # invoices — empty when invoicing is complete and the offer needs no nagging.
+  def missing_statuses(offer)
+    milestones = offer.accepted_version.milestones
+    unconverted = milestones.count { |m| m.invoice.nil? }
+    unbooked = milestones.count { |m| m.invoice && !m.invoice.published? }
+    unsent = milestones.count { |m| m.invoice&.published? && m.invoice.email_sent_at.nil? }
+
+    { unconverted: unconverted, unbooked: unbooked, unsent: unsent }
+      .filter_map do |key, count|
+        I18n.t("mailers.upcoming_offer_deliveries.status.#{key}", count: count) if count > 0
+      end
+  end
+end

--- a/app/mailers/upcoming_offer_deliveries_mailer.rb
+++ b/app/mailers/upcoming_offer_deliveries_mailer.rb
@@ -1,0 +1,15 @@
+class UpcomingOfferDeliveriesMailer < ApplicationMailer
+  def upcoming_report
+    @entries = params[:entries]
+    @today = Date.current
+
+    I18n.with_locale(I18n.default_locale) do
+      mail(
+        to: @issuer.reporting_email,
+        subject: I18n.t("mailers.upcoming_offer_deliveries.subject",
+                        issuer_name: sanitize_header_value(@issuer.short_name),
+                        count: @entries.size)
+      )
+    end
+  end
+end

--- a/app/views/upcoming_offer_deliveries_mailer/upcoming_report.html.haml
+++ b/app/views/upcoming_offer_deliveries_mailer/upcoming_report.html.haml
@@ -1,0 +1,39 @@
+- content_for :title, t('mailers.upcoming_offer_deliveries.title', count: @entries.size)
+
+:css
+  table.upcoming {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 20px 0;
+    font-size: 14px;
+  }
+  table.upcoming th, table.upcoming td {
+    border: 1px solid #dee2e6;
+    padding: 8px 10px;
+    text-align: left;
+  }
+  table.upcoming th {
+    background-color: #f8f9fa;
+    font-weight: 600;
+  }
+
+.greeting
+  = t('mailers.upcoming_offer_deliveries.heading', date: l(@today))
+
+.main-message
+  = t('mailers.upcoming_offer_deliveries.main_message', count: @entries.size)
+
+%table.upcoming
+  %thead
+    %tr
+      %th= t('mailers.upcoming_offer_deliveries.columns.offer_number')
+      %th= t('mailers.upcoming_offer_deliveries.columns.customer')
+      %th= t('mailers.upcoming_offer_deliveries.columns.delivery_date')
+      %th= t('mailers.upcoming_offer_deliveries.columns.missing')
+  %tbody
+    - @entries.each do |entry|
+      %tr
+        %td= entry[:offer].document_number
+        %td= entry[:offer].customer.name
+        %td= l(entry[:offer].accepted_version.delivery_date)
+        %td= entry[:missing].join('; ')

--- a/app/views/upcoming_offer_deliveries_mailer/upcoming_report.text.haml
+++ b/app/views/upcoming_offer_deliveries_mailer/upcoming_report.text.haml
@@ -1,0 +1,6 @@
+= t('mailers.upcoming_offer_deliveries.heading', date: l(@today))
+\
+= t('mailers.upcoming_offer_deliveries.main_message', count: @entries.size)
+\
+- @entries.each do |entry|
+  = "#{entry[:offer].document_number}  #{entry[:offer].customer.name}  #{t('mailers.upcoming_offer_deliveries.short.delivery')} #{l(entry[:offer].accepted_version.delivery_date)}  #{entry[:missing].join('; ')}"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -41,6 +41,33 @@ de:
       short:
         expired_on: "Abgelaufen:"
 
+    upcoming_offer_deliveries:
+      subject:
+        one: "[%{issuer_name}] 1 Angebotslieferung naht mit offener Verrechnung"
+        other: "[%{issuer_name}] %{count} Angebotslieferungen nahen mit offener Verrechnung"
+      title: "Bericht über anstehende Angebotslieferungen"
+      heading: "Anstehende Angebotslieferungen am %{date}"
+      main_message:
+        one: "1 angenommenes Angebot erreicht den Liefertermin innerhalb von 5 Tagen ohne vollständig gebuchte und versendete Rechnungen."
+        other: "%{count} angenommene Angebote erreichen den Liefertermin innerhalb von 5 Tagen ohne vollständig gebuchte und versendete Rechnungen."
+      columns:
+        offer_number: "Angebotsnr."
+        customer: "Kunde"
+        delivery_date: "Liefertermin"
+        missing: "Offen"
+      short:
+        delivery: "Lieferung:"
+      status:
+        unconverted:
+          one: "1 Meilenstein nicht umgewandelt"
+          other: "%{count} Meilensteine nicht umgewandelt"
+        unbooked:
+          one: "1 Rechnung nicht gebucht"
+          other: "%{count} Rechnungen nicht gebucht"
+        unsent:
+          one: "1 Rechnung nicht versendet"
+          other: "%{count} Rechnungen nicht versendet"
+
     invoice:
       subject: "%{issuer_name} Rechnung %{document_number}"
       greeting: "Sehr geehrte Damen und Herren,"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -117,6 +117,33 @@ en:
       short:
         expired_on: "Expired:"
 
+    upcoming_offer_deliveries:
+      subject:
+        one: "[%{issuer_name}] 1 offer delivery nearing with open invoicing"
+        other: "[%{issuer_name}] %{count} offer deliveries nearing with open invoicing"
+      title: "Upcoming offer deliveries report"
+      heading: "Offer deliveries nearing as of %{date}"
+      main_message:
+        one: "1 accepted offer reaches its delivery date within 5 days without fully booked and sent invoices."
+        other: "%{count} accepted offers reach their delivery date within 5 days without fully booked and sent invoices."
+      columns:
+        offer_number: "Offer no."
+        customer: "Customer"
+        delivery_date: "Delivery date"
+        missing: "Missing"
+      short:
+        delivery: "Delivery:"
+      status:
+        unconverted:
+          one: "1 milestone not converted"
+          other: "%{count} milestones not converted"
+        unbooked:
+          one: "1 invoice not booked"
+          other: "%{count} invoices not booked"
+        unsent:
+          one: "1 invoice not sent"
+          other: "%{count} invoices not sent"
+
     invoice:
       subject: "%{issuer_name} Invoice %{document_number}"
       greeting: "Dear %{customer_name},"

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -21,6 +21,10 @@ production:
     class: OverdueInvoicesReportJob
     queue: default
     schedule: "0 8 */2 * *"
+  upcoming_offer_deliveries_report:
+    class: UpcomingOfferDeliveriesReportJob
+    queue: default
+    schedule: every day at 07:45
   refresh_vat_verifications:
     class: RefreshStaleVatVerificationsJob
     queue: default

--- a/test/jobs/upcoming_offer_deliveries_report_job_test.rb
+++ b/test/jobs/upcoming_offer_deliveries_report_job_test.rb
@@ -1,0 +1,76 @@
+require "test_helper"
+
+class UpcomingOfferDeliveriesReportJobTest < ActiveJob::TestCase
+  include ActionMailer::TestHelper
+
+  setup do
+    @offer = offers(:sent_offer)
+    @offer.accept!(order_number: "PO-77", ordered_on: Date.current)
+    @offer.accepted_version.update!(delivery_date: Date.current + 3)
+  end
+
+  test "reports a nearing delivery with unconverted milestones in one digest" do
+    assert_emails 1 do
+      UpcomingOfferDeliveriesReportJob.perform_now
+    end
+    mail = ActionMailer::Base.deliveries.last
+    assert_equal [ IssuerCompany.get_the_issuer!.reporting_email ], mail.to
+    [ mail.html_part.body.to_s, mail.text_part.body.to_s ].each do |body|
+      assert_match @offer.document_number, body
+      assert_match @offer.customer.name, body
+      assert_match @offer.accepted_version.delivery_date.strftime("%d.%m.%Y"), body
+      assert_match "2 milestones not converted", body
+    end
+  end
+
+  test "distinguishes unbooked and unsent invoices in the status" do
+    offer_milestones(:sent_ms_one).update!(invoice: build_invoice(published: false))
+    offer_milestones(:sent_ms_two).update!(invoice: build_invoice(published: true))
+    assert_emails 1 do
+      UpcomingOfferDeliveriesReportJob.perform_now
+    end
+    body = ActionMailer::Base.deliveries.last.text_part.body.to_s
+    assert_match "1 invoice not booked", body
+    assert_match "1 invoice not sent", body
+    assert_no_match(/not converted/, body)
+  end
+
+  test "no-op when every milestone has a booked and sent invoice" do
+    offer_milestones(:sent_ms_one).update!(invoice: build_invoice(published: true, sent: true))
+    offer_milestones(:sent_ms_two).update!(invoice: build_invoice(published: true, sent: true))
+    assert_emails 0 do
+      UpcomingOfferDeliveriesReportJob.perform_now
+    end
+  end
+
+  test "no-op when the delivery date is beyond the window" do
+    @offer.accepted_version.update!(delivery_date: Date.current + 10)
+    assert_emails 0 do
+      UpcomingOfferDeliveriesReportJob.perform_now
+    end
+  end
+
+  test "an overdue delivery date keeps being reported" do
+    @offer.accepted_version.update!(delivery_date: Date.yesterday)
+    assert_emails 1 do
+      UpcomingOfferDeliveriesReportJob.perform_now
+    end
+  end
+
+  test "offers without a delivery date or not accepted are ignored" do
+    @offer.accepted_version.update!(delivery_date: nil)
+    offers(:draft_offer).draft_version.update!(delivery_date: Date.current)
+    assert_emails 0 do
+      UpcomingOfferDeliveriesReportJob.perform_now
+    end
+  end
+
+  private
+
+  def build_invoice(published:, sent: false)
+    Invoice.create!(customer: @offer.customer, project: @offer.project,
+                    customer_country_iso2: @offer.customer.country_iso2,
+                    date: Date.current, published: published,
+                    email_sent_at: (Time.current if sent))
+  end
+end


### PR DESCRIPTION
Adds `UpcomingOfferDeliveriesReportJob` (daily at 07:45, following the overdue-invoices/expiring-offers pattern): it finds **accepted** offers whose accepted version's delivery date is within 5 days — including already-past dates, so it keeps nagging daily until resolved — where not every milestone has a booked **and sent** invoice, and mails one digest to the issuer's reporting address.

Per offer the digest shows number, customer, delivery date, and exactly what's missing:
- `N milestones not converted` (no invoice yet)
- `N invoices not booked` (converted, still draft)
- `N invoices not sent` (booked, no email yet)

Offers with complete invoicing, no delivery date, or outside the window are skipped; a run with nothing to report sends no email. English + German mailer strings with proper pluralization; CLAUDE.md job enumeration updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)