### PR TITLE
Add "failed" offer state

### DIFF
--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -5,6 +5,7 @@ class OffersController < ApplicationController
                 only: %i[index show preview preview_email preview_email_html]
   before_action -> { require_permission!("offers.edit") },
                 only: %i[new create edit update destroy send_offer accept reject reopen
+                         mark_failed restore
                          scaffold_milestones upload_order_pdf send_email]
   before_action -> { require_permission!("offers.edit_notes") },
                 only: %i[update_internal_notes]
@@ -112,6 +113,20 @@ class OffersController < ApplicationController
   def reopen
     @offer.reopen!
     redirect_to @offer, notice: "Offer reopened."
+  rescue Offer::InvalidTransition => e
+    redirect_to @offer, alert: e.message
+  end
+
+  def mark_failed
+    @offer.mark_failed!
+    redirect_to @offer, notice: "Offer marked as failed."
+  rescue Offer::InvalidTransition => e
+    redirect_to @offer, alert: e.message
+  end
+
+  def restore
+    @offer.restore!
+    redirect_to @offer, notice: "Offer restored to ordered."
   rescue Offer::InvalidTransition => e
     redirect_to @offer, alert: e.message
   end

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -6,7 +6,7 @@ class Offer < ApplicationRecord
 
   class InvalidTransition < StandardError; end
 
-  STATES = %w[draft sent accepted rejected expired].freeze
+  STATES = %w[draft sent accepted rejected expired failed].freeze
 
   # Delivery is "soon" within this window (shared with UpcomingOfferDeliveriesReportJob).
   DELIVERY_SOON_WINDOW = 5.days
@@ -109,6 +109,20 @@ class Offer < ApplicationRecord
     end
   end
 
+  def mark_failed!
+    with_lock do
+      raise InvalidTransition, "mark_failed requires state accepted, was #{state}" unless accepted?
+      update!(state: "failed", failed_at: Time.current)
+    end
+  end
+
+  def restore!
+    with_lock do
+      raise InvalidTransition, "restore requires state failed, was #{state}" unless failed?
+      update!(state: "accepted", failed_at: nil)
+    end
+  end
+
   def email_recipients
     customer.contacts_for_offer(self).map(&:to_email_address)
   end
@@ -137,7 +151,8 @@ class Offer < ApplicationRecord
       { "draft" => [ "Draft", "bg-secondary" ],
         "sent" => [ "Sent", "bg-warning text-dark" ],
         "rejected" => [ "Rejected", "bg-secondary" ],
-        "expired" => [ "Expired", "bg-warning text-dark" ] }.fetch(state)
+        "expired" => [ "Expired", "bg-warning text-dark" ],
+        "failed" => [ "Failed", "bg-secondary" ] }.fetch(state)
     end
   end
 
@@ -161,6 +176,7 @@ class Offer < ApplicationRecord
   # True when the shown version's delivery date is near or past and invoicing
   # isn't complete yet — drives the red delivery date on the offers list.
   def delivery_date_urgent?
+    return false if failed?
     date = (draft_version || current_sent_version)&.delivery_date
     return false if date.nil? || fully_invoiced?
 

--- a/app/views/offers/_conversion_rows.html.haml
+++ b/app/views/offers/_conversion_rows.html.haml
@@ -23,7 +23,7 @@
               = link_to milestone.invoice.display_name, milestone.invoice
               - if milestone.delivery_note
                 = link_to milestone.delivery_note.display_name, milestone.delivery_note
-              - if can?('offers.convert')
+              - if @offer.accepted? && can?('offers.convert')
                 = button_to 'Reopen link', reopen_milestone_link_offer_path(@offer, milestone_id: milestone.id), method: :post, class: 'btn btn-sm btn-outline-secondary', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Clear the conversion link for this milestone?' }
-            - elsif can?('offers.convert')
+            - elsif @offer.accepted? && can?('offers.convert')
               = button_to '🚀 Convert', convert_milestone_offer_path(@offer, milestone_id: milestone.id), method: :post, class: 'btn btn-sm btn-info', form: { class: 'button_to ms-auto' }

--- a/app/views/offers/show.html.haml
+++ b/app/views/offers/show.html.haml
@@ -105,7 +105,7 @@
               .col-sm-8
                 = l(sent_version.sent_at.to_date)
           = render 'shared/email_status_row', resource: @offer, can_edit: can?('offers.edit'), show_send_button: sent_version.attachment.present?
