### PR TITLE
Normalize card-header and section-heading naming/casing

### DIFF
--- a/app/views/customers/_form.html.haml
+++ b/app/views/customers/_form.html.haml
@@ -79,7 +79,7 @@
       .col-lg-5.col-md-4
         = f.number_field :payment_terms_days, :class => 'form-control', :min => 1, :max => 365, :value => (@customer.payment_terms_days || 30)
     %hr
-    %h5.mb-3 Offer settings
+    %h5.mb-3 Offer Settings
     .row.mb-3
       = f.label :offer_validity_days, 'Validity (days)', class: 'col-lg-2 col-md-3 col-form-label'
       .col-lg-3.col-md-4

--- a/app/views/customers/show.html.haml
+++ b/app/views/customers/show.html.haml
@@ -10,7 +10,7 @@
 .row
   .col-md-6
     .card
-      .card-header Basic Information
+      .card-header Customer Information
       .card-body
         .row.mb-2
           .col-sm-4
@@ -152,7 +152,7 @@
   .col-md-12
     .card
       .card-header
-        Offer settings
+        Offer Settings
       .card-body
         .row.mb-2
           .col-sm-3

--- a/app/views/delivery_notes/_acceptance_submissions.html.haml
+++ b/app/views/delivery_notes/_acceptance_submissions.html.haml
@@ -7,7 +7,7 @@
   .mb-4
     .card
       .card-header
-        %h5.mb-0 Customer acceptance submissions
+        %h5.mb-0 Customer Acceptance Submissions
       .card-body
         .d-flex.align-items-center.gap-2.mb-3
           %i.fas.fa-file-pdf.text-danger

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -3,7 +3,7 @@
 .row
   .col-md-8
     .card.mb-3
-      .card-header Information
+      .card-header Group Information
       .card-body
         .row.mb-2
           .col-sm-3

--- a/app/views/teams/show.html.haml
+++ b/app/views/teams/show.html.haml
@@ -3,7 +3,7 @@
 .row
   .col-md-8
     .card.mb-3
-      .card-header Information
+      .card-header Team Information
       .card-body
         .row.mb-2
           .col-sm-3

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -33,6 +33,7 @@ The canonical style reference for this repo. Project structure, architecture, mo
 - Index pages (list + filter toolbar) don't use cards at all — a distinct, consistent convention across every `index.html.haml`. Don't introduce cards there.
 - Multi-column card grids: `.row > .col-md-6 > .card.mb-3`. Stack full-width cards with `.mb-4` — without it, adjacent borderless cards touch and visually fuse into one.
 - Don't call a multi-column card layout imbalanced by card count — judge by realistic per-column rendered height. List-bound cards (sessions, audit events, line items) grow with data and naturally fill a column.
+- Card header text is Title Case, and a primary "show the whole record" card is named `"{Entity} Information"` (`Customer Information`, `Company Information`, `Team Information`) — not a bare `Information` or `Basic Information` that drops the entity name. A card for one specific sub-topic just names that topic (`Notes`, `Members`, `Offer Settings`) rather than forcing the `{Entity} Information` pattern onto it.
 
 ## Status badges
 - Show only deviation from the healthy default. Active/normal renders no badge in headers and as plain text in tables.

--- a/test/controllers/delivery_notes_controller_test.rb
+++ b/test/controllers/delivery_notes_controller_test.rb
@@ -538,14 +538,14 @@ class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
   test "show keeps the submissions card while a submission is pending" do
     dn, = pending_submission
     get delivery_note_url(dn)
-    assert_select "h5", text: "Customer acceptance submissions"
+    assert_select "h5", text: "Customer Acceptance Submissions"
   end
 
   test "show hides the submissions card once accepted with no pending submission" do
     dn, sub = pending_submission
     sub.accept!(by: users(:alice))
     get delivery_note_url(dn)
-    assert_select "h5", text: "Customer acceptance submissions", count: 0
+    assert_select "h5", text: "Customer Acceptance Submissions", count: 0
   end
 
   test "show hides the submissions card after an accepted document is deleted" do
@@ -554,7 +554,7 @@ class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
     post delete_acceptance_delivery_note_url(dn)
     assert_nil dn.reload.acceptance_attachment_id
     get delivery_note_url(dn)
-    assert_select "h5", text: "Customer acceptance submissions", count: 0
+    assert_select "h5", text: "Customer Acceptance Submissions", count: 0
   end
 
   private


### PR DESCRIPTION
## Summary

Swept `.card-header`/`%h5` section labels app-wide for naming/casing consistency. Found three different naming schemes for the same "show the whole record" primary card:

- `"{Entity} Information"` — Company, Project, Product (the dominant pattern, 3+ instances)
- Bare `"Information"` — Team, Group show pages
- `"Basic Information"` — Customer show page

Normalized all of them to `"{Entity} Information"` (`Customer Information`, `Team Information`, `Group Information`).

Also found two headings that were sentence case while every sibling on the same page/area was Title Case:

- Customer show *and* edit form's `"Offer settings"` → `Offer Settings` (matches the sibling `Automated Email Settings` card on the same show page).
- Delivery-note acceptance card's `"Customer acceptance submissions"` → `Customer Acceptance Submissions` (matches sibling cards `Acceptance Document`, `Internal Notes`, `Order`, `Proposal`).

Documented the `"{Entity} Information"` convention in `docs/code-style.md`'s Cards section so it doesn't drift again.

## Test plan

- [x] `bundle exec rails test` (1046 runs, 0 failures)
- [x] `bundle exec rails test test/system/` (68 runs, 0 failures)
- [x] `./bin/rubocop` clean
- [x] Visual confirmation via Capybara screenshots on customer show and team show

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZqSFbngHkfr37F9UHo5Ee)_