### PR TITLE
Flag urgent offer deliveries on the list and in the report

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.scss
@@ -115,3 +115,12 @@ nav[aria-label="breadcrumb"] > div {
 .document-details .row {
   border-bottom: 1px solid var(--bs-border-color-translucent);
 }
+
+// Offer list: a delivery date that needs attention. Bootstrap's --bs-danger is
+// too dark on the dark background, so lighten it under data-bs-theme="dark".
+.delivery-urgent {
+  color: var(--bs-danger);
+}
+[data-bs-theme="dark"] .delivery-urgent {
+  color: #ff8085;
+}

--- a/app/jobs/upcoming_offer_deliveries_report_job.rb
+++ b/app/jobs/upcoming_offer_deliveries_report_job.rb
@@ -1,12 +1,14 @@
 class UpcomingOfferDeliveriesReportJob < ApplicationJob
   queue_as :default
 
+  FAR_FUTURE = Date.new(9999, 1, 1)
+
   def perform
     offers = Offer.where(state: "accepted")
-                  .joins(:accepted_version)
-                  .where(offer_versions: { delivery_date: ..(Date.current + Offer::DELIVERY_SOON_WINDOW) })
                   .includes(:customer, accepted_version: { milestones: :invoice })
-                  .order("offer_versions.delivery_date")
+                  .to_a
+                  .select { |offer| report?(offer) }
+                  .sort_by { |offer| offer.accepted_version.delivery_date || FAR_FUTURE }
 
     entries = offers.filter_map do |offer|
       missing = missing_statuses(offer)
@@ -18,6 +20,24 @@ class UpcomingOfferDeliveriesReportJob < ApplicationJob
   end
 
   private
+
+  # An accepted offer needs attention when its delivery date is near or past, or
+  # when an on-order milestone (billable the moment the order lands) still has no
+  # booked invoice — the latter regardless of how far off delivery is.
+  def report?(offer)
+    delivery_soon?(offer) || on_order_awaiting_invoice?(offer)
+  end
+
+  def delivery_soon?(offer)
+    date = offer.accepted_version.delivery_date
+    date.present? && date <= Date.current + Offer::DELIVERY_SOON_WINDOW
+  end
+
+  def on_order_awaiting_invoice?(offer)
+    offer.accepted_version.milestones.any? do |milestone|
+      milestone.trigger == "on_order" && !milestone.invoice&.published?
+    end
+  end
 
   # What still stands between this offer's milestones and fully booked, sent
   # invoices — empty when invoicing is complete and the offer needs no nagging.

--- a/app/jobs/upcoming_offer_deliveries_report_job.rb
+++ b/app/jobs/upcoming_offer_deliveries_report_job.rb
@@ -1,12 +1,10 @@
 class UpcomingOfferDeliveriesReportJob < ApplicationJob
   queue_as :default
 
-  DELIVERY_WINDOW = 5.days
-
   def perform
     offers = Offer.where(state: "accepted")
                   .joins(:accepted_version)
-                  .where(offer_versions: { delivery_date: ..(Date.current + DELIVERY_WINDOW) })
+                  .where(offer_versions: { delivery_date: ..(Date.current + Offer::DELIVERY_SOON_WINDOW) })
                   .includes(:customer, accepted_version: { milestones: :invoice })
                   .order("offer_versions.delivery_date")
 

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -8,6 +8,9 @@ class Offer < ApplicationRecord
 
   STATES = %w[draft sent accepted rejected expired].freeze
 
+  # Delivery is "soon" within this window (shared with UpcomingOfferDeliveriesReportJob).
+  DELIVERY_SOON_WINDOW = 5.days
+
   belongs_to :customer
   belongs_to :project
   belongs_to :customer_contact, optional: true
@@ -148,6 +151,19 @@ class Offer < ApplicationRecord
     return nil unless invoices.all? { |invoice| invoice&.published? }
 
     invoices.all?(&:paid?) ? :paid : :invoiced
+  end
+
+  def fully_invoiced?
+    accepted_invoicing_status.present?
+  end
+
+  # True when the shown version's delivery date is near or past and invoicing
+  # isn't complete yet — drives the red delivery date on the offers list.
+  def delivery_date_urgent?
+    date = (draft_version || current_sent_version)&.delivery_date
+    return false if date.nil? || fully_invoiced?
+
+    date <= Date.current + DELIVERY_SOON_WINDOW
   end
 
   def attach_order_pdf(uploaded_file)

--- a/app/views/offers/index.html.haml
+++ b/app/views/offers/index.html.haml
@@ -43,6 +43,6 @@
         %td
           - label, badge_class = offer.status_badge
           %span.badge{class: badge_class}= label
-      %td= l(version.delivery_date) if version&.delivery_date
+      %td{class: ('delivery-urgent' if offer.delivery_date_urgent?)}= l(version.delivery_date) if version&.delivery_date
       %td.numeric= format_currency(version&.sum_net || 0)
       %td= l(offer.expires_at) if offer.expires_at

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -48,8 +48,8 @@ de:
       title: "Bericht über anstehende Angebotslieferungen"
       heading: "Anstehende Angebotslieferungen am %{date}"
       main_message:
-        one: "1 angenommenes Angebot erreicht den Liefertermin innerhalb von 5 Tagen ohne vollständig gebuchte und versendete Rechnungen."
-        other: "%{count} angenommene Angebote erreichen den Liefertermin innerhalb von 5 Tagen ohne vollständig gebuchte und versendete Rechnungen."
+        one: "1 angenommenes Angebot braucht Verrechnungsaufmerksamkeit: Liefertermin innerhalb von 5 Tagen oder ein Meilenstein bei Auftrag ist noch nicht gebucht."
+        other: "%{count} angenommene Angebote brauchen Verrechnungsaufmerksamkeit: Liefertermin innerhalb von 5 Tagen oder ein Meilenstein bei Auftrag ist noch nicht gebucht."
       columns:
         offer_number: "Angebotsnr."
         customer: "Kunde"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -124,8 +124,8 @@ en:
       title: "Upcoming offer deliveries report"
       heading: "Offer deliveries nearing as of %{date}"
       main_message:
-        one: "1 accepted offer reaches its delivery date within 5 days without fully booked and sent invoices."
-        other: "%{count} accepted offers reach their delivery date within 5 days without fully booked and sent invoices."
+        one: "1 accepted offer needs invoicing attention: delivery is within 5 days or an on-order milestone is not yet booked."
+        other: "%{count} accepted offers need invoicing attention: delivery is within 5 days or an on-order milestone is not yet booked."
       columns:
         offer_number: "Offer no."
         customer: "Customer"

--- a/test/controllers/offers_controller_test.rb
+++ b/test/controllers/offers_controller_test.rb
@@ -218,6 +218,22 @@ class OffersControllerTest < ActionDispatch::IntegrationTest
     assert_match offer.rejected_at.to_date.strftime("%d.%m.%Y"), response.body
   end
 
+  test "index marks an urgent delivery date in red" do
+    offer = offers(:sent_offer)
+    offer.accept!(order_number: "PO", ordered_on: Date.current)
+    offer.accepted_version.update!(delivery_date: Date.current + 2)
+    get offers_url(year: "all")
+    assert_select "td.delivery-urgent"
+  end
+
+  test "index leaves a comfortable delivery date uncolored" do
+    offer = offers(:sent_offer)
+    offer.accept!(order_number: "PO", ordered_on: Date.current)
+    offer.accepted_version.update!(delivery_date: Date.current + 30)
+    get offers_url(year: "all")
+    assert_select "td.delivery-urgent", false
+  end
+
   private
 
   def attach_pdf_to(version)

--- a/test/jobs/upcoming_offer_deliveries_report_job_test.rb
+++ b/test/jobs/upcoming_offer_deliveries_report_job_test.rb
@@ -43,13 +43,6 @@ class UpcomingOfferDeliveriesReportJobTest < ActiveJob::TestCase
     end
   end
 
-  test "no-op when the delivery date is beyond the window" do
-    @offer.accepted_version.update!(delivery_date: Date.current + 10)
-    assert_emails 0 do
-      UpcomingOfferDeliveriesReportJob.perform_now
-    end
-  end
-
   test "an overdue delivery date keeps being reported" do
     @offer.accepted_version.update!(delivery_date: Date.yesterday)
     assert_emails 1 do
@@ -57,8 +50,25 @@ class UpcomingOfferDeliveriesReportJobTest < ActiveJob::TestCase
     end
   end
 
-  test "offers without a delivery date or not accepted are ignored" do
-    @offer.accepted_version.update!(delivery_date: nil)
+  test "reports an unbooked on-order milestone even when delivery is far off" do
+    @offer.accepted_version.update!(delivery_date: Date.current + 30)
+    # sent_ms_one is an on_order milestone with no invoice
+    assert_emails 1 do
+      UpcomingOfferDeliveriesReportJob.perform_now
+    end
+  end
+
+  test "no-op when delivery is far and the on-order milestone is booked" do
+    @offer.accepted_version.update!(delivery_date: Date.current + 30)
+    offer_milestones(:sent_ms_one).update!(invoice: build_invoice(published: true))
+    assert_emails 0 do
+      UpcomingOfferDeliveriesReportJob.perform_now
+    end
+  end
+
+  test "a non-accepted offer is ignored even with a nearing delivery date" do
+    @offer.accepted_version.update!(delivery_date: Date.current + 30)
+    offer_milestones(:sent_ms_one).update!(invoice: build_invoice(published: true))
     offers(:draft_offer).draft_version.update!(delivery_date: Date.current)
     assert_emails 0 do
       UpcomingOfferDeliveriesReportJob.perform_now

--- a/test/models/offer_test.rb
+++ b/test/models/offer_test.rb
@@ -169,7 +169,40 @@ class OfferTest < ActiveSupport::TestCase
     assert_equal [ "Paid", "bg-success" ], offer.status_badge
   end
 
+  test "delivery date is urgent within the window" do
+    offer = accepted_with_delivery(Date.current + 3)
+    assert offer.delivery_date_urgent?
+  end
+
+  test "delivery date is urgent when already passed" do
+    offer = accepted_with_delivery(Date.yesterday)
+    assert offer.delivery_date_urgent?
+  end
+
+  test "delivery date is not urgent beyond the window" do
+    offer = accepted_with_delivery(Date.current + 10)
+    assert_not offer.delivery_date_urgent?
+  end
+
+  test "delivery date is not urgent without a date" do
+    offer = accepted_with_delivery(nil)
+    assert_not offer.delivery_date_urgent?
+  end
+
+  test "a fully invoiced offer keeps the default delivery color" do
+    offer = accepted_with_delivery(Date.current + 1)
+    offer.accepted_version.milestones.each { |m| m.update!(invoice: booked_invoice(offer)) }
+    assert_not offer.delivery_date_urgent?
+  end
+
   private
+
+  def accepted_with_delivery(date)
+    offer = offers(:sent_offer)
+    offer.accept!(order_number: "PO", ordered_on: Date.current)
+    offer.accepted_version.update!(delivery_date: date)
+    Offer.find(offer.id)
+  end
 
   def booked_invoice(offer, paid: false)
     Invoice.create!(customer: offer.customer, project: offer.project,


### PR DESCRIPTION
Two commits.

**1 — Urgent delivery dates on the offers list.** An offer whose shown delivery date is within five days (or already past) and that isn't fully invoiced yet now shows its delivery date in **red**; a fully invoiced offer keeps the default color. The red is theme-aware (a lighter shade under `data-bs-theme="dark"`). The five-day window is now `Offer::DELIVERY_SOON_WINDOW`, shared with the report job.

**2 — Expand the upcoming-deliveries report.** The daily job now also flags an accepted offer whenever an **on-order** milestone still lacks a booked invoice, regardless of how far off delivery is (those are billable the moment the order lands). Digest copy updated to state both reasons.

Model + controller + job tests cover the urgency states (near / past / far / no-date / fully-invoiced) and the expanded reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)