### PR TITLE
Guard offer order-PDF upload against oversized and non-file input

### DIFF
--- a/app/controllers/concerns/pdf_upload_checks.rb
+++ b/app/controllers/concerns/pdf_upload_checks.rb
@@ -1,0 +1,13 @@
+# Shared guard for user-supplied PDF uploads. The check order is load-bearing:
+# a non-upload param 500s on #tempfile and an oversized file raises
+# RecordInvalid from Attachment#save! unless caught here first.
+module PdfUploadChecks
+  # Returns :missing, :too_large, :not_pdf, or nil when the file is an
+  # acceptable PDF upload. Callers map the symbol to their own wording.
+  def pdf_upload_error(file)
+    return :missing if file.blank? || !file.is_a?(ActionDispatch::Http::UploadedFile)
+    return :too_large if file.size > Attachment::MAX_SIZE_BYTES
+    return :not_pdf if Attachment.detect_content_type(file.tempfile) != "application/pdf"
+    nil
+  end
+end

--- a/app/controllers/customer_portal/acceptances_controller.rb
+++ b/app/controllers/customer_portal/acceptances_controller.rb
@@ -1,5 +1,7 @@
 module CustomerPortal
   class AcceptancesController < BaseController
+    include PdfUploadChecks
+
     before_action :load_delivery_note
 
     def show
@@ -37,11 +39,11 @@ module CustomerPortal
 
     # Returns a user-facing error string, or nil when the file is an acceptable PDF.
     def file_error(file)
-      return t("customer_portal.acceptance.errors.missing") if file.blank?
-      return t("customer_portal.acceptance.errors.missing") unless file.is_a?(ActionDispatch::Http::UploadedFile)
-      return t("customer_portal.acceptance.errors.too_large", max: Attachment::MAX_SIZE_BYTES / 1.megabyte) if file.size > Attachment::MAX_SIZE_BYTES
-      return t("customer_portal.acceptance.errors.not_pdf") if Attachment.detect_content_type(file.tempfile) != "application/pdf"
-      nil
+      case pdf_upload_error(file)
+      when :missing then t("customer_portal.acceptance.errors.missing")
+      when :too_large then t("customer_portal.acceptance.errors.too_large", max: Attachment::MAX_SIZE_BYTES / 1.megabyte)
+      when :not_pdf then t("customer_portal.acceptance.errors.not_pdf")
+      end
     end
   end
 end

--- a/app/controllers/customer_portal/acceptances_controller.rb
+++ b/app/controllers/customer_portal/acceptances_controller.rb
@@ -41,7 +41,7 @@ module CustomerPortal
     def file_error(file)
       case pdf_upload_error(file)
       when :missing then t("customer_portal.acceptance.errors.missing")
-      when :too_large then t("customer_portal.acceptance.errors.too_large", max: Attachment::MAX_SIZE_BYTES / 1.megabyte)
+      when :too_large then t("customer_portal.acceptance.errors.too_large", max: Attachment::MAX_SIZE_MB)
       when :not_pdf then t("customer_portal.acceptance.errors.not_pdf")
       end
     end

--- a/app/controllers/delivery_notes_controller.rb
+++ b/app/controllers/delivery_notes_controller.rb
@@ -306,7 +306,7 @@ protected
   def acceptance_pdf_error(file)
     case pdf_upload_error(file)
     when :missing then "Please select a PDF file to upload."
-    when :too_large then "Acceptance document is too large (maximum is #{Attachment::MAX_SIZE_BYTES / 1.megabyte} MB)."
+    when :too_large then "Acceptance document is too large (maximum is #{Attachment::MAX_SIZE_MB} MB)."
     when :not_pdf then "Only PDF files are allowed for acceptance documents (detected: #{Attachment.detect_content_type(file.tempfile)})."
     end
   end

--- a/app/controllers/delivery_notes_controller.rb
+++ b/app/controllers/delivery_notes_controller.rb
@@ -2,6 +2,7 @@ class DeliveryNotesController < ApplicationController
   include EmailableDocument
   include PublishableDocument
   include DocumentWithLines
+  include PdfUploadChecks
 
   publishable_document :delivery_note, label: "delivery note"
   document_with_lines line_class: DeliveryNoteLine
@@ -153,19 +154,8 @@ class DeliveryNotesController < ApplicationController
   def upload_acceptance
     uploaded_file = params[:acceptance_pdf]
 
-    if uploaded_file.blank?
-      flash[:error] = "Please select a PDF file to upload."
-      redirect_to @delivery_note and return
-    end
-
-    if uploaded_file.size > Attachment::MAX_SIZE_BYTES
-      flash[:error] = "Acceptance document is too large (maximum is #{Attachment::MAX_SIZE_BYTES / 1.megabyte} MB)."
-      redirect_to @delivery_note and return
-    end
-
-    detected_type = Attachment.detect_content_type(uploaded_file.tempfile)
-    if detected_type != "application/pdf"
-      flash[:error] = "Only PDF files are allowed for acceptance documents (detected: #{detected_type})."
+    if (error = acceptance_pdf_error(uploaded_file))
+      flash[:error] = error
       redirect_to @delivery_note and return
     end
 
