### PR TITLE
Harden invite consumption against a single-use bypass race

### DIFF
--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -132,6 +132,8 @@ class InvitesController < ApplicationController
                             metadata: { username: user.username, address: pending["email"], via: "signup" })
 
     render json: { redirect_url: account_profile_path }
+  rescue UserInvite::AlreadyConsumed
+    render_invalid
   rescue ActiveRecord::RecordInvalid => e
     render json: { error: e.record.errors.full_messages.join(", ") }, status: :unprocessable_content
   end
@@ -174,6 +176,8 @@ class InvitesController < ApplicationController
     end
 
     render json: { redirect_url: account_profile_path }
+  rescue UserInvite::AlreadyConsumed
+    render_invalid
   rescue ActiveRecord::RecordInvalid => e
     render json: { error: e.record.errors.full_messages.join(", ") }, status: :unprocessable_content
   end

--- a/app/models/user_invite.rb
+++ b/app/models/user_invite.rb
@@ -1,6 +1,10 @@
 class UserInvite < ApplicationRecord
   include DigestedToken
 
+  # Raised when consume! loses the race to another concurrent flow that
+  # already claimed (or expired) the same invite.
+  class AlreadyConsumed < StandardError; end
+
   EXPIRY = 24.hours
 
   PURPOSE_SIGNUP = "signup".freeze
@@ -46,8 +50,19 @@ class UserInvite < ApplicationRecord
     usable.where(token_digest: digest_token(plaintext)).first
   end
 
+  # Atomically claim the invite. The conditional UPDATE re-checks the `usable`
+  # predicate (unused and unexpired) at the database level, so two concurrent
+  # WebAuthn flows carrying valid pending challenges for the same signup invite
+  # cannot both succeed: the loser's UPDATE affects zero rows and raises,
+  # rolling back its enclosing transaction (and the account it just built).
+  # A plain update! here would let one invite mint several accounts under a
+  # race, defeating invite-only signup's one-invite-one-account guarantee.
   def consume!(user:)
-    update!(used_at: Time.current, used_by_user: user)
+    claimed = self.class.usable.where(id: id).update_all(
+      used_at: Time.current, used_by_user_id: user.id
+    )
+    raise AlreadyConsumed, "invite #{id} already consumed" if claimed.zero?
+    reload
   end
 
   def signup?

--- a/test/models/user_invite_test.rb
+++ b/test/models/user_invite_test.rb
@@ -43,6 +43,27 @@ class UserInviteTest < ActiveSupport::TestCase
     assert_equal users(:alice), invite.used_by_user
   end
 
+  test "consume! raises AlreadyConsumed on a second claim of the same invite" do
+    invite, _plain = UserInvite.create_signup!(actor: nil)
+    invite.consume!(user: users(:alice))
+
+    # A concurrent flow holding its own reference to the still-unused invite
+    # loses the race: the conditional UPDATE affects zero rows.
+    other = UserInvite.find(invite.id)
+    assert_raises(UserInvite::AlreadyConsumed) do
+      other.consume!(user: users(:bob))
+    end
+    assert_equal users(:alice), invite.reload.used_by_user
+  end
+
+  test "consume! raises AlreadyConsumed when the invite has expired" do
+    invite, _plain = UserInvite.create_signup!(actor: nil)
+    invite.update_column(:expires_at, 1.minute.ago)
+    assert_raises(UserInvite::AlreadyConsumed) do
+      invite.consume!(user: users(:alice))
+    end
+  end
+
   test "signup invite cannot have a target_user" do
     invite = UserInvite.new(
       token_digest: "xyz",


### PR DESCRIPTION
## Problem

`UserInvite#consume!` did an unconditional `update!(used_at:)`, separated from the earlier `find_usable` check by the entire WebAuthn verification round-trip. Two concurrent signup flows, each carrying a valid pending challenge for the same still-usable invite, could both pass `find_usable` (used_at still nil) before either consumed it — minting **two accounts from one single-use invite** and defeating the invite-only signup guarantee. Sequential reuse was already blocked; this closes the concurrent (TOCTOU) window.

## Fix

- `consume!` now performs an atomic conditional claim: `usable.where(id:).update_all(...)` re-checks the `usable` predicate (unused **and** unexpired) at the database level. The race-loser's UPDATE affects zero rows and raises `UserInvite::AlreadyConsumed`, which rolls back its enclosing transaction (and the `User`/credential it just built).
- `InvitesController#complete_signup` and `#complete_passkey_reset` rescue `AlreadyConsumed` and return the standard invalid-invite response instead of a 500.
- As a side benefit, an invite that expires mid-flow is now also rejected at consume time.

## Tests

- `consume! raises AlreadyConsumed on a second claim of the same invite`
- `consume! raises AlreadyConsumed when the invite has expired`
- Existing invite model/controller and passkey-signup integration tests still pass (20 runs, 53 assertions green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYpZZettfDnpJdCUrcs38R

---
_Generated by [Claude Code](https://claude.ai/code/session_01QYpZZettfDnpJdCUrcs38R)_