### PR TITLE
Report refused Admin-group changes instead of claiming success

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -46,6 +46,11 @@ class GroupsController < ApplicationController
     if @group.update(group_attributes)
       assign_permissions(@group, params.dig(:group, :permission_keys))
       assign_members(@group, params.dig(:group, :user_ids))
+    end
+
+    if @group.errors.any?
+      render :edit, status: :unprocessable_content
+    else
       after_perms = @group.permissions
       after_members = @group.reload.user_ids.to_set
       audit_privilege_change!("group_updated", metadata: {
@@ -57,8 +62,6 @@ class GroupsController < ApplicationController
         bypass_team_scoping_changed: before_bypass != @group.bypass_team_scoping?
       })
       redirect_to groups_path, notice: "Group updated."
-    else
-      render :edit, status: :unprocessable_content
     end
   end
 

--- a/test/controllers/groups_controller_test.rb
+++ b/test/controllers/groups_controller_test.rb
@@ -149,11 +149,24 @@ class GroupsControllerTest < ActionDispatch::IntegrationTest
     helpdesk.users << users(:bob)
 
     sign_in_as(users(:bob))
-    patch group_path(groups(:admin)), params: {
-      group: { description: groups(:admin).description,
-               user_ids: [ users(:alice).id, users(:bob).id ] }
-    }
+    assert_no_difference "UserAuditEvent.count" do
+      patch group_path(groups(:admin)), params: {
+        group: { description: groups(:admin).description,
+                 user_ids: [ users(:alice).id, users(:bob).id ] }
+      }
+    end
     refute_includes groups(:admin).reload.users, users(:bob)
+    assert_response :unprocessable_content
+    assert_select ".alert-danger li", text: "Only members of the Admin group can change its membership"
+  end
+
+  test "emptying the Admin group's membership reports the error instead of success" do
+    patch group_path(groups(:admin)), params: {
+      group: { description: groups(:admin).description, user_ids: [] }
+    }
+    assert_response :unprocessable_content
+    assert_select ".alert-danger li", text: "Admin group must have at least one member"
+    assert_includes groups(:admin).reload.users, users(:alice)
   end
 
   # Symmetric guard: a non-admin must not be able to REMOVE admins by


### PR DESCRIPTION
The `assign_members` guards (empty Admin membership, non-admin editing Admin membership) add to `group.errors`, but `GroupsController#update` never checked them — the user got a "Group updated." success flash and a `group_updated` audit event with empty deltas.

Now `update` checks `@group.errors` after the assignments and re-renders the edit form with 422, so the refusal message is shown and no misleading audit event is recorded.

Tests: refusal assertions folded into the existing non-admin-membership-change test; new test for the empty-Admin-membership guard (previously uncovered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)