### PR TITLE
Make single-use invite consumption atomic

### DIFF
--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -134,6 +134,8 @@ class InvitesController < ApplicationController
     render json: { redirect_url: account_profile_path }
   rescue ActiveRecord::RecordInvalid => e
     render json: { error: e.record.errors.full_messages.join(", ") }, status: :unprocessable_content
+  rescue UserInvite::AlreadyConsumed
+    render_invalid
   end
 
   def complete_passkey_reset
@@ -176,6 +178,8 @@ class InvitesController < ApplicationController
     render json: { redirect_url: account_profile_path }
   rescue ActiveRecord::RecordInvalid => e
     render json: { error: e.record.errors.full_messages.join(", ") }, status: :unprocessable_content
+  rescue UserInvite::AlreadyConsumed
+    render_invalid
   end
 
   def invite_token_matches?(pending)

--- a/app/models/user_invite.rb
+++ b/app/models/user_invite.rb
@@ -1,6 +1,8 @@
 class UserInvite < ApplicationRecord
   include DigestedToken
 
+  class AlreadyConsumed < StandardError; end
+
   EXPIRY = 24.hours
 
   PURPOSE_SIGNUP = "signup".freeze
@@ -47,7 +49,9 @@ class UserInvite < ApplicationRecord
   end
 
   def consume!(user:)
-    update!(used_at: Time.current, used_by_user: user)
+    updated = self.class.usable.where(id: id).update_all(used_at: Time.current, used_by_user_id: user.id)
+    raise AlreadyConsumed, "invite #{id} is no longer usable" if updated.zero?
+    reload
   end
 
   def signup?

--- a/test/integration/passkey_signup_flow_test.rb
+++ b/test/integration/passkey_signup_flow_test.rb
@@ -53,6 +53,31 @@ class PasskeySignupFlowTest < ActionDispatch::IntegrationTest
     assert invite_record.used_at.present?
   end
 
+  test "a second verify with the same invite token yields 422, not a second account" do
+    _invite, plaintext = UserInvite.create_signup!(actor: nil)
+    origin = WebAuthn.configuration.allowed_origins.first
+
+    first = open_session
+    second = open_session
+
+    first_credential = signup_credential(first, plaintext, origin, username: "racewinner", email: "racewinner@example.com")
+    second_credential = signup_credential(second, plaintext, origin, username: "raceloser", email: "raceloser@example.com")
+
+    assert_difference -> { User.count } => 1 do
+      first.post verify_invite_path(token: plaintext), params: { credential: first_credential }, as: :json
+    end
+    assert_equal 200, first.response.status
+
+    assert_no_difference -> { User.count } do
+      second.post verify_invite_path(token: plaintext), params: { credential: second_credential }, as: :json
+    end
+    assert_equal 422, second.response.status
+    assert_match(/invalid or expired/i, JSON.parse(second.response.body)["error"])
+
+    assert User.exists?(username: "racewinner")
+    assert_not User.exists?(username: "raceloser")
+  end
+
   test "invalid invite token redirects to invalid view" do
     get invite_path(token: "not-a-real-token")
     assert_response :not_found
@@ -65,5 +90,16 @@ class PasskeySignupFlowTest < ActionDispatch::IntegrationTest
          as: :json
     assert_response :unprocessable_content
     assert_match(/taken/i, JSON.parse(response.body)["error"])
+  end
+
+  private
+
+  def signup_credential(session, plaintext, origin, username:, email:)
+    session.post options_invite_path(token: plaintext),
+                 params: { username: username, full_name: "Race #{username}", email: email },
+                 as: :json
+    assert_equal 200, session.response.status
+    challenge = JSON.parse(session.response.body)["challenge"]
+    WebAuthn::FakeClient.new(origin).create(challenge: challenge)
   end
 end

--- a/test/models/user_invite_test.rb
+++ b/test/models/user_invite_test.rb
@@ -43,6 +43,35 @@ class UserInviteTest < ActiveSupport::TestCase
     assert_equal users(:alice), invite.used_by_user
   end
 
+  test "consume! on an already-consumed invite raises AlreadyConsumed" do
+    invite, _plain = UserInvite.create_signup!(actor: nil)
+    invite.consume!(user: users(:alice))
+
+    assert_raises(UserInvite::AlreadyConsumed) do
+      invite.consume!(user: users(:bob))
+    end
+  end
+
+  test "consume! on an already-consumed invite keeps the original used_by_user" do
+    invite, _plain = UserInvite.create_signup!(actor: nil)
+    invite.consume!(user: users(:alice))
+    used_at = invite.used_at
+
+    assert_raises(UserInvite::AlreadyConsumed) do
+      invite.consume!(user: users(:bob))
+    end
+
+    invite.reload
+    assert_equal users(:alice), invite.used_by_user
+    assert_equal used_at.to_f, invite.used_at.to_f
+  end
+
+  test "find_usable returns nil after consumption" do
+    invite, plaintext = UserInvite.create_signup!(actor: nil)
+    invite.consume!(user: users(:alice))
+    assert_nil UserInvite.find_usable(plaintext)
+  end
+
   test "signup invite cannot have a target_user" do
     invite = UserInvite.new(
       token_digest: "xyz",


### PR DESCRIPTION
## The race

`UserInvite.find_usable` filters `used_at: nil` + not-expired, and `consume!` was a plain `update!(used_at:, used_by_user:)` with no lock or conditional update. Two concurrent `POST /invites/verify` requests carrying the same token (`InvitesController#complete_signup` / `#complete_passkey_reset`, both calling `@invite.consume!` inside a `User.transaction`) could BOTH pass `find_usable` before either wrote `used_at` — minting two accounts from one signup invite, or attaching two passkeys from one reset invite. The single-use guarantee was not actually enforced.

## The fix

- `UserInvite#consume!` now consumes via a single conditional UPDATE the database serializes: `usable.where(id: id).update_all(...)`. A zero row count means the invite was already consumed (or expired) and raises the new `UserInvite::AlreadyConsumed`; on success the record is reloaded. `update_all` bypasses validations/callbacks, which is fine — the model has none relevant.
- `InvitesController` rescues `AlreadyConsumed` in both verify paths. Because `consume!` runs inside the existing `User.transaction`, the raise rolls back the just-created user/credential, and the race-loser gets a clean 422 (`render_invalid`, "Invite is invalid or expired") instead of an unhandled 500.

## Tests

- Model tests: consuming a usable invite marks it used; consuming an already-consumed invite raises `AlreadyConsumed` and leaves the original `used_by_user`/`used_at` intact; `find_usable` returns nil after consumption.
- Integration test: two independent sessions each complete the signup options step for the same token, then both verify — the first succeeds, the second gets 422 and no second account is created.

All touched tests pass (`bin/rails test test/models/user_invite_test.rb test/integration/passkey_signup_flow_test.rb test/controllers/invites_controller_test.rb` → 22 runs, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SzuWKE8pSxg4G8qUWyTCUz

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzuWKE8pSxg4G8qUWyTCUz)_