### PR TITLE
State the decision on decided offers

### DIFF
--- a/app/views/offers/show.html.haml
+++ b/app/views/offers/show.html.haml
@@ -97,17 +97,26 @@
               .col-sm-8
                 = l(sent_version.sent_at.to_date)
           = render 'shared/email_status_row', resource: @offer, can_edit: can?('offers.edit'), show_send_button: sent_version.attachment.present?
-          - if can?('offers.edit')
+          - if can?('offers.edit') || @offer.accepted? || @offer.rejected?
             .row.mb-2{data: {controller: 'modal'}}
               .col-sm-4
                 %strong Decision:
               .col-sm-8.d-flex.align-items-center.gap-2
-                - if @offer.sent?
-                  %button.btn.btn-sm.btn-success.ms-auto{data: {action: 'click->modal#open'}} Accept…
-                  = button_to 'Reject', reject_offer_path(@offer), method: :post, class: 'btn btn-sm btn-outline-danger', data: { 'turbo-confirm': 'Reject this offer?' }
-                  = render 'accept_modal'
-                - elsif @offer.accepted? || @offer.rejected?
-                  = button_to 'Reopen', reopen_offer_path(@offer), method: :post, class: 'btn btn-sm btn-outline-secondary', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Reopen this offer? A fresh draft version branches from the accepted version.' }
+                - if @offer.accepted?
+                  %span.badge.bg-success Accepted
+                  - if @offer.accepted_at
+                    = l(@offer.accepted_at.to_date)
+                - elsif @offer.rejected?
+                  %span.badge.bg-danger Rejected
+                  - if @offer.rejected_at
+                    = l(@offer.rejected_at.to_date)
+                - if can?('offers.edit')
+                  - if @offer.sent?
+                    %button.btn.btn-sm.btn-success.ms-auto{data: {action: 'click->modal#open'}} Accept…
+                    = button_to 'Reject', reject_offer_path(@offer), method: :post, class: 'btn btn-sm btn-outline-danger', data: { 'turbo-confirm': 'Reject this offer?' }
+                    = render 'accept_modal'
+                  - elsif @offer.accepted? || @offer.rejected?
+                    = button_to 'Reopen', reopen_offer_path(@offer), method: :post, class: 'btn btn-sm btn-outline-secondary', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Reopen this offer? A fresh draft version branches from the accepted version.' }
 
   - if @offer.accepted?
     .mb-4

--- a/test/controllers/offers_controller_test.rb
+++ b/test/controllers/offers_controller_test.rb
@@ -202,6 +202,22 @@ class OffersControllerTest < ActionDispatch::IntegrationTest
     assert_nil offer.reload.email_sent_at
   end
 
+  test "show states the decision on accepted offers" do
+    offer = offers(:sent_offer)
+    offer.accept!(order_number: "PO", ordered_on: Date.current)
+    get offer_url(offer)
+    assert_select ".badge.bg-success", text: "Accepted", minimum: 2
+    assert_match offer.accepted_at.to_date.strftime("%d.%m.%Y"), response.body
+  end
+
+  test "show states the decision on rejected offers" do
+    offer = offers(:sent_offer)
+    offer.reject!
+    get offer_url(offer)
+    assert_select ".badge.bg-danger", text: "Rejected", minimum: 2
+    assert_match offer.rejected_at.to_date.strftime("%d.%m.%Y"), response.body
+  end
+
   private
 
   def attach_pdf_to(version)


### PR DESCRIPTION
The Decision row on the offer page only carried action buttons: an accepted or rejected offer showed a bare "Reopen" button with no statement of the decision, and view-only users saw no row at all (it was gated on `offers.edit`). The rejection date wasn't visible anywhere on the page.

Now:
- The row shows an **Accepted**/**Rejected** badge (matching the header badge colors) with the decision date.
- It renders for viewers too once a decision exists; Accept…/Reject/Reopen stay editor-only alongside.

Controller tests pin badge + date for both outcomes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)