### PR TITLE
Restyle navbar: teal bar with rainbow underline

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.scss
@@ -11,29 +11,42 @@ $info:      #36a2eb;
 @import "bootstrap";
 body { padding-top: 60px; }
 
-// Rainbow gradient navbar
+// Navbar: brand-teal bar with the rainbow reduced to a 4px underline. Non-active
+// links sit at 80% white; the active page is full white with a teal underline.
+// A transparent underline is reserved on every link so switching pages doesn't
+// shift the layout.
 .navbar {
-  background: linear-gradient(90deg,
-    rgba(255, 99, 132, 0.8) 0%,
-    rgba(255, 159, 64, 0.8) 20%,
-    rgba(255, 205, 86, 0.8) 40%,
-    rgba(75, 192, 192, 0.8) 60%,
-    rgba(54, 162, 235, 0.8) 80%,
-    rgba(153, 102, 255, 0.8) 100%
-  ) !important;
+  background: #1d6b6a !important;
+  border-bottom: 4px solid transparent;
+  border-image: linear-gradient(90deg,
+    #ff6384, #ff9f40, #ffcd56, #4bc0c0, #36a2eb, #9966ff) 1;
 
   .navbar-brand {
-    text-shadow: 0 0 10px rgba(255, 255, 255, 0.8);
-    font-weight: 700;
+    color: #fff;
+    font-weight: 800;
+    font-size: 1.35rem;
+    letter-spacing: 0.03em;
   }
 
   .navbar-nav .nav-link {
-    text-shadow: 0 0 3px rgba(255, 255, 255, 0.8);
+    color: rgba(234, 255, 251, 0.8);
     font-weight: 500;
+    border-bottom: 2px solid transparent;
   }
 
-  .navbar-nav .nav-link.active, .navbar-nav .nav-link:hover {
-    text-shadow: 0 0 10px rgba(255, 255, 255, 0.8);
+  .navbar-nav .nav-link:hover { color: #fff; }
+
+  .navbar-nav .nav-link.active {
+    color: #fff;
+    font-weight: 600;
+    border-bottom-color: #7fe0dc;
+  }
+
+  // The bar is a solid dark teal in both color modes, so pin the collapse
+  // toggler to the white icon variant (it followed data-bs-theme before).
+  .navbar-toggler { border-color: rgba(255, 255, 255, 0.35); }
+  .navbar-toggler-icon {
+    --bs-navbar-toggler-icon-bg: #{escape-svg($navbar-dark-toggler-icon-bg)};
   }
 }
 


### PR DESCRIPTION
CSS-only navbar restyle. The rainbow gradient background is replaced by a solid dark-teal bar; the rainbow survives as a 4px underline.

## Changes
- Solid `#1d6b6a` teal bar (was a 6-stop rainbow gradient).
- Rainbow reduced to a 4px bottom rule via `border-image`.
- ABT wordmark enlarged to 1.35rem / weight 800.
- Inactive nav links at 80% white; active link is white with a `#7fe0dc` teal underline.
- A transparent 2px underline is reserved on every link so switching pages doesn't shift layout.
- Collapse toggler pinned to the white icon variant (bar is dark in both color modes).

Only `app/assets/stylesheets/bootstrap_and_overrides.css.scss` is touched. SCSS verified via `bundle exec rails assets:precompile` (no Sass error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)