### PR TITLE
Fix remaining style-guide gaps found in a follow-up sweep

### DIFF
--- a/app/controllers/configurations_controller.rb
+++ b/app/controllers/configurations_controller.rb
@@ -1,7 +1,7 @@
 class ConfigurationsController < ApplicationController
-  # Replaces the old navbar dropdown: a hub page linking to the various
-  # config sub-sections. Visibility is an any-of across those sections'
-  # own permissions, not a single scope, so it can't use require_permission!.
+  # A hub page linking to the various config sub-sections. Visibility is an
+  # any-of across those sections' own permissions, not a single scope, so it
+  # can't use require_permission!.
   PERMS = %w[issuer_company.view products.view sales_tax.view users.view jobs_status.view groups.manage teams.manage].freeze
 
   allow_without_permission_check only: [ :index ]

--- a/app/helpers/action_buttons_helper.rb
+++ b/app/helpers/action_buttons_helper.rb
@@ -66,7 +66,7 @@ module ActionButtonsHelper
   # Primary submit button for edit/new pages. Lives in the breadcrumb action
   # cluster and submits the page's main form via the HTML5 `form=` attribute,
   # so the button can sit outside the <form> element. The breadcrumb's parent
-  # crumb replaces what Cancel used to do.
+  # crumb is the way back — there is no separate Cancel button.
   def save_button(label: "Save", permission: nil)
     return nil if permission && !can?(permission)
     button_tag label, type: :submit, form: PAGE_FORM_ID, class: "btn btn-primary"

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -237,7 +237,7 @@ private
     # Walk the in-memory association target so we also see records built
     # earlier in this same save cycle (e.g. via accepts_nested_attributes_for).
     # Going through .includes here would issue a fresh SQL load and miss
-    # those, which previously caused duplicate InvoiceTaxClass rows.
+    # those, causing duplicate InvoiceTaxClass rows.
     existing_tax_classes = self.invoice_tax_classes.to_a.index_by(&:sales_tax_product_class_id)
 
     # Update/create required tax classes

--- a/app/views/invoices/_invoice_line_fields.html.haml
+++ b/app/views/invoices/_invoice_line_fields.html.haml
@@ -27,7 +27,7 @@
             %option{value: ''} Select a product...
             - Product.order(:title).each do |product|
               %option{value: product.id, data: {title: product.title, description: product.description, rate: product.rate, tax_class: product.sales_tax_product_class_id}}
-                = "#{product.title} - €#{product.rate}"
+                = "#{product.title} - #{format_currency(product.rate)}"
 
           %button.btn.btn-success{type: 'button', data: {action: 'click->invoice-lines#useSelectedProduct'}} ✓
 

--- a/app/views/shared/_mark_paid_modal.html.haml
+++ b/app/views/shared/_mark_paid_modal.html.haml
@@ -17,4 +17,5 @@
           .text-end
             %button.btn.btn-secondary.me-2{type: "button", data: {action: "click->modal#close"}}
               Cancel
-            = f.submit "Mark Paid", class: "btn btn-success"
+            = f.button class: "btn btn-success" do
+              = icon_label(:'check-circle-fill', 'Mark Paid')

--- a/test/controllers/invoices_controller_paid_test.rb
+++ b/test/controllers/invoices_controller_paid_test.rb
@@ -83,7 +83,7 @@ class InvoicesControllerPaidTest < ActionDispatch::IntegrationTest
     assert_select "button", text: /Paid/
     assert_select ".mark-paid-modal form[action=?]", mark_paid_invoice_path(invoice)
     assert_select ".mark-paid-modal input[type='date'][name='paid_at']"
-    assert_select ".mark-paid-modal input[type='submit'][value='Mark Paid']"
+    assert_select ".mark-paid-modal button[type='submit']", text: /Mark Paid/
   end
 
   test "show page exposes paid status with mark unpaid button when paid" do


### PR DESCRIPTION
## Summary

A follow-up sweep across `docs/code-style.md`'s conventions after #566 landed, checking for cards, formatting, action-button icons, status badges/buttons, tests, controllers, and comments. Most categories came back clean; three genuine gaps:

- `app/views/invoices/_invoice_line_fields.html.haml` — the product dropdown price label hardcoded a `€` instead of going through `format_currency`, so it wouldn't follow the issuer's configured currency.
- `app/views/shared/_mark_paid_modal.html.haml` — the modal's submit button was still a plain `<input type="submit">` (`f.submit`, which can't hold an SVG), left behind when Paid/Unpaid got icons elsewhere on the invoice show page. Switched to `f.button` + `icon_label` with `check-circle-fill`.
- Three comments (`action_buttons_helper.rb`, `configurations_controller.rb`, `invoice.rb`) described what code "used to do" or "previously" caused instead of the present behavior, per the Comments section's "describe the present, not the history" rule.

Other categories checked and confirmed clean: `assigns()` in tests, permission gates, tenant scoping, `.border-{color}`/`.border` pairing, `rich_text_area` card-wrapping, date formatting, inline `style=`, status badges, `ms-auto` placement, icon-mapping consistency. A couple of borderline findings were investigated and ruled out as false positives — e.g. the bare invoice/delivery-note line-items tables (deliberately not card-wrapped, a separate documented convention) and the inline `customer_contacts` row-edit "Cancel" links (a Turbo-frame inline-edit pattern, not a breadcrumb-backed page).

## Test plan

- [x] `bundle exec rails test` (1046 runs, 0 failures)
- [x] `bundle exec rails test test/system/` (68 runs, 0 failures)
- [x] `./bin/rubocop` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)