### PR TITLE
Restyle cards and line-item tables to match the teal identity

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.scss
@@ -12,6 +12,16 @@ $border-radius: .25rem; // tighter corners app-wide (was .375rem)
 @import "bootstrap";
 body { padding-top: 60px; }
 
+// —— Page background: a soft tint instead of stock white/near-black, so
+// `.card` (which keeps Bootstrap's default white/dark surface color) reads
+// as a distinct surface without needing a border. Deliberately overrides
+// `body`'s background-color directly rather than the `--bs-body-bg`
+// variable, so components that derive their background from that variable
+// (cards, dropdowns, modals, popovers) are unaffected and stay on the
+// original white/dark surface color.
+body { background-color: #f4f6f6; }
+[data-bs-theme="dark"] body { background-color: #17191a; }
+
 // Navbar: brand-teal bar with the rainbow reduced to a 4px underline. Non-active
 // links sit at 80% white; the active page is full white with a teal underline.
 // A transparent underline is reserved on every link so switching pages doesn't
@@ -174,6 +184,37 @@ nav[aria-label="breadcrumb"] > div {
 
 // —— Compact rows: a hair tighter than Bootstrap's .table-sm default.
 .table-sm { --bs-table-cell-padding-y: 0.2rem; }
+
+// —— Totals row: a teal top rule (matching the header rule's weight/color)
+// instead of Bootstrap's default cell borders.
+.table-total-row > td {
+  border-top: 2px solid $primary;
+  border-bottom: 0;
+}
+[data-bs-theme="dark"] .table-total-row > td {
+  border-top-color: tint-color($primary, 40%);
+}
+
+// —— Cards: borderless, marked only by a teal rule under the header (same
+// weight/color as the table header rule above) instead of Bootstrap's
+// default border + flat gray header fill.
+.card {
+  border: 0;
+  box-shadow: none;
+}
+.card-header {
+  background-color: transparent;
+  border-bottom: 2px solid $primary;
+}
+[data-bs-theme="dark"] .card-header {
+  border-bottom-color: tint-color($primary, 40%);
+}
+
+// A card with no header (e.g. a lone `.card > .card-body`) shouldn't
+// reserve the vertical space a header would have taken; only restore the
+// full top padding when a header actually precedes the body.
+.card-body { padding-top: .5rem; }
+.card-header + .card-body { padding-top: var(--bs-card-spacer-y); }
 
 // —— Badges: soft, fully-rounded pills instead of solid blocks.
 @each $name, $color in $theme-colors {

--- a/app/assets/stylesheets/documents.css.scss
+++ b/app/assets/stylesheets/documents.css.scss
@@ -10,9 +10,6 @@ table.document-lines-table {
   th.col-amount      { width: 15%; }
 
   th {
-    background-color: var(--bs-secondary-bg) !important;
-    color: var(--bs-secondary-color) !important;
-    border-color: var(--bs-border-color);
     font-weight: 600;
     padding: 0.75rem 0.5rem;
   }
@@ -20,22 +17,31 @@ table.document-lines-table {
   td {
     padding: 0.5rem;
     vertical-align: top;
-    background-color: var(--bs-body-bg);
-    color: var(--bs-body-color);
-    border-color: var(--bs-border-color);
   }
 
-  tr:nth-child(even) td {
-    background-color: var(--bs-secondary-bg-subtle);
+  // Subheading rows: a soft teal tint band with a left rule instead of a
+  // flat gray fill, echoing the teal header rule above. Hardcoded to match
+  // $primary (#22807f) / tint-color($primary, 40%) (#7ab3b2) from
+  // bootstrap_and_overrides.css.scss — this file compiles standalone via
+  // Sprockets, so it can't share that file's Sass variables. `box-shadow:
+  // none` opts the row out of the table's striped/hover inset-shadow
+  // overlay (see Bootstrap's _tables.scss), so this tint doesn't shift with
+  // row parity or hover.
+  td.document-section-row {
+    background-color: rgba(34, 128, 127, 0.09);
+    border-left: 3px solid #22807f;
+    box-shadow: none;
+    padding: 12px 8px 12px calc(8px - 3px);
   }
-
-  .table-secondary {
-    background-color: var(--bs-secondary-bg) !important;
-    color: var(--bs-secondary-color) !important;
+  td.document-text-row {
+    box-shadow: none;
+    padding: 8px;
   }
-
-  td.document-section-row { padding: 12px 8px; }
-  td.document-text-row    { padding: 8px; }
 
   .document-line-comment { margin-left: 20px; }
+}
+
+[data-bs-theme="dark"] table.document-lines-table td.document-section-row {
+  background-color: rgba(122, 179, 178, 0.14);
+  border-left-color: #7ab3b2;
 }

--- a/app/views/delivery_notes/show.html.haml
+++ b/app/views/delivery_notes/show.html.haml
@@ -149,7 +149,7 @@
           = @delivery_note.prelude
 
   .mb-2
-    %table.table.table-bordered.document-lines-table
+    %table.table.table-striped.table-hover.document-lines-table
       %thead
         %tr
           %th.text-end.col-quantity Quantity
@@ -173,7 +173,7 @@
                 =#line.delivery_time
           - when 'subheading'
             %tr
-              %td.fw-bold.table-secondary.document-section-row{colspan: 5}
+              %td.fw-bold.document-section-row{colspan: 5}
                 = line.title
           - when 'text', 'plain'
             %tr

--- a/app/views/invoices/show.html.haml
+++ b/app/views/invoices/show.html.haml
@@ -165,7 +165,7 @@
           %li= w
 
   .mb-2
-    %table.table.table-bordered.document-lines-table
+    %table.table.table-striped.table-hover.document-lines-table
       %thead
         %tr
           %th.col-description Description
@@ -197,7 +197,7 @@
                 %strong= format_currency(line.amount || (line.quantity * line.rate))
           - when 'subheading'
             %tr
-              %td.fw-bold.table-secondary.document-section-row{colspan: 5}
+              %td.fw-bold.document-section-row{colspan: 5}
                 = line.title
           - when 'text', 'plain'
             %tr

--- a/app/views/offers/_conversion_rows.html.haml
+++ b/app/views/offers/_conversion_rows.html.haml
@@ -1,4 +1,4 @@
-%table.table.table-bordered
+%table.table.table-striped.table-hover
   %thead
     %tr
       %th Milestone

--- a/app/views/offers/show.html.haml
+++ b/app/views/offers/show.html.haml
@@ -183,7 +183,7 @@
         - if @offer.accepted? || @offer.failed?
           = render 'conversion_rows'
         - elsif @version
-          %table.table.table-bordered
+          %table.table.table-striped.table-hover
             %thead
               %tr
                 %th Milestone
@@ -199,7 +199,7 @@
                       %small.text-muted= simple_format(milestone.description, {}, wrapper_tag: 'span')
                   %td= milestone.trigger_label
                   %td.numeric= format_currency(milestone.amount)
-              %tr
+              %tr.table-total-row
                 %td.text-end{colspan: 2}
                   %strong Total Net:
                 %td.numeric

--- a/docs/card-table-restyle.md
+++ b/docs/card-table-restyle.md
@@ -1,0 +1,48 @@
+# Card and table visual identity
+
+This documents the design decisions behind the `.card` and line-item table
+styling in `bootstrap_and_overrides.css.scss` / `documents.css.scss`, so
+future changes stay consistent instead of drifting back toward stock
+Bootstrap. Edit forms are intentionally out of scope here; they will get
+their own pass separately.
+
+## Page background
+
+The app body background is a soft tint rather than plain white/near-black,
+so cards read as a distinct surface without needing a border:
+
+- Light: `#f4f6f6`
+- Dark: `#17191a`
+
+Cards keep their own surface color (`#fff` light / `#212529` dark,
+Bootstrap's stock dark surface) independent of the page background.
+
+## Cards
+
+- No border, no box-shadow on `.card`.
+- `.card-header`, when present, drops its background/border in favor of a
+  2px solid teal rule (`$primary`, tinted 40% in dark mode) — the same
+  weight/color already used under `.table thead th`. Header text stays a
+  normal heading, no uppercase/eyebrow treatment.
+- `.card-body` immediately following a `.card-header` keeps normal top
+  padding; a `.card-body` with no preceding header (e.g. the plain
+  boilerplate card on `offers/show`) gets a reduced top padding instead of
+  reserving space for a header that isn't there.
+- Layout (grid of `.card`s in `.row > .col-md-*`) is unchanged — this is a
+  CSS-only restyle.
+
+## Tables
+
+`table.document-lines-table` and the offer-milestones table both drop their
+own header/border treatment and inherit the generic `.table` rules (2px
+teal header rule, faint teal zebra stripe, teal hover) instead of each
+having a slightly different look:
+
+- `document-lines-table` no longer paints its own gray header or its own
+  `nth-child(even)` stripe; only column-width rules and the
+  section/free-text row treatments remain bespoke.
+- The offer-milestones table drops `table-bordered` (no more full grid) and
+  gets a `.table-total-row` modifier for its totals row (2px teal top rule,
+  no boxed borders) instead of relying on Bootstrap's default cell borders.
+- No table is wrapped in a card shell — tables stay directly in their
+  existing containers.

--- a/test/controllers/invoices_controller_test.rb
+++ b/test/controllers/invoices_controller_test.rb
@@ -203,7 +203,7 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
 
     get invoice_url(invoice)
     assert_response :success
-    assert_select "table.table-bordered"
+    assert_select "table.document-lines-table"
     assert_select ".badge.bg-success", text: "Booked"
   end
 


### PR DESCRIPTION
## Summary

- Adopts a soft tinted page background (light `#f4f6f6` / dark `#17191a`) app-wide, replacing plain white/near-black.
- Restyles `.card`: no border/shadow, a 2px teal rule under the header (matching the existing table-header rule), and a collapsed top padding on headerless cards instead of reserving space for a header that isn't there. Cards keep their own white/dark surface color, independent of the new page background.
- Unifies the line-item tables — `document-lines-table` (invoice/delivery-note lines) and the offer milestones/conversion tables — under the same teal-header, zebra-striped treatment already used by generic list tables, dropping the old separate gray header and full-grid borders.
- Adds `docs/card-table-restyle.md` documenting the resulting card/table conventions for future changes. Edit forms are intentionally out of scope; a separate pass will cover those.

## Test plan

- [x] `bundle exec rails test` (1044 runs, 0 failures)
- [x] `bundle exec rails test test/system/` (65 runs, 0 failures)
- [x] Manual visual check via Capybara screenshots: customer show (headered + headerless cards), offer show (milestones table + totals row), invoice show (line-item table with subheading/zebra rows), delivery note show, all in both light and dark theme
- [x] `./bin/rubocop` on touched Ruby files

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HZqSFbngHkfr37F9UHo5Ee)_