### PR TITLE
Show customer order number on the offers list

### DIFF
--- a/app/views/offers/index.html.haml
+++ b/app/views/offers/index.html.haml
@@ -25,6 +25,7 @@
       %th Customer
     %th Project
     %th Int.Reference
+    %th Cust.Order No.
     - if @state_filter == 'all'
       %th Status
     %th Delivery date
@@ -39,6 +40,7 @@
         %td{:title => offer.customer.name}= offer.customer.matchcode
       %td{:title => offer.project && offer.project.display_name}= offer.project && offer.project.matchcode
       %td= offer.internal_reference
+      %td= offer.order_number
       - if @state_filter == 'all'
         %td
           - label, badge_class = offer.status_badge

--- a/test/controllers/offers_controller_test.rb
+++ b/test/controllers/offers_controller_test.rb
@@ -11,6 +11,13 @@ class OffersControllerTest < ActionDispatch::IntegrationTest
     assert_select "td", text: offers(:sent_offer).document_number
   end
 
+  test "index shows the customer order number" do
+    offer = offers(:sent_offer)
+    offer.accept!(order_number: "PO-4711", ordered_on: Date.current)
+    get offers_url(state: "all", year: "all")
+    assert_select "td", text: "PO-4711"
+  end
+
   test "index denied without offers.view" do
     sign_in_as users(:bob)
     get offers_url


### PR DESCRIPTION
Add a **Cust.Order No.** column to the offers list, shown after **Int.Reference**. It surfaces `offer.order_number` (set when an offer is accepted).

## Testing
- `bundle exec rails test test/controllers/offers_controller_test.rb` — 39 runs, 0 failures. Includes a new test asserting the order number renders on the index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)