### PR TITLE
Replace Configuration dropdown with hub page and simplified navbar

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ gem "config"
 
 gem "sass-rails"  # necessary for bootstrap
 gem "bootstrap", "~> 5.3"
+gem "bootstrap-icons", "~> 1.0", require: "bootstrap_icons"
 gem "haml-rails"
 gem "simple_form"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,8 @@ GEM
       msgpack (~> 1.2)
     bootstrap (5.3.8)
       popper_js (>= 2.11.8, < 3)
+    bootstrap-icons (1.0.15)
+      nokogiri (~> 1)
     brakeman (8.0.5)
       racc
     builder (3.3.0)
@@ -455,6 +457,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   bootstrap (~> 5.3)
+  bootstrap-icons (~> 1.0)
   brakeman
   capybara
   config

--- a/app/assets/stylesheets/bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.scss
@@ -67,6 +67,21 @@ body { padding-top: 60px; }
   left: auto;
 }
 
+// Sign out renders as a <button> (button_to's form) inside the navbar, so it
+// needs its own reset to match the surrounding .nav-link anchors' look.
+.navbar .nav-icon-btn {
+  background: none;
+  border: none;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+}
+.navbar .nav-icon-btn:hover {
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: $border-radius;
+}
+.navbar svg.bi { vertical-align: -0.125em; }
+
 // Fix searchable dropdown hover in dark mode
 .searchable-dropdown .dropdown-item {
   &:hover,
@@ -172,3 +187,37 @@ nav[aria-label="breadcrumb"] > div {
   }
 }
 .badge { border-radius: 50rem; }
+
+// —— Configuration hub: card-grid tiles replacing the old dropdown menu.
+.config-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: .6rem;
+}
+@include media-breakpoint-up(sm) {
+  .config-grid { grid-template-columns: repeat(3, 1fr); }
+}
+@include media-breakpoint-up(lg) {
+  .config-grid { grid-template-columns: repeat(4, 1fr); }
+}
+.config-tile {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: .4rem;
+  padding: 1rem .5rem;
+  border: 1px solid var(--bs-border-color);
+  border-radius: $border-radius;
+  text-decoration: none;
+  color: var(--bs-body-color);
+  text-align: center;
+  font-size: .9rem;
+  font-weight: 500;
+  background: var(--bs-body-bg);
+}
+.config-tile:hover {
+  border-color: $primary;
+  background: rgba($primary, .06);
+  color: var(--bs-body-color);
+}
+.config-tile-icon { font-size: 1.3rem; }

--- a/app/controllers/configurations_controller.rb
+++ b/app/controllers/configurations_controller.rb
@@ -1,0 +1,15 @@
+class ConfigurationsController < ApplicationController
+  # Replaces the old navbar dropdown: a hub page linking to the various
+  # config sub-sections. Visibility is an any-of across those sections'
+  # own permissions, not a single scope, so it can't use require_permission!.
+  PERMS = %w[issuer_company.view products.view sales_tax.view users.view jobs_status.view groups.manage teams.manage].freeze
+
+  allow_without_permission_check only: [ :index ]
+
+  before_action do
+    redirect_to root_path, alert: "You don't have permission to access that page." unless PERMS.any? { |p| current_user&.permission?(p) }
+  end
+
+  def index
+  end
+end

--- a/app/helpers/action_buttons_helper.rb
+++ b/app/helpers/action_buttons_helper.rb
@@ -80,6 +80,14 @@ module ActionButtonsHelper
     link_to text, path, class: "btn btn-outline-secondary", data: data
   end
 
+  # Navbar-only: icon-only on desktop, icon + text once the navbar collapses
+  # to its mobile stacked list (where a lone icon would be the only
+  # unlabeled row). See docs/code-style.md's "Navigation icons" section.
+  def sign_out_button
+    label = nav_icon(:box_arrow_right) + content_tag(:span, "Sign out", class: "d-inline d-sm-none ms-1")
+    button_to label, session_path, method: :delete, class: "nav-link nav-icon-btn", title: "Sign out", form_class: "d-inline"
+  end
+
   private
 
   # Tier-2 shape: POST form button with a Bootstrap class and an optional

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,13 @@
 module ApplicationHelper
+  # Inline monochrome SVG icon for navbar chrome — Configuration, the account
+  # link, Sign out. A narrow, deliberate exception to the emoji-based
+  # action-button glyphs: see docs/code-style.md's "Navigation icons" section
+  # for why. Sourced from the bootstrap-icons gem rather than copied path
+  # data, so icon geometry stays correct and updatable via bundle update.
+  def nav_icon(name, size: 15)
+    BootstrapIcons::BootstrapIcon.new(name.to_s.tr("_", "-"), width: size, height: size).to_svg.html_safe
+  end
+
   # Permission check helper for views. Uses current_user via the controller
   # (already defined as a helper_method in ApplicationController).
   def can?(key)
