### PR TITLE
Group offer subject and prelude into a Proposal card

### DIFF
--- a/app/views/offers/show.html.haml
+++ b/app/views/offers/show.html.haml
@@ -157,8 +157,12 @@
   .mb-4
     .card
       .card-header
-        %h5.mb-0 Milestones
+        %h5.mb-0 Proposal
       .card-body
+        - if @version&.subject.present?
+          %h5.mb-3= @version.subject
+        - if @version&.prelude&.present?
+          .mb-3= @version.prelude
         - if @offer.accepted?
           = render 'conversion_rows'
         - elsif @version
@@ -194,12 +198,6 @@
             = form.rich_text_area :internal_notes, data: { controller: 'rich-text' }
             .text-end.mt-2
               = form.submit 'Save', class: 'btn btn-primary'
-
-  - if @version&.prelude&.present?
-    .mb-4
-      .card
-        .card-body
-          = @version.prelude
 
   - boilerplate = @version&.frozen? ? @version.boilerplate : @offer.customer.offer_boilerplate
   - if boilerplate&.present?

--- a/test/controllers/offers_controller_test.rb
+++ b/test/controllers/offers_controller_test.rb
@@ -218,6 +218,15 @@ class OffersControllerTest < ActionDispatch::IntegrationTest
     assert_match offer.rejected_at.to_date.strftime("%d.%m.%Y"), response.body
   end
 
+  test "show renders the version subject and prelude in the proposal card" do
+    offer = offers(:draft_offer)
+    offer.draft_version.update!(prelude: "Prelude body text")
+    get offer_url(offer)
+    assert_select ".card-header h5", text: "Proposal"
+    assert_select ".card-body h5", text: "Draft offer subject"
+    assert_match "Prelude body text", response.body
+  end
+
   test "index marks an urgent delivery date in red" do
     offer = offers(:sent_offer)
     offer.accept!(order_number: "PO", ordered_on: Date.current)


### PR DESCRIPTION
## Summary
- Rename the offer detail **Milestones** card to **Proposal**.
- Show the version **subject** (as a heading) and **prelude** inside that card, above the milestones table and the accepted-state conversion rows.
- Subject was previously visible only in the customer email and PDF; prelude moves out of its standalone card so both read as the head of the proposal content.

Both fields live on `OfferVersion` and render in every state via the existing `@version` the controller selects (draft version when editable, current sent version otherwise). Each is guarded by `present?`, so an offer with neither renders exactly as before.

## Test plan
- New controller test asserts subject + prelude render inside the Proposal card.
- `bundle exec rails test test/controllers/offers_controller_test.rb` — 40 runs, 0 failures.
- `bundle exec rails test test/system/offer_form_test.rb` — 6 runs, 0 failures.
- `pre-commit run --all-files` — passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)