@@ -311,6 +301,14 @@ class DeliveryNotesController < ApplicationController
 protected
   def set_delivery_note
     @delivery_note = DeliveryNote.visible_to(current_user).find(params[:id])
+  end
+
+  def acceptance_pdf_error(file)
+    case pdf_upload_error(file)
+    when :missing then "Please select a PDF file to upload."
+    when :too_large then "Acceptance document is too large (maximum is #{Attachment::MAX_SIZE_BYTES / 1.megabyte} MB)."
+    when :not_pdf then "Only PDF files are allowed for acceptance documents (detected: #{Attachment.detect_content_type(file.tempfile)})."
+    end
   end
 
   # EmailableDocument hooks.

--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -1,5 +1,6 @@
 class OffersController < ApplicationController
   include EmailableDocument
+  include PdfUploadChecks
 
   before_action -> { require_permission!("offers.view") },
                 only: %i[index show preview preview_email preview_email_html]
@@ -149,7 +150,7 @@ class OffersController < ApplicationController
 
   def upload_order_pdf
     uploaded = params[:order_pdf]
-    if (error = uploaded.blank? ? "Order document must be a PDF." : order_pdf_error(uploaded))
+    if (error = order_pdf_error(uploaded))
       return redirect_to @offer, alert: error
     end
     @offer.attach_order_pdf(uploaded)
@@ -221,14 +222,11 @@ class OffersController < ApplicationController
     false
   end
 
-  # Mirrors CustomerPortal::AcceptancesController#file_error: without the
-  # UploadedFile and size checks, a crafted non-file param 500s on #tempfile
-  # and an oversized PDF raises RecordInvalid from Attachment#save!.
   def order_pdf_error(file)
-    return "Order document must be a PDF." unless file.is_a?(ActionDispatch::Http::UploadedFile)
-    return "Order document is too large (maximum is #{Attachment::MAX_SIZE_BYTES / 1.megabyte} MB)." if file.size > Attachment::MAX_SIZE_BYTES
-    return "Order document must be a PDF." if Attachment.detect_content_type(file.tempfile) != "application/pdf"
-    nil
+    case pdf_upload_error(file)
+    when :missing, :not_pdf then "Order document must be a PDF."
+    when :too_large then "Order document is too large (maximum is #{Attachment::MAX_SIZE_BYTES / 1.megabyte} MB)."
+    end
   end
 
   def accepted_milestone!

--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -225,7 +225,7 @@ class OffersController < ApplicationController
   def order_pdf_error(file)
     case pdf_upload_error(file)
     when :missing, :not_pdf then "Order document must be a PDF."
-    when :too_large then "Order document is too large (maximum is #{Attachment::MAX_SIZE_BYTES / 1.megabyte} MB)."
+    when :too_large then "Order document is too large (maximum is #{Attachment::MAX_SIZE_MB} MB)."
     end
   end
 

--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -93,8 +93,8 @@ class OffersController < ApplicationController
 
   def accept
     order_pdf = params[:order_pdf]
-    if order_pdf.present? && Attachment.detect_content_type(order_pdf.tempfile) != "application/pdf"
-      return redirect_to @offer, alert: "Order document must be a PDF."
+    if order_pdf.present? && (error = order_pdf_error(order_pdf))
+      return redirect_to @offer, alert: error
     end
     @offer.accept!(order_number: params[:order_number], ordered_on: params[:ordered_on],
                    order_pdf: order_pdf)
@@ -149,8 +149,8 @@ class OffersController < ApplicationController
 
   def upload_order_pdf
     uploaded = params[:order_pdf]
-    if uploaded.blank? || Attachment.detect_content_type(uploaded.tempfile) != "application/pdf"
-      return redirect_to @offer, alert: "Order document must be a PDF."
+    if (error = uploaded.blank? ? "Order document must be a PDF." : order_pdf_error(uploaded))
+      return redirect_to @offer, alert: error
     end
     @offer.attach_order_pdf(uploaded)
     @offer.save!
@@ -219,6 +219,16 @@ class OffersController < ApplicationController
     return true if @offer.accepted?
     redirect_to @offer, alert: "This offer must be accepted before its milestones can be converted."
     false
+  end
+
+  # Mirrors CustomerPortal::AcceptancesController#file_error: without the
+  # UploadedFile and size checks, a crafted non-file param 500s on #tempfile
+  # and an oversized PDF raises RecordInvalid from Attachment#save!.
+  def order_pdf_error(file)
+    return "Order document must be a PDF." unless file.is_a?(ActionDispatch::Http::UploadedFile)
+    return "Order document is too large (maximum is #{Attachment::MAX_SIZE_BYTES / 1.megabyte} MB)." if file.size > Attachment::MAX_SIZE_BYTES
+    return "Order document must be a PDF." if Attachment.detect_content_type(file.tempfile) != "application/pdf"
+    nil
   end
 
   def accepted_milestone!

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -1,5 +1,6 @@
 class Attachment < ApplicationRecord
