### PR TITLE
Refine offer list status and columns

### DIFF
--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -20,7 +20,8 @@ class OffersController < ApplicationController
     @state_filter = params[:state].presence_in(Offer::STATES) || "all"
     @selected_customer_id = params[:customer_id].presence&.to_i
 
-    scope = Offer.visible_to(current_user).ordered.includes(:customer, :project)
+    scope = Offer.visible_to(current_user).ordered
+                 .includes(:customer, :project, draft_version: :milestones, accepted_version: { milestones: :invoice })
     scope = scope.in_year(@selected_year, include_drafts: @selected_year == Date.current.year) unless @selected_year == "all"
     scope = scope.where(state: @state_filter) unless @state_filter == "all"
     scope = scope.where(customer_id: @selected_customer_id) if @selected_customer_id

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -123,11 +123,31 @@ class Offer < ApplicationRecord
   end
 
   def status_badge
-    { "draft" => [ "Draft", "bg-secondary" ],
-      "sent" => [ "Sent", "bg-info text-dark" ],
-      "accepted" => [ "Accepted", "bg-success" ],
-      "rejected" => [ "Rejected", "bg-danger" ],
-      "expired" => [ "Expired", "bg-warning text-dark" ] }.fetch(state)
+    if accepted?
+      case accepted_invoicing_status
+      when :paid then [ "Paid", "bg-success" ]
+      when :invoiced then [ "Invoiced", "bg-info text-dark" ]
+      else [ "Ordered", "bg-primary" ]
+      end
+    else
+      { "draft" => [ "Draft", "bg-secondary" ],
+        "sent" => [ "Sent", "bg-warning text-dark" ],
+        "rejected" => [ "Rejected", "bg-danger" ],
+        "expired" => [ "Expired", "bg-warning text-dark" ] }.fetch(state)
+    end
+  end
+
+  # Once accepted, the status refines by invoicing progress: :invoiced when every
+  # milestone has a booked invoice, :paid when those invoices are all paid too,
+  # nil while any milestone is still un- or under-invoiced.
+  def accepted_invoicing_status
+    milestones = accepted_version&.milestones.to_a
+    return nil if milestones.empty?
+
+    invoices = milestones.map(&:invoice)
+    return nil unless invoices.all? { |invoice| invoice&.published? }
+
+    invoices.all?(&:paid?) ? :paid : :invoiced
   end
 
   def attach_order_pdf(uploaded_file)

--- a/app/views/offers/index.html.haml
+++ b/app/views/offers/index.html.haml
@@ -2,7 +2,8 @@
 
 .btn-toolbar.mb-3{:role=>"toolbar", "aria-label"=>"List toolbar"}
   .btn-group.btn-group-sm.me-2.offer-filter{:role=>"group", "aria-label"=>"Filter"}
