### PR TITLE
Harden TeamsController#update against swallowed assign_members errors

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -41,6 +41,11 @@ class TeamsController < ApplicationController
     before_members = @team.user_ids.to_set
     if @team.update(team_attributes)
       assign_members(@team, params.dig(:team, :user_ids))
+    end
+
+    if @team.errors.any?
+      render :edit, status: :unprocessable_content
+    else
       after_members = @team.reload.user_ids.to_set
       audit_privilege_change!("team_updated", metadata: {
         name: @team.name,
@@ -48,8 +53,6 @@ class TeamsController < ApplicationController
         members_removed: User.where(id: (before_members - after_members).to_a).pluck(:username)
       })
       redirect_to teams_path, notice: "Team updated."
-    else
-      render :edit, status: :unprocessable_content
     end
   end
 


### PR DESCRIPTION
Latent hardening — no user-visible behavior change today.

`TeamsController#update` is the structural sibling of `GroupsController#update`, which PR #611 fixed: its `assign_members` refusals were added to `errors` but the caller still reported success and logged an audit event with empty deltas. Teams' `assign_members` has no refusal guards yet, so nothing misbehaves today — but the old shape would regress silently the moment a guard is added.

This restructures `update` to the same shape as #611: assignments run only after a successful `update`, then the action branches on `@team.errors.any?` — rendering `:edit` with `unprocessable_content` on errors, otherwise auditing the member delta and redirecting as before.

No new test: the error branch is unreachable today, and per project convention trivial tests aren't mirrored across parallel controllers. Existing `test/controllers/teams_controller_test.rb` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)