### PR TITLE
Tune Bootstrap theme colors to match the navbar gradient

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.scss
@@ -15,12 +15,11 @@ body { padding-top: 60px; }
 .navbar {
   background: linear-gradient(90deg,
     rgba(255, 99, 132, 0.8) 0%,
-    rgba(255, 159, 64, 0.8) 16.66%,
-    rgba(255, 205, 86, 0.8) 33.33%,
-    rgba(75, 192, 192, 0.8) 50%,
-    rgba(54, 162, 235, 0.8) 66.66%,
-    rgba(153, 102, 255, 0.8) 83.33%,
-    rgba(201, 203, 207, 0.8) 100%
+    rgba(255, 159, 64, 0.8) 20%,
+    rgba(255, 205, 86, 0.8) 40%,
+    rgba(75, 192, 192, 0.8) 60%,
+    rgba(54, 162, 235, 0.8) 80%,
+    rgba(153, 102, 255, 0.8) 100%
   ) !important;
 
   .navbar-brand {
@@ -35,17 +34,6 @@ body { padding-top: 60px; }
 
   .navbar-nav .nav-link.active, .navbar-nav .nav-link:hover {
     text-shadow: 0 0 10px rgba(255, 255, 255, 0.8);
-  }
-
-  .navbar-toggler {
-    border-color: #333 !important;
-  }
-
-  // The gradient's right edge (where the toggler always sits) is light in
-  // both color modes, so pin the icon to the light-background variant
-  // instead of following data-bs-theme.
-  .navbar-toggler-icon {
-    --bs-navbar-toggler-icon-bg: #{escape-svg($navbar-light-toggler-icon-bg)};
   }
 }
 

--- a/app/assets/stylesheets/bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.scss
@@ -1,3 +1,13 @@
+// Theme colors derived from the navbar gradient (teal-led). Deepened where
+// needed so filled buttons keep white text at >= 4.5:1 contrast; warning and
+// info stay light with dark text, matching stock Bootstrap's split.
+$primary:   #22807f;
+$secondary: #6f7278;
+$success:   #27794a;
+$danger:    #db2e58;
+$warning:   #ff9f40;
+$info:      #36a2eb;
+
 @import "bootstrap";
 body { padding-top: 60px; }
 
@@ -116,11 +126,12 @@ nav[aria-label="breadcrumb"] > div {
   border-bottom: 1px solid var(--bs-border-color-translucent);
 }
 
-// Offer list: a delivery date that needs attention. Bootstrap's --bs-danger is
-// too dark on the dark background, so lighten it under data-bs-theme="dark".
+// Offer list: a delivery date that needs attention. --bs-danger is too dark
+// on the dark background, so lighten it under data-bs-theme="dark" using
+// Bootstrap's own dark-mode emphasis formula.
 .delivery-urgent {
   color: var(--bs-danger);
 }
 [data-bs-theme="dark"] .delivery-urgent {
-  color: #ff8085;
+  color: tint-color($danger, 40%);
 }

--- a/app/assets/stylesheets/scaffolds.css.scss
+++ b/app/assets/stylesheets/scaffolds.css.scss
@@ -9,12 +9,12 @@ div {
 
   /* For form controls inside error wrapper */
   .form-control, .form-select {
-    border-color: #dc3545;
-    box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25);
+    border-color: var(--bs-danger);
+    box-shadow: 0 0 0 0.2rem rgba(var(--bs-danger-rgb), 0.25);
   }
 
   /* For labels */
   .form-label {
-    color: #dc3545;
+    color: var(--bs-danger);
   }
 }


### PR DESCRIPTION
Replaces the stock Bootstrap theme colors with a teal-led palette derived from the navbar gradient, and drops the grey stop from the gradient itself.

## Theme colors

| Role | Before | After |
|---|---|---|
| primary | `#0d6efd` | `#22807f` (gradient teal, deepened) |
| secondary | `#6c757d` | `#6f7278` (gradient grey, deepened) |
| success | `#198754` | `#27794a` |
| danger | `#dc3545` | `#db2e58` (gradient coral, deepened) |
| warning | `#ffc107` | `#ff9f40` (gradient orange) |
| info | `#0dcaf0` | `#36a2eb` (gradient blue) |

All filled-with-white-text roles clear 4.5:1 WCAG AA, so Bootstrap keeps the same white/black button-text split as stock — no component surprises. Buttons, badges, alerts, links, focus rings and the dark-mode subtle variants all regenerate from the six variables.

Follow-ups included:
- `.delivery-urgent` dark-mode color now derives from `$danger` via `tint-color` (Bootstrap's dark-mode emphasis formula) instead of a hand-tuned hex.
- `scaffolds.css.scss` form-error styling uses `var(--bs-danger)` / `var(--bs-danger-rgb)` instead of hardcoding the old red.

## Navbar gradient

The trailing grey stop is removed; the gradient now ends on purple. That edge has enough contrast for the theme-following toggler icon in both modes (dark icon 5.6:1 on light, white icon 4.9:1 on dark), so the light-variant icon pin and the `#333` border override are deleted.

Palette preview (all four candidate sets on mock ABT UI, light + dark): https://claude.ai/code/artifact/8d1f799c-776c-48bc-aac3-dc71c85e7bda

## Testing
- Full suite: 1021 runs, 0 failures
- System tests headless: 64 runs, 0 failures
- Verified compiled CSS emits the new `--bs-*` values and the derived `#e9829b` delivery-urgent tint

🤖 Generated with [Claude Code](https://claude.com/claude-code)