### PR TITLE
Hide the Addressed Contact field on new offers

### DIFF
--- a/app/views/offers/_form.html.haml
+++ b/app/views/offers/_form.html.haml
@@ -73,10 +73,11 @@
             = f.text_field :internal_reference, class: 'form-control'
 
       .row
-        .col-sm-4
-          .mb-3
-            = f.label :customer_contact_id, 'Addressed Contact', class: 'form-label'
-            = f.collection_select :customer_contact_id, @offer.customer&.customer_contacts || [], :id, :name, { include_blank: 'None' }, { class: 'form-select' }
+        - unless @offer.new_record?
+          .col-sm-4
+            .mb-3
+              = f.label :customer_contact_id, 'Addressed Contact', class: 'form-label'
+              = f.collection_select :customer_contact_id, @offer.customer&.customer_contacts || [], :id, :name, { include_blank: 'None' }, { class: 'form-select' }
         .col-sm-4
           .mb-3
             %label.form-label Document number

--- a/test/controllers/offers_controller_test.rb
+++ b/test/controllers/offers_controller_test.rb
@@ -240,6 +240,18 @@ class OffersControllerTest < ActionDispatch::IntegrationTest
     assert_select "input#offer_customer_id[value=?]", customers(:good_eu).id.to_s
   end
 
+  test "new omits the addressed contact field" do
+    get new_offer_url
+    assert_response :success
+    assert_select "select[name=?]", "offer[customer_contact_id]", false
+  end
+
+  test "edit renders the addressed contact field" do
+    get edit_offer_url(offers(:draft_offer))
+    assert_response :success
+    assert_select "select[name=?]", "offer[customer_contact_id]"
+  end
+
   test "create with invalid params re-renders the form" do
     assert_no_difference("Offer.count") do
       post offers_url, params: { offer: { customer_id: "", project_id: "" } }


### PR DESCRIPTION
## What

The **Addressed Contact** field was always empty on the *create new offer* page.

## Why

It's a static server-rendered `collection_select` whose options come from `@offer.customer&.customer_contacts`. On the new-offer page:

- No customer is selected yet — the Customer field is an async JS searchable dropdown — so `@offer.customer` is `nil` and the collection is empty.
- Unlike the **Project** field (a *dependent* async dropdown that reloads on customer change), the contact select is never repopulated client-side, so it stays empty even after a customer is picked.

`create` redirects to `edit_offer_path`, where the customer is set and the field renders its contacts correctly.

## Change

Show the field only for existing offers (`unless @offer.new_record?`). The create → edit flow already lands you on a page where the field works, so nothing is lost on the new page.

## Tests

- `new omits the addressed contact field`
- `edit renders the addressed contact field`

🤖 Generated with [Claude Code](https://claude.com/claude-code)