### PR TITLE
Exclude already-sent documents from bulk email send

### DIFF
--- a/app/controllers/concerns/emailable_document.rb
+++ b/app/controllers/concerns/emailable_document.rb
@@ -71,7 +71,8 @@ module EmailableDocument
 
   # Shared scaffolding for the bulk "email the selected published documents"
   # action: parse the checkbox ids, guard an empty selection, load the
-  # visible-and-published scope, and build the queued/skipped notice. The block
+  # visible, published, not-yet-emailed scope, and build the queued/skipped
+  # notice. The block
   # receives that scope and returns [queued, skipped]; how each document type
   # groups recipients and delivers differs, so that stays in the host.
   def bulk_send_document_emails(model, ids_param:, redirect_path:, noun:)
@@ -81,7 +82,7 @@ module EmailableDocument
       return
     end
 
-    scope = model.visible_to(current_user).where(id: ids, published: true)
+    scope = model.visible_to(current_user).where(id: ids, published: true, email_sent_at: nil)
     queued, skipped = yield(scope)
 
     notice = "#{queued} emails queued for sending."

--- a/test/controllers/invoices_controller_email_test.rb
+++ b/test/controllers/invoices_controller_email_test.rb
@@ -168,6 +168,21 @@ class InvoicesControllerEmailTest < ActionDispatch::IntegrationTest
     assert_equal "2 emails queued for sending.", flash[:notice]
   end
 
+  test "bulk_send_emails excludes already-sent invoices" do
+    sent_invoice = invoices(:published_invoice)
+    sent_invoice.update_column(:email_sent_at, 1.day.ago)
+    sent_at = sent_invoice.reload.email_sent_at
+    unsent_invoice = invoices(:auto_email_invoice)
+
+    assert_enqueued_emails 1 do
+      post bulk_send_emails_invoices_path, params: { invoice_ids: [ sent_invoice.id, unsent_invoice.id ] }
+    end
+    perform_enqueued_jobs
+
+    assert_equal "1 emails queued for sending.", flash[:notice]
+    assert_equal sent_at, sent_invoice.reload.email_sent_at
+  end
+
   test "bulk_send_emails handles empty selection" do
     post bulk_send_emails_invoices_path, params: { invoice_ids: [] }
 


### PR DESCRIPTION
## Bug

`EmailableDocument#bulk_send_document_emails` loaded `where(id: ids, published: true)` with no `email_sent_at: nil` filter. The index view only filters checkboxes client-side, so a stale form or hand-crafted POST re-sent invoices/delivery notes that were already emailed.

## Fix

Add `email_sent_at: nil` to the shared scope. The concern is shared by `InvoicesController` and `DeliveryNotesController`, so one change covers both document types.

Deliberate choice on the notice: already-sent documents are silently excluded from both counts — they are neither "queued" nor "skipped (no recipients)", so the notice stays truthful about what actually happened.

## Test

Regression test in `test/controllers/invoices_controller_email_test.rb` only (shared concern, per convention): posting an already-sent published invoice's id alongside an unsent one enqueues exactly one email and leaves the sent invoice's `email_sent_at` unchanged. Verified red before the fix (2 emails enqueued), green after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)