### PR TITLE
Apply teal header rule and row hover to list tables

### DIFF
--- a/app/views/account/audit_events/index.html.haml
+++ b/app/views/account/audit_events/index.html.haml
@@ -2,7 +2,7 @@
 
 = page_header('My activity')
 
-%table.table.table-striped.table-sm
+%table.table.table-striped.table-hover.table-sm
   %thead
     %tr
       %th When

--- a/app/views/account/credentials/index.html.haml
+++ b/app/views/account/credentials/index.html.haml
@@ -2,7 +2,7 @@
 
 = page_header('My passkeys', action: action_button('+ New', new_account_credential_path))
 
-%table.table.table-striped.table-sm
+%table.table.table-striped.table-hover.table-sm
   %thead
     %tr
       %th Nickname

--- a/app/views/account/emails/index.html.haml
+++ b/app/views/account/emails/index.html.haml
@@ -2,7 +2,7 @@
 
 = page_header('My emails')
 
-%table.table.table-striped.table-sm
+%table.table.table-striped.table-hover.table-sm
   %thead
     %tr
       %th Address

--- a/app/views/account/sessions/index.html.haml
+++ b/app/views/account/sessions/index.html.haml
@@ -6,7 +6,7 @@
 
 = page_header('My sessions', action: log_out_all)
 
-%table.table.table-striped.table-sm
+%table.table.table-striped.table-hover.table-sm
   %thead
     %tr
       %th IP

