### PR TITLE
Don't lose expired-offers digest when delivery fails

### DIFF
--- a/app/jobs/expiring_offers_report_job.rb
+++ b/app/jobs/expiring_offers_report_job.rb
@@ -10,7 +10,10 @@ class ExpiringOffersReportJob < ApplicationJob
 
     return if expiring.empty?
 
-    Offer.where(id: expiring.map(&:id), state: "sent").update_all(state: "expired", reported_expired_at: Time.current)
+    # Deliver before marking so a delivery failure raises and leaves the
+    # offers unmarked — the next run picks them up again. Same rationale as
+    # VatVerificationsReportJob.
     ExpiringOffersMailer.with(offers: expiring).expiring_report.deliver_now
+    Offer.where(id: expiring.map(&:id), state: "sent").update_all(state: "expired", reported_expired_at: Time.current)
   end
 end

--- a/test/jobs/expiring_offers_report_job_test.rb
+++ b/test/jobs/expiring_offers_report_job_test.rb
@@ -70,6 +70,20 @@ class ExpiringOffersReportJobTest < ActiveJob::TestCase
     assert_nil offer.reported_expired_at
   end
 
+  test "delivery failure leaves offers unmarked so the next run retries" do
+    offer = offers(:sent_offer)
+    offer.update!(expires_at: Date.yesterday)
+
+    ExpiringOffersMailer.define_singleton_method(:with) { |*| raise "Mailgun down" }
+    assert_raises(RuntimeError) { ExpiringOffersReportJob.perform_now }
+
+    offer.reload
+    assert offer.sent?
+    assert_nil offer.reported_expired_at
+  ensure
+    ExpiringOffersMailer.singleton_class.send(:remove_method, :with)
+  end
+
   test "already-reported offers are not re-reported" do
     offer = offers(:sent_offer)
     offer.update!(state: "expired", expires_at: Date.yesterday, reported_expired_at: Time.current)


### PR DESCRIPTION
## Summary
- `ExpiringOffersReportJob` stamped `reported_expired_at` (and flipped state to `expired`) **before** `deliver_now`. A Mailgun outage meant the next run's `reported_expired_at: nil` filter excluded those offers and the digest never went out.
- Swap the order: deliver first, mark after — the ordering `VatVerificationsReportJob` already documents for exactly this reason. A delivery failure now raises and leaves the offers untouched, so the next run retries them.
- Email content is unchanged: `update_all` never touched the in-memory offers the mailer renders.

## Testing
- New regression test: delivery failure leaves offers `sent`/unmarked for retry (fails on the old ordering).
- `bundle exec rails test test/jobs/expiring_offers_report_job_test.rb` — 7 runs, 0 failures.
- Full suite passes apart from two pre-existing FOP/podman GID-mapping environment failures unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)