### PR TITLE
Fix unreadable Trix toolbar icons in dark mode

### DIFF
--- a/app/assets/stylesheets/actiontext.css.scss
+++ b/app/assets/stylesheets/actiontext.css.scss
@@ -15,3 +15,15 @@ trix-editor {
 
 // Hide the toolbar groups we don't support (belt-and-suspenders with the JS).
 trix-toolbar .trix-button-group--file-tools { display: none; }
+
+// Trix draws its toolbar icons as embedded SVGs with hardcoded black fill,
+// invisible on the dark background. Invert them (the ::before pseudo-element
+// carries only the icon), and swap Trix's hardcoded light-gray button borders
+// for the theme border color. Active buttons keep Trix's light-blue fill, so
+// their icons stay un-inverted.
+[data-bs-theme="dark"] trix-toolbar {
+  .trix-button--icon::before { filter: invert(1); }
+  .trix-button--icon.trix-active::before { filter: none; }
+  .trix-button { border-bottom-color: var(--bs-border-color); }
+  .trix-button:not(:first-child) { border-left-color: var(--bs-border-color); }
+}


### PR DESCRIPTION
Trix embeds its toolbar icons as SVG data URIs with hardcoded black fill, which makes them invisible against the dark background under `data-bs-theme="dark"`.

Changes in `app/assets/stylesheets/actiontext.css.scss`:
- Invert the toolbar icons in dark mode (`filter: invert(1)` on the `::before` pseudo-element that carries the icon).
- Active buttons keep Trix's light-blue fill, so their icons stay un-inverted (black on light blue, matching light mode).
- Swap Trix's hardcoded light-gray button borders (`#ddd` / `#ccc`) for `var(--bs-border-color)`.

Verified with headless system-test screenshots in both themes, including an active Bold button; screenshots attached in the session chat (not committed, per repo policy). Full system test suite and pre-commit pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K44J3vz9wqQXorzqZRwwkB

---
_Generated by [Claude Code](https://claude.ai/code/session_01K44J3vz9wqQXorzqZRwwkB)_