### PR TITLE
Style-align the Publish/Create action buttons

### DIFF
--- a/app/views/delivery_notes/show.html.haml
+++ b/app/views/delivery_notes/show.html.haml
@@ -85,10 +85,10 @@
                     %span.badge.bg-warning No item lines
                   - if can_edit_dn
                     - if @delivery_note.has_items?
-                      = button_to 'Publish…', publish_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-sm btn-info', form: { class: 'button_to ms-auto' }
+                      = button_to icon_label(:send, 'Publish'), publish_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-sm btn-info', form: { class: 'button_to ms-auto' }
                     - else
                       %span.ms-auto
-                        %button.btn.btn-sm.btn-info{disabled: true} Publish…
+                        %button.btn.btn-sm.btn-info{disabled: true}= icon_label(:send, 'Publish')
             - if @delivery_note.published?
               = render 'shared/email_status_row', resource: @delivery_note, can_edit: can_edit_dn, show_send_button: true
             - if @delivery_note.published? || @delivery_note.invoice
@@ -105,7 +105,7 @@
                   - else
                     Not invoiced
                     - if can_edit_dn
-                      = button_to icon_label(:send, 'Create…'), convert_to_invoice_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-sm btn-info', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Create an invoice draft from this delivery note?' }
+                      = button_to icon_label(:send, 'Create'), convert_to_invoice_delivery_note_path(@delivery_note), method: :post, class: 'btn btn-sm btn-info', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Create an invoice draft from this delivery note?' }
             - if @delivery_note.offer_milestone
               .row.mb-2
                 .col-sm-4

--- a/app/views/invoices/show.html.haml
+++ b/app/views/invoices/show.html.haml
@@ -105,9 +105,9 @@
                   - if can_edit_invoice
                     - if problems.any?
                       %span.ms-auto{title: problems.join("\n")}
-                        %button.btn.btn-sm.btn-info{disabled: true} Publish Invoice…
+                        %button.btn.btn-sm.btn-info{disabled: true}= icon_label(:send, 'Publish')
                     - else
-                      = button_to 'Publish Invoice…', publish_invoice_path(@invoice), method: :post, class: 'btn btn-sm btn-info', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Publish invoice and assign a document number? This cannot be undone.' }
+                      = button_to icon_label(:send, 'Publish'), publish_invoice_path(@invoice), method: :post, class: 'btn btn-sm btn-info', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Publish invoice and assign a document number? This cannot be undone.' }
 
             - if @invoice.published?
               = render 'shared/email_status_row', resource: @invoice, can_edit: can_edit_invoice, show_send_button: @invoice.attachment.present?

--- a/app/views/offers/show.html.haml
+++ b/app/views/offers/show.html.haml
@@ -80,9 +80,9 @@
             - if can?('offers.edit')
               - if problems.any?
                 %span.ms-auto{title: problems.join("\n")}
-                  %button.btn.btn-sm.btn-info{disabled: true}= icon_label(:send, 'Send')
+                  %button.btn.btn-sm.btn-info{disabled: true}= icon_label(:send, 'Publish')
               - else
