### PR TITLE
Require a subject to preview or send an offer

### DIFF
--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -54,6 +54,7 @@ class Offer < ApplicationRecord
     problems = []
     problems << "No draft version to send." if draft_version.nil?
     problems << "Add at least one milestone before sending." if draft_version && draft_version.milestones.none?
+    problems << "Add a subject before sending." if draft_version && draft_version.subject.blank?
     problems << "Offer is #{state}; reopen it before sending a revision." unless %w[draft sent expired].include?(state)
     problems
   end

--- a/app/views/offers/show.html.haml
+++ b/app/views/offers/show.html.haml
@@ -1,6 +1,6 @@
 - content_for :title, @offer.display_name
 - edit_action = action_button('Edit', edit_offer_path(@offer), permission: 'offers.edit') if @offer.editable?
-- preview_action = preview_button(preview_offer_path(@offer), permission: 'offers.view') if @offer.draft_version && @offer.draft_version.milestones.any?
+- preview_action = preview_button(preview_offer_path(@offer), permission: 'offers.view') if @offer.draft_version && @offer.draft_version.milestones.any? && @offer.draft_version.subject.present?
 - delete_action = delete_button(@offer) if @offer.deletable? && can?('offers.edit')
 = breadcrumbs ['Offers', offers_path], @offer.display_label, actions: [preview_action, delete_action], action: edit_action do
   - label, badge_class = @offer.status_badge

--- a/test/controllers/offers_controller_test.rb
+++ b/test/controllers/offers_controller_test.rb
@@ -367,6 +367,14 @@ class OffersControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_path
   end
 
+  test "preview is refused without a subject" do
+    offer = create_offer_with_milestone
+    offer.draft_version.update!(subject: "")
+    get preview_offer_url(offer)
+    assert_redirected_to offer_url(offer)
+    assert_match(/subject/i, flash[:alert])
+  end
+
   private
 
   def attach_pdf_to(version)

--- a/test/models/offer_test.rb
+++ b/test/models/offer_test.rb
@@ -195,6 +195,17 @@ class OfferTest < ActiveSupport::TestCase
     assert_not offer.delivery_date_urgent?
   end
 
+  test "send_problems requires a subject" do
+    offer = create_offer_with_milestone
+    offer.draft_version.update!(subject: "")
+    assert_includes offer.send_problems.join, "subject"
+  end
+
+  test "send_problems is empty for a complete draft" do
+    offer = create_offer_with_milestone
+    assert_empty offer.send_problems
+  end
+
   private
 
   def accepted_with_delivery(date)

--- a/test/support/document_factories.rb
+++ b/test/support/document_factories.rb
@@ -57,6 +57,7 @@ module DocumentFactories
 
   def create_offer_with_milestone(**kwargs)
     offer = create_draft_offer(**kwargs)
+    offer.draft_version.update!(subject: "Offer subject")
     offer.draft_version.milestones.create!(title: "Milestone", amount: 1000, trigger: "on_acceptance", position: 1)
     offer
   end


### PR DESCRIPTION
The customer-facing subject is the printed title of the offer, so an offer shouldn't go out without one. `subject` is now part of `Offer#send_problems`, which gates both **send** (via `OfferSender`) and **preview** (which redirects with the problem list) — one check covers both.

UI: the Send button already reflects `send_problems` (disabled with a tooltip); the Preview button now also stays hidden until the draft has a subject.

Tests cover the new `send_problems` entry and a subject-less preview being refused; the send-ready test factory now sets a subject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)