### PR TITLE
Escape server data in email preview modal

### DIFF
--- a/app/javascript/controllers/generic_email_preview_controller.js
+++ b/app/javascript/controllers/generic_email_preview_controller.js
@@ -163,7 +163,7 @@ export default class extends ModalController {
           ${data.attachments.map(attachment => `
             <div class="d-flex align-items-center mb-1">
               <span class="me-1">📎</span>
-              <span>${attachment.filename}</span>
+              <span>${this.escapeHTML(attachment.filename)}</span>
               <small class="text-muted ms-2">(${this.formatFileSize(attachment.size)})</small>
             </div>
           `).join('')}
@@ -177,7 +177,7 @@ export default class extends ModalController {
 
     const textContentSection = data.text_body ? `
       <div class="card-body email-preview-content d-none" data-format-content="text">
-        <pre class="mb-0 font-monospace text-pre-wrap">${data.text_body}</pre>
+        <pre class="mb-0 font-monospace text-pre-wrap">${this.escapeHTML(data.text_body)}</pre>
       </div>
     ` : ''
 
@@ -198,7 +198,7 @@ export default class extends ModalController {
                   <strong>To:</strong>
                 </div>
                 <div class="col-sm-10">
-                  ${data.to || '<i>No recipient configured</i>'}
+                  ${this.escapeHTML(data.to) || '<i>No recipient configured</i>'}
                 </div>
               </div>
 
@@ -207,7 +207,7 @@ export default class extends ModalController {
                   <strong>From:</strong>
                 </div>
                 <div class="col-sm-10">
-                  ${data.from || '<i>No sender configured</i>'}
+                  ${this.escapeHTML(data.from) || '<i>No sender configured</i>'}
                 </div>
               </div>
 
@@ -217,7 +217,7 @@ export default class extends ModalController {
                     <strong>CC:</strong>
                   </div>
                   <div class="col-sm-10">
-                    ${data.cc}
+                    ${this.escapeHTML(data.cc)}
                   </div>
                 </div>
               ` : ''}
@@ -228,7 +228,7 @@ export default class extends ModalController {
                     <strong>BCC:</strong>
                   </div>
                   <div class="col-sm-10">
-                    ${data.bcc}
+                    ${this.escapeHTML(data.bcc)}
                   </div>
                 </div>
               ` : ''}
@@ -238,7 +238,7 @@ export default class extends ModalController {
                   <strong>Subject:</strong>
                 </div>
                 <div class="col-sm-10">
-                  ${data.subject || '<i>No subject</i>'}
+                  ${this.escapeHTML(data.subject) || '<i>No subject</i>'}
                 </div>
               </div>
 
@@ -259,6 +259,13 @@ export default class extends ModalController {
         </div>
       </div>
     `
+  }
+
+  escapeHTML(value) {
+    if (value == null) return ''
+    const el = document.createElement('div')
+    el.textContent = value
+    return el.innerHTML
   }
 
   formatFileSize(bytes) {

--- a/test/system/email_preview_test.rb
+++ b/test/system/email_preview_test.rb
@@ -46,6 +46,18 @@ class EmailPreviewTest < ApplicationSystemTestCase
     end
   end
 
+  test "email preview shows angle-bracket subject tokens literally" do
+    invoice = invoices(:auto_email_invoice)
+    invoice.update_column(:cust_reference, "Ref <B7>")
+    visit invoice_path(invoice)
+
+    click_on "Send"
+
+    within "[data-generic-email-preview-target='content']" do
+      assert_text "Invoice AUTO-ORDER-111 - Ref: Ref <B7>", wait: 5
+    end
+  end
+
   test "post-publish banner strips the published query param so reloads don't re-trigger auto-download" do
     visit invoice_path(@invoice, published: 1)
     assert_selector ".alert-success", text: "booked"


### PR DESCRIPTION
## What corrupts today

`generic_email_preview_controller.js#buildPreviewHTML` interpolates the server's JSON mail fields straight into `innerHTML`. User-entered data reaches those fields — the subject carries `cust_order`/`cust_reference` via the customer's auto-subject template, headers and attachment filenames come through raw, and since #609 the `text_body` is genuinely raw text as well. Any value containing `<` followed by a letter (e.g. a reference like `Bestellung <B2024-17>`) is parsed as a tag and silently swallowed, so the operator previews content that is missing the `<…>` token they are about to send.

Not XSS: the app's strict CSP blocks script execution, so this is display corruption / passive markup injection only.

## Fix

Add an `escapeHTML` helper (textContent → innerHTML on a detached element) and wrap the seven server-data interpolation sites: `to`, `from`, `cc`, `bcc`, `subject`, `text_body`, and `attachment.filename`. The authored `<i>No recipient configured</i>`-style fallbacks still render as markup for blank values; the iframe `src` and `formatFileSize` output are controlled values and stay as-is.

System test: an auto-subject invoice with `cust_reference = "Ref <B7>"` asserts the modal shows the token literally (fails against the old controller: subject rendered as `… - Ref: Ref`).

## Relationship to #609 (merged)

#609 fixed the server side: plaintext email parts no longer arrive HTML-escaped. That makes this PR the remaining half — with raw text in `text_body`, the preview's text tab needs this escaping to display special characters correctly instead of swallowing them. Branch is rebased onto post-#609 main; the preview system tests pass against the raw-text server behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)