### PR TITLE
Reject non-file acceptance_pdf param instead of 500ing

### DIFF
--- a/app/controllers/customer_portal/acceptances_controller.rb
+++ b/app/controllers/customer_portal/acceptances_controller.rb
@@ -37,7 +37,10 @@ module CustomerPortal
 
     # Returns a user-facing error string, or nil when the file is an acceptable PDF.
     def file_error(file)
-      return t("customer_portal.acceptance.errors.missing") if file.blank?
+      # A non-multipart param (e.g. acceptance_pdf=x) arrives as a String/Array,
+      # not an uploaded file. Treat it as "missing" rather than letting the
+      # later .size / .tempfile calls raise a 500 on an unauthenticated path.
+      return t("customer_portal.acceptance.errors.missing") if file.blank? || !file.respond_to?(:tempfile)
       return t("customer_portal.acceptance.errors.too_large", max: Attachment::MAX_SIZE_BYTES / 1.megabyte) if file.size > Attachment::MAX_SIZE_BYTES
       return t("customer_portal.acceptance.errors.not_pdf") if Attachment.detect_content_type(file.tempfile) != "application/pdf"
       nil

--- a/test/integration/public_acceptances_test.rb
+++ b/test/integration/public_acceptances_test.rb
@@ -61,6 +61,13 @@ class PublicAcceptancesTest < ActionDispatch::IntegrationTest
     assert_select ".alert", text: /PDF/i
   end
 
+  test "POST a non-file acceptance_pdf param is rejected as missing, not a 500" do
+    open_note
+    post delivery_acceptance_upload_submit_url(token: @token, host: Settings.customer_portal.host), params: { acceptance_pdf: "x" }
+    assert_response :unprocessable_content
+    assert_select ".alert"
+  end
+
   test "the upload route is unreachable on the app host" do
     host! "app.example.com"
     get "/delivery-acceptance/sometoken"


### PR DESCRIPTION
## Problem

The unauthenticated customer-portal acceptance upload (`CustomerPortal::AcceptancesController#create`) assumed `params[:acceptance_pdf]` was always an uploaded file. A non-multipart value (e.g. `acceptance_pdf=x`) arrives as a `String`/`Array`, so `file.blank?` is false and the subsequent `file.size` / `file.tempfile` calls raised `NoMethodError` — returning a **500 on a public, token-gated endpoint** instead of a validation error.

## Fix

Guard `file_error` with `respond_to?(:tempfile)` so a non-file param is treated as a missing upload and re-renders the form with the standard validation error. No data exposure was involved; this is a robustness/DoS-surface fix on an unauthenticated path.

## Tests

- `POST a non-file acceptance_pdf param is rejected as missing, not a 500`
- Existing public-acceptance integration tests still pass (8 runs, 24 assertions green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYpZZettfDnpJdCUrcs38R

---
_Generated by [Claude Code](https://claude.ai/code/session_01QYpZZettfDnpJdCUrcs38R)_