-    - ([ [ 'all', 'All' ] ] + Offer::STATES.map { |s| [ s, s.capitalize ] }).each do |state, label|
+    - state_labels = { 'accepted' => 'Ordered' }
+    - ([ [ 'all', 'All' ] ] + Offer::STATES.map { |s| [ s, state_labels.fetch(s, s.capitalize) ] }).each do |state, label|
       = link_to label, offers_path(state: state, year: @selected_year, customer_id: @selected_customer_id), class: (@state_filter == state ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
 
   = render 'shared/customer_filter',
@@ -24,9 +25,9 @@
       %th Customer
     %th Project
     %th Int.Reference
-    %th Subject
     - if @state_filter == 'all'
       %th Status
+    %th Delivery date
     %th.numeric Sum Net
     %th Valid until
 
@@ -38,10 +39,10 @@
         %td{:title => offer.customer.name}= offer.customer.matchcode
       %td{:title => offer.project && offer.project.display_name}= offer.project && offer.project.matchcode
       %td= offer.internal_reference
-      %td= version&.subject
       - if @state_filter == 'all'
         %td
           - label, badge_class = offer.status_badge
           %span.badge{class: badge_class}= label
+      %td= l(version.delivery_date) if version&.delivery_date
       %td.numeric= format_currency(version&.sum_net || 0)
       %td= l(offer.expires_at) if offer.expires_at

--- a/app/views/offers/show.html.haml
+++ b/app/views/offers/show.html.haml
@@ -103,7 +103,7 @@
                 %strong Decision:
               .col-sm-8.d-flex.align-items-center.gap-2
                 - if @offer.accepted?
-                  %span.badge.bg-success Accepted
+                  %span.badge.bg-primary Ordered
                   - if @offer.accepted_at
                     = l(@offer.accepted_at.to_date)
                 - elsif @offer.rejected?
@@ -126,7 +126,7 @@
         .card-body
           .row.mb-2
             .col-sm-4
-              %strong Accepted:
+              %strong Ordered:
             .col-sm-8
               = l(@offer.accepted_at.to_date) if @offer.accepted_at
               %span.text-muted.ms-2 (version #{@offer.accepted_version.version_number})

--- a/test/controllers/offers_controller_test.rb
+++ b/test/controllers/offers_controller_test.rb
@@ -206,7 +206,7 @@ class OffersControllerTest < ActionDispatch::IntegrationTest
     offer = offers(:sent_offer)
     offer.accept!(order_number: "PO", ordered_on: Date.current)
     get offer_url(offer)
-    assert_select ".badge.bg-success", text: "Accepted", minimum: 2
+    assert_select ".badge.bg-primary", text: "Ordered", minimum: 2
     assert_match offer.accepted_at.to_date.strftime("%d.%m.%Y"), response.body
   end
 

--- a/test/models/offer_test.rb
+++ b/test/models/offer_test.rb
@@ -138,4 +138,42 @@ class OfferTest < ActiveSupport::TestCase
     offer.update!(internal_notes: "<div>keep<br><br>this</div><p><br></p>")
     assert_equal "<div>keep<br><br>this</div>", offer.reload.internal_notes.body.to_html
   end
+  test "accepted offer shows Ordered until milestones are invoiced" do
+    offer = offers(:sent_offer)
+    offer.accept!(order_number: "PO", ordered_on: Date.current)
+    assert_equal [ "Ordered", "bg-primary" ], offer.status_badge
+  end
+
+  test "accepted offer shows Invoiced once every milestone has a booked invoice" do
+    offer = offers(:sent_offer)
+    offer.accept!(order_number: "PO", ordered_on: Date.current)
+    offer.accepted_version.milestones.each { |m| m.update!(invoice: booked_invoice(offer)) }
+    assert_equal [ "Invoiced", "bg-info text-dark" ], offer.status_badge
+  end
+
+  test "a single unbooked invoice keeps the status at Ordered" do
+    offer = offers(:sent_offer)
+    offer.accept!(order_number: "PO", ordered_on: Date.current)
+    milestones = offer.accepted_version.milestones.to_a
+    milestones.first.update!(invoice: booked_invoice(offer))
+    milestones.last.update!(invoice: Invoice.create!(customer: offer.customer, project: offer.project,
+                                                     customer_country_iso2: offer.customer.country_iso2,
+                                                     date: Date.current, published: false))
+    assert_equal [ "Ordered", "bg-primary" ], offer.status_badge
+  end
+
+  test "accepted offer shows Paid once every invoice is paid" do
+    offer = offers(:sent_offer)
+    offer.accept!(order_number: "PO", ordered_on: Date.current)
+    offer.accepted_version.milestones.each { |m| m.update!(invoice: booked_invoice(offer, paid: true)) }
+    assert_equal [ "Paid", "bg-success" ], offer.status_badge
+  end
+
+  private
+
+  def booked_invoice(offer, paid: false)
+    Invoice.create!(customer: offer.customer, project: offer.project,
+                    customer_country_iso2: offer.customer.country_iso2,
+                    date: Date.current, published: true, paid_at: (Time.current if paid))
+  end
 end


### PR DESCRIPTION
## Status column reflects invoicing progress
For accepted offers the Status now refines by how far invoicing has gone:
- **Ordered** (blue) — accepted, milestones not fully invoiced yet (renamed from "Accepted")
- **Invoiced** (cyan) — every milestone has a booked invoice
- **Paid** (green) — those invoices are all paid too

Other states: **Sent** is now yellow; Draft/Rejected/Expired unchanged. The rename + recolor also applies to the show-page header badge, the Decision-row badge, and the state filter button; the order card's date label becomes "Ordered:".

## List columns
- Removed the **Subject** column.
- Added a **Delivery date** column after **Status**.

Model tests cover the Ordered → Invoiced → Paid transitions (including that one unbooked invoice holds it at Ordered); index eager-loads the accepted version's milestones + invoices to avoid N+1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)