@@ -8,9 +17,10 @@ module ApplicationHelper
   # Top-level navbar link that highlights the current section. Marks the link
   # active (Bootstrap .active + aria-current) when the request belongs to one of
   # the controllers in `active_for`, so show/edit/new pages of a section stay
-  # highlighted, not just its index.
-  def nav_link_to(label, path, active_for:)
-    active_nav_link("nav-link", label, path, active_for)
+  # highlighted, not just its index. Pass a block instead of `label` to render
+  # custom content (e.g. a mobile-only icon ahead of the text).
+  def nav_link_to(label, path, active_for:, &block)
+    active_nav_link("nav-link", label, path, active_for, &block)
   end
 
   # Same as nav_link_to but for links inside a dropdown menu.
@@ -237,10 +247,10 @@ module ApplicationHelper
 
   private
 
-  def active_nav_link(base_class, label, path, active_for)
+  def active_nav_link(base_class, label, path, active_for, &block)
     active = nav_section_active?(active_for)
     options = { class: "#{base_class}#{' active' if active}" }
     options["aria-current"] = "page" if active
-    link_to(label, path, options)
+    block ? link_to(path, options, &block) : link_to(label, path, options)
   end
 end

--- a/app/views/configurations/index.html.haml
+++ b/app/views/configurations/index.html.haml
@@ -1,0 +1,40 @@
+= breadcrumbs 'Configuration'
+
+- if can?('issuer_company.view') || can?('products.view') || can?('sales_tax.view')
+  %h6.text-uppercase.text-body-secondary.small.fw-bold.mb-2 Company &amp; Catalog
+  .config-grid.mb-4
+    - if can?('issuer_company.view')
+      = link_to issuer_company_path, class: "config-tile" do
+        %span.config-tile-icon 🏢
+        Issuer Company
+    - if can?('products.view')
+      = link_to products_path, class: "config-tile" do
+        %span.config-tile-icon 📦
+        Product Catalog
+    - if can?('sales_tax.view')
+      = link_to sales_tax_rates_path, class: "config-tile" do
+        %span.config-tile-icon 🧾
+        Sales Tax
+
+- if can?('users.view') || can?('groups.manage') || can?('teams.manage')
+  %h6.text-uppercase.text-body-secondary.small.fw-bold.mb-2 People
+  .config-grid.mb-4
+    - if can?('users.view')
+      = link_to users_path, class: "config-tile" do
+        %span.config-tile-icon 👤
+        Users
+    - if can?('groups.manage')
+      = link_to groups_path, class: "config-tile" do
+        %span.config-tile-icon 👥
+        Groups
+    - if can?('teams.manage')
+      = link_to teams_path, class: "config-tile" do
+        %span.config-tile-icon 🧑‍🤝‍🧑
+        Teams
+
+- if can?('jobs_status.view')
+  %h6.text-uppercase.text-body-secondary.small.fw-bold.mb-2 System
+  .config-grid
+    = link_to jobs_status_path, class: "config-tile" do
+      %span.config-tile-icon ⚙️
+      Background Jobs

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,4 +1,4 @@
 - content_for :title, @group.name
-= breadcrumbs 'Configuration', ['Groups', groups_path], [@group.name, group_path(@group)], 'Edit', action: save_button
+= breadcrumbs ['Configuration', configuration_path], ['Groups', groups_path], [@group.name, group_path(@group)], 'Edit', action: save_button
 
 = render 'form'

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -1,4 +1,4 @@
-= breadcrumbs 'Configuration', 'Groups', action: action_button('+ New', new_group_path, permission: 'groups.manage')
+= breadcrumbs ['Configuration', configuration_path], 'Groups', action: action_button('+ New', new_group_path, permission: 'groups.manage')
 
 %p.text-muted
   Groups bundle system-level permissions. A user inherits all permissions of every group they belong to.

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,4 +1,4 @@
 - content_for :title, 'New group'
-= breadcrumbs 'Configuration', ['Groups', groups_path], 'New', action: save_button
+= breadcrumbs ['Configuration', configuration_path], ['Groups', groups_path], 'New', action: save_button
 
 = render 'form'

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -1,4 +1,4 @@
-= breadcrumbs 'Configuration', ['Groups', groups_path], @group.name, action: action_button('Edit', edit_group_path(@group))
+= breadcrumbs ['Configuration', configuration_path], ['Groups', groups_path], @group.name, action: action_button('Edit', edit_group_path(@group))
 
 .row
   .col-md-8

