### PR TITLE
Preserve whitespace in copied FO fragments

### DIFF
--- a/lib/foptemplate/document_base.xsl
+++ b/lib/foptemplate/document_base.xsl
@@ -6,6 +6,10 @@
                 xmlns:abt="http://deduktiva.com/Namespace/ABT/XSLT">
     <xsl:output method="xml" indent="yes"/>
     <xsl:strip-space elements="*" />
+    <!-- The prelude/boilerplate FO fragments carry significant whitespace-only
+         text nodes (e.g. the space between two styled inlines); exempt them
+         from strip-space or "Bold Italic" renders as "BoldItalic". -->
+    <xsl:preserve-space elements="fo:*" />
     <xsl:decimal-format name="european" decimal-separator=',' grouping-separator='.' />
 
     <!-- Common definitions -->

--- a/test/services/rich_text_fo_converter_test.rb
+++ b/test/services/rich_text_fo_converter_test.rb
@@ -32,6 +32,15 @@ class RichTextFoConverterTest < ActiveSupport::TestCase
     assert_includes fo("<div><em>y</em></div>"), %(<fo:inline font-style="italic">y</fo:inline>)
   end
 
+  # document_base.xsl exempts fo:* from strip-space, so ALL whitespace in
+  # fragments survives into the PDF — the converter must never emit
+  # indentation, only user whitespace like the space between styled runs.
+  test "fragments contain no indentation whitespace" do
+    out = fo("<h1>t</h1><div><strong>Bold</strong> <em>Italic</em></div><ul><li>a<ul><li>s</li></ul></li></ul>")
+    assert_not_includes out, "\n"
+    assert_includes out, %(</fo:inline> <fo:inline)
+  end
+
   test "h1 becomes a spaced fo:block at body size" do
     out = fo("<h1>Title</h1>")
     assert_includes out, %(<fo:block space-after="4pt">Title</fo:block>)


### PR DESCRIPTION
`<xsl:strip-space elements="*"/>` in `document_base.xsl` strips whitespace-only text nodes from the input XML — including inside the `fo:inline` fragments that `RichTextFoConverter` emits into `<prelude>`/`<boilerplate>`. A lone space between two styled runs is such a node, so "**Bold** *Italic*" in a prelude rendered as "BoldItalic" in the PDF (reproduced via FOP + `pdftotext`).

Add `<xsl:preserve-space elements="fo:*"/>`. The scope is exact: `fo:*` elements appear in the input only as `RichTextFoConverter` output, which is serialized without indentation, so any whitespace-only node inside them is genuine user content. That no-indentation invariant is now locked by a converter unit test, since all fragment whitespace survives into the PDF under this rule.

**Alternative considered and rejected:** having the converter emit `xml:space="preserve"` on its `fo:block`s (declarative, travels with the data). Saxon honors it for whitespace stripping, but `xsl:copy-of` carries the attribute into the FO output and FOP fails strict validation: `Invalid property encountered on "fo:block": xml:space`. Working around that would need an identity-copy mode stripping the attribute — more machinery than the one-line exemption, with the same reliance on non-indented fragments.

Verification: end-to-end render of a prelude `<strong>Bold</strong> <em>Italic</em> tail` — `pdftotext` shows `BoldItalic tail` before, `Bold Italic tail` after; a seeded multi-line invoice renders byte-identical apart from the restored space.

The PDF-metadata separator fix originally in this branch was split out to #596.

🤖 Generated with [Claude Code](https://claude.com/claude-code)