-  MAX_SIZE_BYTES = 25.megabytes
+  MAX_SIZE_MB = 25
+  MAX_SIZE_BYTES = MAX_SIZE_MB.megabytes
   SAFE_CONTENT_TYPES = %w[application/pdf image/png image/jpeg].freeze
   DEFAULT_CONTENT_TYPE = "application/octet-stream".freeze
 
@@ -51,7 +52,7 @@ class Attachment < ApplicationRecord
   def data_size_within_limit
     return if data.blank?
     if data.bytesize > MAX_SIZE_BYTES
-      errors.add(:data, "is too large (maximum is #{MAX_SIZE_BYTES / 1.megabyte} MB)")
+      errors.add(:data, "is too large (maximum is #{MAX_SIZE_MB} MB)")
     end
   end
 

--- a/app/views/customer_portal/acceptances/_form.html.haml
+++ b/app/views/customer_portal/acceptances/_form.html.haml
@@ -3,5 +3,5 @@
 = form_with url: delivery_acceptance_upload_submit_path(token: params[:token]), method: :post, multipart: true do |f|
   .mb-2
     = f.file_field :acceptance_pdf, accept: "application/pdf", class: "form-control", required: true
-  %small.text-muted.d-block.mb-3= t("customer_portal.acceptance.hint", max: Attachment::MAX_SIZE_BYTES / 1.megabyte)
+  %small.text-muted.d-block.mb-3= t("customer_portal.acceptance.hint", max: Attachment::MAX_SIZE_MB)
   = f.submit t("customer_portal.acceptance.submit"), class: "btn btn-primary"

--- a/test/controllers/delivery_notes_controller_test.rb
+++ b/test/controllers/delivery_notes_controller_test.rb
@@ -220,6 +220,12 @@ class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
     assert_match "Only PDF files are allowed", flash[:error]
   end
 
+  test "upload_acceptance rejects a non-file acceptance_pdf param" do
+    post upload_acceptance_delivery_note_url(delivery_notes(:published_delivery_note)), params: { acceptance_pdf: "not-a-file" }
+    assert_redirected_to delivery_note_url(delivery_notes(:published_delivery_note))
+    assert_match "Please select a PDF file", flash[:error]
+  end
+
   test "should convert published delivery note to invoice" do
     published_note = delivery_notes(:published_delivery_note)
     assert_nil published_note.invoice

--- a/test/controllers/offers_controller_test.rb
+++ b/test/controllers/offers_controller_test.rb
@@ -348,6 +348,19 @@ class OffersControllerTest < ActionDispatch::IntegrationTest
     assert offer.reload.sent?
   end
 
+  test "accept rejects an oversized order document" do
+    offer = offers(:sent_offer)
+    big = Rack::Test::UploadedFile.new(
+      StringIO.new("%PDF-1.4\n" + "x" * Attachment::MAX_SIZE_BYTES),
+      "application/pdf",
+      original_filename: "big.pdf"
+    )
+    post accept_offer_url(offer), params: { order_number: "PO", ordered_on: "2026-07-01", order_pdf: big }
+    assert_redirected_to offer_url(offer)
+    assert_match(/too large/, flash[:alert])
+    assert offer.reload.sent?
+  end
+
   test "accept refused when the offer is already accepted" do
     offer = offers(:sent_offer)
     offer.accept!(order_number: "PO-1", ordered_on: Date.current)
@@ -372,6 +385,15 @@ class OffersControllerTest < ActionDispatch::IntegrationTest
     post upload_order_pdf_offer_url(offer), params: { order_pdf: fixture_file_upload("acceptance.pdf", "application/pdf") }
     assert_redirected_to offer_url(offer)
     assert offer.reload.order_attachment.present?
+  end
+
+  test "upload_order_pdf rejects a non-file order_pdf param" do
+    offer = offers(:sent_offer)
+    offer.accept!(order_number: "PO", ordered_on: Date.current)
+    post upload_order_pdf_offer_url(offer), params: { order_pdf: "not-a-file" }
+    assert_redirected_to offer_url(offer)
+    assert_match(/must be a PDF/, flash[:alert])
+    assert_nil offer.reload.order_attachment_id
   end
 
   test "upload_order_pdf refuses a missing file" do


### PR DESCRIPTION
`OffersController#accept` and `#upload_order_pdf` only checked the sniffed content type of `params[:order_pdf]`:

- A valid PDF larger than `Attachment::MAX_SIZE_BYTES` (25 MB) passed the check and raised unrescued `RecordInvalid` from `Attachment#save!` — a 500 that also rolled back the whole accept transition.
- A non-file `order_pdf` param (plain string) 500ed on `.tempfile`.

The customer-portal acceptance upload already ran the full real-upload → size → sniffed-type sequence, and the delivery-note admin upload had its own partial copy (size but no real-upload check — same non-file 500). Since the offers bug existed exactly because these copies drifted, the second commit extracts the sequence into a `PdfUploadChecks` concern returning an error symbol; each controller maps the symbol to its own wording (i18n on the portal, hardcoded nouns in admin). Adopting it in `upload_acceptance` fixes that action's non-file 500 too.

Tests: oversized order document on accept (offer stays sent), non-file param on upload_order_pdf and upload_acceptance; existing portal integration tests cover the refactored `file_error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)