### PR TITLE
Keep invoice prelude adjacent to the line-item table

### DIFF
--- a/app/views/invoices/show.html.haml
+++ b/app/views/invoices/show.html.haml
@@ -143,12 +143,6 @@
             .col-sm-8
               = link_to @invoice.offer_milestone.offer.display_name, @invoice.offer_milestone.offer
 
-  - if @invoice.prelude.present?
-    .mb-4
-      .card
-        .card-body
-          = @invoice.prelude
-
   - if !@invoice.published? && problems.any?
     .alert.alert-warning.mb-3
       %strong This invoice cannot be published yet:
@@ -163,6 +157,12 @@
       %ul.mb-0
         - warnings.each do |w|
           %li= w
+
+  - if @invoice.prelude.present?
+    .mb-4
+      .card
+        .card-body
+          = @invoice.prelude
 
   .mb-2
     %table.table.table-striped.table-hover.document-lines-table


### PR DESCRIPTION
## Summary

- Stacked on #564 (card/table restyle).
- Moves the publish-problems / publish-warnings alert boxes above the prelude card on `invoices/show` instead of between it and the line-item table, so the prelude text sits directly next to the lines it describes.
- `delivery_notes/show` already had this ordering (prelude directly above the lines table, nothing in between) — no change needed there.

## Test plan

- [x] `bundle exec rails test` (1046 runs, 0 failures)
- [x] `bundle exec rails test test/system/` (65 runs, 0 failures)
- [x] Manual visual check via Capybara screenshot on a draft invoice with both problems and warnings present — prelude now renders immediately above the line table

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HZqSFbngHkfr37F9UHo5Ee)_