-                = button_to icon_label(:send, 'Send'), send_offer_offer_path(@offer), method: :post, class: 'btn btn-sm btn-info', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Send this offer to the customer? A PDF is generated and this version is frozen.' }
+                = button_to icon_label(:send, 'Publish'), send_offer_offer_path(@offer), method: :post, class: 'btn btn-sm btn-info', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Send this offer to the customer? A PDF is generated and this version is frozen.' }
 
   - if problems.any?
     .alert.alert-warning.mb-3

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -59,7 +59,7 @@ Icons are inline monochrome SVG via `action_icon(:name)` (`app/helpers/applicati
 When the icon carries the verb, drop the leading verb from the label: `Mark Paid` → `Paid…`, `Mark Unpaid` → `Unpaid`. Keep verb+object when the icon alone isn't enough.
 
 Reuse icons for the same archetype — don't invent new ones:
-- `send` (paper plane) promote forward (Publish, Convert to Invoice, Send offer, Convert milestone)
+- `send` (paper plane) promote forward (Publish — invoice/delivery-note/offer, Convert to Invoice, Convert milestone)
 - `check-circle-fill` / `shield-check` positive state change (Paid, Unblock)
 - `arrow-counterclockwise` revert state (Unpaid, Unpublish)
 - `trash3` delete (Delete, and the inline "remove line" buttons on invoice/delivery-note/offer-milestone edit forms)
@@ -79,9 +79,9 @@ Established mapping — extend it, don't invent new icons for existing verbs:
 | Mark Paid | `check-circle-fill` | icon + `Paid…` | (status-row, inline) |
 | Mark Unpaid | `arrow-counterclockwise` | icon + `Unpaid` | (status-row, inline) |
 | Send e-mail | `envelope` | icon + `Send` | (status-row, inline) |
-| Publish | `send` | icon + `Publish` | `publish_button` |
+| Publish | `send` | icon + `Publish` | (status-row, inline) |
 | Unpublish | `arrow-counterclockwise` | icon + `Unpublish` | `unpublish_button` |
-| Convert to Invoice | `send` | icon + `Create…` | (status-row, inline) |
+| Convert to Invoice | `send` | icon + `Create` | (status-row, inline) |
 | Upload PDF | `upload` | icon + `Upload PDF` | (form, inline) |
 | Block | `shield-slash` | icon + `Block` | (form-with-reason, inline) |
 | Unblock | `shield-check` | icon + `Unblock` | `unblock_button` |

--- a/test/controllers/invoices_controller_test.rb
+++ b/test/controllers/invoices_controller_test.rb
@@ -222,7 +222,7 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select ".badge.bg-warning", text: "Draft"
     assert_select ".badge.bg-success", text: "Ready"
-    assert_select "form.button_to button", text: /Publish Invoice/
+    assert_select "form.button_to button", text: /Publish/
   end
 
   test "draft invoice show renders problems alert and disabled Publish button when invoice has missing data" do
@@ -236,7 +236,7 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
     get invoice_url(invoice)
     assert_response :success
     assert_select ".alert-warning li", text: /Broken Line.*rate/
-    assert_select "button[disabled]", text: /Publish Invoice/
+    assert_select "button[disabled]", text: /Publish/
   end
 
   test "should get edit" do

--- a/test/controllers/offers_controller_test.rb
+++ b/test/controllers/offers_controller_test.rb
@@ -48,12 +48,12 @@ class OffersControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to offer_url(offers(:sent_offer))
   end
 
-  test "draft offer show renders problems alert and disabled Send button when there are no milestones" do
+  test "draft offer show renders problems alert and disabled Publish button when there are no milestones" do
     offer = create_draft_offer
     get offer_url(offer)
     assert_response :success
     assert_select ".alert-warning li", text: /milestone/i
-    assert_select "button[disabled]", text: /Send/
+    assert_select "button[disabled]", text: /Publish/
   end
 
   test "send_offer transitions to sent" do

--- a/test/system/offer_form_test.rb
+++ b/test/system/offer_form_test.rb
@@ -45,10 +45,10 @@ class OfferFormTest < ApplicationSystemTestCase
     assert milestone.skip_delivery_note
   end
 
-  test "send button disabled without milestones" do
+  test "publish button disabled without milestones" do
     offer = create_draft_offer
     visit offer_path(offer)
-    assert_selector "button[disabled]", text: /Send/
+    assert_selector "button[disabled]", text: /Publish/
   end
 
   test "accepting without an order document succeeds" do


### PR DESCRIPTION
## Summary

Four status-row action buttons across invoice/delivery-note/offer show pages had drifted out of sync with each other:

- Invoice's "Publish Invoice…" — plain text, no icon, trailing dots.
- Delivery-note's "Publish…" — same (plain text, no icon, trailing dots); found while auditing the other two since it's the same pattern.
- Delivery-note's "Create…" (convert to invoice) — already had the `send` icon, but kept the dots.
- Offer's "Send" (send the offer to the customer) — already had the `send` icon and no dots, but a different label.

All four now share the `send` (paper-plane) icon and no trailing ellipsis. The three "finalize/publish" actions (invoice, delivery-note, offer) now render as `Publish` — sending an offer is its publish-equivalent action, so its button reads the same as the others rather than standing out as `Send`. Delivery-note's `Create` keeps its own label since it's a different verb (spawning an invoice, not finalizing the current document).

`docs/code-style.md`'s icon mapping table and archetype list updated to match.

## Test plan

- [x] `bundle exec rails test` (1046 runs, 0 failures)
- [x] `bundle exec rails test test/system/` (68 runs, 0 failures)
- [x] `./bin/rubocop` clean
- [x] Visual confirmation via Capybara screenshots on invoice, delivery-note (both Publish and Create states), and offer show pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZqSFbngHkfr37F9UHo5Ee)_