### PR TITLE
Replace action-button emoji glyphs with bootstrap-icons

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,7 @@ For testing against PostgreSQL (matches production environment):
 
 ## Code Style
 
-See [`docs/code-style.md`](docs/code-style.md) for the canonical style reference (HAML, Bootstrap, Stimulus, tests, status badges, action button glyphs, formatting, comments, commit messages). Read it before writing code.
+See [`docs/code-style.md`](docs/code-style.md) for the canonical style reference (HAML, Bootstrap, Stimulus, tests, status badges, action button icons, formatting, comments, commit messages). Read it before writing code.
 
 UI helpers live in `app/helpers/application_helper.rb` (page chrome: `breadcrumbs`, `page_header`, `action_button`, `destroy_link`, `list_action_link`, `action_buttons_wrapper`) and `app/helpers/action_buttons_helper.rb` (per-verb wrappers: `delete_button`, `pdf_button`, `preview_button`, `publish_button`, `unpublish_button`, `unblock_button`, `reset_passkeys_button`, `audit_log_button`, `save_button`, `nav_button`). Read the source for signatures.
 

--- a/app/assets/stylesheets/actiontext.css.scss
+++ b/app/assets/stylesheets/actiontext.css.scss
@@ -15,3 +15,73 @@ trix-editor {
 
 // Hide the toolbar groups we don't support (belt-and-suspenders with the JS).
 trix-toolbar .trix-button-group--file-tools { display: none; }
+
+// —— Toolbar restyle: match the app's small-button radius (.25rem) instead
+// of Trix's default rounded corners, and swap Trix's baked-in icon set for
+// the same bootstrap-icons family used by action_icon/nav_icon. Hardcoded
+// to $primary (#22807f) / tint-color($primary, 40%) (#7ab3b2) from
+// bootstrap_and_overrides.css.scss — this file compiles standalone via
+// Sprockets, so it can't share that file's Sass variables (see the same
+// note in documents.css.scss).
+trix-toolbar .trix-button-group {
+  border-color: var(--bs-border-color);
+  border-radius: .25rem;
+}
+trix-toolbar .trix-button {
+  color: var(--bs-secondary-color);
+}
+trix-toolbar .trix-button:not(:first-child) {
+  border-left-color: var(--bs-border-color);
+}
+trix-toolbar .trix-button:hover:not(:disabled) {
+  color: #22807f;
+  background: rgba(34, 128, 127, 0.09);
+}
+trix-toolbar .trix-button.trix-active {
+  color: #22807f;
+  background: rgba(34, 128, 127, 0.15);
+}
+[data-bs-theme="dark"] trix-toolbar .trix-button:hover:not(:disabled) {
+  color: #7ab3b2;
+  background: rgba(122, 179, 178, 0.14);
+}
+[data-bs-theme="dark"] trix-toolbar .trix-button.trix-active {
+  color: #7ab3b2;
+  background: rgba(122, 179, 178, 0.22);
+}
+
+// Each icon is a single shape, embedded once and reused as a CSS mask —
+// mask-image only consumes the alpha channel, so the actual visible color
+// always comes from the button's own `color` (set above per state) rather
+// than from the SVG itself. No separate SVG copy is needed per color/theme.
+$trix-icon-shapes: (
+  "bold": "<path d='M8.21 13c2.106 0 3.412-1.087 3.412-2.823 0-1.306-.984-2.283-2.324-2.386v-.055a2.176 2.176 0 0 0 1.852-2.14c0-1.51-1.162-2.46-3.014-2.46H3.843V13zM5.908 4.674h1.696c.963 0 1.517.451 1.517 1.244 0 .834-.629 1.32-1.73 1.32H5.908V4.673zm0 6.788V8.598h1.73c1.217 0 1.88.492 1.88 1.415 0 .943-.643 1.449-1.832 1.449H5.907z'/>",
+  "italic": "<path d='M7.991 11.674 9.53 4.455c.123-.595.246-.71 1.347-.807l.11-.52H7.211l-.11.52c1.06.096 1.128.212 1.005.807L6.57 11.674c-.123.595-.246.71-1.346.806l-.11.52h3.774l.11-.52c-1.06-.095-1.129-.211-1.006-.806z'/>",
+  "heading-1": "<path d='M7.648 13V3H6.3v4.234H1.348V3H0v10h1.348V8.421H6.3V13zM14 13V3h-1.333l-2.381 1.766V6.12L12.6 4.443h.066V13z'/>",
+  "bullet-list": "<path fill-rule='evenodd' d='M5 11.5a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5m0-4a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5m0-4a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5m-3 1a1 1 0 1 0 0-2 1 1 0 0 0 0 2m0 4a1 1 0 1 0 0-2 1 1 0 0 0 0 2m0 4a1 1 0 1 0 0-2 1 1 0 0 0 0 2'/>",
+  "number-list": "<path fill-rule='evenodd' d='M5 11.5a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5m0-4a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5m0-4a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5'/><path d='M1.713 11.865v-.474H2c.217 0 .363-.137.363-.317 0-.185-.158-.31-.361-.31-.223 0-.367.152-.373.31h-.59c.016-.467.373-.787.986-.787.588-.002.954.291.957.703a.595.595 0 0 1-.492.594v.033a.615.615 0 0 1 .569.631c.003.533-.502.8-1.051.8-.656 0-1-.37-1.008-.794h.582c.008.178.186.306.422.309.254 0 .424-.145.422-.35-.002-.195-.155-.348-.414-.348h-.3zm-.004-4.699h-.604v-.035c0-.408.295-.844.958-.844.583 0 .96.326.96.756 0 .389-.257.617-.476.848l-.537.572v.03h1.054V9H1.143v-.395l.957-.99c.138-.142.293-.304.293-.508 0-.18-.147-.32-.342-.32a.33.33 0 0 0-.342.338zM2.564 5h-.635V2.924h-.031l-.598.42v-.567l.629-.443h.635z'/>",
+  "undo": "<path fill-rule='evenodd' d='M8 3a5 5 0 1 1-4.546 2.914.5.5 0 0 0-.908-.417A6 6 0 1 0 8 2z'/><path d='M8 4.466V.534a.25.25 0 0 0-.41-.192L5.23 2.308a.25.25 0 0 0 0 .384l2.36 1.966A.25.25 0 0 0 8 4.466'/>",
+  "redo": "<path fill-rule='evenodd' d='M8 3a5 5 0 1 0 4.546 2.914.5.5 0 0 1 .908-.417A6 6 0 1 1 8 2z'/><path d='M8 4.466V.534a.25.25 0 0 1 .41-.192l2.36 1.966c.12.1.12.284 0 .384L8.41 4.658A.25.25 0 0 1 8 4.466'/>",
+);
+
+trix-toolbar .trix-button--icon::before {
+  background-image: none;
+  opacity: 1;
+}
+trix-toolbar .trix-button--icon:disabled::before {
+  opacity: .3;
+}
+@each $name, $shape in $trix-icon-shapes {
+  trix-toolbar .trix-button--icon-#{$name}::before {
+    $svg: "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='black'>#{$shape}</svg>";
+    -webkit-mask-image: url("data:image/svg+xml,#{$svg}");
+    mask-image: url("data:image/svg+xml,#{$svg}");
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-position: center;
+    mask-position: center;
+    -webkit-mask-size: 55%;
+    mask-size: 55%;
+    background-color: currentColor;
+  }
+}

