### PR TITLE
Restore mobile responsive layout: add viewport meta tag

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,6 +4,7 @@
     - issuer = IssuerCompany.get_the_issuer!
     - default_title = issuer&.short_name.present? ? "ABT: #{issuer.short_name}" : "ABT"
     %title= content_for?(:title) ? yield(:title) : default_title
+    %meta{name: "viewport", content: "width=device-width, initial-scale=1"}
     %meta{name: "robots", content: "noindex, nofollow"}
     = csrf_meta_tags
     = csp_meta_tag

--- a/app/views/layouts/customer_portal.html.haml
+++ b/app/views/layouts/customer_portal.html.haml
@@ -2,6 +2,7 @@
 %html
   %head
     %title= content_for?(:title) ? yield(:title) : @issuer&.short_name
+    %meta{name: "viewport", content: "width=device-width, initial-scale=1"}
     %meta{name: "robots", content: "noindex, nofollow"}
     = csrf_meta_tags
     = csp_meta_tag

--- a/test/system/mobile_layout_test.rb
+++ b/test/system/mobile_layout_test.rb
@@ -1,0 +1,68 @@
+require "application_system_test_case"
+
+# Regression tests for the responsive mobile layout. The viewport meta tag is
+# what makes mobile browsers lay pages out at device width instead of a ~980px
+# virtual desktop viewport; without it Bootstrap's breakpoints never trigger on
+# phones (no burger menu, desktop-sized pages). Plain window resizing cannot
+# catch that regression -- desktop browsers ignore the viewport meta -- so
+# these tests use Chrome's mobile device emulation via CDP.
+class MobileLayoutTest < ApplicationSystemTestCase
+  IPHONE = { width: 390, height: 844, deviceScaleFactor: 3, mobile: true }.freeze
+
+  teardown do
+    cdp("Emulation.clearDeviceMetricsOverride")
+  end
+
+  test "app layout lays out at device width on a phone" do
+    emulate_iphone
+    visit root_path
+
+    assert page.find("meta[name='viewport']", visible: false)[:content].include?("width=device-width")
+
+    layout_width = page.evaluate_script("document.documentElement.clientWidth")
+    assert_operator layout_width, :<=, IPHONE[:width],
+      "expected mobile layout viewport of ~#{IPHONE[:width]}px, got #{layout_width}px " \
+      "(980px means the viewport meta tag is missing or ignored)"
+  end
+
+  test "navbar collapses to a burger menu on a phone" do
+    emulate_iphone
+    visit root_path
+
+    assert_selector ".navbar-toggler", visible: true
+    assert_no_selector ".navbar-collapse.show"
+    assert_no_selector ".navbar-nav .nav-link", text: "Invoices"
+
+    find(".navbar-toggler").click
+    assert_selector ".navbar-collapse.show"
+    assert_selector ".navbar-nav .nav-link", text: "Invoices"
+  end
+
+  test "customer portal lays out at device width on a phone" do
+    prev_app_host = Capybara.app_host
+    prev_include_port = Capybara.always_include_port
+    Capybara.app_host = "http://#{Settings.customer_portal.host}"
+    Capybara.always_include_port = true
+
+    emulate_iphone
+    visit public_root_path
+
+    layout_width = page.evaluate_script("document.documentElement.clientWidth")
+    assert_operator layout_width, :<=, IPHONE[:width],
+      "expected mobile layout viewport of ~#{IPHONE[:width]}px, got #{layout_width}px " \
+      "(980px means the viewport meta tag is missing or ignored)"
+  ensure
+    Capybara.app_host = prev_app_host
+    Capybara.always_include_port = prev_include_port
+  end
+
+  private
+
+  def emulate_iphone
+    cdp("Emulation.setDeviceMetricsOverride", **IPHONE)
+  end
+
+  def cdp(method, **params)
+    page.driver.browser.page.command(method, **params)
+  end
+end


### PR DESCRIPTION
The application and customer-portal layouts were missing the viewport
meta tag, so mobile browsers rendered pages at a ~980px virtual desktop
viewport. Bootstrap's breakpoints never triggered on phones: no burger
menu, desktop-sized pages.

Add system tests using Chrome's mobile device emulation (CDP
Emulation.setDeviceMetricsOverride) since plain window resizing cannot
catch a missing viewport tag - desktop browsers ignore it.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015ouazeqJ5zFottbF94bVmt