### PR TITLE
Align table cell padding with card insets on document/detail pages

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.scss
@@ -236,6 +236,17 @@ nav[aria-label="breadcrumb"] > div {
 .card-body { padding-top: .5rem; }
 .card-header + .card-body { padding-top: var(--bs-card-spacer-y); }
 
+// A `.table` sitting directly in a `.card-body` (e.g. the offer milestones
+// table, sales-tax rate lists, jobs-status worker tables) gets its own
+// default 0.5rem cell padding on top of the card-body's 1rem inset, so its
+// text sits further right than any label/paragraph text above it in the
+// same card. Zero out the outer edge so the first/last column lines up with
+// the card's own inset instead of double-indenting.
+.card-body table {
+  th:first-child, td:first-child { padding-left: 0; }
+  th:last-child, td:last-child { padding-right: 0; }
+}
+
 // —— Badges: soft, fully-rounded pills instead of solid blocks.
 @each $name, $color in $theme-colors {
   .badge.bg-#{$name} {

--- a/app/assets/stylesheets/documents.css.scss
+++ b/app/assets/stylesheets/documents.css.scss
@@ -9,13 +9,16 @@ table.document-lines-table {
   th.col-tax-class   { width: 10%; }
   th.col-amount      { width: 15%; }
 
+  // Horizontal padding matches .card-body's inset (--bs-card-spacer-x,
+  // 1rem) so the table's text lines up with the cards stacked above/below
+  // it on the same page instead of sitting closer to the edge.
   th {
     font-weight: 600;
-    padding: 0.75rem 0.5rem;
+    padding: 0.75rem 1rem;
   }
 
   td {
-    padding: 0.5rem;
+    padding: 0.5rem 1rem;
     vertical-align: top;
   }
 
@@ -31,11 +34,11 @@ table.document-lines-table {
     background-color: rgba(34, 128, 127, 0.09);
     border-left: 3px solid #22807f;
     box-shadow: none;
-    padding: 12px 8px 12px calc(8px - 3px);
+    padding: 12px 16px 12px calc(16px - 3px);
   }
   td.document-text-row {
     box-shadow: none;
-    padding: 8px;
+    padding: 8px 16px;
   }
 
   .document-line-comment { margin-left: 20px; }

--- a/docs/card-table-restyle.md
+++ b/docs/card-table-restyle.md
@@ -51,3 +51,11 @@ having a slightly different look:
   below/above cards on the same page (invoice/delivery-note show), so its
   text needs to line up with theirs rather than sitting closer to the edge
   at Bootstrap's default `0.5rem` table padding.
+- A `.table` sitting *inside* a `.card-body` (offer milestones, sales-tax
+  rate lists, jobs-status worker tables) hits the opposite problem: its own
+  `0.5rem` cell padding stacks on top of the card-body's `1rem` inset
+  instead of matching it, so the first/last column sits further in than any
+  label text above it in the same card. `.card-body table` zeroes the
+  outer-edge cell padding (`th:first-child`/`td:first-child` left,
+  `th:last-child`/`td:last-child` right) so the table's edge lines up with
+  the card's own inset instead of double-indenting.

--- a/docs/card-table-restyle.md
+++ b/docs/card-table-restyle.md
@@ -46,3 +46,8 @@ having a slightly different look:
   no boxed borders) instead of relying on Bootstrap's default cell borders.
 - No table is wrapped in a card shell — tables stay directly in their
   existing containers.
+- `document-lines-table`'s cell horizontal padding is `1rem`, matching
+  `.card-body`'s inset (`--bs-card-spacer-x`) — a bare table sits directly
+  below/above cards on the same page (invoice/delivery-note show), so its
+  text needs to line up with theirs rather than sitting closer to the edge
+  at Bootstrap's default `0.5rem` table padding.


### PR DESCRIPTION
## Summary

The invoice detail page's line-item table and cards used different horizontal insets, so text didn't line up when the two sat stacked on the page. Two variants of the same root cause (Bootstrap's default `0.5rem` table cell padding vs. `.card-body`'s `1rem` inset), found by checking other pages with the same structure:

- **Bare table sibling to cards** (`document-lines-table` on invoice/delivery-note show): the table sits directly in the page body, not inside a card, so its `0.5rem` cell padding put its text 8px closer to the edge than the cards above/below it. Bumped to `1rem` to match. Measured precisely via screenshot pixel-scanning before and after (text left-edge at x=62 vs. x=70 for the surrounding cards; now both at x=70).
- **Table nested inside a card** (offer milestones/conversion tables, sales-tax rate lists on `sales_tax_customer_classes`/`sales_tax_product_classes` show, jobs-status worker/task tables): here the table's own `0.5rem` cell padding stacks *on top of* the card-body's `1rem` inset, so the table's first/last column sits further in than the label text above it in the same card. Added a general `.card-body table` rule zeroing the outer-edge cell padding so it lines up with the card's own inset instead of double-indenting. Verified across offers/show, both sales-tax class show pages, and jobs_status/show.

Both fixes and the reasoning are documented in `docs/card-table-restyle.md`.

## Test plan

- [x] `bundle exec rails test` (1046 runs, 0 failures)
- [x] `bundle exec rails test test/system/` (68 runs, 0 failures)
- [x] `./bin/rubocop` clean
- [x] Visual verification via Capybara screenshots + pixel-level left/right-edge measurement on invoice show (with and without line items), delivery-note show, offer show (milestones + totals), sales-tax customer/product class show, and jobs-status show

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZqSFbngHkfr37F9UHo5Ee)_