--- a/app/assets/stylesheets/actiontext.css.scss.erb
+++ b/app/assets/stylesheets/actiontext.css.scss.erb
@@ -54,14 +54,27 @@ trix-toolbar .trix-button.trix-active {
 // mask-image only consumes the alpha channel, so the actual visible color
 // always comes from the button's own `color` (set above per state) rather
 // than from the SVG itself. No separate SVG copy is needed per color/theme.
+// Path data comes straight from the bootstrap-icons gem at asset-compile
+// time (this file is a Sprockets .scss.erb) rather than being hand-copied,
+// so it can't drift from the icon set action_icon/nav_icon use.
+<%
+  trix_icon_names = {
+    "bold" => "type-bold",
+    "italic" => "type-italic",
+    "heading-1" => "type-h1",
+    "bullet-list" => "list-ul",
+    "number-list" => "list-ol",
+    "undo" => "arrow-counterclockwise",
+    "redo" => "arrow-clockwise",
+  }
+  trix_icon_shapes = trix_icon_names.transform_values do |gem_name|
+    BootstrapIcons::BootstrapIcon.new(gem_name).path.gsub('"', "'").gsub(/\n\s*/, "")
+  end
+%>
 $trix-icon-shapes: (
-  "bold": "<path d='M8.21 13c2.106 0 3.412-1.087 3.412-2.823 0-1.306-.984-2.283-2.324-2.386v-.055a2.176 2.176 0 0 0 1.852-2.14c0-1.51-1.162-2.46-3.014-2.46H3.843V13zM5.908 4.674h1.696c.963 0 1.517.451 1.517 1.244 0 .834-.629 1.32-1.73 1.32H5.908V4.673zm0 6.788V8.598h1.73c1.217 0 1.88.492 1.88 1.415 0 .943-.643 1.449-1.832 1.449H5.907z'/>",
-  "italic": "<path d='M7.991 11.674 9.53 4.455c.123-.595.246-.71 1.347-.807l.11-.52H7.211l-.11.52c1.06.096 1.128.212 1.005.807L6.57 11.674c-.123.595-.246.71-1.346.806l-.11.52h3.774l.11-.52c-1.06-.095-1.129-.211-1.006-.806z'/>",
-  "heading-1": "<path d='M7.648 13V3H6.3v4.234H1.348V3H0v10h1.348V8.421H6.3V13zM14 13V3h-1.333l-2.381 1.766V6.12L12.6 4.443h.066V13z'/>",
-  "bullet-list": "<path fill-rule='evenodd' d='M5 11.5a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5m0-4a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5m0-4a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5m-3 1a1 1 0 1 0 0-2 1 1 0 0 0 0 2m0 4a1 1 0 1 0 0-2 1 1 0 0 0 0 2m0 4a1 1 0 1 0 0-2 1 1 0 0 0 0 2'/>",
-  "number-list": "<path fill-rule='evenodd' d='M5 11.5a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5m0-4a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5m0-4a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5'/><path d='M1.713 11.865v-.474H2c.217 0 .363-.137.363-.317 0-.185-.158-.31-.361-.31-.223 0-.367.152-.373.31h-.59c.016-.467.373-.787.986-.787.588-.002.954.291.957.703a.595.595 0 0 1-.492.594v.033a.615.615 0 0 1 .569.631c.003.533-.502.8-1.051.8-.656 0-1-.37-1.008-.794h.582c.008.178.186.306.422.309.254 0 .424-.145.422-.35-.002-.195-.155-.348-.414-.348h-.3zm-.004-4.699h-.604v-.035c0-.408.295-.844.958-.844.583 0 .96.326.96.756 0 .389-.257.617-.476.848l-.537.572v.03h1.054V9H1.143v-.395l.957-.99c.138-.142.293-.304.293-.508 0-.18-.147-.32-.342-.32a.33.33 0 0 0-.342.338zM2.564 5h-.635V2.924h-.031l-.598.42v-.567l.629-.443h.635z'/>",
-  "undo": "<path fill-rule='evenodd' d='M8 3a5 5 0 1 1-4.546 2.914.5.5 0 0 0-.908-.417A6 6 0 1 0 8 2z'/><path d='M8 4.466V.534a.25.25 0 0 0-.41-.192L5.23 2.308a.25.25 0 0 0 0 .384l2.36 1.966A.25.25 0 0 0 8 4.466'/>",
-  "redo": "<path fill-rule='evenodd' d='M8 3a5 5 0 1 0 4.546 2.914.5.5 0 0 1 .908-.417A6 6 0 1 1 8 2z'/><path d='M8 4.466V.534a.25.25 0 0 1 .41-.192l2.36 1.966c.12.1.12.284 0 .384L8.41 4.658A.25.25 0 0 1 8 4.466'/>",
+<% trix_icon_shapes.each do |name, shape| %>
+  "<%= name %>": "<%= shape %>",
+<% end %>
 );
 
 trix-toolbar .trix-button--icon::before {

--- a/app/assets/stylesheets/bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.scss
@@ -221,6 +221,15 @@ nav[aria-label="breadcrumb"] > div {
   border-bottom-color: tint-color($primary, 40%);
 }
 
+// A header with an explicit solid-fill background (e.g. `.bg-danger` on
+// the account "Danger zone" / users "Block user" cards) already reads as
+// visually separated from the body via the fill itself — the default teal
+// rule looked like a mismatched stray line under a colored block, so drop
+// it there.
+.card-header[class*="bg-"] {
+  border-bottom: 0;
+}
+
 // A card with no header (e.g. a lone `.card > .card-body`) shouldn't
 // reserve the vertical space a header would have taken; only restore the
 // full top padding when a header actually precedes the body.

--- a/app/assets/stylesheets/bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.scss
@@ -92,6 +92,17 @@ body { background-color: #f4f6f6; }
 }
 .navbar svg.bi { vertical-align: -0.125em; }
 
+// Action-button icons (action_icon): same baseline fix as the navbar icons,
+// plus a gap before any label text. `:not(:last-child)` only matches when
+// icon_label's <span> is present, so icon-only buttons (Delete, PDF,
+// Preview, ...) stay centered with no lopsided trailing margin.
+.btn svg.bi {
+  vertical-align: -0.125em;
+}
+.btn svg.bi:not(:last-child) {
+  margin-right: .35rem;
+}
+
 // Fix searchable dropdown hover in dark mode
 .searchable-dropdown .dropdown-item {
   &:hover,

--- a/app/helpers/action_buttons_helper.rb
+++ b/app/helpers/action_buttons_helper.rb
@@ -1,15 +1,17 @@
 module ActionButtonsHelper
   # Per-verb helpers for the show-page breadcrumb action cluster. Each helper
-  # bakes in the established glyph, Bootstrap color, accessible name (for
-  # glyph-only Tier 3), and the link_to-vs-button_to choice. See CLAUDE.md's
-  # "Button Glyphs" section for the policy and full mapping.
+  # bakes in the established icon, Bootstrap color, accessible name (for
+  # icon-only Tier 3), and the link_to-vs-button_to choice. See
+  # docs/code-style.md's "Action button icons" section for the policy and
+  # full mapping.
   #
   # Every helper supports `permission:` and returns nil when denied, so views
   # can pass `actions: [pdf_button(...), delete_button(...)]` and let the
   # breadcrumbs helper compact out the nils.
   #
   # Shared shapes live as private helpers below: `post_button` for the
-  # button_to POST cluster, `glyph_link` for the glyph-only link_to cluster.
+  # button_to POST cluster, `icon_link` for the icon-only link_to cluster,
+  # `icon_label` for building an icon + text button label.
 
   # Shared HTML id for the single page-level form on edit/new pages. The
   # breadcrumb's `save_button` and the form element both reference this
@@ -17,39 +19,39 @@ module ActionButtonsHelper
   # via the HTML5 `form=` attribute.
   PAGE_FORM_ID = "page-form"
 
-  # --- Tier 3: glyph-only (title required) ---
+  # --- Tier 3: icon-only (title required) ---
 
   def delete_button(resource, confirm: nil, permission: nil)
     confirm ||= "Are you sure you want to delete this #{resource.class.name.downcase}?"
-    glyph_link "🗑", resource, klass: "btn btn-danger", title: "Delete",
-               permission: permission,
-               data: { "turbo-method": "delete", "turbo-confirm": confirm }
+    icon_link :trash3, resource, klass: "btn btn-danger", title: "Delete",
+              permission: permission,
+              data: { "turbo-method": "delete", "turbo-confirm": confirm }
   end
 
   def pdf_button(path, permission: nil)
-    glyph_link "📄", path, klass: "btn btn-success", title: "PDF",
-               permission: permission,
-               target: "_blank", data: { turbo: false }
+    icon_link :"file-earmark-pdf-fill", path, klass: "btn btn-success", title: "PDF",
+              permission: permission,
+              target: "_blank", data: { turbo: false }
   end
 
   def preview_button(path, permission: nil)
-    glyph_link "👁", path, klass: "btn btn-info", title: "Preview",
-               permission: permission,
-               target: "_blank", data: { turbo: false }
+    icon_link :"eye-fill", path, klass: "btn btn-info", title: "Preview",
+              permission: permission,
+              target: "_blank", data: { turbo: false }
   end
 
-  # --- Tier 2: glyph + text ---
+  # --- Tier 2: icon + text ---
 
   def publish_button(path, permission: nil, confirm: nil)
-    post_button "🚀 Publish", path, klass: "btn btn-warning", permission: permission, confirm: confirm
+    post_button icon_label(:send, "Publish"), path, klass: "btn btn-warning", permission: permission, confirm: confirm
   end
 
   def unpublish_button(path, permission: nil, confirm: nil)
-    post_button "↩️ Unpublish", path, klass: "btn btn-outline-secondary", permission: permission, confirm: confirm
+    post_button icon_label(:"arrow-counterclockwise", "Unpublish"), path, klass: "btn btn-outline-secondary", permission: permission, confirm: confirm
   end
 
   def unblock_button(path, permission: nil, confirm: nil)
-    post_button "✅ Unblock", path, klass: "btn btn-success", permission: permission, confirm: confirm
+    post_button icon_label(:"shield-check", "Unblock"), path, klass: "btn btn-success", permission: permission, confirm: confirm
   end
 
   def reset_passkeys_button(path, permission: nil, confirm: nil)
@@ -58,7 +60,7 @@ module ActionButtonsHelper
 
   def audit_log_button(path, permission: nil)
     return nil if permission && !can?(permission)
-    link_to "📋 Audit log", path, class: "btn btn-secondary"
+    link_to icon_label(:"journal-check", "Audit log"), path, class: "btn btn-secondary"
   end
 
   # Primary submit button for edit/new pages. Lives in the breadcrumb action
@@ -101,12 +103,23 @@ module ActionButtonsHelper
               data: { "turbo-confirm": confirm }.compact
   end
 
-  # Tier-3 shape: glyph-only link with a Bootstrap class and an accessible
+  # Tier-3 shape: icon-only link with a Bootstrap class and an accessible
   # name. The `title:` becomes both the hover tooltip and the screen-reader
-  # `aria-label`. Extra `link_opts` (e.g. `target:`, `data:`) pass through.
-  # Returns nil when `permission:` is set and the current user lacks it.
-  def glyph_link(glyph, path, klass:, title:, permission: nil, **link_opts)
+  # `aria-label` (the icon itself is `aria-hidden`, via action_icon/nav_icon's
+  # shared a11y handling). Extra `link_opts` (e.g. `target:`, `data:`) pass
+  # through. Returns nil when `permission:` is set and the current user lacks
+  # it.
+  def icon_link(icon, path, klass:, title:, permission: nil, **link_opts)
     return nil if permission && !can?(permission)
-    link_to glyph, path, link_opts.merge(class: klass, title: title, "aria-label": title)
+    link_to action_icon(icon), path, link_opts.merge(class: klass, title: title, "aria-label": title)
+  end
+
+  # Tier-2 shape: an icon followed by its label text, for buttons that carry
+  # both (Publish, Unblock, Audit log, ...). Text is wrapped in a <span> (not
+  # a bare text node) so the `.btn svg.bi:not(:last-child)` CSS rule can tell
+  # icon+text buttons apart from icon-only ones and only add the icon/text
+  # gap where there's text to gap against.
+  def icon_label(icon, text)
+    action_icon(icon) + content_tag(:span, text)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,11 +1,17 @@
 module ApplicationHelper
   # Inline monochrome SVG icon for navbar chrome — Configuration, the account
-  # link, Sign out. A narrow, deliberate exception to the emoji-based
-  # action-button glyphs: see docs/code-style.md's "Navigation icons" section
-  # for why. Sourced from the bootstrap-icons gem rather than copied path
-  # data, so icon geometry stays correct and updatable via bundle update.
+  # link, Sign out. See docs/code-style.md's "Navigation icons" section.
+  # Sourced from the bootstrap-icons gem rather than copied path data, so
+  # icon geometry stays correct and updatable via bundle update.
   def nav_icon(name, size: 15)
-    BootstrapIcons::BootstrapIcon.new(name.to_s.tr("_", "-"), width: size, height: size).to_svg.html_safe
+    bootstrap_icon_svg(name, size)
+  end
+
+  # Same icon source as nav_icon, sized for inline use inside action-button
+  # labels (Delete, Publish, Mark Paid, ...). See docs/code-style.md's
+  # "Action button icons" section.
+  def action_icon(name, size: 14)
+    bootstrap_icon_svg(name, size)
   end
 
   # Permission check helper for views. Uses current_user via the controller
@@ -163,14 +169,16 @@ module ApplicationHelper
 
   # Index-context delete link: a small outline trashcan that fits into row
   # actions. Detail-page delete uses `delete_button(resource)` (defined in
-  # ActionButtonsHelper) — both render the 🗑 glyph, but the index variant is
-  # the small btn-outline-danger sized for table rows.
+  # ActionButtonsHelper) — both render the trash3 icon, but the index variant
+  # is the small btn-outline-danger sized for table rows.
   # When permission: is given and the current user lacks it, returns nil so
   # views can gate inline without an `- if can?('xxx.edit')` wrap.
   def destroy_link(resource, confirm_text = nil, permission: nil)
     return nil if permission && !can?(permission)
     confirm_text ||= "Are you sure you want to delete this #{resource.class.name.downcase}?"
-    list_action_link("🗑", resource, :destroy, {
+    list_action_link(action_icon(:trash3), resource, :destroy, {
+      title: "Delete",
+      "aria-label": "Delete",
       data: {
         'turbo-method': "delete",
         'turbo-confirm': confirm_text
@@ -246,6 +254,10 @@ module ApplicationHelper
   end
 
   private
+
+  def bootstrap_icon_svg(name, size)
+    BootstrapIcons::BootstrapIcon.new(name.to_s.tr("_", "-"), width: size, height: size).to_svg.html_safe
+  end
 
   def active_nav_link(base_class, label, path, active_for, &block)
     active = nav_section_active?(active_for)

--- a/app/views/account/profiles/show.html.haml
+++ b/app/views/account/profiles/show.html.haml
@@ -67,7 +67,7 @@
               = team.name
               - if team.builtin?
                 %span.badge.bg-secondary.ms-1 built-in
-    .card.border-danger
+    .card
       .card-header.bg-danger.text-white Danger zone
       .card-body
         %p Self-block disables your account, terminates all your sessions, and prevents you from signing in. An administrator can re-enable your account.

--- a/app/views/customers/_form.html.haml
+++ b/app/views/customers/_form.html.haml
@@ -110,7 +110,9 @@
     .row.mb-3
       = f.label :offer_boilerplate, class: 'col-lg-2 col-md-3 col-form-label'
       .col-lg-8
-        = f.rich_text_area :offer_boilerplate, data: { controller: 'rich-text' }
+        .card
+          .card-body
+            = f.rich_text_area :offer_boilerplate, data: { controller: 'rich-text' }
     %hr
     .row.mb-3
       = f.label :notes, class: 'col-lg-2 col-md-3 col-form-label'

--- a/app/views/delivery_notes/_delivery_note_line_fields.html.haml
+++ b/app/views/delivery_notes/_delivery_note_line_fields.html.haml
@@ -22,7 +22,7 @@
         %div
           %button.btn.btn-sm.btn-secondary{type: 'button', data: {action: 'click->delivery-note-lines#moveLineUp'}} ▲
           %button.btn.btn-sm.btn-secondary{type: 'button', data: {action: 'click->delivery-note-lines#moveLineDown'}} ▼
-          %button.btn.btn-sm.btn-danger{type: 'button', data: {action: 'click->delivery-note-lines#removeLine'}} 🗑
+          %button.btn.btn-sm.btn-danger{type: 'button', title: 'Remove line', 'aria-label': 'Remove line', data: {action: 'click->delivery-note-lines#removeLine'}}= action_icon(:trash3)
 
     .row.mt-2{data: {line_type_target: 'notSubheading'}}
       .col-sm-12

--- a/app/views/delivery_notes/_form.html.haml
+++ b/app/views/delivery_notes/_form.html.haml
@@ -98,7 +98,9 @@
         .col-sm-12
           .mb-3
             %label.form-label Prelude
-            = f.rich_text_area :prelude, data: { controller: 'rich-text' }
+            .card
+              .card-body
+                = f.rich_text_area :prelude, data: { controller: 'rich-text' }
 
     - unless @delivery_note.id.nil?
       %div{data: {controller: 'delivery-note-lines'}}

--- a/app/views/delivery_notes/show.html.haml
+++ b/app/views/delivery_notes/show.html.haml
@@ -103,7 +103,7 @@
               - else
                 Not invoiced
                 - if can_edit_dn
-                  = button_to '🚀 Create…', convert_to_invoice_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-sm btn-info', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Create an invoice draft from this delivery note?' }
+                  = button_to icon_label(:send, 'Create…'), convert_to_invoice_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-sm btn-info', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Create an invoice draft from this delivery note?' }
         - if @delivery_note.offer_milestone
           .row.mb-2
             .col-sm-4
@@ -135,7 +135,8 @@
             = form_with url: upload_acceptance_delivery_note_path(@delivery_note), method: :post, multipart: true, local: true, data: { controller: 'file-upload-validation' } do |form|
               .input-group.w-fixed-400
                 = form.file_field :acceptance_pdf, accept: 'application/pdf', class: 'form-control', data: { file_upload_validation_target: 'fileInput' }
-                = form.submit 'Upload PDF', class: 'btn btn-primary', data: { file_upload_validation_target: 'submitButton' }
+                = form.button class: 'btn btn-primary', data: { file_upload_validation_target: 'submitButton' } do
+                  = icon_label(:upload, 'Upload PDF')
             %small.text-muted.d-block.mt-2
               Upload the signed acceptance document (PDF only)
 

--- a/app/views/delivery_notes/show.html.haml
+++ b/app/views/delivery_notes/show.html.haml
@@ -22,94 +22,96 @@
         - if @delivery_note.emailable?
           %button.btn.btn-outline-success{data: {action: 'click->generic-email-preview#open'}} Send E-Mail
 
-  .row.mb-2
-    .col-md-6
-      .document-details
-        - if @delivery_note.date
-          .row.mb-2
-            .col-sm-4
-              %strong Date:
-            .col-sm-8
-              = l(@delivery_note.date)
-        .row.mb-2
-          .col-sm-4
-            %strong Customer:
-          .col-sm-8
-            = link_to @delivery_note.customer.name, @delivery_note.customer
-        - if @delivery_note.project_id.present?
-          .row.mb-2
-            .col-sm-4
-              %strong Project:
-            .col-sm-8
-              - if @delivery_note.project
-                = link_to @delivery_note.project.display_name, @delivery_note.project
-              - else
-                %em (Project ##{@delivery_note.project_id} - not found)
-        - if @delivery_note.cust_order.present?
-          .row.mb-2
-            .col-sm-4
-              %strong Cust. Order No:
-            .col-sm-8
-              = @delivery_note.cust_order
-        - if @delivery_note.cust_reference.present?
-          .row.mb-2
-            .col-sm-4
-              %strong Cust. Reference:
-            .col-sm-8
-              = @delivery_note.cust_reference
-        - if @delivery_note.internal_reference.present?
-          .row.mb-2
-            .col-sm-4
-              %strong Internal Reference:
-            .col-sm-8
-              = @delivery_note.internal_reference
+  .card.mb-4
+    .card-body
+      .row.mb-2
+        .col-md-6
+          .document-details
+            - if @delivery_note.date
+              .row.mb-2
+                .col-sm-4
+                  %strong Date:
+                .col-sm-8
+                  = l(@delivery_note.date)
+            .row.mb-2
+              .col-sm-4
+                %strong Customer:
+              .col-sm-8
+                = link_to @delivery_note.customer.name, @delivery_note.customer
+            - if @delivery_note.project_id.present?
+              .row.mb-2
+                .col-sm-4
+                  %strong Project:
+                .col-sm-8
+                  - if @delivery_note.project
+                    = link_to @delivery_note.project.display_name, @delivery_note.project
+                  - else
+                    %em (Project ##{@delivery_note.project_id} - not found)
+            - if @delivery_note.cust_order.present?
+              .row.mb-2
+                .col-sm-4
+                  %strong Cust. Order No:
+                .col-sm-8
+                  = @delivery_note.cust_order
+            - if @delivery_note.cust_reference.present?
+              .row.mb-2
+                .col-sm-4
+                  %strong Cust. Reference:
+                .col-sm-8
+                  = @delivery_note.cust_reference
+            - if @delivery_note.internal_reference.present?
+              .row.mb-2
+                .col-sm-4
+                  %strong Internal Reference:
+                .col-sm-8
+                  = @delivery_note.internal_reference
 
-    .col-md-6
-      .document-details
-        - if @delivery_note.delivery_timeframe.present?
-          .row.mb-2
-            .col-sm-4
-              %strong Delivery Period:
-            .col-sm-8
-              = @delivery_note.delivery_timeframe
-        - unless @delivery_note.published?
-          .row.mb-2
-            .col-sm-4
-              %strong Publish Status:
-            .col-sm-8.d-flex.align-items-center.gap-2
-              - if @delivery_note.has_items?
-                %span.badge.bg-success Ready
-              - else
-                %span.badge.bg-warning No item lines
-              - if can_edit_dn
-                - if @delivery_note.has_items?
-                  = button_to 'Publish…', publish_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-sm btn-info', form: { class: 'button_to ms-auto' }
-                - else
-                  %span.ms-auto
-                    %button.btn.btn-sm.btn-info{disabled: true} Publish…
-        - if @delivery_note.published?
-          = render 'shared/email_status_row', resource: @delivery_note, can_edit: can_edit_dn, show_send_button: true
-        - if @delivery_note.published? || @delivery_note.invoice
-          .row.mb-2
-            .col-sm-4
-              %strong Invoice:
-            .col-sm-8.d-flex.align-items-center.gap-2
-              - if @delivery_note.invoice
-                = link_to @delivery_note.invoice.display_name, @delivery_note.invoice
-                - if @delivery_note.invoice.published?
-                  %span.badge.bg-success Booked
-                - else
-                  %span.badge.bg-warning Draft
-              - else
-                Not invoiced
-                - if can_edit_dn
-                  = button_to icon_label(:send, 'Create…'), convert_to_invoice_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-sm btn-info', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Create an invoice draft from this delivery note?' }
-        - if @delivery_note.offer_milestone
-          .row.mb-2
-            .col-sm-4
-              %strong Source:
-            .col-sm-8
-              = link_to @delivery_note.offer_milestone.offer.display_name, @delivery_note.offer_milestone.offer
+        .col-md-6
+          .document-details
+            - if @delivery_note.delivery_timeframe.present?
+              .row.mb-2
+                .col-sm-4
+                  %strong Delivery Period:
+                .col-sm-8
+                  = @delivery_note.delivery_timeframe
+            - unless @delivery_note.published?
+              .row.mb-2
+                .col-sm-4
+                  %strong Publish Status:
+                .col-sm-8.d-flex.align-items-center.gap-2
+                  - if @delivery_note.has_items?
+                    %span.badge.bg-success Ready
+                  - else
+                    %span.badge.bg-warning No item lines
+                  - if can_edit_dn
+                    - if @delivery_note.has_items?
+                      = button_to 'Publish…', publish_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-sm btn-info', form: { class: 'button_to ms-auto' }
+                    - else
+                      %span.ms-auto
+                        %button.btn.btn-sm.btn-info{disabled: true} Publish…
+            - if @delivery_note.published?
+              = render 'shared/email_status_row', resource: @delivery_note, can_edit: can_edit_dn, show_send_button: true
+            - if @delivery_note.published? || @delivery_note.invoice
+              .row.mb-2
+                .col-sm-4
+                  %strong Invoice:
+                .col-sm-8.d-flex.align-items-center.gap-2
+                  - if @delivery_note.invoice
+                    = link_to @delivery_note.invoice.display_name, @delivery_note.invoice
+                    - if @delivery_note.invoice.published?
+                      %span.badge.bg-success Booked
+                    - else
+                      %span.badge.bg-warning Draft
+                  - else
+                    Not invoiced
+                    - if can_edit_dn
+                      = button_to icon_label(:send, 'Create…'), convert_to_invoice_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-sm btn-info', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Create an invoice draft from this delivery note?' }
+            - if @delivery_note.offer_milestone
+              .row.mb-2
+                .col-sm-4
+                  %strong Source:
+                .col-sm-8
+                  = link_to @delivery_note.offer_milestone.offer.display_name, @delivery_note.offer_milestone.offer
 
 
   - if @delivery_note.published?

--- a/app/views/errors/csrf_failure.html.haml
+++ b/app/views/errors/csrf_failure.html.haml
@@ -2,7 +2,7 @@
 
 .row.justify-content-center
   .col-md-6
-    .card.border-warning
+    .card.border.border-warning
       .card-body
         %h1.h4.card-title Session expired
         %p

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -8,24 +8,24 @@
       .card-body
         .row.mb-3
           .col-md-6
-            .card.border-success
+            .card.border.border-success
               .card-body.text-center
                 %h2.text-success.mb-1= format_currency(@stats[:cashflow_ytd_total])
                 %p.card-text.mb-0 Cashflow YTD
           .col-md-6
-            .card.border-primary
+            .card.border.border-primary
               .card-body.text-center
                 %h2.text-primary.mb-1= @stats[:invoices_ytd_count]
                 %p.card-text.mb-0 Invoices YTD
 
         .row
           .col-md-6
-            .card.border-success
+            .card.border.border-success
               .card-body.text-center
                 %h2.text-success.mb-1= format_currency(@stats[:invoices_ytd_total])
                 %p.card-text.mb-0 Revenue YTD
           .col-md-6
-            .card.border-info
+            .card.border.border-info
               .card-body.text-center
                 %h2.text-info.mb-1= format_currency(@stats[:invoices_yoy_total])
                 %p.card-text.mb-0 Revenue YoY

--- a/app/views/invoices/_form.html.haml
+++ b/app/views/invoices/_form.html.haml
@@ -90,7 +90,9 @@
         .col-sm-12
           .mb-3
             %label.form-label Prelude
-            = f.rich_text_area :prelude, data: { controller: 'rich-text' }
+            .card
+              .card-body
+                = f.rich_text_area :prelude, data: { controller: 'rich-text' }
 
       - unless @invoice.id.nil?
         %div{data: {controller: 'invoice-lines', invoice_lines_currency_symbol_value: currency_symbol, invoice_lines_money_decimal_places_value: current_money_decimal_places, invoice_lines_import_url_value: import_lines_invoice_path(@invoice)}}

--- a/app/views/invoices/_invoice_line_fields.html.haml
+++ b/app/views/invoices/_invoice_line_fields.html.haml
@@ -18,7 +18,7 @@
           %button.btn.btn-sm.btn-info{type: 'button', data: {action: 'click->invoice-lines#toggleProductDropdown', line_type_target: 'itemOnly'}} ...
           %button.btn.btn-sm.btn-secondary{type: 'button', data: {action: 'click->invoice-lines#moveLineUp'}} ▲
           %button.btn.btn-sm.btn-secondary{type: 'button', data: {action: 'click->invoice-lines#moveLineDown'}} ▼
-          %button.btn.btn-sm.btn-danger{type: 'button', data: {action: 'click->invoice-lines#removeLine'}} 🗑
+          %button.btn.btn-sm.btn-danger{type: 'button', title: 'Remove line', 'aria-label': 'Remove line', data: {action: 'click->invoice-lines#removeLine'}}= action_icon(:trash3)
 
     .row.mt-2.d-none{data: {product_dropdown: true}}
       .col-sm-11

--- a/app/views/invoices/show.html.haml
+++ b/app/views/invoices/show.html.haml
@@ -32,116 +32,118 @@
         - if @invoice.emailable?
           %button.btn.btn-outline-success{data: {action: 'click->generic-email-preview#open'}} Send E-Mail
 
-  .row.mb-2
-    .col-md-6
-      .document-details
-        - if @invoice.date
-          .row.mb-2
-            .col-sm-4
-              %strong Date:
-            .col-sm-8
-              = l(@invoice.date)
-        .row.mb-2
-          .col-sm-4
-            %strong Customer:
-          .col-sm-8
-            = link_to(@invoice.customer_name || @invoice.customer.name, @invoice.customer)
-        - if @invoice.project_id.present?
-          .row.mb-2
-            .col-sm-4
-              %strong Project:
-            .col-sm-8
-              - if @invoice.project
-                = link_to @invoice.project.display_name, @invoice.project
-              - else
-                %em (Project ##{@invoice.project_id} - not found)
-        - if @invoice.cust_order.present?
-          .row.mb-2
-            .col-sm-4
-              %strong Cust. Order No:
-            .col-sm-8
-              = @invoice.cust_order
-        - if @invoice.cust_reference.present?
-          .row.mb-2
-            .col-sm-4
-              %strong Cust. Reference:
-            .col-sm-8
-              = @invoice.cust_reference
-        - if @invoice.internal_reference.present?
-          .row.mb-2
-            .col-sm-4
-              %strong Internal Reference:
-            .col-sm-8
-              = @invoice.internal_reference
+  .card.mb-4
+    .card-body
+      .row.mb-2
+        .col-md-6
+          .document-details
+            - if @invoice.date
+              .row.mb-2
+                .col-sm-4
+                  %strong Date:
+                .col-sm-8
+                  = l(@invoice.date)
+            .row.mb-2
+              .col-sm-4
+                %strong Customer:
+              .col-sm-8
+                = link_to(@invoice.customer_name || @invoice.customer.name, @invoice.customer)
+            - if @invoice.project_id.present?
+              .row.mb-2
+                .col-sm-4
+                  %strong Project:
+                .col-sm-8
+                  - if @invoice.project
+                    = link_to @invoice.project.display_name, @invoice.project
+                  - else
+                    %em (Project ##{@invoice.project_id} - not found)
+            - if @invoice.cust_order.present?
+              .row.mb-2
+                .col-sm-4
+                  %strong Cust. Order No:
+                .col-sm-8
+                  = @invoice.cust_order
+            - if @invoice.cust_reference.present?
+              .row.mb-2
+                .col-sm-4
+                  %strong Cust. Reference:
+                .col-sm-8
+                  = @invoice.cust_reference
+            - if @invoice.internal_reference.present?
+              .row.mb-2
+                .col-sm-4
+                  %strong Internal Reference:
+                .col-sm-8
+                  = @invoice.internal_reference
 
-    .col-md-6
-      .document-details
-        - if @invoice.due_date
-          .row.mb-2
-            .col-sm-4
-              %strong Due Date:
-            .col-sm-8
-              = l(@invoice.due_date)
-              %span.text-muted.ms-2 (#{@invoice.payment_terms_days} days net)
-        - else
-          .row.mb-2
-            .col-sm-4
-              %strong Payment Terms:
-            .col-sm-8
-              = @invoice.payment_terms_days
-              days net
+        .col-md-6
+          .document-details
+            - if @invoice.due_date
+              .row.mb-2
+                .col-sm-4
+                  %strong Due Date:
+                .col-sm-8
+                  = l(@invoice.due_date)
+                  %span.text-muted.ms-2 (#{@invoice.payment_terms_days} days net)
+            - else
+              .row.mb-2
+                .col-sm-4
+                  %strong Payment Terms:
+                .col-sm-8
+                  = @invoice.payment_terms_days
+                  days net
 
-        - unless @invoice.published?
-          .row.mb-2
-            .col-sm-4
-              %strong Publish Status:
-            .col-sm-8.d-flex.align-items-center.gap-2
-              - if problems.any?
-                %span.badge.bg-warning= pluralize(problems.size, 'problem')
-              - else
-                %span.badge.bg-success Ready
-              - if can_edit_invoice
-                - if problems.any?
-                  %span.ms-auto{title: problems.join("\n")}
-                    %button.btn.btn-sm.btn-info{disabled: true} Publish Invoice…
-                - else
-                  = button_to 'Publish Invoice…', publish_invoice_path(@invoice), method: :post, class: 'btn btn-sm btn-info', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Publish invoice and assign a document number? This cannot be undone.' }
+            - unless @invoice.published?
+              .row.mb-2
+                .col-sm-4
+                  %strong Publish Status:
+                .col-sm-8.d-flex.align-items-center.gap-2
+                  - if problems.any?
+                    %span.badge.bg-warning= pluralize(problems.size, 'problem')
+                  - else
+                    %span.badge.bg-success Ready
+                  - if can_edit_invoice
+                    - if problems.any?
+                      %span.ms-auto{title: problems.join("\n")}
+                        %button.btn.btn-sm.btn-info{disabled: true} Publish Invoice…
+                    - else
+                      = button_to 'Publish Invoice…', publish_invoice_path(@invoice), method: :post, class: 'btn btn-sm btn-info', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Publish invoice and assign a document number? This cannot be undone.' }
 
-        - if @invoice.published?
-          = render 'shared/email_status_row', resource: @invoice, can_edit: can_edit_invoice, show_send_button: @invoice.attachment.present?
+            - if @invoice.published?
+              = render 'shared/email_status_row', resource: @invoice, can_edit: can_edit_invoice, show_send_button: @invoice.attachment.present?
 
-          .row.mb-2
-            .col-sm-4
-              %strong Payment Status:
-            .col-sm-8.d-flex.align-items-center.gap-2{data: {controller: 'modal'}}
-              - if @invoice.paid?
-                Paid #{l(@invoice.paid_at.to_date)}
-              - elsif @invoice.overdue?
-                %span.badge.bg-danger Overdue
-              - else
-                %span.badge.bg-warning Unpaid
-              - if can_edit_invoice
-                - if @invoice.paid?
-                  -# button_to wraps the button in a form; the form is the flex
-                  -# child, so ms-auto must go on the form to push it right.
-                  = button_to icon_label(:'arrow-counterclockwise', 'Unpaid'), mark_unpaid_invoice_path(@invoice), method: :post, class: 'btn btn-sm btn-outline-secondary', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Mark this invoice as unpaid?' }
-                - else
-                  %button.btn.btn-sm.btn-success.ms-auto{data: {action: 'click->modal#open'}}
-                    = icon_label(:'check-circle-fill', 'Paid…')
-                  = render 'shared/mark_paid_modal', invoice: @invoice
+              .row.mb-2
+                .col-sm-4
+                  %strong Payment Status:
+                .col-sm-8.d-flex.align-items-center.gap-2{data: {controller: 'modal'}}
+                  - if @invoice.paid?
+                    Paid #{l(@invoice.paid_at.to_date)}
+                  - elsif @invoice.overdue?
+                    %span.badge.bg-danger Overdue
+                  - else
+                    %span.badge.bg-warning Unpaid
+                  - if can_edit_invoice
+                    - if @invoice.paid?
+                      -# button_to wraps the button in a form; the form is the flex
+                      -# child, so ms-auto must go on the form to push it right.
+                      = button_to icon_label(:'arrow-counterclockwise', 'Unpaid'), mark_unpaid_invoice_path(@invoice), method: :post, class: 'btn btn-sm btn-outline-secondary', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Mark this invoice as unpaid?' }
+                    - else
+                      %button.btn.btn-sm.btn-success.ms-auto{data: {action: 'click->modal#open'}}
+                        = icon_label(:'check-circle-fill', 'Paid…')
+                      = render 'shared/mark_paid_modal', invoice: @invoice
 
-        - if @invoice.delivery_note
-          .row.mb-2
-            .col-sm-4
-              %strong Source:
-            .col-sm-8
-              = link_to @invoice.delivery_note.display_name, @invoice.delivery_note
-        - if @invoice.offer_milestone
-          .row.mb-2
-            .col-sm-4
-              %strong Source:
-            .col-sm-8
-              = link_to @invoice.offer_milestone.offer.display_name, @invoice.offer_milestone.offer
+            - if @invoice.delivery_note
+              .row.mb-2
+                .col-sm-4
+                  %strong Source:
+                .col-sm-8
+                  = link_to @invoice.delivery_note.display_name, @invoice.delivery_note
+            - if @invoice.offer_milestone
+              .row.mb-2
+                .col-sm-4
+                  %strong Source:
+                .col-sm-8
+                  = link_to @invoice.offer_milestone.offer.display_name, @invoice.offer_milestone.offer
 
   - if !@invoice.published? && problems.any?
     .alert.alert-warning.mb-3

--- a/app/views/invoices/show.html.haml
+++ b/app/views/invoices/show.html.haml
@@ -124,10 +124,10 @@
                 - if @invoice.paid?
                   -# button_to wraps the button in a form; the form is the flex
                   -# child, so ms-auto must go on the form to push it right.
-                  = button_to 'Mark Unpaid', mark_unpaid_invoice_path(@invoice), method: :post, class: 'btn btn-sm btn-outline-secondary', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Mark this invoice as unpaid?' }
+                  = button_to icon_label(:'arrow-counterclockwise', 'Unpaid'), mark_unpaid_invoice_path(@invoice), method: :post, class: 'btn btn-sm btn-outline-secondary', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Mark this invoice as unpaid?' }
                 - else
                   %button.btn.btn-sm.btn-success.ms-auto{data: {action: 'click->modal#open'}}
-                    Mark Paid…
+                    = icon_label(:'check-circle-fill', 'Paid…')
                   = render 'shared/mark_paid_modal', invoice: @invoice
 
         - if @invoice.delivery_note

--- a/app/views/jobs_status/show.html.haml
+++ b/app/views/jobs_status/show.html.haml
@@ -29,7 +29,7 @@
         .h3.mb-0= @counts[:blocked]
         .small.text-muted Blocked
   .col-md-2.col-6.mb-2
-    .card.text-center.border-danger{class: ('text-danger' if @counts[:failed].positive?)}
+    .card.text-center.border.border-danger{class: ('text-danger' if @counts[:failed].positive?)}
       .card-body.py-3
         .h3.mb-0= @counts[:failed]
         .small Failed

--- a/app/views/offers/_conversion_rows.html.haml
+++ b/app/views/offers/_conversion_rows.html.haml
@@ -26,4 +26,4 @@
               - if @offer.accepted? && can?('offers.convert')
                 = button_to 'Reopen link', reopen_milestone_link_offer_path(@offer, milestone_id: milestone.id), method: :post, class: 'btn btn-sm btn-outline-secondary', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Clear the conversion link for this milestone?' }
             - elsif @offer.accepted? && can?('offers.convert')
-              = button_to '🚀 Convert', convert_milestone_offer_path(@offer, milestone_id: milestone.id), method: :post, class: 'btn btn-sm btn-info', form: { class: 'button_to ms-auto' }
+              = button_to icon_label(:send, 'Convert'), convert_milestone_offer_path(@offer, milestone_id: milestone.id), method: :post, class: 'btn btn-sm btn-info', form: { class: 'button_to ms-auto' }

--- a/app/views/offers/_form.html.haml
+++ b/app/views/offers/_form.html.haml
@@ -100,7 +100,9 @@
             .col-sm-8
               .mb-3
                 = vf.label :prelude, 'Prelude', class: 'form-label'
-                = vf.rich_text_area :prelude, data: { controller: 'rich-text' }
+                .card
+                  .card-body
+                    = vf.rich_text_area :prelude, data: { controller: 'rich-text' }
             .col-sm-4
               .mb-3
                 = vf.label :salutation_override, 'Salutation override', class: 'form-label'

--- a/app/views/offers/_milestone_fields.html.haml
+++ b/app/views/offers/_milestone_fields.html.haml
@@ -13,7 +13,7 @@
         %div
           %button.btn.btn-sm.btn-secondary{type: 'button', data: {action: 'click->offer-milestones#moveLineUp'}} ▲
           %button.btn.btn-sm.btn-secondary{type: 'button', data: {action: 'click->offer-milestones#moveLineDown'}} ▼
-          %button.btn.btn-sm.btn-danger{type: 'button', data: {action: 'click->offer-milestones#removeLine'}} 🗑
+          %button.btn.btn-sm.btn-danger{type: 'button', title: 'Remove milestone', 'aria-label': 'Remove milestone', data: {action: 'click->offer-milestones#removeLine'}}= action_icon(:trash3)
 
     .row.mt-2
       .col-sm-12

--- a/app/views/offers/show.html.haml
+++ b/app/views/offers/show.html.haml
@@ -8,79 +8,81 @@
   %span.badge{class: badge_class}= label
 
 %div{data: (@offer.current_sent_version ? email_preview_data(@offer) : {})}
-  .row.mb-2
-    .col-md-6
-      .document-details
-        .row.mb-2
-          .col-sm-4
-            %strong Customer:
-          .col-sm-8
-            = link_to @offer.customer.name, @offer.customer
-        - if @offer.project
-          .row.mb-2
-            .col-sm-4
-              %strong Project:
-            .col-sm-8
-              = link_to @offer.project.display_name, @offer.project
-        - if @offer.customer_contact
-          .row.mb-2
-            .col-sm-4
-              %strong Addressed Contact:
-            .col-sm-8
-              = @offer.customer_contact.name
-        - if @offer.internal_reference.present?
-          .row.mb-2
-            .col-sm-4
-              %strong Internal Reference:
-            .col-sm-8
-              = @offer.internal_reference
+  .card.mb-4
+    .card-body
+      .row.mb-2
+        .col-md-6
+          .document-details
+            .row.mb-2
+              .col-sm-4
+                %strong Customer:
+              .col-sm-8
+                = link_to @offer.customer.name, @offer.customer
+            - if @offer.project
+              .row.mb-2
+                .col-sm-4
+                  %strong Project:
+                .col-sm-8
+                  = link_to @offer.project.display_name, @offer.project
+            - if @offer.customer_contact
+              .row.mb-2
+                .col-sm-4
+                  %strong Addressed Contact:
+                .col-sm-8
+                  = @offer.customer_contact.name
+            - if @offer.internal_reference.present?
+              .row.mb-2
+                .col-sm-4
+                  %strong Internal Reference:
+                .col-sm-8
+                  = @offer.internal_reference
 
-    .col-md-6
-      .document-details
-        .row.mb-2
-          .col-sm-4
-            %strong Document Number:
-          .col-sm-8
-            = @offer.document_number.presence || content_tag(:em, '(assigned at first send)')
-        .row.mb-2
-          .col-sm-4
-            %strong Document Date:
-          .col-sm-8
-            = @offer.date ? l(@offer.date) : content_tag(:em, '(assigned at first send)')
-        - if @offer.expires_at
-          .row.mb-2
-            .col-sm-4
-              %strong Valid Until:
-            .col-sm-8
-              = l(@offer.expires_at)
-        - if @version&.delivery_date
-          .row.mb-2
-            .col-sm-4
-              %strong Delivery Date:
-            .col-sm-8
-              = l(@version.delivery_date)
-        - if @version&.sales_tax_product_class
-          .row.mb-2
-            .col-sm-4
-              %strong Tax Class:
-            .col-sm-8
-              = @version.sales_tax_product_class.name
+        .col-md-6
+          .document-details
+            .row.mb-2
+              .col-sm-4
+                %strong Document Number:
+              .col-sm-8
+                = @offer.document_number.presence || content_tag(:em, '(assigned at first send)')
+            .row.mb-2
+              .col-sm-4
+                %strong Document Date:
+              .col-sm-8
+                = @offer.date ? l(@offer.date) : content_tag(:em, '(assigned at first send)')
+            - if @offer.expires_at
+              .row.mb-2
+                .col-sm-4
+                  %strong Valid Until:
+                .col-sm-8
+                  = l(@offer.expires_at)
+            - if @version&.delivery_date
+              .row.mb-2
+                .col-sm-4
+                  %strong Delivery Date:
+                .col-sm-8
+                  = l(@version.delivery_date)
+            - if @version&.sales_tax_product_class
+              .row.mb-2
+                .col-sm-4
+                  %strong Tax Class:
+                .col-sm-8
+                  = @version.sales_tax_product_class.name
 
-  - if @offer.editable?
-    .row.mb-2
-      .col-sm-4
-        %strong Send:
-      .col-sm-8.d-flex.align-items-center.gap-2
-        - if problems.any?
-          %span.badge.bg-warning= pluralize(problems.size, 'problem')
-        - else
-          %span.badge.bg-success Ready
-        - if can?('offers.edit')
-          - if problems.any?
-            %span.ms-auto{title: problems.join("\n")}
-              %button.btn.btn-sm.btn-info{disabled: true}= icon_label(:send, 'Send')
-          - else
-            = button_to icon_label(:send, 'Send'), send_offer_offer_path(@offer), method: :post, class: 'btn btn-sm btn-info', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Send this offer to the customer? A PDF is generated and this version is frozen.' }
+      - if @offer.editable?
+        .row.mb-2
+          .col-sm-4
+            %strong Send:
+          .col-sm-8.d-flex.align-items-center.gap-2
+            - if problems.any?
+              %span.badge.bg-warning= pluralize(problems.size, 'problem')
+            - else
+              %span.badge.bg-success Ready
+            - if can?('offers.edit')
+              - if problems.any?
+                %span.ms-auto{title: problems.join("\n")}
+                  %button.btn.btn-sm.btn-info{disabled: true}= icon_label(:send, 'Send')
+              - else
+                = button_to icon_label(:send, 'Send'), send_offer_offer_path(@offer), method: :post, class: 'btn btn-sm btn-info', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Send this offer to the customer? A PDF is generated and this version is frozen.' }
 
   - if problems.any?
     .alert.alert-warning.mb-3

--- a/app/views/offers/show.html.haml
+++ b/app/views/offers/show.html.haml
@@ -78,9 +78,9 @@
         - if can?('offers.edit')
           - if problems.any?
             %span.ms-auto{title: problems.join("\n")}
-              %button.btn.btn-sm.btn-info{disabled: true} 🚀 Send
+              %button.btn.btn-sm.btn-info{disabled: true}= icon_label(:send, 'Send')
           - else
-            = button_to '🚀 Send', send_offer_offer_path(@offer), method: :post, class: 'btn btn-sm btn-info', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Send this offer to the customer? A PDF is generated and this version is frozen.' }
+            = button_to icon_label(:send, 'Send'), send_offer_offer_path(@offer), method: :post, class: 'btn btn-sm btn-info', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Send this offer to the customer? A PDF is generated and this version is frozen.' }
 
   - if problems.any?
     .alert.alert-warning.mb-3
@@ -169,7 +169,8 @@
                 = form_with url: upload_order_pdf_offer_path(@offer), method: :post, multipart: true, data: { controller: 'file-upload-validation' } do |form|
                   .input-group.w-fixed-400
                     = file_field_tag :order_pdf, accept: 'application/pdf', class: 'form-control', data: { file_upload_validation_target: 'fileInput' }
-                    = form.submit 'Upload PDF', class: 'btn btn-primary', data: { file_upload_validation_target: 'submitButton' }
+                    = form.button class: 'btn btn-primary', data: { file_upload_validation_target: 'submitButton' } do
+                      = icon_label(:upload, 'Upload PDF')
 
   .mb-4
     .card

--- a/app/views/shared/_email_status_row.html.haml
+++ b/app/views/shared/_email_status_row.html.haml
@@ -21,8 +21,8 @@
     - if can_edit && show_send_button
       - if resource.emailable?
         %button.btn.btn-sm.btn-warning.ms-auto{data: {action: 'click->generic-email-preview#open'}}
-          Send E-Mail
+          = icon_label(:envelope, 'Send')
       - else
         %span.ms-auto{data: {'bs-toggle': 'tooltip'}, title: 'No contact is configured to receive this document. Add a contact on the customer.'}
           %button.btn.btn-sm.btn-warning{disabled: true}
-            Send E-Mail
+            = icon_label(:envelope, 'Send')

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -63,6 +63,17 @@
               = f.submit 'Add email', class: 'btn btn-outline-primary'
           .form-text Admin-added emails are confirmed immediately (no email verification needed).
 
+    - if !@user.blocked? && @user.id != current_user.id && can?('users.block')
+      .card.mb-3
+        .card-header Block user
+        .card-body
+          = form_with url: block_user_path(@user), method: :post, local: true do |f|
+            .input-group.w-fixed-400
+              = f.text_field :reason, class: 'form-control', placeholder: 'Reason (required)', required: true
+              = f.button class: 'btn btn-danger',
+                  data: { turbo_confirm: "Block #{@user.username}? All sessions will be terminated." } do
+                = icon_label(:'shield-slash', 'Block')
+
   .col-md-6
     .card.mb-3
       .card-header Passkeys
@@ -148,15 +159,3 @@
                 = team.name
                 - if team.builtin?
                   %span.badge.bg-secondary.ms-1 built-in
-
-- if !@user.blocked? && @user.id != current_user.id && can?('users.block')
-  .row.mb-3
-    .col-sm-4
-      %strong Block user:
-    .col-sm-8
-      = form_with url: block_user_path(@user), method: :post, local: true do |f|
-        .input-group.w-fixed-400
-          = f.text_field :reason, class: 'form-control', placeholder: 'Reason (required)', required: true
-          = f.button class: 'btn btn-danger',
-              data: { turbo_confirm: "Block #{@user.username}? All sessions will be terminated." } do
-            = icon_label(:'shield-slash', 'Block')

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -157,5 +157,6 @@
       = form_with url: block_user_path(@user), method: :post, local: true do |f|
         .input-group.w-fixed-400
           = f.text_field :reason, class: 'form-control', placeholder: 'Reason (required)', required: true
-          = f.submit '🚫 Block', class: 'btn btn-danger',
-              data: { turbo_confirm: "Block #{@user.username}? All sessions will be terminated." }
+          = f.button class: 'btn btn-danger',
+              data: { turbo_confirm: "Block #{@user.username}? All sessions will be terminated." } do
+            = icon_label(:'shield-slash', 'Block')

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -65,7 +65,7 @@
 
     - if !@user.blocked? && @user.id != current_user.id && can?('users.block')
       .card.mb-3
-        .card-header Block user
+        .card-header.bg-danger.text-white Block user
         .card-body
           = form_with url: block_user_path(@user), method: :post, local: true do |f|
             .input-group.w-fixed-400

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -22,6 +22,18 @@ The canonical style reference for this repo. Project structure, architecture, mo
 - Non-dashboard / non-account pages use `breadcrumbs(...)` as the page header — no separate `<h1>`. Edit/new pages put the primary submit in `action:` via `save_button`. No Cancel button — the parent crumb is the way back.
 - Page titles: rely on `breadcrumbs` / `page_header` auto-deriving `content_for :title` from the active crumb. Override with an explicit `- content_for :title, "..."` only when the crumb is too generic for a browser tab (Edit/New pages; invoice/delivery-note show pages where the bare number isn't a useful label — use `display_name` for the prefixed form).
 
+## Cards
+- Every distinct block of content on a show/dashboard page belongs in a `.card` — the page should read as one consistent stack of cards, not a mix of bare label/value rows and boxed cards. If a page has any card on it, put everything else on it in cards too (see `docs/card-table-restyle.md` for the invoice/offer/delivery-note top info grid and the dashboard stat tiles, both retrofitted for exactly this reason) — a bare block reads as unfinished once its neighbors are card-wrapped.
+- Cards are borderless with a 2px teal rule under the header (`bootstrap_and_overrides.css.scss`) — that rule is the only boundary needed against the app's tinted page background. Don't add `border`/`border-*` back for an ordinary card.
+- Headerless card (`.card` wrapping only a `.card-body`, no `.card-header`) for a single-purpose block whose context is already labeled elsewhere — a lone prelude/boilerplate rich-text field (label sits above it, outside the card), a lone paragraph. `.card-body`'s top padding is already collapsed for this case and only restored to the full amount when a `.card-header` precedes it — don't add a header just to "fill" the space.
+- Solid-fill headers (`.card-header.bg-danger.text-white`, e.g. "Danger zone" / "Block user") drop the teal rule automatically since the fill itself is the boundary — don't add one back.
+- `.border-{color}` utilities (e.g. flagging the dashboard's cashflow tile or a failed-jobs count) only set `border-color`; pair them with the base `.border` utility (`.card.border.border-success`) — `.border-{color}` alone is silently invisible now that `.card` defaults to `border: 0`.
+- `rich_text_area` fields always sit inside a card — the Trix toolbar looks like an app-native bordered component, not plain text, so it can't float bare on the page. Wrap just the editor, not the field's own label.
+- Tables are **not** card-wrapped (a separate, deliberate decision — see `docs/card-table-restyle.md`); a line-items table, milestones table, or totals summary sits bare in its container. Don't wrap a table in a card to "fix" perceived inconsistency.
+- Index pages (list + filter toolbar) don't use cards at all — a distinct, consistent convention across every `index.html.haml`. Don't introduce cards there.
+- Multi-column card grids: `.row > .col-md-6 > .card.mb-3`. Stack full-width cards with `.mb-4` — without it, adjacent borderless cards touch and visually fuse into one.
+- Don't call a multi-column card layout imbalanced by card count — judge by realistic per-column rendered height. List-bound cards (sessions, audit events, line items) grow with data and naturally fill a column.
+
 ## Status badges
 - Show only deviation from the healthy default. Active/normal renders no badge in headers and as plain text in tables.
 - Lifecycle states (Draft, Booked, Published, Sent, Paid, Overdue) all get header badges — no state is implicitly "good".
@@ -99,9 +111,6 @@ A separate convention from the action-button icons above — these mark navbar c
 ## Formatting
 - Dates: `DD.MM.YYYY` via `l(date)`; datetimes `DD.MM.YYYY HH:MM` via `l(time)`. Use `l(value.to_date)` to render a datetime as date-only. `DD.MM` (short) when the year is implied. Never American formats.
 - Currency: never hardcode `$` / `€` / `EUR`. Use `format_currency(amount)`; symbol comes from `IssuerCompany.currency`.
-
-## Layout judgment
-- Don't call a multi-column card layout imbalanced by card count — judge by realistic per-column rendered height. List-bound cards (sessions, audit events, line items) grow with data and naturally fill a column.
 
 ## Comments
 - Default to none. Add a one-liner only when the *why* isn't obvious from the code (workaround, invariant, hidden constraint).

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -36,49 +36,55 @@ The canonical style reference for this repo. Project structure, architecture, mo
   - Disabled-tooltip variant (`%span` wrapping a disabled `%button`) → on the wrapping `%span`.
   - `button_to` → on the generated `<form>`: `button_to ..., form: { class: 'button_to ms-auto' }`. Keep `button_to` — `bootstrap_and_overrides.css.scss` styles it.
 
-## Action button glyphs
+## Action button icons
 Three tiers:
-- **Text only** when the label is short and universally clear (`Edit`, `+ New`, `Save`, `Reset passkeys`) — no glyph prefix.
-- **Glyph + text** for less-familiar workflow actions (`🚀 Publish`, `📥 Upload PDF`, `🚫 Block`).
-- **Glyph only** for universally-understood verbs. Always pass `title:` (sets tooltip + `aria-label`): `🗑` Delete, `📄` PDF, `👁` Preview.
+- **Text only** when the label is short and universally clear (`Edit`, `+ New`, `Save`, `Reset passkeys`) — no icon prefix.
+- **Icon + text** for less-familiar workflow actions (`Publish`, `Upload PDF`, `Block`).
+- **Icon only** for universally-understood verbs. Always pass `title:` (sets tooltip + `aria-label`): Delete, PDF, Preview.
 
-When the glyph carries the verb, drop the leading verb from the label: `Mark Paid` → `✅ Paid`, `Mark Unpaid` → `↩ Unpaid`. Keep verb+object when the glyph alone isn't enough.
+Icons are inline monochrome SVG via `action_icon(:name)` (`app/helpers/application_helper.rb`), backed by the `bootstrap-icons` gem — not emoji. `action_icon` takes the gem's icon name (underscores are converted to hyphens, so `:"eye-fill"` or `:eye_fill` both map to the `eye-fill` icon). Build an icon + text label with `icon_label(:name, "Text")` (`app/helpers/action_buttons_helper.rb`) — it wraps the text in a `<span>` so `.btn svg.bi:not(:last-child)` in `bootstrap_and_overrides.css.scss` only adds the icon/text gap where there's text to gap against, keeping icon-only buttons symmetrically centered. `<input type="submit">` can't hold an SVG — use `f.button(...) do ... end` instead of `f.submit` wherever the label needs an icon.
 
-Reuse glyphs for the same archetype — don't invent new ones:
-- 🚀 promote forward (Publish, Create invoice from delivery note)
-- ✅ positive state change (Paid, Unblock)
-- ↩ / ↩️ revert state (Unpaid, Unpublish) — Unicode-distinct but visually similar; never coexist on the same page
+When the icon carries the verb, drop the leading verb from the label: `Mark Paid` → `Paid…`, `Mark Unpaid` → `Unpaid`. Keep verb+object when the icon alone isn't enough.
 
-Established mapping — extend it, don't invent new glyphs for existing verbs:
+Reuse icons for the same archetype — don't invent new ones:
+- `send` (paper plane) promote forward (Publish, Convert to Invoice, Send offer, Convert milestone)
+- `check-circle-fill` / `shield-check` positive state change (Paid, Unblock)
+- `arrow-counterclockwise` revert state (Unpaid, Unpublish)
+- `trash3` delete (Delete, and the inline "remove line" buttons on invoice/delivery-note/offer-milestone edit forms)
+- `shield-slash` restrict access (Block)
 
-| Verb | Render | Helper |
-|---|---|---|
-| Edit | `Edit` | `action_button` |
-| + New | `+ New` | `action_button` |
-| Save | `Save` | `save_button` |
-| Reset passkeys | `Reset passkeys` | `reset_passkeys_button` |
-| Delete | `🗑` | `delete_button` |
-| PDF | `📄` | `pdf_button` |
-| Preview | `👁` | `preview_button` |
-| Mark Paid | `✅ Paid` | (status-row, inline) |
-| Mark Unpaid | `↩ Unpaid` | (status-row, inline) |
-| Send e-mail | `✉️ Send` | (status-row, inline) |
-| Publish | `🚀 Publish` | `publish_button` |
-| Unpublish | `↩️ Unpublish` | `unpublish_button` |
-| Convert to Invoice | `🚀 Create…` | (status-row, inline) |
-| Upload PDF | `📥 Upload PDF` | (form, inline) |
-| Block | `🚫 Block` | (form-with-reason, inline) |
-| Unblock | `✅ Unblock` | `unblock_button` |
-| Audit log | `📋 Audit log` | `audit_log_button` |
+Established mapping — extend it, don't invent new icons for existing verbs:
+
+| Verb | Icon | Render | Helper |
+|---|---|---|---|
+| Edit | — | `Edit` | `action_button` |
+| + New | — | `+ New` | `action_button` |
+| Save | — | `Save` | `save_button` |
+| Reset passkeys | — | `Reset passkeys` | `reset_passkeys_button` |
+| Delete | `trash3` | icon only | `delete_button` |
+| PDF | `file-earmark-pdf-fill` | icon only | `pdf_button` |
+| Preview | `eye-fill` | icon only | `preview_button` |
+| Mark Paid | `check-circle-fill` | icon + `Paid…` | (status-row, inline) |
+| Mark Unpaid | `arrow-counterclockwise` | icon + `Unpaid` | (status-row, inline) |
+| Send e-mail | `envelope` | icon + `Send` | (status-row, inline) |
+| Publish | `send` | icon + `Publish` | `publish_button` |
+| Unpublish | `arrow-counterclockwise` | icon + `Unpublish` | `unpublish_button` |
+| Convert to Invoice | `send` | icon + `Create…` | (status-row, inline) |
+| Upload PDF | `upload` | icon + `Upload PDF` | (form, inline) |
+| Block | `shield-slash` | icon + `Block` | (form-with-reason, inline) |
+| Unblock | `shield-check` | icon + `Unblock` | `unblock_button` |
+| Audit log | `journal-check` | icon + `Audit log` | `audit_log_button` |
 
 For cross-resource navigation in a breadcrumb action cluster, use `nav_button` (outline-secondary). Don't reach for filled variants for nav.
 
+Out of scope for this convention — deliberately left as emoji, don't convert without a separate decision: Configuration hub tiles (`app/views/configurations/index.html.haml`, page content rather than a workflow action), the "Reusable" badge in the searchable dropdown, and the `✓`/`▲`/`▼` symbols in the invoice/delivery-note/offer-milestone edit-form line toolbars (unlabeled by design, matching their siblings).
+
 ## Navigation icons
-A separate, narrow convention from the action-button glyphs above — these mark navbar chrome (Configuration, the account link, Sign out), not workflow actions:
-- Inline monochrome SVG via `nav_icon(:name)`, backed by the `bootstrap-icons` gem (`BootstrapIcons::BootstrapIcon`) — not emoji. Emoji render inconsistently across platforms/color, which matters for chrome that's on screen at all times; it doesn't matter enough for one-off action buttons to be worth a second icon mechanism there. `nav_icon` takes the gem's icon name (underscores are converted to hyphens, so `:box_arrow_right` maps to the `box-arrow-right` icon).
+A separate convention from the action-button icons above — these mark navbar chrome (Configuration, the account link, Sign out), not workflow actions:
+- Inline monochrome SVG via `nav_icon(:name)` — same underlying `bootstrap-icons` lookup as `action_icon`, just a different default size (15px vs 14px) and semantic name for the call site.
 - Configuration and the account link show their icon only below the `sm` breakpoint (`d-inline d-sm-none`) — on desktop they're plain text like every other top-level nav item; the icon exists to break up an otherwise-identical run of text rows once the navbar collapses to its mobile stacked list.
 - Sign out is the exception: icon-only on desktop (`nav_icon(:box_arrow_right)`), icon + text once collapsed — it's the one control that isn't paired with adjacent context, so a lone icon reads fine on desktop but would be the only unlabeled row in the mobile list.
-- Configuration hub tiles (`app/views/configurations/index.html.haml`) use the existing emoji convention, not `nav_icon` — that page isn't chrome, it's page content, so the action-button glyph rules apply there instead.
+- Configuration hub tiles (`app/views/configurations/index.html.haml`) use the existing emoji convention, not `nav_icon` — that page isn't chrome, it's page content, so the action-button icon rules apply there instead (and are themselves out of scope for now, see above).
 
 ## Controllers
 - Permission gates: `before_action -> { require_permission!("scope.verb") }, only: [...]`.

--- a/test/controllers/invoices_controller_paid_test.rb
+++ b/test/controllers/invoices_controller_paid_test.rb
@@ -80,7 +80,7 @@ class InvoicesControllerPaidTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select ".badge.bg-warning", text: "Unpaid"
-    assert_select "button", text: /Mark Paid/
+    assert_select "button", text: /Paid/
     assert_select ".mark-paid-modal form[action=?]", mark_paid_invoice_path(invoice)
     assert_select ".mark-paid-modal input[type='date'][name='paid_at']"
     assert_select ".mark-paid-modal input[type='submit'][value='Mark Paid']"
@@ -95,7 +95,7 @@ class InvoicesControllerPaidTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select ".badge.bg-success", text: /Paid/
     assert_select "form[action=?]", mark_unpaid_invoice_path(invoice)
-    assert_select "form[action=?] button[type='submit']", mark_unpaid_invoice_path(invoice), text: "Mark Unpaid"
+    assert_select "form[action=?] button[type='submit']", mark_unpaid_invoice_path(invoice), text: "Unpaid"
   end
 
   test "show page does not show payment status for draft invoices" do

--- a/test/helpers/action_buttons_helper_test.rb
+++ b/test/helpers/action_buttons_helper_test.rb
@@ -3,65 +3,65 @@ require "test_helper"
 class ActionButtonsHelperTest < ActionView::TestCase
   helper ApplicationHelper
 
-  # Smoke tests that pin the established glyph + Bootstrap color + accessible
-  # name for each helper. Update these when CLAUDE.md's "Button Glyphs" table
+  # Smoke tests that pin the established icon + Bootstrap color + accessible
+  # name for each helper. Update these when CLAUDE.md's "Button Icons" table
   # changes — they are the executable copy of the policy.
   #
   # The permission: mechanic is shared via `return nil if permission && !can?(...)`
   # in every helper, so it gets one set of dedicated cases against delete_button
   # rather than being re-tested per verb.
 
-  # --- Tier 3 (glyph-only) ---
+  # --- Tier 3 (icon-only) ---
 
-  test "delete_button renders glyph-only with title and aria-label" do
+  test "delete_button renders icon-only with title and aria-label" do
     customer = Customer.new
     customer.class.define_singleton_method(:name) { "Customer" }
     html = delete_button(customer)
-    assert_glyph_link html, glyph: "🗑", klass: "btn-danger", title: "Delete"
+    assert_icon_link html, icon: "trash3", klass: "btn-danger", title: "Delete"
     assert_match(/data-turbo-confirm=/, html)
   end
 
-  test "pdf_button renders glyph-only with title, opens in new tab" do
+  test "pdf_button renders icon-only with title, opens in new tab" do
     html = pdf_button("/foo.pdf")
-    assert_glyph_link html, glyph: "📄", klass: "btn-success", title: "PDF"
+    assert_icon_link html, icon: "file-earmark-pdf-fill", klass: "btn-success", title: "PDF"
     assert_match(/target="_blank"/, html)
   end
 
-  test "preview_button renders glyph-only, info color, new tab" do
+  test "preview_button renders icon-only, info color, new tab" do
     html = preview_button("/preview")
-    assert_glyph_link html, glyph: "👁", klass: "btn-info", title: "Preview"
+    assert_icon_link html, icon: "eye-fill", klass: "btn-info", title: "Preview"
     assert_match(/target="_blank"/, html)
   end
 
-  # --- Tier 2 (glyph + text, POST form) ---
+  # --- Tier 2 (icon + text, POST form) ---
 
-  test "publish_button renders glyph + text, warning color, POST form" do
+  test "publish_button renders icon + text, warning color, POST form" do
     html = publish_button("/publish")
-    assert_post_button html, label: "🚀 Publish", klass: "btn-warning"
+    assert_post_button html, icon: "send", text: "Publish", klass: "btn-warning"
     assert_match(%r{<form[^>]*action="/publish"}, html)
   end
 
-  test "unblock_button renders glyph + text, success color" do
+  test "unblock_button renders icon + text, success color" do
     html = unblock_button("/unblock")
-    assert_post_button html, label: "✅ Unblock", klass: "btn-success"
+    assert_post_button html, icon: "shield-check", text: "Unblock", klass: "btn-success"
   end
 
   test "reset_passkeys_button is text-only despite Tier 2 form rendering" do
     html = reset_passkeys_button("/reset")
-    assert_post_button html, label: "Reset passkeys", klass: "btn-warning"
-    refute_match(/🔄/, html)
+    assert_post_button html, icon: nil, text: "Reset passkeys", klass: "btn-warning"
   end
 
-  test "unpublish_button renders glyph + text, outline-secondary color" do
+  test "unpublish_button renders icon + text, outline-secondary color" do
     html = unpublish_button("/unpublish")
-    assert_post_button html, label: "↩️ Unpublish", klass: "btn-outline-secondary"
+    assert_post_button html, icon: "arrow-counterclockwise", text: "Unpublish", klass: "btn-outline-secondary"
   end
 
   # --- Tier 1 (plain link) ---
 
-  test "audit_log_button uses clipboard glyph + text" do
+  test "audit_log_button uses journal-check icon + text" do
     html = audit_log_button("/audit")
-    assert_includes html, "📋 Audit log"
+    assert_includes html, "bi-journal-check"
+    assert_includes html, "Audit log"
     assert_match(/btn-secondary/, html)
   end
 
@@ -93,7 +93,7 @@ class ActionButtonsHelperTest < ActionView::TestCase
     Current.user = users(:alice)
     html = delete_button(customers(:good_eu), permission: "customers.edit")
     assert_match(/btn-danger/, html)
-    assert_includes html, "🗑"
+    assert_includes html, "bi-trash3"
   ensure
     Current.user = nil
   end
@@ -119,15 +119,16 @@ class ActionButtonsHelperTest < ActionView::TestCase
 
   private
 
-  def assert_glyph_link(html, glyph:, klass:, title:)
-    assert_includes html, glyph
+  def assert_icon_link(html, icon:, klass:, title:)
+    assert_includes html, "bi-#{icon}"
     assert_match(/#{Regexp.escape(klass)}/, html)
     assert_match(/title="#{Regexp.escape(title)}"/, html)
     assert_match(/aria-label="#{Regexp.escape(title)}"/, html)
   end
 
-  def assert_post_button(html, label:, klass:)
-    assert_includes html, label
+  def assert_post_button(html, text:, klass:, icon: nil)
+    assert_includes html, "bi-#{icon}" if icon
+    assert_includes html, text
     assert_match(/#{Regexp.escape(klass)}/, html)
     assert_match(%r{<form[^>]*method="post"}, html)
   end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -134,7 +134,8 @@ class ApplicationHelperTest < ActionView::TestCase
     html = Nokogiri::HTML.fragment(destroy_link(customer).to_s)
     a = html.at_css("a")
     assert_not_nil a
-    assert_equal "🗑", a.text
+    assert_not_nil a.at_css("svg.bi-trash3")
+    assert_equal "Delete", a["title"]
   end
 
   test "destroy_link with permission: returns the link when user has it" do
@@ -143,7 +144,8 @@ class ApplicationHelperTest < ActionView::TestCase
     html = Nokogiri::HTML.fragment(destroy_link(customer, nil, permission: "customers.edit").to_s)
     a = html.at_css("a")
     assert_not_nil a
-    assert_equal "🗑", a.text
+    assert_not_nil a.at_css("svg.bi-trash3")
+    assert_equal "Delete", a["title"]
   ensure
     Current.user = nil
   end

--- a/test/system/customer_contacts_test.rb
+++ b/test/system/customer_contacts_test.rb
@@ -97,7 +97,7 @@ class CustomerContactsTest < ApplicationSystemTestCase
     other_row = "##{ActionView::RecordIdentifier.dom_id(@project_lead)}"
 
     accept_confirm do
-      within(row) { click_link "🗑" }
+      within(row) { find('a[title="Delete"]').click }
     end
 
     assert_no_selector row
@@ -122,7 +122,7 @@ class CustomerContactsTest < ApplicationSystemTestCase
     assert_no_selector "#customer_contacts_empty_message"
 
     accept_confirm do
-      within("##{ActionView::RecordIdentifier.dom_id(new_contact)}") { click_link "🗑" }
+      within("##{ActionView::RecordIdentifier.dom_id(new_contact)}") { find('a[title="Delete"]').click }
     end
 
     assert_no_selector "##{ActionView::RecordIdentifier.dom_id(new_contact)}"

--- a/test/system/email_preview_test.rb
+++ b/test/system/email_preview_test.rb
@@ -31,7 +31,7 @@ class EmailPreviewTest < ApplicationSystemTestCase
   test "invoice email preview iframe renders styled email body under strict CSP" do
     visit invoice_path(@invoice)
 
-    click_on "Send E-Mail"
+    click_on "Send"
 
     iframe_element = find("iframe.email-preview-iframe", wait: 5)
 

--- a/test/system/invoice_mark_paid_test.rb
+++ b/test/system/invoice_mark_paid_test.rb
@@ -13,7 +13,7 @@ class InvoiceMarkPaidTest < ApplicationSystemTestCase
     # The trigger lives in the Payment Status row, not the bottom action row.
     # Modal starts hidden via d-none.
     assert_selector ".mark-paid-modal", visible: :hidden
-    click_on "Mark Paid…"
+    click_on "Paid…"
 
     # Modal opens (d-none removed).
     assert_selector ".mark-paid-modal", visible: :visible
@@ -26,7 +26,7 @@ class InvoiceMarkPaidTest < ApplicationSystemTestCase
     # Redirect back to show page with the invoice now marked paid.
     assert_text(/Paid/)
     # No "Unpaid" badge (the bare word "Unpaid" still appears inside the
-    # "Mark Unpaid" button that's now rendered).
+    # "Unpaid" button that's now rendered).
     assert_no_selector ".badge.bg-warning", text: "Unpaid"
     assert_equal Date.current, @invoice.reload.paid_at.to_date
   end
@@ -37,7 +37,7 @@ class InvoiceMarkPaidTest < ApplicationSystemTestCase
     visit invoice_path(@invoice)
 
     accept_confirm do
-      click_on "Mark Unpaid"
+      click_on "Unpaid"
     end
 
     assert_text "Unpaid", wait: 5
@@ -49,7 +49,7 @@ class InvoiceMarkPaidTest < ApplicationSystemTestCase
 
     visit invoice_path(@invoice)
 
-    click_on "Mark Paid…"
+    click_on "Paid…"
     assert_selector ".mark-paid-modal", visible: :visible
 
     within ".mark-paid-modal" do

--- a/test/system/line_management_test.rb
+++ b/test/system/line_management_test.rb
@@ -24,7 +24,7 @@ class LineManagementTest < ApplicationSystemTestCase
 
     first_line = first("[data-line-index]")
     within first_line do
-      click_button "🗑"
+      find('button[title="Remove line"]').click
     end
 
     # Persisted line should be hidden, not removed
@@ -44,7 +44,7 @@ class LineManagementTest < ApplicationSystemTestCase
     # Remove the new line
     new_line = all("[data-line-index]").last
     within new_line do
-      click_button "🗑"
+      find('button[title="Remove line"]').click
     end
 
     # New line should be completely removed from DOM
@@ -171,7 +171,7 @@ class LineManagementTest < ApplicationSystemTestCase
     # Remove existing lines to get down to single line scenario
     all("[data-line-index]")[1..-1].each do |line|
       within line do
-        click_button "🗑"
+        find('button[title="Remove line"]').click
       end
     end
 
@@ -180,7 +180,7 @@ class LineManagementTest < ApplicationSystemTestCase
 
     # Remove the last line - should work now
     within first("[data-line-index]") do
-      click_button "🗑"
+      find('button[title="Remove line"]').click
     end
 
     # Persisted line should be hidden but marked for destruction

--- a/test/system/offer_form_test.rb
+++ b/test/system/offer_form_test.rb
@@ -23,7 +23,7 @@ class OfferFormTest < ApplicationSystemTestCase
       click_on "▲"
     end
     within all("[data-line-index]")[2] do
-      click_on "🗑"
+      find('button[title="Remove milestone"]').click
     end
     click_on "Save"
     assert_text "Offer updated"


### PR DESCRIPTION
## Summary

- Stacked on #566 (icon proposal) → #565 (prelude order) → #564 (card/table restyle).
- Implements the picked icon options from #566: `trash3` (Delete + inline "remove line"/"remove milestone" buttons), `envelope` (Send e-mail), `send` paper-plane (Publish, Convert to Invoice, offer Send, milestone Convert — sharing one icon per the existing "promote forward" glyph-reuse rule), `arrow-counterclockwise` (Mark Unpaid, Unpublish — shared "revert state"), `check-circle-fill` (Mark Paid), `shield-slash`/`shield-check` (Block/Unblock), `upload` (Upload PDF), `journal-check` (Audit log), `file-earmark-pdf-fill` (PDF), `eye-fill` (Preview).
- Also fixes an existing docs/code gap: Mark Paid, Mark Unpaid, Send e-mail, and Upload PDF were documented with icons/glyphs in `docs/code-style.md` but actually shipped as plain text — they now match the docs. `Block` and `Upload PDF` move from `f.submit` to `f.button` since a plain `<input type="submit">` can't hold an SVG.
- New helpers: `action_icon` (mirrors `nav_icon`, sized for inline button use), `icon_label` (icon + `<span>` text), `icon_link` (icon-only link, replaces `glyph_link`) in `application_helper.rb` / `action_buttons_helper.rb`.
- New CSS: `.btn svg.bi:not(:last-child) { margin-right: .35rem; }` — only adds the icon/text gap when `icon_label`'s `<span>` is present, so icon-only buttons (Delete, PDF, Preview, ...) stay symmetrically centered. Verified visually via screenshots at pixel level (cropped icon-only buttons show no lopsided margin).
- `docs/code-style.md`'s "Action button glyphs" section renamed to "Action button icons" with the updated mapping table; explicitly scopes out Configuration hub tile emoji, the "Reusable" badge, and the line-toolbar `✓`/`▲`/`▼` symbols as separate, deliberately-untouched conventions.

## Test plan

- [x] `bundle exec rails test` (1046 runs, 0 failures)
- [x] `bundle exec rails test test/system/` (65 runs, 0 failures) — updated Capybara button-text/selector lookups in `line_management_test.rb`, `offer_form_test.rb`, `customer_contacts_test.rb`, `invoice_mark_paid_test.rb`, `email_preview_test.rb` for the new labels
- [x] `./bin/rubocop` on touched Ruby files
- [x] Manual visual check via Capybara screenshots across customer/offer/invoice/user show and invoice edit pages, light + dark theme; pixel-level crop inspection confirms icon-only buttons (Delete, PDF, Preview, line-remove trash) are centered with no lopsided margin

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HZqSFbngHkfr37F9UHo5Ee)_