### PR TITLE
Auto-unlink customer contacts when deleting a project

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -6,6 +6,7 @@ class Project < ApplicationRecord
   has_many :invoices
   has_many :delivery_notes
   has_many :offers
+  has_and_belongs_to_many :customer_contacts, join_table: :customer_contact_projects
 
   validate :team_must_match_customer
 

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -113,6 +113,21 @@ class ProjectTest < ActiveSupport::TestCase
     assert @project.destroy
   end
 
+  test "destroying an unused project unlinks it from customer contacts" do
+    contact = customer_contacts(:good_eu_accounting)
+    contact.projects << @project
+    assert @project.destroy
+    assert_not_includes contact.reload.projects, @project
+  end
+
+  test "blocked destroy leaves customer contact links untouched" do
+    Invoice.create!(customer: @customer, project: @project)
+    contact = customer_contacts(:good_eu_accounting)
+    contact.projects << @project
+    assert_not @project.destroy
+    assert_includes contact.reload.projects, @project
+  end
+
   test "database rejects deleting a project still referenced by an invoice" do
     Invoice.create!(customer: @customer, project: @project)
     assert_raises(ActiveRecord::InvalidForeignKey) { @project.delete }


### PR DESCRIPTION
## Defect

Destroying a project that passes the document guards (no invoices, delivery notes, or offers) but is referenced by a customer contact raised `ActiveRecord::InvalidForeignKey` — a 500 — because `customer_contact_projects` join rows were never cleaned up. `CustomerContact` declares the HABTM association, but `Project` had no inverse, so nothing deleted the join rows on project destroy.

## Design

Per the review direction on PR #616: contact links do **not** block deletion — deleting a project auto-unlinks it from customer contacts. The document-based guards in `Project#check_if_used` are unchanged and keep precedence.

Implementation is the minimal inverse declaration on `Project`:

```ruby
has_and_belongs_to_many :customer_contacts, join_table: :customer_contact_projects
```

Rails deletes HABTM join rows as part of owner destroy, and only after `before_destroy` callbacks pass.

## Callback-ordering verification

Verified empirically with `sql.active_record` instrumentation:

- Blocked destroy (project has an invoice + a contact link): `destroy` returns `false`, **no** `DELETE FROM customer_contact_projects` is issued at all, and the contact link survives — HABTM cleanup happens in `destroy_associations`, which only runs after `before_destroy` (`check_if_used`) passes, regardless of declaration order.
- Successful destroy: `DELETE FROM customer_contact_projects WHERE project_id = ?` runs before `DELETE FROM projects`, so the FK constraint is satisfied.

## Tests

- New: destroying an unused project linked to a contact succeeds and the contact's `projects` no longer includes it (raised `InvalidForeignKey` before the fix).
- New: blocked destroy (invoice + contact link) returns `false` and leaves the contact link untouched.
- `bundle exec rails test test/models`: 369 runs, 0 failures. `pre-commit run --all-files` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)