-          - if can?('offers.edit') || @offer.accepted? || @offer.rejected?
+          - if can?('offers.edit') || @offer.accepted? || @offer.rejected? || @offer.failed?
             .row.mb-2{data: {controller: 'modal'}}
               .col-sm-4
                 %strong Decision:
@@ -118,15 +118,24 @@
                   %span.badge.bg-secondary Rejected
                   - if @offer.rejected_at
                     = l(@offer.rejected_at.to_date)
+                - elsif @offer.failed?
+                  %span.badge.bg-secondary Failed
+                  - if @offer.failed_at
+                    = l(@offer.failed_at.to_date)
                 - if can?('offers.edit')
                   - if @offer.sent?
                     %button.btn.btn-sm.btn-success.ms-auto{data: {action: 'click->modal#open'}} Accept…
                     = button_to 'Reject', reject_offer_path(@offer), method: :post, class: 'btn btn-sm btn-outline-danger', data: { 'turbo-confirm': 'Reject this offer?' }
                     = render 'accept_modal'
-                  - elsif @offer.accepted? || @offer.rejected?
+                  - elsif @offer.accepted?
+                    = button_to 'Mark failed', mark_failed_offer_path(@offer), method: :post, class: 'btn btn-sm btn-outline-danger', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Mark this ordered offer as failed? It will be ignored by the deliveries report until restored.' }
+                    = button_to 'Reopen', reopen_offer_path(@offer), method: :post, class: 'btn btn-sm btn-outline-secondary', data: { 'turbo-confirm': 'Reopen this offer? A fresh draft version branches from the accepted version.' }
+                  - elsif @offer.rejected?
                     = button_to 'Reopen', reopen_offer_path(@offer), method: :post, class: 'btn btn-sm btn-outline-secondary', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Reopen this offer? A fresh draft version branches from the accepted version.' }
+                  - elsif @offer.failed?
+                    = button_to 'Restore to Ordered', restore_offer_path(@offer), method: :post, class: 'btn btn-sm btn-outline-secondary', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Restore this failed offer back to ordered?' }
 
-  - if @offer.accepted?
+  - if @offer.accepted? || @offer.failed?
     .mb-4
       .card
         .card-header
@@ -171,7 +180,7 @@
           %h5.mb-3= @version.subject
         - if @version&.prelude&.present?
           .mb-3= @version.prelude
-        - if @offer.accepted?
+        - if @offer.accepted? || @offer.failed?
           = render 'conversion_rows'
         - elsif @version
           %table.table.table-bordered

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -116,6 +116,8 @@ Rails.application.routes.draw do
         post "accept"
         post "reject"
         post "reopen"
+        post "mark_failed"
+        post "restore"
         post "scaffold_milestones"
         patch "update_internal_notes"
         post "upload_order_pdf"

--- a/db/migrate/20260707120000_add_failed_at_to_offers.rb
+++ b/db/migrate/20260707120000_add_failed_at_to_offers.rb
@@ -1,0 +1,5 @@
+class AddFailedAtToOffers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :offers, :failed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_06_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_07_120000) do
   create_table "acceptance_submissions", force: :cascade do |t|
     t.integer "attachment_id"
     t.datetime "created_at", null: false
@@ -385,6 +385,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_06_120000) do
     t.string "document_number"
     t.datetime "email_sent_at"
     t.date "expires_at"
+    t.datetime "failed_at"
     t.text "internal_reference"
     t.integer "order_attachment_id"
     t.text "order_number"

--- a/docs/superpowers/plans/2026-07-05-offers.md
+++ b/docs/superpowers/plans/2026-07-05-offers.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Add Offers — sales quotes with versioning, a lifecycle (draft → sent → accepted/rejected/expired), an FOP-rendered PDF, offer emails, and milestone-to-invoice/delivery-note conversion — per issue #530.
+**Goal:** Add Offers — sales quotes with versioning, a lifecycle (draft → sent → accepted/rejected/expired, plus accepted ⇄ failed; see "Follow-up: failed state"), an FOP-rendered PDF, offer emails, and milestone-to-invoice/delivery-note conversion — per issue #530.
 
 **Architecture:** Offer is a third document type next to Invoice and DeliveryNote, but with a richer shape: an `Offer` carries identity/lifecycle, `OfferVersion` carries the customer-facing content (frozen at send, re-branched as a new draft), and `OfferMilestone` rows are the line items that later convert 1:1 into draft Invoices/DeliveryNotes. Send/accept/reject/reopen are service- and model-level operations; the PDF pipeline reuses `FopRenderer` + `document_base.xsl` + `RichTextFoConverter`; email mirrors the DeliveryNote contact-opt-in pattern with a stored PDF like invoices.
 
