### PR TITLE
Separate PDF metadata fields with explicit spaces

### DIFF
--- a/lib/foptemplate/document_base.xsl
+++ b/lib/foptemplate/document_base.xsl
@@ -282,7 +282,7 @@
                         xmlns:pdfaid="http://www.aiim.org/pdfa/ns/id/">
                         <dc:title>
                             <rdf:Alt>
-                                <rdf:li xml:lang="x-default"><xsl:value-of select="/document/issuer/short-name"/> <xsl:value-of select="$document-type" /> <xsl:value-of select="$document-number" /></rdf:li>
+                                <rdf:li xml:lang="x-default"><xsl:value-of select="/document/issuer/short-name"/><xsl:text> </xsl:text><xsl:value-of select="$document-type" /><xsl:text> </xsl:text><xsl:value-of select="$document-number" /></rdf:li>
                             </rdf:Alt>
                         </dc:title>
                         <dc:creator>
@@ -292,7 +292,7 @@
                         </dc:creator>
                         <dc:description>
                             <rdf:Alt>
-                                <rdf:li xml:lang="x-default"><xsl:value-of select="$document-type" /> <xsl:value-of select="$document-number" /></rdf:li>
+                                <rdf:li xml:lang="x-default"><xsl:value-of select="$document-type" /><xsl:text> </xsl:text><xsl:value-of select="$document-number" /></rdf:li>
                             </rdf:Alt>
                         </dc:description>
                         <dc:format>application/pdf</dc:format>

--- a/test/services/invoice_renderer_test.rb
+++ b/test/services/invoice_renderer_test.rb
@@ -62,6 +62,12 @@ class InvoiceRendererTest < ActiveSupport::TestCase
     assert_includes xml, %(xmlns:fo="http://www.w3.org/1999/XSL/Format")
   end
 
+  test "PDF title metadata separates issuer, type, and number (FOP smoke)" do
+    @invoice.update_columns(document_number: "R2024-001")
+    pdf = InvoiceRenderer.new(@invoice, @issuer).render
+    assert_includes pdf, "/Title (My Example Invoice R2024-001)"
+  end
+
   test "renders a PDF with rich-text prelude formatting (FOP smoke)" do
     @invoice.prelude = "<h1>Title</h1><div>Hello <strong>bold</strong> and <em>italic</em></div><ul><li>one</li><li>two</li></ul><ol><li>a</li><li>b<ol><li>nested</li></ol></li></ol>"
     @invoice.save!


### PR DESCRIPTION
Whitespace between consecutive `<xsl:value-of>` instructions in the `pdf-metadata` template is a whitespace-only stylesheet text node and gets stripped per XSLT rules, so every rendered PDF carried run-together metadata: `pdfinfo` showed `Title: My ExampleInvoice20250001` / `Subject: Invoice20250001` — visible in browser PDF-viewer tab titles and file managers.

Replace the literal spaces with explicit `<xsl:text> </xsl:text>` separators (the pattern already used in invoice.xsl). After the fix: `Title: My Example Invoice 20250001`, `Subject: Invoice 20250001`.

Includes a smoke test in `invoice_renderer_test.rb` asserting the spaced `/Title (…)` string in the PDF bytes.

Split out of #595 so it can land independently; #595 now carries only the preserve-space fix for rich-text whitespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)