### PR TITLE
Show the offer send-problem list instead of just a count

### DIFF
--- a/app/views/offers/show.html.haml
+++ b/app/views/offers/show.html.haml
@@ -2,6 +2,7 @@
 - edit_action = action_button('Edit', edit_offer_path(@offer), permission: 'offers.edit') if @offer.editable?
 - preview_action = preview_button(preview_offer_path(@offer), permission: 'offers.view') if @offer.draft_version && @offer.draft_version.milestones.any?
 - delete_action = delete_button(@offer) if @offer.deletable? && can?('offers.edit')
+- problems = @offer.editable? ? @offer.send_problems : []
 = breadcrumbs ['Offers', offers_path], @offer.display_label, actions: [preview_action, delete_action], action: edit_action do
   - label, badge_class = @offer.status_badge
   %span.badge{class: badge_class}= label
@@ -70,16 +71,23 @@
       .col-sm-4
         %strong Send:
       .col-sm-8.d-flex.align-items-center.gap-2
-        - problems = @offer.send_problems
         - if problems.any?
           %span.badge.bg-warning= pluralize(problems.size, 'problem')
-          - if can?('offers.edit')
-            %span.ms-auto{title: problems.join("\n")}
-              %button.btn.btn-sm.btn-info{disabled: true} 🚀 Send
         - else
           %span.badge.bg-success Ready
-          - if can?('offers.edit')
+        - if can?('offers.edit')
+          - if problems.any?
+            %span.ms-auto{title: problems.join("\n")}
+              %button.btn.btn-sm.btn-info{disabled: true} 🚀 Send
+          - else
             = button_to '🚀 Send', send_offer_offer_path(@offer), method: :post, class: 'btn btn-sm btn-info', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Send this offer to the customer? A PDF is generated and this version is frozen.' }
+
+  - if problems.any?
+    .alert.alert-warning.mb-3
+      %strong This offer cannot be sent yet:
+      %ul.mb-0
+        - problems.each do |p|
+          %li= p
 
   - if @offer.current_sent_version
     - sent_version = @offer.current_sent_version

--- a/test/controllers/offers_controller_test.rb
+++ b/test/controllers/offers_controller_test.rb
@@ -41,6 +41,14 @@ class OffersControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to offer_url(offers(:sent_offer))
   end
 
+  test "draft offer show renders problems alert and disabled Send button when there are no milestones" do
+    offer = create_draft_offer
+    get offer_url(offer)
+    assert_response :success
+    assert_select ".alert-warning li", text: /milestone/i
+    assert_select "button[disabled]", text: /Send/
+  end
+
   test "send_offer transitions to sent" do
     offer = create_offer_with_milestone
     post send_offer_offer_url(offer)


### PR DESCRIPTION
## Problem

An offer that can't be sent yet showed a bare `1 problem` badge. The actual reason lived only in a `title=` tooltip on the disabled Send button — invisible on touch devices and not rendered at all for users without `offers.edit`. The lone badge with a right-shoved disabled button also read as broken alignment.

## Fix

Copy the invoice/delivery-note pattern (`invoices/show` lines 152-157): keep the status badge + disabled button row, and add a full-width `.alert.alert-warning` listing every problem from `Offer#send_problems`. This also aligns the offer status row structure with invoices, resolving the odd spacing.

For an editable offer the only problem that fires is the missing-milestone case ("Add at least one milestone before sending."), which is now spelled out. Note `subject` is not a send blocker — it isn't validated in the send path.

## Test

Added a controller show test mirroring the invoice one: a draft with no milestones renders `.alert-warning li` with the milestone message and a disabled Send button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)