--- a/app/views/issuer_companies/edit.html.haml
+++ b/app/views/issuer_companies/edit.html.haml
@@ -1,5 +1,5 @@
 - content_for :title, 'Issuer Company'
-= breadcrumbs 'Configuration', ['Issuer Company', issuer_company_path], 'Edit', action: save_button
+= breadcrumbs ['Configuration', configuration_path], ['Issuer Company', issuer_company_path], 'Edit', action: save_button
 
 = form_with(model: @issuer_company, url: issuer_company_path, method: :patch, local: true, id: ActionButtonsHelper::PAGE_FORM_ID, class: 'form', multipart: true) do |form|
   - if @issuer_company.errors.any?

--- a/app/views/issuer_companies/show.html.haml
+++ b/app/views/issuer_companies/show.html.haml
@@ -1,4 +1,4 @@
-= breadcrumbs 'Configuration', 'Issuer Company', action: action_button('Edit', edit_issuer_company_path, permission: 'issuer_company.edit')
+= breadcrumbs ['Configuration', configuration_path], 'Issuer Company', action: action_button('Edit', edit_issuer_company_path, permission: 'issuer_company.edit')
 
 .row
   .col-md-6

--- a/app/views/jobs_status/show.html.haml
+++ b/app/views/jobs_status/show.html.haml
@@ -1,4 +1,4 @@
-= breadcrumbs 'Configuration', 'Background Jobs'
+= breadcrumbs ['Configuration', configuration_path], 'Background Jobs'
 
 - if @queue_adapter != :solid_queue
   .alert.alert-warning

--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -31,50 +31,17 @@
           %li
             %hr.dropdown-divider
           %ul.list-unstyled.mb-0{"data-error-notification-target" => "list"}
-      - config_perms = %w[issuer_company.view products.view sales_tax.view users.view jobs_status.view groups.manage teams.manage]
-      - show_config = config_perms.any? { |p| can?(p) }
       - config_controllers = %w[issuer_companies products sales_tax_rates users groups teams jobs_status]
-      - if show_config
-        %li.nav-item.dropdown{"data-controller" => "navbar"}
-          %a.nav-link.dropdown-toggle{:href => "#", :role => "button", :class => ("active" if nav_section_active?(config_controllers)), :"data-navbar-target" => "toggle", :"data-action" => "click->navbar#toggle"}
+      - if ConfigurationsController::PERMS.any? { |p| can?(p) }
+        %li.nav-item
+          = nav_link_to(nil, configuration_path, active_for: config_controllers) do
+            %span.d-inline.d-sm-none.me-1
+              = nav_icon(:gear)
             Configuration
-          %ul.dropdown-menu.dropdown-menu-end{"data-navbar-target" => "menu"}
-            - if can?('issuer_company.view')
-              %li
-                = dropdown_link_to('Issuer Company', issuer_company_path, active_for: 'issuer_companies')
-              %li
-                %hr.dropdown-divider
-            - if can?('products.view')
-              %li
-                = dropdown_link_to('Product Catalog', products_path, active_for: 'products')
-            - if can?('sales_tax.view')
-              %li
-                = dropdown_link_to('Sales Tax', sales_tax_rates_path, active_for: 'sales_tax_rates')
-            - if can?('products.view') || can?('sales_tax.view')
-              %li
-                %hr.dropdown-divider
-            - if can?('users.view')
-              %li
-                = dropdown_link_to('Users', users_path, active_for: 'users')
-            - if can?('groups.manage')
-              %li
-                = dropdown_link_to('Groups', groups_path, active_for: 'groups')
-            - if can?('teams.manage')
-              %li
-                = dropdown_link_to('Teams', teams_path, active_for: 'teams')
-            - if can?('users.view') || can?('groups.manage') || can?('teams.manage')
-              %li
-                %hr.dropdown-divider
-            - if can?('jobs_status.view')
-              %li
-                = dropdown_link_to('Background Jobs', jobs_status_path, active_for: 'jobs_status')
-      %li.nav-item.dropdown{"data-controller" => "navbar"}
-        %a.nav-link.dropdown-toggle{:href => "#", :role => "button", :class => ("active" if nav_section_active?('account')), :"data-navbar-target" => "toggle", :"data-action" => "click->navbar#toggle"}
+      %li.nav-item
+        = nav_link_to(nil, account_profile_path, active_for: 'account') do
+          %span.d-inline.d-sm-none.me-1
+            = nav_icon(:person)
           = Current.user.username
-        %ul.dropdown-menu.dropdown-menu-end{"data-navbar-target" => "menu"}
-          %li
-            = dropdown_link_to('My account', account_profile_path, active_for: 'account')
-          %li
-            %hr.dropdown-divider
-          %li
-            = button_to('Sign out', session_path, method: :delete, class: 'dropdown-item', form_class: 'd-inline')
+      %li.nav-item
+        = sign_out_button

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -1,4 +1,4 @@
 - content_for :title, @product.title
