### PR TITLE
Roll back contact project changes when update validation fails

### DIFF
--- a/app/controllers/customer_contacts_controller.rb
+++ b/app/controllers/customer_contacts_controller.rb
@@ -47,10 +47,17 @@ class CustomerContactsController < ApplicationController
 
   # PATCH /customer_contacts/:id
   def update
-    @contact.assign_attributes(contact_params)
-    assign_projects(@contact, params.dig(:customer_contact, :project_ids))
+    saved = false
+    # On a persisted record, `projects=` writes the join rows immediately, so
+    # roll them back when validation fails.
+    ActiveRecord::Base.transaction do
+      @contact.assign_attributes(contact_params)
+      assign_projects(@contact, params.dig(:customer_contact, :project_ids))
+      saved = @contact.save
+      raise ActiveRecord::Rollback unless saved
+    end
 
-    if @contact.save
+    if saved
       render partial: "customer_contacts/row", locals: { contact: @contact }
     else
       render :edit, status: :unprocessable_content

--- a/test/controllers/customer_contacts_controller_test.rb
+++ b/test/controllers/customer_contacts_controller_test.rb
@@ -73,6 +73,15 @@ class CustomerContactsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "GOOD Accounting", @contact.reload.name
   end
 
+  test "update on validation failure does not persist project changes" do
+    contact = customer_contacts(:good_eu_project_one_lead)
+    patch customer_contact_path(contact),
+          params: { customer_contact: { name: "", email: contact.email, project_ids: [ "" ] } }
+
+    assert_response :unprocessable_content
+    assert_equal [ projects(:one) ], contact.reload.projects
+  end
+
   test "destroy removes the row via turbo-stream" do
     contact_id = @contact.id
     delete customer_contact_path(@contact), headers: { Accept: "text/vnd.turbo-stream.html" }


### PR DESCRIPTION
## Bug

`CustomerContactsController#update` called `assign_projects` (ending in `contact.projects = ...`) before `@contact.save`. `projects` is a `has_and_belongs_to_many` association, and on a persisted record that collection assignment writes the `customer_contact_projects` join rows to the database immediately. When the save then failed validation (blank name, bad email format, project/customer-visibility validators), the user saw the 422 edit form saying the change failed — but the contact→project scoping change was already persisted. That scoping decides which contacts receive future document emails, so a "failed" edit silently changed email routing.

`create` is unaffected: the record is unsaved there, so the assignment is deferred until save.

## Fix

Wrap the update mutation in a transaction and raise `ActiveRecord::Rollback` when save fails, so the join-row writes are rolled back along with everything else.

Regression test: update a persisted contact with a blank name and changed `project_ids`, assert 422 and that `contact.reload.projects` is unchanged (failed on the old code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)