### PR TITLE
Fix uncheck-all being silently ignored on group and team forms

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -44,8 +44,8 @@ class GroupsController < ApplicationController
     before_members = @group.user_ids.to_set
     before_bypass = @group.bypass_team_scoping?
     if @group.update(group_attributes)
-      assign_permissions(@group, params.dig(:group, :permission_keys)) if params.dig(:group, :permission_keys)
-      assign_members(@group, params.dig(:group, :user_ids)) if params.dig(:group, :user_ids)
+      assign_permissions(@group, params.dig(:group, :permission_keys))
+      assign_members(@group, params.dig(:group, :user_ids))
       after_perms = @group.permissions
       after_members = @group.reload.user_ids.to_set
       audit_privilege_change!("group_updated", metadata: {

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -40,7 +40,7 @@ class TeamsController < ApplicationController
   def update
     before_members = @team.user_ids.to_set
     if @team.update(team_attributes)
-      assign_members(@team, params.dig(:team, :user_ids)) if params.dig(:team, :user_ids)
+      assign_members(@team, params.dig(:team, :user_ids))
       after_members = @team.reload.user_ids.to_set
       audit_privilege_change!("team_updated", metadata: {
         name: @team.name,

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -34,6 +34,7 @@
         .row.mb-3{"data-controller" => "permission-pair"}
           = label_tag nil, 'Permissions', class: 'col-lg-2 col-md-3 col-form-label'
           .col-sm-9
+            = hidden_field_tag 'group[permission_keys][]', ''
             - selected = @group.permissions
             - Permission.grouped.each do |category, entries|
               .card.mb-2
@@ -58,6 +59,7 @@
       .row.mb-3
         = label_tag nil, 'Members', class: 'col-lg-2 col-md-3 col-form-label'
         .col-sm-9
+          = hidden_field_tag 'group[user_ids][]', ''
           - current_member_ids = @group.user_ids
           - User.order(:username).each do |user|
             .form-check

--- a/app/views/teams/_form.html.haml
+++ b/app/views/teams/_form.html.haml
@@ -23,6 +23,7 @@
       .row.mb-3
         = label_tag nil, 'Members', class: 'col-lg-2 col-md-3 col-form-label'
         .col-sm-9
+          = hidden_field_tag 'team[user_ids][]', ''
           - current_member_ids = @team.user_ids
           - User.order(:username).each do |user|
             .form-check

--- a/test/controllers/groups_controller_test.rb
+++ b/test/controllers/groups_controller_test.rb
@@ -41,6 +41,16 @@ class GroupsControllerTest < ActionDispatch::IntegrationTest
     assert_equal %w[customers.view], group.permissions.to_a
   end
 
+  test "unchecking all permissions and members removes them" do
+    group = groups(:sales)
+    group.users << users(:bob)
+    patch group_path(group), params: {
+      group: { name: group.name, description: group.description }
+    }
+    assert_empty group.reload.permissions.to_a
+    assert_empty group.users
+  end
+
   test "built-in admin group cannot be deleted" do
     admin = groups(:admin)
     assert_no_difference "Group.count" do

--- a/test/controllers/teams_controller_test.rb
+++ b/test/controllers/teams_controller_test.rb
@@ -23,6 +23,12 @@ class TeamsControllerTest < ActionDispatch::IntegrationTest
     assert_includes new_team.users, users(:bob)
   end
 
+  test "unchecking all members removes them" do
+    team = teams(:acme)
+    patch team_path(team), params: { team: { name: team.name, description: team.description } }
+    assert_empty team.reload.users
+  end
+
   test "built-in default team cannot be deleted" do
     default = teams(:default)
     assert_no_difference "Team.count" do


### PR DESCRIPTION
## Bug

On the group and team edit forms, unchecking **all** permission or member checkboxes and saving was a silent no-op: the checkbox arrays (`group[permission_keys][]`, `group[user_ids][]`, `team[user_ids][]`) had no hidden fallback field, so an all-unchecked submission sent no param at all, and the update actions guarded assignment with `if params.dig(...)`. The DB stayed unchanged while the flash claimed "Group updated." — an operator revoking access got no revocation.

## Fix

- Add the standard Rails empty hidden fallback field before each checkbox group, so an all-unchecked submit still sends the param as `[""]` (both `assign_permissions` and `assign_members` already `reject(&:blank?)`).
- Drop the `if params.dig(...)` guards in `GroupsController#update` / `TeamsController#update`: an absent param now means remove-all, matching the established semantics of `UsersController#update_groups`.

The Admin-group safety guards in `assign_members` (must keep at least one member; only admins may change its membership) are untouched and still apply.

## Tests

New regression tests in the existing controller test files reproduce the real browser submission (no param) and assert permissions/members are actually removed; both failed before the fix. Full suite: 1048 runs, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)