-= breadcrumbs 'Configuration', ['Product Catalog', products_path], [@product.title, product_path(@product)], 'Edit', action: save_button
+= breadcrumbs ['Configuration', configuration_path], ['Product Catalog', products_path], [@product.title, product_path(@product)], 'Edit', action: save_button
 
 = render 'form'

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -1,4 +1,4 @@
-= breadcrumbs 'Configuration', 'Product Catalog', action: action_button('+ New', new_product_path, permission: 'products.edit')
+= breadcrumbs ['Configuration', configuration_path], 'Product Catalog', action: action_button('+ New', new_product_path, permission: 'products.edit')
 
 %table.table.table-striped.table-hover.table-sm
   %thead

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -1,4 +1,4 @@
 - content_for :title, 'New product'
-= breadcrumbs 'Configuration', ['Product Catalog', products_path], 'New', action: save_button
+= breadcrumbs ['Configuration', configuration_path], ['Product Catalog', products_path], 'New', action: save_button
 
 = render 'form'

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -1,4 +1,4 @@
-= breadcrumbs 'Configuration', ['Product Catalog', products_path], @product.title, action: action_button('Edit', edit_product_path(@product), permission: 'products.edit')
+= breadcrumbs ['Configuration', configuration_path], ['Product Catalog', products_path], @product.title, action: action_button('Edit', edit_product_path(@product), permission: 'products.edit')
 
 .row
   .col-md-8

--- a/app/views/sales_tax_customer_classes/edit.html.haml
+++ b/app/views/sales_tax_customer_classes/edit.html.haml
@@ -1,4 +1,4 @@
 - content_for :title, @sales_tax_customer_class.name
-= breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], ['Customer Tax Classes', sales_tax_customer_classes_path], [@sales_tax_customer_class.name, sales_tax_customer_class_path(@sales_tax_customer_class)], 'Edit', action: save_button
+= breadcrumbs ['Configuration', configuration_path], ['Sales Tax', sales_tax_rates_path], ['Customer Tax Classes', sales_tax_customer_classes_path], [@sales_tax_customer_class.name, sales_tax_customer_class_path(@sales_tax_customer_class)], 'Edit', action: save_button
 
 = render 'form'

--- a/app/views/sales_tax_customer_classes/index.html.haml
+++ b/app/views/sales_tax_customer_classes/index.html.haml
@@ -1,4 +1,4 @@
-= breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], 'Customer Tax Classes', action: action_button('+ New', new_sales_tax_customer_class_path, permission: 'sales_tax.edit')
+= breadcrumbs ['Configuration', configuration_path], ['Sales Tax', sales_tax_rates_path], 'Customer Tax Classes', action: action_button('+ New', new_sales_tax_customer_class_path, permission: 'sales_tax.edit')
 
 %table.table.table-striped.table-hover.table-sm
   %thead

--- a/app/views/sales_tax_customer_classes/new.html.haml
+++ b/app/views/sales_tax_customer_classes/new.html.haml
@@ -1,4 +1,4 @@
 - content_for :title, 'New customer tax class'
-= breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], ['Customer Tax Classes', sales_tax_customer_classes_path], 'New', action: save_button
+= breadcrumbs ['Configuration', configuration_path], ['Sales Tax', sales_tax_rates_path], ['Customer Tax Classes', sales_tax_customer_classes_path], 'New', action: save_button
 
 = render 'form'

--- a/app/views/sales_tax_customer_classes/show.html.haml
+++ b/app/views/sales_tax_customer_classes/show.html.haml
@@ -1,6 +1,6 @@
 - delete_action = delete_button(@sales_tax_customer_class, confirm: "Are you sure you want to delete customer class \"#{@sales_tax_customer_class.name}\"?", permission: 'sales_tax.edit')
 - edit_action = action_button('Edit', edit_sales_tax_customer_class_path(@sales_tax_customer_class), permission: 'sales_tax.edit')
-= breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], ['Customer Tax Classes', sales_tax_customer_classes_path], @sales_tax_customer_class.name, actions: [delete_action], action: edit_action
+= breadcrumbs ['Configuration', configuration_path], ['Sales Tax', sales_tax_rates_path], ['Customer Tax Classes', sales_tax_customer_classes_path], @sales_tax_customer_class.name, actions: [delete_action], action: edit_action
 
 .row
   .col-md-8

--- a/app/views/sales_tax_product_classes/edit.html.haml
+++ b/app/views/sales_tax_product_classes/edit.html.haml
@@ -1,4 +1,4 @@
 - content_for :title, @sales_tax_product_class.name
-= breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], ['Product Tax Classes', sales_tax_product_classes_path], [@sales_tax_product_class.name, sales_tax_product_class_path(@sales_tax_product_class)], 'Edit', action: save_button
+= breadcrumbs ['Configuration', configuration_path], ['Sales Tax', sales_tax_rates_path], ['Product Tax Classes', sales_tax_product_classes_path], [@sales_tax_product_class.name, sales_tax_product_class_path(@sales_tax_product_class)], 'Edit', action: save_button
 
 = render 'form'

--- a/app/views/sales_tax_product_classes/index.html.haml
+++ b/app/views/sales_tax_product_classes/index.html.haml
@@ -1,4 +1,4 @@
-= breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], 'Product Tax Classes', action: action_button('+ New', new_sales_tax_product_class_path, permission: 'sales_tax.edit')
+= breadcrumbs ['Configuration', configuration_path], ['Sales Tax', sales_tax_rates_path], 'Product Tax Classes', action: action_button('+ New', new_sales_tax_product_class_path, permission: 'sales_tax.edit')
 
 %table.table.table-striped.table-hover.table-sm
   %thead

--- a/app/views/sales_tax_product_classes/new.html.haml
+++ b/app/views/sales_tax_product_classes/new.html.haml
@@ -1,4 +1,4 @@
 - content_for :title, 'New product tax class'
-= breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], ['Product Tax Classes', sales_tax_product_classes_path], 'New', action: save_button
+= breadcrumbs ['Configuration', configuration_path], ['Sales Tax', sales_tax_rates_path], ['Product Tax Classes', sales_tax_product_classes_path], 'New', action: save_button
 
 = render 'form'

--- a/app/views/sales_tax_product_classes/show.html.haml
+++ b/app/views/sales_tax_product_classes/show.html.haml
@@ -1,6 +1,6 @@
 - delete_action = delete_button(@sales_tax_product_class, confirm: "Are you sure you want to delete product class \"#{@sales_tax_product_class.name}\"?", permission: 'sales_tax.edit')
 - edit_action = action_button('Edit', edit_sales_tax_product_class_path(@sales_tax_product_class), permission: 'sales_tax.edit')
-= breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], ['Product Tax Classes', sales_tax_product_classes_path], @sales_tax_product_class.name, actions: [delete_action], action: edit_action do
+= breadcrumbs ['Configuration', configuration_path], ['Sales Tax', sales_tax_rates_path], ['Product Tax Classes', sales_tax_product_classes_path], @sales_tax_product_class.name, actions: [delete_action], action: edit_action do
   - if @sales_tax_product_class.is_default?
     %span.badge.bg-success Default
 

--- a/app/views/sales_tax_rates/edit.html.haml
+++ b/app/views/sales_tax_rates/edit.html.haml
@@ -1,4 +1,4 @@
 - content_for :title, "#{@sales_tax_rate.sales_tax_customer_class&.name} / #{@sales_tax_rate.sales_tax_product_class&.name}"
-= breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], [(@sales_tax_rate.sales_tax_customer_class&.name.to_s + ' / ' + @sales_tax_rate.sales_tax_product_class&.name.to_s), sales_tax_rate_path(@sales_tax_rate)], 'Edit', action: save_button
+= breadcrumbs ['Configuration', configuration_path], ['Sales Tax', sales_tax_rates_path], [(@sales_tax_rate.sales_tax_customer_class&.name.to_s + ' / ' + @sales_tax_rate.sales_tax_product_class&.name.to_s), sales_tax_rate_path(@sales_tax_rate)], 'Edit', action: save_button
 
 = render 'form'

--- a/app/views/sales_tax_rates/index.html.haml
+++ b/app/views/sales_tax_rates/index.html.haml
@@ -1,6 +1,6 @@
 - customer_classes_action = nav_button('Customer Classes', sales_tax_customer_classes_path)
 - product_classes_action = nav_button('Product Classes', sales_tax_product_classes_path)
-= breadcrumbs 'Configuration', 'Sales Tax', actions: [customer_classes_action, product_classes_action], action: action_button('+ New', new_sales_tax_rate_path, permission: 'sales_tax.edit')
+= breadcrumbs ['Configuration', configuration_path], 'Sales Tax', actions: [customer_classes_action, product_classes_action], action: action_button('+ New', new_sales_tax_rate_path, permission: 'sales_tax.edit')
 
 %table.table.table-striped.table-hover.table-sm
   %thead

--- a/app/views/sales_tax_rates/new.html.haml
+++ b/app/views/sales_tax_rates/new.html.haml
@@ -1,4 +1,4 @@
 - content_for :title, 'New sales tax rate'
-= breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], 'New', action: save_button
+= breadcrumbs ['Configuration', configuration_path], ['Sales Tax', sales_tax_rates_path], 'New', action: save_button
 
 = render 'form'

--- a/app/views/sales_tax_rates/show.html.haml
+++ b/app/views/sales_tax_rates/show.html.haml
@@ -1,6 +1,6 @@
 - delete_action = delete_button(@sales_tax_rate, confirm: "Are you sure you want to delete tax rate for \"#{@sales_tax_rate.sales_tax_customer_class&.name}\" / \"#{@sales_tax_rate.sales_tax_product_class&.name}\"?", permission: 'sales_tax.edit')
 - edit_action = action_button('Edit', edit_sales_tax_rate_path(@sales_tax_rate), permission: 'sales_tax.edit')
-= breadcrumbs 'Configuration', ['Sales Tax', sales_tax_rates_path], "#{@sales_tax_rate.sales_tax_customer_class&.name} / #{@sales_tax_rate.sales_tax_product_class&.name}", actions: [delete_action], action: edit_action
+= breadcrumbs ['Configuration', configuration_path], ['Sales Tax', sales_tax_rates_path], "#{@sales_tax_rate.sales_tax_customer_class&.name} / #{@sales_tax_rate.sales_tax_product_class&.name}", actions: [delete_action], action: edit_action
 
 .row
   .col-md-8

--- a/app/views/teams/edit.html.haml
+++ b/app/views/teams/edit.html.haml
@@ -1,4 +1,4 @@
 - content_for :title, @team.name
-= breadcrumbs 'Configuration', ['Teams', teams_path], [@team.name, team_path(@team)], 'Edit', action: save_button
+= breadcrumbs ['Configuration', configuration_path], ['Teams', teams_path], [@team.name, team_path(@team)], 'Edit', action: save_button
 
 = render 'form'

--- a/app/views/teams/index.html.haml
+++ b/app/views/teams/index.html.haml
@@ -1,4 +1,4 @@
-= breadcrumbs 'Configuration', 'Teams', action: action_button('+ New', new_team_path, permission: 'teams.manage')
+= breadcrumbs ['Configuration', configuration_path], 'Teams', action: action_button('+ New', new_team_path, permission: 'teams.manage')
 
 %p.text-muted
   Teams control which customers and projects a user can see. Every customer and project belongs to exactly one team.

--- a/app/views/teams/new.html.haml
+++ b/app/views/teams/new.html.haml
@@ -1,4 +1,4 @@
 - content_for :title, 'New team'
-= breadcrumbs 'Configuration', ['Teams', teams_path], 'New', action: save_button
+= breadcrumbs ['Configuration', configuration_path], ['Teams', teams_path], 'New', action: save_button
 
 = render 'form'

--- a/app/views/teams/show.html.haml
+++ b/app/views/teams/show.html.haml
@@ -1,4 +1,4 @@
-= breadcrumbs 'Configuration', ['Teams', teams_path], @team.name, action: action_button('Edit', edit_team_path(@team))
+= breadcrumbs ['Configuration', configuration_path], ['Teams', teams_path], @team.name, action: action_button('Edit', edit_team_path(@team))
 
 .row
   .col-md-8

--- a/app/views/user_invites/index.html.haml
+++ b/app/views/user_invites/index.html.haml
@@ -1,6 +1,6 @@
 - content_for :title, 'Invites'
 
-= breadcrumbs 'Configuration', ['Users', users_path], 'Invites', action: button_to('+ New', user_invites_path, method: :post, class: 'btn btn-primary', data: { turbo: false })
+= breadcrumbs ['Configuration', configuration_path], ['Users', users_path], 'Invites', action: button_to('+ New', user_invites_path, method: :post, class: 'btn btn-primary', data: { turbo: false })
 
 %table.table.table-striped.table-hover.table-sm
   %thead

--- a/app/views/user_invites/show_invite.html.haml
+++ b/app/views/user_invites/show_invite.html.haml
@@ -1,6 +1,6 @@
 - content_for :title, 'Invite generated'
 
-= breadcrumbs 'Configuration', ['Users', users_path], ['Invites', user_invites_path], 'Generated'
+= breadcrumbs ['Configuration', configuration_path], ['Users', users_path], ['Invites', user_invites_path], 'Generated'
 = page_header('Invite generated')
 
 .alert.alert-info

--- a/app/views/users/audit.html.haml
+++ b/app/views/users/audit.html.haml
@@ -1,6 +1,6 @@
 - content_for :title, "Audit log for #{@user.username}"
 
