### PR TITLE
Fix searchable dropdown wedging on empty dependent results

### DIFF
--- a/app/javascript/controllers/searchable_dropdown_controller.js
+++ b/app/javascript/controllers/searchable_dropdown_controller.js
@@ -217,16 +217,17 @@ export default class extends Controller {
 
   observeDropdownChanges(callback) {
     const observer = new MutationObserver((mutations) => {
-      // Check if item options were added/changed
-      const hasItemOptions = mutations.some(mutation =>
+      // The Turbo Stream re-render always adds .dropdown-content, even when
+      // there are no options (empty-state message only)
+      const contentReplaced = mutations.some(mutation =>
         Array.from(mutation.addedNodes).some(node =>
           node.nodeType === Node.ELEMENT_NODE &&
-          (node.classList?.contains('searchable-option') ||
-           node.querySelector?.('.searchable-option'))
+          (node.classList?.contains('dropdown-content') ||
+           node.querySelector?.('.dropdown-content'))
         )
       )
 
-      if (hasItemOptions) {
+      if (contentReplaced) {
         observer.disconnect()
         callback()
       }

--- a/test/system/invoice_edit_test.rb
+++ b/test/system/invoice_edit_test.rb
@@ -229,6 +229,26 @@ class InvoiceEditTest < ApplicationSystemTestCase
     end
   end
 
+  test "project dropdown shows empty state and clears stale selection when customer has no projects" do
+    projects(:reusable_project).update!(active: false)
+    invoice = invoices(:draft_invoice)
+    visit "/invoices/#{invoice.id}/edit"
+    assert_no_text "Loading...", wait: 10
+
+    within(".customer-dropdown") do
+      find('[data-searchable-dropdown-target="select"]').click
+      assert_selector ".searchable-option", wait: 10
+      find(".searchable-option", text: "No Email Customer Ltd").click
+    end
+
+    within(".project-dropdown") do
+      find('[data-searchable-dropdown-target="select"]').click
+      assert_text "No projects available", wait: 10
+      assert_no_text "Loading..."
+    end
+    assert_equal "", find('input[name="invoice[project_id]"]', visible: false).value
+  end
+
   test "customer dropdown keyboard navigation works" do
     invoice = invoices(:draft_invoice)
     visit "/invoices/#{invoice.id}/edit"


### PR DESCRIPTION
## Problem

`searchable_dropdown_controller.js#observeDropdownChanges` registers a MutationObserver whose callback only fires when the added nodes include `.searchable-option` elements. When a selected customer has zero projects, the turbo-stream partial renders only the "No projects available" empty-state div — no `.searchable-option` nodes — so the callback never runs:

- The dropdown display sticks on "Loading...".
- `validateCurrentItem` never runs, so a project selected under the previous customer stays visibly selected even though it is invalid for the new customer.
- Search-input listeners are never re-attached.
- The observer is never disconnected — one leaks per reload.

## Fix

Fire the callback when the re-rendered `.dropdown-content` is added — the Turbo Stream update always adds it, with or without options. The existing post-reload path (hide loading, validate/clear stale selection, re-attach listeners, disconnect observer) now also runs for empty results; the non-empty path fires on the same mutation batch as before.

## Test

System test in `invoice_edit_test.rb`: select a customer with no projects, assert the dropdown shows the empty-state message instead of "Loading..." and the stale project selection is cleared. Fails without the fix (stale project id persists), passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)