### PR TITLE
Mute the Rejected offer status

### DIFF
--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -132,7 +132,7 @@ class Offer < ApplicationRecord
     else
       { "draft" => [ "Draft", "bg-secondary" ],
         "sent" => [ "Sent", "bg-warning text-dark" ],
-        "rejected" => [ "Rejected", "bg-danger" ],
+        "rejected" => [ "Rejected", "bg-secondary" ],
         "expired" => [ "Expired", "bg-warning text-dark" ] }.fetch(state)
     end
   end

--- a/app/views/offers/show.html.haml
+++ b/app/views/offers/show.html.haml
@@ -107,7 +107,7 @@
                   - if @offer.accepted_at
                     = l(@offer.accepted_at.to_date)
                 - elsif @offer.rejected?
-                  %span.badge.bg-danger Rejected
+                  %span.badge.bg-secondary Rejected
                   - if @offer.rejected_at
                     = l(@offer.rejected_at.to_date)
                 - if can?('offers.edit')

--- a/test/controllers/offers_controller_test.rb
+++ b/test/controllers/offers_controller_test.rb
@@ -214,7 +214,7 @@ class OffersControllerTest < ActionDispatch::IntegrationTest
     offer = offers(:sent_offer)
     offer.reject!
     get offer_url(offer)
-    assert_select ".badge.bg-danger", text: "Rejected", minimum: 2
+    assert_select ".badge.bg-secondary", text: "Rejected", minimum: 2
     assert_match offer.rejected_at.to_date.strftime("%d.%m.%Y"), response.body
   end
 


### PR DESCRIPTION
A rejected offer is almost always final — nothing left to act on — so the red "attention" badge is overkill. The Rejected badge now renders muted (`bg-secondary`) on the offer list, the show-page header, and the Decision row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)