### PR TITLE
Skip outage rows in VAT report dedup and prior-state lookup

### DIFF
--- a/app/jobs/vat_verifications_report_job.rb
+++ b/app/jobs/vat_verifications_report_job.rb
@@ -63,7 +63,9 @@ class VatVerificationsReportJob < ApplicationJob
       # Recovery — never reported, but consume to keep the index small.
       consumed_ids << latest.id
     when false
-      prior = prior_verification(latest)
+      # Look back to the most recent conclusive result — a transient outage
+      # row between two invalid results must not restart the invalid streak.
+      prior = most_recent_non_nil(latest.customer_id, before: latest.created_at)
       if prior&.valid_response == false
         consumed_ids << latest.id
       else
@@ -96,20 +98,12 @@ class VatVerificationsReportJob < ApplicationJob
     end
   end
 
-  def prior_verification(verification)
-    CustomerVatVerification
-      .where(customer_id: verification.customer_id)
-      .where("created_at < ?", verification.created_at)
-      .order(created_at: :desc, id: :desc)
-      .first
-  end
-
-  def most_recent_non_nil(customer_id)
-    CustomerVatVerification
-      .where(customer_id: customer_id)
-      .where.not(valid_response: nil)
-      .order(created_at: :desc, id: :desc)
-      .first
+  def most_recent_non_nil(customer_id, before: nil)
+    scope = CustomerVatVerification
+              .where(customer_id: customer_id)
+              .where.not(valid_response: nil)
+    scope = scope.where("created_at < ?", before) if before
+    scope.order(created_at: :desc, id: :desc).first
   end
 
   # Earliest verification in the current run of nil results (going back from

--- a/app/mailers/vat_verifications_report_mailer.rb
+++ b/app/mailers/vat_verifications_report_mailer.rb
@@ -20,14 +20,16 @@ class VatVerificationsReportMailer < ApplicationMailer
 
   private
 
-  # For each newly-invalid verification, find the immediately-prior verification
-  # for the same customer to label the row as either "was valid until <date>"
-  # or "first confirmed invalid result". Returns a Hash keyed by verification id.
+  # For each newly-invalid verification, find the most recent conclusive
+  # (non-nil, i.e. skipping transient outage rows) prior verification for the
+  # same customer to label the row as either "was valid until <date>" or
+  # "first confirmed invalid result". Returns a Hash keyed by verification id.
   def compute_prior_states(verifications)
     verifications.each_with_object({}) do |v, h|
       prior = CustomerVatVerification
                 .where(customer_id: v.customer_id)
                 .where("created_at < ?", v.created_at)
+                .where.not(valid_response: nil)
                 .order(created_at: :desc)
                 .first
       h[v.id] = if prior&.valid_response == true

--- a/test/jobs/vat_verifications_report_job_test.rb
+++ b/test/jobs/vat_verifications_report_job_test.rb
@@ -70,6 +70,19 @@ class VatVerificationsReportJobTest < ActiveJob::TestCase
     assert_not_nil continuation.reload.notified_at
   end
 
+  test "does not re-report when an outage row interrupts an invalid streak" do
+    make_verification(valid: true, created_at: 30.days.ago)
+    make_verification(valid: false, created_at: 5.days.ago, notified_at: 5.days.ago)
+    make_verification(valid: nil, created_at: 2.days.ago, notified_at: 2.days.ago,
+                      error_code: "MS_UNAVAILABLE")
+    continuation = make_verification(valid: false, created_at: 1.hour.ago)
+
+    assert_no_emails do
+      VatVerificationsReportJob.perform_now
+    end
+    assert_not_nil continuation.reload.notified_at
+  end
+
   test "does not report and does not mark recovery (invalid -> valid)" do
     make_verification(valid: false, created_at: 5.days.ago, notified_at: 5.days.ago)
     recovery = make_verification(valid: true, created_at: 1.hour.ago)

--- a/test/mailers/vat_verifications_report_mailer_test.rb
+++ b/test/mailers/vat_verifications_report_mailer_test.rb
@@ -64,6 +64,22 @@ class VatVerificationsReportMailerTest < ActionMailer::TestCase
     assert_match @customer_b.matchcode, text
   end
 
+  test "daily_report prior state skips outage rows when finding the last valid result" do
+    CustomerVatVerification.create!(
+      customer: @customer_a, vat_id: "BE0123456749", country_iso2: "BE",
+      valid_response: true, raw_response: "{}", created_at: 10.days.ago
+    )
+    CustomerVatVerification.create!(
+      customer: @customer_a, vat_id: "BE0123456749", country_iso2: "BE",
+      valid_response: nil, error_code: "MS_UNAVAILABLE", raw_response: "{}",
+      created_at: 2.days.ago
+    )
+
+    mail = VatVerificationsReportMailer.with(newly_invalid: @newly_invalid, stuck_unavailable: []).daily_report
+
+    assert_match "was valid until", mail.html_part.body.to_s
+  end
+
   test "daily_report returns NullMail when both event lists are empty" do
     mail = VatVerificationsReportMailer.with(newly_invalid: [], stuck_unavailable: []).daily_report
 


### PR DESCRIPTION
## Problem

The VAT verifications report looked only at the immediately-prior verification row in two places:

- `VatVerificationsReportJob#classify` (false branch): a transient VIES-outage row (`valid_response: nil`) between two invalid results made the dedup miss the earlier invalid, re-reporting the customer as newly invalid in a duplicate email.
- `VatVerificationsReportMailer#compute_prior_states`: an outage row between a valid and an invalid result made the prior-state label fall back to "first confirmed invalid result" instead of "was valid until \<date\>".

The stuck-unavailable (nil) branch of the same job already did this correctly via `most_recent_non_nil`.

## Fix

Both lookups now skip nil rows and use the most recent conclusive (non-nil) verification. The job's `prior_verification` is folded into `most_recent_non_nil` with a `before:` keyword.

## Tests

- Job: invalid → outage → invalid sends no duplicate email and consumes the continuation row.
- Mailer: valid → outage → invalid still labels the row "was valid until".

Full suite passes (the FOP container smoke test fails in this sandbox for environmental reasons — podman GID mapping — unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)