-= breadcrumbs 'Configuration', ['Users', users_path], [@user.username, user_path(@user)], 'Audit Log'
+= breadcrumbs ['Configuration', configuration_path], ['Users', users_path], [@user.username, user_path(@user)], 'Audit Log'
 
 %table.table.table-striped.table-hover.table-sm
   %thead

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -3,7 +3,7 @@
 - can_invite = can?('user_invites.manage')
 - invite_action = can_invite ? button_to('+ Invite user', user_invites_path, method: :post, class: 'btn btn-primary', data: { turbo: false }) : nil
 - invites_nav = nav_button('View invites', user_invites_path, permission: 'user_invites.manage')
-= breadcrumbs 'Configuration', 'Users', actions: [invites_nav], action: invite_action
+= breadcrumbs ['Configuration', configuration_path], 'Users', actions: [invites_nav], action: invite_action
 
 %table.table.table-striped.table-hover.table-sm
   %thead

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -3,7 +3,7 @@
 - unblock_action = unblock_button(unblock_user_path(@user), permission: 'users.block', confirm: "Unblock #{@user.username}?") if @user.blocked?
 - reset_action = reset_passkeys_button(reset_passkeys_user_path(@user), permission: 'users.reset_passkeys', confirm: "Delete all of #{@user.username}'s passkeys and email them an invite to register a new one?") if @user.blocked?
 - audit_action = audit_log_button(audit_user_path(@user))
-= breadcrumbs 'Configuration', ['Users', users_path], @user.username, actions: [unblock_action, reset_action, audit_action] do
+= breadcrumbs ['Configuration', configuration_path], ['Users', users_path], @user.username, actions: [unblock_action, reset_action, audit_action] do
   - if @user.blocked?
     %span.badge.bg-danger Blocked
   - if @user.id == current_user.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,8 @@ Rails.application.routes.draw do
     resources :groups
     resources :teams
 
+    get "configuration", to: "configurations#index", as: :configuration
+
     resource :issuer_company, only: [ :show, :edit, :update ] do
       get :png_logo, on: :member
     end

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -73,6 +73,13 @@ Established mapping — extend it, don't invent new glyphs for existing verbs:
 
 For cross-resource navigation in a breadcrumb action cluster, use `nav_button` (outline-secondary). Don't reach for filled variants for nav.
 
+## Navigation icons
+A separate, narrow convention from the action-button glyphs above — these mark navbar chrome (Configuration, the account link, Sign out), not workflow actions:
+- Inline monochrome SVG via `nav_icon(:name)`, backed by the `bootstrap-icons` gem (`BootstrapIcons::BootstrapIcon`) — not emoji. Emoji render inconsistently across platforms/color, which matters for chrome that's on screen at all times; it doesn't matter enough for one-off action buttons to be worth a second icon mechanism there. `nav_icon` takes the gem's icon name (underscores are converted to hyphens, so `:box_arrow_right` maps to the `box-arrow-right` icon).
+- Configuration and the account link show their icon only below the `sm` breakpoint (`d-inline d-sm-none`) — on desktop they're plain text like every other top-level nav item; the icon exists to break up an otherwise-identical run of text rows once the navbar collapses to its mobile stacked list.
+- Sign out is the exception: icon-only on desktop (`nav_icon(:box_arrow_right)`), icon + text once collapsed — it's the one control that isn't paired with adjacent context, so a lone icon reads fine on desktop but would be the only unlabeled row in the mobile list.
+- Configuration hub tiles (`app/views/configurations/index.html.haml`) use the existing emoji convention, not `nav_icon` — that page isn't chrome, it's page content, so the action-button glyph rules apply there instead.
+
 ## Controllers
 - Permission gates: `before_action -> { require_permission!("scope.verb") }, only: [...]`.
 - Read through tenant scopes (`Model.visible_to(current_user)`).

--- a/test/controllers/configurations_controller_test.rb
+++ b/test/controllers/configurations_controller_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class ConfigurationsControllerTest < ActionDispatch::IntegrationTest
+  test "renders tiles for every section the user can view" do
+    get configuration_path
+    assert_response :success
+    assert_select ".breadcrumb-item.active", text: "Configuration"
+    assert_select ".config-tile", text: /Issuer Company/
+    assert_select ".config-tile", text: /Product Catalog/
+    assert_select ".config-tile", text: /Sales Tax/
+    assert_select ".config-tile", text: /Users/
+    assert_select ".config-tile", text: /Groups/
+    assert_select ".config-tile", text: /Teams/
+    assert_select ".config-tile", text: /Background Jobs/
+  end
+
+  test "redirects a user with none of the configuration permissions" do
+    sign_in_as(users(:bob))
+    get configuration_path
+    assert_redirected_to root_path
+  end
+end