--- a/app/views/customers/index.html.haml
+++ b/app/views/customers/index.html.haml
@@ -8,15 +8,16 @@
       = link_to 'Inactive', customers_path(filter: 'inactive'), class: (params[:filter] == 'inactive' ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
 
 - show_status_column = params[:filter] == 'all'
-%table.table.table-striped.table-sm
-  %tr
-    %th{:width => "10%"} Matchcode
-    - if show_status_column
-      %th{:width => "7%"} Status
-    %th Name
-    %th{:width => "10%"} Team
-    %th{:width => "3%"}
-    %th{:width => "3%"}
+%table.table.table-striped.table-hover.table-sm
+  %thead
+    %tr
+      %th{:width => "10%"} Matchcode
+      - if show_status_column
+        %th{:width => "7%"} Status
+      %th Name
+      %th{:width => "10%"} Team
+      %th{:width => "3%"}
+      %th{:width => "3%"}
 
   - @customers.each do |customer|
     %tr

--- a/app/views/delivery_notes/index.html.haml
+++ b/app/views/delivery_notes/index.html.haml
@@ -30,19 +30,20 @@
         = link_to 'All', delivery_notes_path(year: 'all', email_filter: @email_filter, customer_id: @selected_customer_id), class: (@selected_year == 'all' ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
 
   - if @email_filter == 'unsent'
-    %table.table.table-striped.table-sm
-      %tr
-        %th
-          %input#select-all{type: 'checkbox', 'data-action': 'change->bulk-select#toggleAll', 'data-bulk-select-target': 'selectAll'}
-        %th Document#
-        - if @selected_customer_id.nil?
-          %th Customer
-        %th Project
-        %th Doc.Date
-        %th Del.Date
-        %th Int.Reference
-        %th Cust.Order No.
-        %th{:width => "3%"}
+    %table.table.table-striped.table-hover.table-sm
+      %thead
+        %tr
+          %th
+            %input#select-all{type: 'checkbox', 'data-action': 'change->bulk-select#toggleAll', 'data-bulk-select-target': 'selectAll'}
+          %th Document#
+          - if @selected_customer_id.nil?
+            %th Customer
+          %th Project
+          %th Doc.Date
+          %th Del.Date
+          %th Int.Reference
+          %th Cust.Order No.
+          %th{:width => "3%"}
 
       - @delivery_notes.each do |delivery_note|
         %tr
@@ -63,18 +64,19 @@
           %td
 
   - else
-    %table.table.table-striped.table-sm
-      %tr
-        %th Document#
-        - if @selected_customer_id.nil?
-          %th Customer
-        %th Project
-        %th Doc.Date
-        %th Del.Date
-        %th Int.Reference
-        %th Cust.Order No.
-        %th Status
-        %th{:width => "3%"}
+    %table.table.table-striped.table-hover.table-sm
+      %thead
+        %tr
+          %th Document#
+          - if @selected_customer_id.nil?
+            %th Customer
+          %th Project
+          %th Doc.Date
+          %th Del.Date
+          %th Int.Reference
+          %th Cust.Order No.
+          %th Status
+          %th{:width => "3%"}
 
       - @delivery_notes.each do |delivery_note|
         %tr

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -3,15 +3,16 @@
 %p.text-muted
   Groups bundle system-level permissions. A user inherits all permissions of every group they belong to.
 
-%table.table.table-striped.table-sm
-  %tr
-    %th Name
-    %th Description
-    %th Members
-    %th Permissions
-    %th Bypass team scoping
-    %th{width: "3%"}
-    %th{width: "3%"}
+%table.table.table-striped.table-hover.table-sm
+  %thead
+    %tr
+      %th Name
+      %th Description
+      %th Members
+      %th Permissions
+      %th Bypass team scoping
+      %th{width: "3%"}
+      %th{width: "3%"}
 
   - @groups.each do |group|
     %tr

--- a/app/views/invoices/index.html.haml
+++ b/app/views/invoices/index.html.haml
@@ -29,19 +29,20 @@
         = link_to 'All', invoices_path(year: 'all', filter: @filter, customer_id: @selected_customer_id), class: (@selected_year == 'all' ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
 
   - if @filter == 'unsent' && @invoices.any?
-    %table.table.table-striped.table-sm
-      %tr
-        %th
-          %input#select-all{type: 'checkbox', 'data-action': 'change->bulk-select#toggleAll', 'data-bulk-select-target': 'selectAll'}
-        %th Document#
-        - if @selected_customer_id.nil?
-          %th Customer
-        %th Project
-        %th Date
-        %th Int.Reference
-        %th Cust.Order No.
-        %th E-Mail
-        %th{:width => "3%"}
+    %table.table.table-striped.table-hover.table-sm
+      %thead
+        %tr
+          %th
+            %input#select-all{type: 'checkbox', 'data-action': 'change->bulk-select#toggleAll', 'data-bulk-select-target': 'selectAll'}
+          %th Document#
+          - if @selected_customer_id.nil?
+            %th Customer
+          %th Project
+          %th Date
+          %th Int.Reference
+          %th Cust.Order No.
+          %th E-Mail
+          %th{:width => "3%"}
 
       - @invoices.each do |invoice|
         %tr
@@ -68,18 +69,19 @@
               = link_to 'PDF', attachment_path(invoice.attachment), target: '_blank', data: { turbo: false }, class: 'btn btn-sm btn-outline-success py-0'
 
   - else
-    %table.table.table-striped.table-sm
-      %tr
-        %th Document#
-        - if @selected_customer_id.nil?
-          %th Customer
-        %th Project
-        %th Date
-        %th Int.Reference
-        %th Cust.Order No.
-        %th Payment
-        %th.numeric Sum Net
-        %th{:width => "3%"}
+    %table.table.table-striped.table-hover.table-sm
+      %thead
+        %tr
+          %th Document#
+          - if @selected_customer_id.nil?
+            %th Customer
+          %th Project
+          %th Date
+          %th Int.Reference
+          %th Cust.Order No.
+          %th Payment
+          %th.numeric Sum Net
+          %th{:width => "3%"}
 
       - @invoices.each do |invoice|
         %tr

--- a/app/views/offers/index.html.haml
+++ b/app/views/offers/index.html.haml
@@ -18,19 +18,20 @@
         = link_to year, offers_path(year: year, state: @state_filter, customer_id: @selected_customer_id), class: (@selected_year == year ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
       = link_to 'All', offers_path(year: 'all', state: @state_filter, customer_id: @selected_customer_id), class: (@selected_year == 'all' ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
 
-%table.table.table-striped.table-sm
-  %tr
-    %th Document#
-    - if @selected_customer_id.nil?
-      %th Customer
-    %th Project
-    %th Int.Reference
-    %th Cust.Order No.
-    - if @state_filter == 'all'
-      %th Status
-    %th Delivery date
-    %th.numeric Sum Net
-    %th Valid until
+%table.table.table-striped.table-hover.table-sm
+  %thead
+    %tr
+      %th Document#
+      - if @selected_customer_id.nil?
+        %th Customer
+      %th Project
+      %th Int.Reference
+      %th Cust.Order No.
+      - if @state_filter == 'all'
+        %th Status
+      %th Delivery date
+      %th.numeric Sum Net
+      %th Valid until
 
   - @offers.each do |offer|
     - version = offer.draft_version || offer.current_sent_version

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -1,12 +1,13 @@
 = breadcrumbs 'Configuration', 'Product Catalog', action: action_button('+ New', new_product_path, permission: 'products.edit')
 
-%table.table.table-striped.table-sm
-  %tr
-    %th Title
-    %th Rate
-    %th Product Class
-    %th{width: "3%"}
-    %th{width: "3%"}
+%table.table.table-striped.table-hover.table-sm
+  %thead
+    %tr
+      %th Title
+      %th Rate
+      %th Product Class
+      %th{width: "3%"}
+      %th{width: "3%"}
 
   - @products.each do |product|
     %tr

--- a/app/views/projects/index.html.haml
+++ b/app/views/projects/index.html.haml
@@ -8,16 +8,17 @@
       = link_to 'Inactive', projects_path(filter: 'inactive'), class: (params[:filter] == 'inactive' ? 'btn btn-outline-primary active' : 'btn btn-outline-primary')
 
 - show_status_column = params[:filter] == 'all'
-%table.table.table-striped.table-sm
-  %tr
-    %th{:width => "10%"} Matchcode
-    - if show_status_column
-      %th{:width => "7%"} Status
-    %th Name
-    %th Bill to customer
-    %th{:width => "10%"} Team
-    %th{:width => "3%"}
-    %th{:width => "3%"}
+%table.table.table-striped.table-hover.table-sm
+  %thead
+    %tr
+      %th{:width => "10%"} Matchcode
+      - if show_status_column
+        %th{:width => "7%"} Status
+      %th Name
+      %th Bill to customer
+      %th{:width => "10%"} Team
+      %th{:width => "3%"}
+      %th{:width => "3%"}
 
   - @projects.each do |project|
     %tr

--- a/app/views/sales_tax_customer_classes/index.html.haml
+++ b/app/views/sales_tax_customer_classes/index.html.haml
@@ -1,11 +1,12 @@
 = breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], 'Customer Tax Classes', action: action_button('+ New', new_sales_tax_customer_class_path, permission: 'sales_tax.edit')
 
-%table.table.table-striped.table-sm
-  %tr
-    %th Name
-    %th Invoice note
-    %th{:width => "3%"}
-    %th{:width => "3%"}
+%table.table.table-striped.table-hover.table-sm
+  %thead
+    %tr
+      %th Name
+      %th Invoice note
+      %th{:width => "3%"}
+      %th{:width => "3%"}
 
   - @sales_tax_customer_classes.each do |sales_tax_customer_class|
     %tr

--- a/app/views/sales_tax_customer_classes/show.html.haml
+++ b/app/views/sales_tax_customer_classes/show.html.haml
@@ -36,10 +36,11 @@
         .card-header
           Tax Rates
         .card-body
-          %table.table.table-striped.table-sm.mb-0
-            %tr
-              %th Product class
-              %th Rate
+          %table.table.table-striped.table-hover.table-sm.mb-0
+            %thead
+              %tr
+                %th Product class
+                %th Rate
             - @sales_tax_customer_class.sales_tax_rates.includes(:sales_tax_product_class).each do |rate|
               %tr
                 %td= link_to rate.sales_tax_product_class.name, rate.sales_tax_product_class

--- a/app/views/sales_tax_product_classes/index.html.haml
+++ b/app/views/sales_tax_product_classes/index.html.haml
@@ -1,12 +1,13 @@
 = breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], 'Product Tax Classes', action: action_button('+ New', new_sales_tax_product_class_path, permission: 'sales_tax.edit')
 
-%table.table.table-striped.table-sm
-  %tr
-    %th Name
-    %th Indicator code
-    %th Default
-    %th{:width => "3%"}
-    %th{:width => "3%"}
+%table.table.table-striped.table-hover.table-sm
+  %thead
+    %tr
+      %th Name
+      %th Indicator code
+      %th Default
+      %th{:width => "3%"}
+      %th{:width => "3%"}
 
   - @sales_tax_product_classes.each do |sales_tax_product_class|
     %tr

--- a/app/views/sales_tax_product_classes/show.html.haml
+++ b/app/views/sales_tax_product_classes/show.html.haml
@@ -29,10 +29,11 @@
         .card-header
           Tax Rates
         .card-body
-          %table.table.table-striped.table-sm.mb-0
-            %tr
-              %th Customer class
-              %th Rate
+          %table.table.table-striped.table-hover.table-sm.mb-0
+            %thead
+              %tr
+                %th Customer class
+                %th Rate
             - @sales_tax_product_class.sales_tax_rates.includes(:sales_tax_customer_class).each do |rate|
               %tr
                 %td= link_to rate.sales_tax_customer_class.name, rate.sales_tax_customer_class

--- a/app/views/sales_tax_rates/index.html.haml
+++ b/app/views/sales_tax_rates/index.html.haml
@@ -2,13 +2,14 @@
 - product_classes_action = nav_button('Product Classes', sales_tax_product_classes_path)
 = breadcrumbs 'Configuration', 'Sales Tax', actions: [customer_classes_action, product_classes_action], action: action_button('+ New', new_sales_tax_rate_path, permission: 'sales_tax.edit')
 
-%table.table.table-striped.table-sm
-  %tr
-    %th{:width=>"30%"} Customer class
-    %th{:width=>"30%"} Product class
-    %th{:width=>"30%"} Rate
-    %th
-    %th
+%table.table.table-striped.table-hover.table-sm
+  %thead
+    %tr
+      %th{:width=>"30%"} Customer class
+      %th{:width=>"30%"} Product class
+      %th{:width=>"30%"} Rate
+      %th
+      %th
 
   - @sales_tax_rates.each do |sales_tax_rate|
     %tr
@@ -43,13 +44,14 @@
     %p.text-error
       You should create these tax rates:
 
-    %table.table.table-striped.table-sm
-      %tr
-        %th{:width=>"30%"} Customer class
-        %th{:width=>"30%"} Product class
-        %th{:width=>"30%"} Rate
-        %th
-        %th
+    %table.table.table-striped.table-hover.table-sm
+      %thead
+        %tr
+          %th{:width=>"30%"} Customer class
+          %th{:width=>"30%"} Product class
+          %th{:width=>"30%"} Rate
+          %th
+          %th
       - @missing_rates.each do |missing_rate|
         %tr
           %td

--- a/app/views/teams/index.html.haml
+++ b/app/views/teams/index.html.haml
@@ -3,15 +3,16 @@
 %p.text-muted
   Teams control which customers and projects a user can see. Every customer and project belongs to exactly one team.
 
-%table.table.table-striped.table-sm
-  %tr
-    %th Name
-    %th Description
-    %th Members
-    %th Customers
-    %th Projects
-    %th{width: "3%"}
-    %th{width: "3%"}
+%table.table.table-striped.table-hover.table-sm
+  %thead
+    %tr
+      %th Name
+      %th Description
+      %th Members
+      %th Customers
+      %th Projects
+      %th{width: "3%"}
+      %th{width: "3%"}
 
   - @teams.each do |team|
     %tr

--- a/app/views/user_invites/index.html.haml
+++ b/app/views/user_invites/index.html.haml
@@ -2,7 +2,7 @@
 
 = breadcrumbs 'Configuration', ['Users', users_path], 'Invites', action: button_to('+ New', user_invites_path, method: :post, class: 'btn btn-primary', data: { turbo: false })
 
-%table.table.table-striped.table-sm
+%table.table.table-striped.table-hover.table-sm
   %thead
     %tr
       %th Created

--- a/app/views/users/audit.html.haml
+++ b/app/views/users/audit.html.haml
@@ -2,7 +2,7 @@
 
 = breadcrumbs 'Configuration', ['Users', users_path], [@user.username, user_path(@user)], 'Audit Log'
 
-%table.table.table-striped.table-sm
+%table.table.table-striped.table-hover.table-sm
   %thead
     %tr
       %th When

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -5,7 +5,7 @@
 - invites_nav = nav_button('View invites', user_invites_path, permission: 'user_invites.manage')
 = breadcrumbs 'Configuration', 'Users', actions: [invites_nav], action: invite_action
 
-%table.table.table-striped.table-sm
+%table.table.table-striped.table-hover.table-sm
   %thead
     %tr
       %th Username


### PR DESCRIPTION
## Why
The theme work just landed added a teal table-header underline (`.table > thead > tr > th`) and a teal row-hover (`--bs-table-hover-bg`). But the list/index tables never opted into either: they used `.table.table-striped.table-sm` **without** `.table-hover`, and most business list pages put `%tr %th` directly under `%table` with **no `%thead`** — so the header selector matched nothing and Bootstrap's hover (which is gated on `.table-hover`) was inert. That's why the list pages looked unchanged.

## What
- Add `.table-hover` to every striped list table (23 tables across 20 views).
- Wrap header rows in `%thead` on the 13 views that lacked it. Body rows auto-group into `<tbody>`, so the header now:
  - gets the teal underline,
  - is excluded from the zebra striping (previously the header row was treated as an odd data row), and
  - is excluded from hover.

Pure markup change — no SCSS, no new tests (project convention: no pixel tests for CSS).

## Verification
`bundle exec rails test test/controllers …` renders every affected index view: **207 runs, 0 failures**. `pre-commit run --all-files` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)