### PR TITLE
Serialize milestone conversion under a row lock

### DIFF
--- a/app/services/offer_milestone_converter.rb
+++ b/app/services/offer_milestone_converter.rb
@@ -7,21 +7,26 @@ class OfferMilestoneConverter
     @offer = @version.offer
   end
 
+  # with_lock reloads the milestone under a row lock and runs guards plus
+  # document creation in one transaction, so concurrent converts serialize and
+  # the second one sees converted? and raises instead of double-billing.
   def convert!
+    @milestone.with_lock { convert_locked! }
+  end
+
+  private
+
+  def convert_locked!
     raise NotConvertible, "offer is not accepted" unless @offer.accepted?
     raise NotConvertible, "milestone belongs to a non-accepted version" unless @version.id == @offer.accepted_version_id
     raise NotConvertible, "milestone already converted" if @milestone.converted?
 
-    ActiveRecord::Base.transaction do
-      invoice = build_invoice
-      invoice.save!
-      delivery_note = @milestone.skip_delivery_note? ? nil : build_delivery_note(invoice).tap(&:save!)
-      @milestone.update!(invoice: invoice, delivery_note: delivery_note)
-      invoice
-    end
+    invoice = build_invoice
+    invoice.save!
+    delivery_note = @milestone.skip_delivery_note? ? nil : build_delivery_note(invoice).tap(&:save!)
+    @milestone.update!(invoice: invoice, delivery_note: delivery_note)
+    invoice
   end
-
-  private
 
   # The offer's internal reference carries over; with several milestones each
   # document gets the milestone's ordinal appended so they stay tellable apart.

--- a/test/services/offer_milestone_converter_test.rb
+++ b/test/services/offer_milestone_converter_test.rb
@@ -63,8 +63,9 @@ class OfferMilestoneConverterTest < ActiveSupport::TestCase
 
   test "a converted milestone cannot convert twice, and reopen_link! clears it" do
     milestone = offer_milestones(:sent_ms_two)
+    stale = OfferMilestone.find(milestone.id)
     OfferMilestoneConverter.new(milestone).convert!
-    assert_raises(OfferMilestoneConverter::NotConvertible) { OfferMilestoneConverter.new(milestone.reload).convert! }
+    assert_raises(OfferMilestoneConverter::NotConvertible) { OfferMilestoneConverter.new(stale).convert! }
     milestone.reopen_link!
     assert_nil milestone.reload.invoice_id
     assert_nil milestone.delivery_note_id


### PR DESCRIPTION
## Bug

`OfferMilestoneConverter#convert!` ran its three guards (offer accepted, version is the accepted version, `converted?`) outside the transaction and without a row lock. Two concurrent convert requests for the same milestone could both pass the `converted?` check and each create an invoice (plus delivery note) — double billing.

## Fix

Move the guards and document creation into `@milestone.with_lock`, matching the existing pattern in `InvoicePublisher#publish!` and `OfferSender#send!`. `with_lock` reloads the milestone under a row lock inside its own transaction (replacing the explicit `ActiveRecord::Base.transaction`), so concurrent converts serialize and the second caller sees fresh `converted?` state and raises `NotConvertible`. Public behavior is otherwise unchanged: returns the invoice, raises `NotConvertible` with the same messages.

## Tests

Extended the existing "cannot convert twice" test to run the second convert on a stale instance loaded before the first conversion — exactly what the second racer sees. It passes only because `with_lock` reloads before the guard. No multi-threaded race test: true concurrency on SQLite in the test suite is inherently flaky, so coverage is this deterministic stale-instance test plus the restructure following the proven `InvoicePublisher`/`OfferSender` pattern.

Full suite: 1061 runs, 0 failures (one known podman GID-mapping flake in an unrelated FOP test, passes individually).

🤖 Generated with [Claude Code](https://claude.com/claude-code)