### PR TITLE
Link offer numbers in the offer report emails

### DIFF
--- a/app/services/absolute_url.rb
+++ b/app/services/absolute_url.rb
@@ -32,4 +32,8 @@ module AbsoluteUrl
   def delivery_note(dn)
     Rails.application.routes.url_helpers.delivery_note_url(dn, **options)
   end
+
+  def offer(offer)
+    Rails.application.routes.url_helpers.offer_url(offer, **options)
+  end
 end

--- a/app/views/expiring_offers_mailer/expiring_report.html.haml
+++ b/app/views/expiring_offers_mailer/expiring_report.html.haml
@@ -37,7 +37,7 @@
   %tbody
     - @offers.each do |offer|
       %tr
-        %td= offer.document_number
+        %td= link_to offer.document_number, AbsoluteUrl.offer(offer)
         %td= offer.customer.name
         %td= l(offer.expires_at) if offer.expires_at
         %td.numeric= sprintf('%.2f', offer.current_sent_version.sum_net)

--- a/app/views/expiring_offers_mailer/expiring_report.text.haml
+++ b/app/views/expiring_offers_mailer/expiring_report.text.haml
@@ -4,3 +4,4 @@
 \
 - @offers.each do |offer|
   = "#{offer.document_number}  #{offer.customer.name}  #{t('mailers.expiring_offers.short.expired_on')} #{l(offer.expires_at) if offer.expires_at}  #{sprintf('%.2f', offer.current_sent_version.sum_net)}"
+  = AbsoluteUrl.offer(offer)

--- a/app/views/upcoming_offer_deliveries_mailer/upcoming_report.html.haml
+++ b/app/views/upcoming_offer_deliveries_mailer/upcoming_report.html.haml
@@ -33,7 +33,7 @@
   %tbody
     - @entries.each do |entry|
       %tr
-        %td= entry[:offer].document_number
+        %td= link_to entry[:offer].document_number, AbsoluteUrl.offer(entry[:offer])
         %td= entry[:offer].customer.name
         %td= l(entry[:offer].accepted_version.delivery_date)
         %td= entry[:missing].join('; ')

--- a/app/views/upcoming_offer_deliveries_mailer/upcoming_report.text.haml
+++ b/app/views/upcoming_offer_deliveries_mailer/upcoming_report.text.haml
@@ -4,3 +4,4 @@
 \
 - @entries.each do |entry|
   = "#{entry[:offer].document_number}  #{entry[:offer].customer.name}  #{t('mailers.upcoming_offer_deliveries.short.delivery')} #{l(entry[:offer].accepted_version.delivery_date)}  #{entry[:missing].join('; ')}"
+  = AbsoluteUrl.offer(entry[:offer])

--- a/test/jobs/expiring_offers_report_job_test.rb
+++ b/test/jobs/expiring_offers_report_job_test.rb
@@ -46,12 +46,15 @@ class ExpiringOffersReportJobTest < ActiveJob::TestCase
     [ offer1, offer2 ].each do |offer|
       offer.reload
       version = offer.current_sent_version
+      offer_url = AbsoluteUrl.offer(offer)
       [ html, text ].each do |body|
         assert_match offer.document_number, body
         assert_match offer.customer.name, body
         assert_match offer.expires_at.strftime("%d.%m.%Y"), body
         assert_match sprintf("%.2f", version.sum_net), body
+        assert_match offer_url, body
       end
+      assert_match %r{href="#{Regexp.escape(offer_url)}"}, html
       assert offer.expired?
     end
   end

--- a/test/jobs/upcoming_offer_deliveries_report_job_test.rb
+++ b/test/jobs/upcoming_offer_deliveries_report_job_test.rb
@@ -23,6 +23,14 @@ class UpcomingOfferDeliveriesReportJobTest < ActiveJob::TestCase
     end
   end
 
+  test "links the offer number to the offer detail page" do
+    UpcomingOfferDeliveriesReportJob.perform_now
+    mail = ActionMailer::Base.deliveries.last
+    offer_url = AbsoluteUrl.offer(@offer)
+    assert_match %r{href="#{Regexp.escape(offer_url)}"}, mail.html_part.body.to_s
+    assert_match offer_url, mail.text_part.body.to_s
+  end
+
   test "distinguishes unbooked and unsent invoices in the status" do
     offer_milestones(:sent_ms_one).update!(invoice: build_invoice(published: false))
     offer_milestones(:sent_ms_two).update!(invoice: build_invoice(published: true))


### PR DESCRIPTION
## Summary
Render each offer number as a link to the offer detail page in both offer digest emails:
- **"Offer deliveries nearing…"** (`UpcomingOfferDeliveriesMailer`)
- **"Expired offers"** (`ExpiringOffersMailer`)

HTML part: `link_to` in the table cell; text part: bare URL on its own line — mirroring the existing VAT verifications report. Adds an `AbsoluteUrl.offer` helper so the URLs go through the established `Settings.app.*` path.

## Test plan
- Each report's job test asserts both the HTML `href` and the text URL point at the offer detail page.
- `bundle exec rails test test/jobs/upcoming_offer_deliveries_report_job_test.rb test/jobs/expiring_offers_report_job_test.rb` — 14 runs, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)