### PR TITLE
Guard unauthenticated 500s on missing param type checks

### DIFF
--- a/app/controllers/customer_portal/acceptances_controller.rb
+++ b/app/controllers/customer_portal/acceptances_controller.rb
@@ -38,6 +38,7 @@ module CustomerPortal
     # Returns a user-facing error string, or nil when the file is an acceptable PDF.
     def file_error(file)
       return t("customer_portal.acceptance.errors.missing") if file.blank?
+      return t("customer_portal.acceptance.errors.missing") unless file.is_a?(ActionDispatch::Http::UploadedFile)
       return t("customer_portal.acceptance.errors.too_large", max: Attachment::MAX_SIZE_BYTES / 1.megabyte) if file.size > Attachment::MAX_SIZE_BYTES
       return t("customer_portal.acceptance.errors.not_pdf") if Attachment.detect_content_type(file.tempfile) != "application/pdf"
       nil

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -22,7 +22,12 @@ class SessionsController < ApplicationController
       return render json: { error: "No login in progress" }, status: :unprocessable_content
     end
 
-    webauthn_credential = WebAuthn::Credential.from_get(params[:credential].to_unsafe_h)
+    payload = params[:credential]
+    unless payload.is_a?(ActionController::Parameters)
+      return render json: { error: "Verification failed: missing credential payload" }, status: :unprocessable_content
+    end
+
+    webauthn_credential = WebAuthn::Credential.from_get(payload.to_unsafe_h)
     stored = UserCredential.find_by(external_id: webauthn_credential.id)
     unless stored
       UserAuditEvent.record!(

--- a/test/integration/passkey_login_flow_test.rb
+++ b/test/integration/passkey_login_flow_test.rb
@@ -49,6 +49,15 @@ class PasskeyLoginFlowTest < ActionDispatch::IntegrationTest
     assert @user.sessions.active.exists?
   end
 
+  test "verify with a scalar credential payload returns 422, not 500" do
+    post options_session_path, params: {}, as: :json
+    assert_response :success
+
+    post verify_session_path, params: { credential: "x" }, as: :json
+    assert_response :unprocessable_content
+    assert JSON.parse(response.body)["error"].present?
+  end
+
   test "blocked users cannot sign in" do
     @user.update!(blocked_at: Time.current, blocked_reason: "test")
 

--- a/test/integration/public_acceptances_test.rb
+++ b/test/integration/public_acceptances_test.rb
@@ -61,6 +61,13 @@ class PublicAcceptancesTest < ActionDispatch::IntegrationTest
     assert_select ".alert", text: /PDF/i
   end
 
+  test "POST with a non-file acceptance_pdf re-renders the form with an error" do
+    open_note
+    post delivery_acceptance_upload_submit_url(token: @token, host: Settings.customer_portal.host), params: { acceptance_pdf: "not a file" }
+    assert_response :unprocessable_content
+    assert_select ".alert"
+  end
+
   test "the upload route is unreachable on the app host" do
     host! "app.example.com"
     get "/delivery-acceptance/sometoken"


### PR DESCRIPTION
Two unauthenticated-reachable endpoints raised `NoMethodError` (unhandled 500) when given malformed request params. Both now return a 422 instead.

## Changes

- **Login verify** (`app/controllers/sessions_controller.rb`): `WebAuthn::Credential.from_get(params[:credential].to_unsafe_h)` blew up with `NoMethodError` when `params[:credential]` was absent or a scalar. Now verifies `params[:credential].is_a?(ActionController::Parameters)` first and renders `{ error: "Verification failed: missing credential payload" }` with status 422, mirroring the existing `ApplicationController#verify_webauthn_create` guard.

- **Customer portal acceptance upload** (`app/controllers/customer_portal/acceptances_controller.rb`): `file_error` called `Attachment.detect_content_type(file.tempfile)` on whatever `acceptance_pdf` contained — a String or nested hash (from a caller with a valid open token) reached `.tempfile` and raised `NoMethodError`. Now a non-`ActionDispatch::Http::UploadedFile` value is treated as a missing file and re-renders `:show` with a 422, using the existing i18n error key.

## Tests

- `passkey_login_flow_test.rb`: `POST /session/verify` with `credential: "x"` after a valid options call returns 422 with a JSON error, not 500.
- `public_acceptances_test.rb`: POSTing to the acceptance submit URL with a valid open token but `acceptance_pdf` as a string returns 422 and re-renders.

Both test files pass (11 runs, 37 assertions, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SzuWKE8pSxg4G8qUWyTCUz

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzuWKE8pSxg4G8qUWyTCUz)_