### PR TITLE
Fix system test teardown and Ferrum timeout flakes on CI

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -4,7 +4,8 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   cuprite_options = {
     js_errors: true,
     headless: ENV["HEADLESS"] != "0",  # Default to headless unless explicitly disabled
-    process_timeout: 30  # Chromium can take longer than the 10s default to start on busy CI runners
+    process_timeout: 30,  # Chromium can take longer than the 10s default to start on busy CI runners
+    timeout: 15  # First page load pays for Puma's cold start; Ferrum's 5s default flakes on busy CI runners
   }
 
   # Allow pointing at a non-standard Chromium binary (e.g. the Playwright build

--- a/test/system/customer_vat_verification_test.rb
+++ b/test/system/customer_vat_verification_test.rb
@@ -12,7 +12,9 @@ class CustomerVatVerificationTest < ApplicationSystemTestCase
   end
 
   teardown do
-    ActiveJob::Base.queue_adapter = @original_adapter
+    # Skip when setup died before capturing the adapter — assigning nil raises
+    # ArgumentError and buries the original failure.
+    ActiveJob::Base.queue_adapter = @original_adapter if @original_adapter
   end
 
   test "clicking Verify on a never-verified customer updates the row to verified" do


### PR DESCRIPTION
## Summary
Hardens system test reliability by fixing a teardown crash and increasing Ferrum's page-load timeout to account for Puma's cold start on busy CI runners.

## Key Changes
- **CustomerVatVerificationTest teardown**: Guard `ActiveJob::Base.queue_adapter` assignment with a nil check. When setup fails before capturing the original adapter, assigning `nil` raises `ArgumentError` and buries the actual setup failure. Now skips restoration if `@original_adapter` was never set.
- **ApplicationSystemTestCase Ferrum timeout**: Increase `timeout` from Ferrum's 5s default to 15s. The first page load in a test pays for Puma's cold start on busy CI runners, causing flaky timeouts. This aligns with the existing `process_timeout: 30` comment explaining CI runner constraints.

## Implementation Details
Both changes are defensive: they prevent test infrastructure failures from masking real test or application issues. The teardown guard ensures setup failures surface clearly rather than being replaced by a cryptic `ArgumentError`. The timeout increase acknowledges that CI environments have different performance characteristics than local development.

https://claude.ai/code/session_015knoDc45B6HaqteXvyzHao