--- a/test/integration/nav_active_section_test.rb
+++ b/test/integration/nav_active_section_test.rb
@@ -15,17 +15,15 @@ class NavActiveSectionTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "Configuration dropdown highlights its toggle and the matching item on a config section" do
+  test "Configuration link highlights on a config section" do
     get "/products"
     assert_response :success
-    assert_select "a.nav-link.dropdown-toggle.active", text: "Configuration"
-    assert_select "a.dropdown-item.active[aria-current=page]", text: "Product Catalog"
+    assert_select "a.nav-link.active[aria-current=page]", text: /Configuration/
   end
 
-  test "user dropdown highlights its toggle and My account across the account namespace" do
+  test "account link highlights across the account namespace" do
     get "/account/emails"
     assert_response :success
-    assert_select "a.nav-link.dropdown-toggle.active", text: users(:alice).username
-    assert_select "a.dropdown-item.active[aria-current=page]", text: "My account"
+    assert_select "a.nav-link.active[aria-current=page]", text: /#{users(:alice).username}/
   end
 end

--- a/test/integration/permissions_enforcement_test.rb
+++ b/test/integration/permissions_enforcement_test.rb
@@ -57,9 +57,13 @@ class PermissionsEnforcementTest < ActionDispatch::IntegrationTest
     assert_no_match(/href="#{groups_path}"/, response.body)
   end
 
-  test "admin sees groups and teams links in navigation" do
+  test "admin sees the Configuration link in navigation, with groups and teams links on that page" do
     sign_in_as(users(:alice))
     get root_path
+    assert_response :success
+    assert_match(/href="#{configuration_path}"/, response.body)
+
+    get configuration_path
     assert_response :success
     assert_match(/href="#{groups_path}"/, response.body)
     assert_match(/href="#{teams_path}"/, response.body)


### PR DESCRIPTION
## Summary
Replaces the Configuration dropdown menu in the navbar with a dedicated hub page (`/configuration`), simplifying the navbar chrome and improving mobile UX. The navbar now shows Configuration and account links as simple text items (with mobile-only icons), and the Sign out button is repositioned as a dedicated nav item.

## Key Changes

- **New Configuration hub page** (`app/views/configurations/index.html.haml`, `app/controllers/configurations_controller.rb`): Replaces the old dropdown with a card-grid layout organized into three sections (Company & Catalog, People, System). Tiles use emoji icons and are responsive (2 columns on mobile, 3 on tablet, 4 on desktop).

- **Simplified navbar** (`app/views/layouts/_navigation.html.haml`): 
  - Configuration and account links are now simple `nav-link` items (not dropdowns)
  - Mobile-only SVG icons via new `nav_icon()` helper (gear for Configuration, person for account)
  - Sign out moved to a dedicated nav item with icon-only desktop display, icon + text on mobile
  - Removed all permission checks from the dropdown rendering; visibility is now enforced at the controller level

- **New navigation icon system** (`app/helpers/application_helper.rb`, `app/helpers/action_buttons_helper.rb`):
  - `nav_icon()` helper renders inline monochrome SVG icons (Bootstrap Icons, MIT-licensed) for navbar chrome
  - `sign_out_button()` helper renders the Sign out button with responsive icon/text display
  - Icons only appear below the `sm` breakpoint; desktop navbar remains text-only like other top-level items

- **Styling** (`app/assets/stylesheets/bootstrap_and_overrides.css.scss`):
  - `.config-grid` and `.config-tile` classes for the hub page card layout
  - `.nav-icon-btn` styles for the Sign out button to match surrounding nav-link anchors
  - SVG icon vertical alignment fix

- **Breadcrumb updates**: All configuration sub-pages (Groups, Teams, Products, Users, Sales Tax, etc.) now link back to `configuration_path` instead of plain text "Configuration"

- **Tests**:
  - New `ConfigurationsControllerTest` verifies hub page renders all tiles and redirects unauthorized users
  - Updated `NavActiveSectionTest` to reflect simplified navbar (no more dropdown toggles)
  - Updated `PermissionsEnforcementTest` to check Configuration link in nav and tiles on the hub page

## Implementation Details

- Configuration hub visibility is controlled by `ConfigurationsController::PERMS` (any-of permission check), not a single scope, so it can't use `require_permission!`
- `nav_link_to()` helper now accepts a block for custom content (e.g., icon + text)
- Mobile-only icons use Bootstrap's `d-inline d-sm-none` utility classes; Sign out is the exception (icon-only on desktop, icon + text on mobile)
- Breadcrumbs throughout the app now use `['Configuration', configuration_path]` tuples to make them clickable links

https://claude.ai/code/session_01XH8HLHHC1fRrbwvA3uUqjg