@@ -285,7 +285,7 @@ Expected: migrations apply cleanly; existing tests stay green (nothing consumes 
 - Modify: `app/models/customer.rb`, `app/models/customer_contact.rb`, `app/models/project.rb`, `app/models/issuer_company.rb`, `test/support/document_factories.rb`
 
 **Interfaces produced (later tasks rely on these exact names):**
-- `Offer`: `STATES`, `draft?/sent?/accepted?/rejected?/expired?`, `draft_version`, `current_sent_version`, `accepted_version`, `versions`, `validity_days`, `send_problems`, `accept!(order_number:, ordered_on:, order_pdf: nil)`, `reject!`, `reopen!`, `email_recipients`, `email_cc_recipients` (returns `[]`), `email_salutation_contact`, `emailable?`, `status_badge`, `editable?`, `deletable?`
+- `Offer`: `STATES`, `draft?/sent?/accepted?/rejected?/expired?/failed?`, `draft_version`, `current_sent_version`, `accepted_version`, `versions`, `validity_days`, `send_problems`, `accept!(order_number:, ordered_on:, order_pdf: nil)`, `reject!`, `reopen!`, `mark_failed!`, `restore!`, `email_recipients`, `email_cc_recipients` (returns `[]`), `email_salutation_contact`, `emailable?`, `status_badge`, `editable?`, `deletable?`
 - `OfferVersion`: `milestones`, `frozen?` (alias of `sent_at?`), `branch_draft!`, `recalculate_sum_net!`, rich texts `prelude` and `boilerplate`
 - `OfferMilestone`: `TRIGGERS`, `TRIGGER_LABELS`, `trigger_label`, `converted?`, `default_skip_delivery_note`
 
@@ -2219,3 +2219,31 @@ Run, in order — all must pass:
 | UI (searchable dropdowns, year+state filters, labels not enum names, Total Net card, no nested form, disabled Send, accept dialog, order card, internal notes) | Task 9 |
 | Customer/Issuer settings sections | Task 10 |
 | Explicitly rejected items | none implemented — no `cust_reference` analog, single delivery date, plain-text footer, no tax on PDF |
+
+## Follow-up: failed state (2026-07-07)
+
+An accepted (Ordered) offer sometimes falls through afterwards — the customer
+cancels, the project dies, the order is withdrawn. The `failed` state flags such
+an offer as dead while keeping its order record, and can be undone.
+
+- **Transitions**: `failed` is reachable **only** from `accepted`, and
+  `restore!` returns it **only** to `accepted`. `Offer#mark_failed!`
+  (accepted → failed) and `Offer#restore!` (failed → accepted) are `with_lock`
+  guarded and raise `Offer::InvalidTransition` otherwise. A nullable
+  `offers.failed_at` timestamp mirrors `accepted_at`/`rejected_at`. Order data
+  (`accepted_version`, `accepted_at`, `order_number`, `ordered_on`, order PDF)
+  is preserved across fail/restore.
+- **Badge**: `status_badge` shows `Failed` in `bg-secondary` — a resting state
+  needing no action, so it stays muted rather than warning/danger coloured.
+- **Deliveries mailer**: `UpcomingOfferDeliveriesReportJob` scopes to
+  `state: "accepted"`, so failed offers drop out automatically;
+  `delivery_date_urgent?` also short-circuits when failed so the offers list
+  stops flagging a dead order's delivery date.
+- **Controller/routes**: `mark_failed` and `restore` member actions, both
+  gated on `offers.edit`. `require_accepted` is unchanged, so milestone
+  conversion stays blocked while failed.
+- **Detail page** (paused-order view): a **Mark failed** button on Ordered
+  offers, **Restore to Ordered** on failed ones. The Order card and milestone
+  rows stay visible, but the Convert / Reopen-link buttons are hidden
+  (`@offer.accepted? && can?('offers.convert')`). Internal notes stay editable
+  throughout (no state guard).

--- a/test/controllers/offers_controller_test.rb
+++ b/test/controllers/offers_controller_test.rb
@@ -141,6 +141,35 @@ class OffersControllerTest < ActionDispatch::IntegrationTest
     assert flash[:alert].present?
   end
 
+  test "mark_failed then restore move an accepted offer to failed and back" do
+    offer = offers(:sent_offer)
+    offer.accept!(order_number: "PO", ordered_on: Date.current)
+    post mark_failed_offer_url(offer)
+    assert_redirected_to offer_url(offer)
+    assert offer.reload.failed?
+    post restore_offer_url(offer)
+    assert_redirected_to offer_url(offer)
+    assert offer.reload.accepted?
+  end
+
+  test "mark_failed on a non-accepted offer redirects with an alert" do
+    offer = offers(:sent_offer)
+    post mark_failed_offer_url(offer)
+    assert_redirected_to offer_url(offer)
+    assert_match "requires state accepted", flash[:alert]
+    assert offer.reload.sent?
+  end
+
+  test "convert_milestone stays blocked while failed" do
+    offer = offers(:sent_offer)
+    offer.accept!(order_number: "PO", ordered_on: Date.current)
+    milestone = offer.accepted_version.milestones.first
+    offer.mark_failed!
+    post convert_milestone_offer_url(offer, milestone_id: milestone.id)
+    assert_redirected_to offer_url(offer)
+    assert_match "must be accepted", flash[:alert]
+  end
+
   test "convert_milestone denied without offers.convert" do
     offer = offers(:sent_offer)
     offer.accept!(order_number: "PO", ordered_on: Date.current)
@@ -223,6 +252,7 @@ class OffersControllerTest < ActionDispatch::IntegrationTest
     get offer_url(offer)
     assert_select ".badge.bg-primary", text: "Ordered", minimum: 2
     assert_match offer.accepted_at.to_date.strftime("%d.%m.%Y"), response.body
+    assert_select "form[action=?]", mark_failed_offer_path(offer)
   end
 
   test "show states the decision on rejected offers" do
@@ -231,6 +261,17 @@ class OffersControllerTest < ActionDispatch::IntegrationTest
     get offer_url(offer)
     assert_select ".badge.bg-secondary", text: "Rejected", minimum: 2
     assert_match offer.rejected_at.to_date.strftime("%d.%m.%Y"), response.body
+  end
+
+  test "failed offer detail shows a restore button, editable notes, and no convert action" do
+    offer = offers(:sent_offer)
+    offer.accept!(order_number: "PO", ordered_on: Date.current)
+    offer.mark_failed!
+    get offer_url(offer)
+    assert_select ".badge.bg-secondary", text: "Failed", minimum: 2
+    assert_select "form[action=?]", restore_offer_path(offer)
+    assert_select "form[action=?]", update_internal_notes_offer_path(offer)
+    assert_select "form[action=?]", convert_milestone_offer_path(offer, milestone_id: offer.accepted_version.milestones.first.id), count: 0
   end
 
   test "show renders the version subject and prelude in the proposal card" do

--- a/test/jobs/upcoming_offer_deliveries_report_job_test.rb
+++ b/test/jobs/upcoming_offer_deliveries_report_job_test.rb
@@ -83,6 +83,13 @@ class UpcomingOfferDeliveriesReportJobTest < ActiveJob::TestCase
     end
   end
 
+  test "a failed offer is not reported even with a nearing delivery date" do
+    @offer.mark_failed!
+    assert_emails 0 do
+      UpcomingOfferDeliveriesReportJob.perform_now
+    end
+  end
+
   private
 
   def build_invoice(published:, sent: false)

--- a/test/models/offer_test.rb
+++ b/test/models/offer_test.rb
@@ -206,6 +206,47 @@ class OfferTest < ActiveSupport::TestCase
     assert_empty offer.send_problems
   end
 
+  test "mark_failed from accepted preserves order data and stamps failed_at" do
+    offer = offers(:sent_offer)
+    offer.accept!(order_number: "PO-9", ordered_on: Date.new(2026, 7, 1))
+    accepted_version_id = offer.accepted_version_id
+    offer.mark_failed!
+    assert offer.failed?
+    assert_not_nil offer.failed_at
+    assert_equal accepted_version_id, offer.accepted_version_id
+    assert_equal "PO-9", offer.order_number
+    assert_equal Date.new(2026, 7, 1), offer.ordered_on
+  end
+
+  test "restore returns a failed offer to accepted and clears failed_at" do
+    offer = offers(:sent_offer)
+    offer.accept!(order_number: "PO-9", ordered_on: Date.current)
+    offer.mark_failed!
+    offer.restore!
+    assert offer.accepted?
+    assert_nil offer.failed_at
+  end
+
+  test "mark_failed and restore reject a wrong start state" do
+    offer = offers(:sent_offer)
+    assert_raises(Offer::InvalidTransition) { offer.mark_failed! }
+    offer.accept!(order_number: "PO", ordered_on: Date.current)
+    assert_raises(Offer::InvalidTransition) { offer.restore! }
+  end
+
+  test "failed offer shows a muted Failed badge" do
+    offer = offers(:sent_offer)
+    offer.accept!(order_number: "PO", ordered_on: Date.current)
+    offer.mark_failed!
+    assert_equal [ "Failed", "bg-secondary" ], offer.status_badge
+  end
+
+  test "delivery date is not urgent once the offer has failed" do
+    offer = accepted_with_delivery(Date.current + 1)
+    offer.mark_failed!
+    assert_not offer.delivery_date_urgent?
+  end
+
   private
 
   def accepted_with_delivery(date)

--- a/test/system/offer_failed_state_test.rb
+++ b/test/system/offer_failed_state_test.rb
@@ -1,0 +1,16 @@
+require "application_system_test_case"
+
+class OfferFailedStateTest < ApplicationSystemTestCase
+  test "marking an ordered offer failed and restoring it" do
+    offer = offers(:sent_offer)
+    offer.accept!(order_number: "PO", ordered_on: Date.current)
+
+    visit offer_path(offer)
+    accept_confirm { click_on "Mark failed" }
+    assert_selector ".badge.bg-secondary", text: "Failed"
+
+    accept_confirm { click_on "Restore to Ordered" }
+    assert_text "Offer restored to ordered"
+    assert offer.reload.accepted?
+  end
+end


### PR DESCRIPTION
## Summary

Adds a `failed` state to the offer lifecycle for orders that fall through after
being accepted. Reachable only from `accepted`/Ordered and reversible back to
it, a failed offer is excluded from the upcoming-deliveries mailer while keeping
its full order record.

- **State machine** (`app/models/offer.rb`): `STATES` gains `failed`; new
  `mark_failed!` (accepted → failed) and `restore!` (failed → accepted) guarded
  by `with_lock` + `InvalidTransition`. New nullable `failed_at` column. All
  order data (`accepted_version`, `accepted_at`, `order_number`, `ordered_on`,
  order PDF) is preserved across fail/restore.
- **Muted badge**: `status_badge` shows `Failed` in `bg-secondary` — a resting
  state that needs no action.
- **Mailer**: `UpcomingOfferDeliveriesReportJob` already scopes to
  `state: "accepted"`, so failed offers are excluded automatically. Locked in
  with a regression test. `delivery_date_urgent?` also short-circuits when
  failed so the offers list stops flagging a dead order.
- **Controller/routes**: `mark_failed` and `restore` actions (both require
  `offers.edit`); milestone conversion stays blocked while failed.
- **Detail page** (paused-order view): a **Mark failed** button on Ordered
  offers and **Restore to Ordered** on failed ones. Order card and milestone
  rows stay visible, but Convert / Reopen-link buttons are hidden. Internal
  notes remain editable throughout.

Design spec and implementation plan under `docs/superpowers/`.

## Testing

- `bundle exec rails test test/models/offer_test.rb test/controllers/offers_controller_test.rb test/jobs/upcoming_offer_deliveries_report_job_test.rb` — 95 runs, 0 failures
- `bundle exec rails test test/system/` — 65 runs, 0 failures (includes a new end-to-end mark-failed → restore flow)
- `pre-commit run --all-files` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)