### PR TITLE
Cache the Apache FOP pdf-images download in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,17 @@ jobs:
       with:
         bundler-cache: true
 
+    # Cache only the apache.org download (the pdf-images extra jars), not the
+    # apt packages. Keyed on the fetch script so a version bump invalidates it.
+    - name: Cache FOP pdf-images jars
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: vendor/fop-pdf-images-*-bin.tar.gz
+        key: fop-pdf-images-${{ hashFiles('bin/fetch-fop-extra-jars') }}
+
+    - name: Fetch FOP pdf-images jars
+      run: ./bin/fetch-fop-extra-jars
+
     - name: Build FOP Docker container
       run: |
         podman build -f Dockerfile.fop -t abt-fop .

--- a/Dockerfile.fop
+++ b/Dockerfile.fop
@@ -11,9 +11,13 @@ RUN apt-get update -qq && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ENV FOP_EXTRA_JAR_PATH /usr/local/fop-extra-jars
-RUN wcurl -o pdfimages.tgz 'https://www.apache.org/dyn/closer.cgi?filename=/xmlgraphics/fop-pdf-images/binaries/fop-pdf-images-2.11-bin.tar.gz&action=download' && \
-    mkdir "$FOP_EXTRA_JAR_PATH" && \
-    tar --strip-components=1 -x -f pdfimages.tgz -C "$FOP_EXTRA_JAR_PATH"
+# The tarball is fetched into the build context by bin/fetch-fop-extra-jars
+# (run by bin/setup-fop and CI) rather than downloaded here, so the build never
+# hits apache.org and CI can cache it. See bin/fetch-fop-extra-jars.
+COPY vendor/fop-pdf-images-2.11-bin.tar.gz /tmp/pdfimages.tgz
+RUN mkdir "$FOP_EXTRA_JAR_PATH" && \
+    tar --strip-components=1 -x -f /tmp/pdfimages.tgz -C "$FOP_EXTRA_JAR_PATH" && \
+    rm /tmp/pdfimages.tgz
 
 RUN useradd -m -u 1000 fopuser
 USER fopuser

--- a/bin/fetch-fop-extra-jars
+++ b/bin/fetch-fop-extra-jars
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Fetch the Apache FOP pdf-images extra jars into the Docker build context.
+#
+# Dockerfile.fop COPYs vendor/fop-pdf-images-<version>-bin.tar.gz into the image
+# instead of downloading it during the build, so this tarball must exist before
+# `podman build`. Both bin/setup-fop and .github/workflows/ci.yml run this first.
+#
+# The download is idempotent: it's skipped when the tarball is already present,
+# which lets CI restore it from actions/cache and avoid hitting apache.org on
+# every run.
+set -euo pipefail
+
+FOP_PDF_IMAGES_VERSION=2.11
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEST="$PROJECT_ROOT/vendor/fop-pdf-images-${FOP_PDF_IMAGES_VERSION}-bin.tar.gz"
+
+if [[ -f "$DEST" ]]; then
+  echo "✅ fop-pdf-images ${FOP_PDF_IMAGES_VERSION} already present: $DEST"
+  exit 0
+fi
+
+# archive.apache.org keeps every release permanently and is CDN-backed, unlike
+# the closer.cgi mirror chooser which is slow and frequently 503s.
+URL="https://archive.apache.org/dist/xmlgraphics/fop-pdf-images/binaries/fop-pdf-images-${FOP_PDF_IMAGES_VERSION}-bin.tar.gz"
+
+echo "⬇️  Downloading fop-pdf-images ${FOP_PDF_IMAGES_VERSION} from apache.org..."
+mkdir -p "$PROJECT_ROOT/vendor"
+curl --fail --location --silent --show-error --retry 3 --retry-delay 2 \
+  --remove-on-error -o "$DEST" "$URL"
+
+echo "✅ Saved: $DEST"

--- a/bin/setup-fop
+++ b/bin/setup-fop
@@ -33,6 +33,7 @@ if [[ -z "$CONTAINER_CMD" ]]; then
 fi
 
 echo "📦 Building FOP container image..."
+"$SCRIPT_DIR/fetch-fop-extra-jars"
 $CONTAINER_CMD build -f "$PROJECT_ROOT/Dockerfile.fop" -t "$FOP_IMAGE_NAME" "$PROJECT_ROOT"
 
 # bin/abt-fop-container is now tracked in the repo as the canonical


### PR DESCRIPTION
## What

The `abt-fop` image build downloaded `fop-pdf-images-2.11-bin.tar.gz` from apache.org on **every** CI run, via `wcurl` inside `Dockerfile.fop`. The `closer.cgi` mirror chooser it used is slow and intermittently returns 503 (hit that during testing), making the container build flaky.

This caches that single Apache download so it's fetched once and reused. **apt packages are deliberately left alone** — only the apache.org fetch is cached.

## How

- **New `bin/fetch-fop-extra-jars`** — fetches the tarball into `vendor/` (already gitignored), idempotently (skips if present).
- **`Dockerfile.fop`** now `COPY`s the tarball from the build context instead of downloading it, so the image build never touches the network for this.
- **`.github/workflows/ci.yml`** wraps the fetch with `actions/cache`, keyed on the fetch script. Cache hit → no apache.org request; the key only changes when the pinned version bumps.
- **`bin/setup-fop`** runs the fetch before building, so local `setup-fop` keeps working unchanged.
- Switched the source from the flaky `closer.cgi` redirect to **`archive.apache.org`** (CDN-backed, keeps every release permanently).

## Verification

- `bin/fetch-fop-extra-jars` downloads a valid gzip tarball containing the expected jars (`fop-pdf-images-2.11.jar`, `pdfbox-3.0.3.jar`, …) and is idempotent on a second run.
- `podman build -f Dockerfile.fop` succeeds using the COPYed tarball; the extra jars land in `$FOP_EXTRA_JAR_PATH` exactly as before and `bin/abt-fop-container -version` reports `FOP Version 2.10`.
- `pre-commit run --all-files` passes.

## Notes

- Bumping the FOP pdf-images version now means editing `FOP_PDF_IMAGES_VERSION` in `bin/fetch-fop-extra-jars` **and** the `COPY` line in `Dockerfile.fop`. The cache key follows the script automatically.
- `curl` remains in the apt install (previously only used by `wcurl`); left as-is to keep the apt layer untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)