### PR TITLE
Reject unparseable order dates in Offer#accept!

### DIFF
--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -62,11 +62,11 @@ class Offer < ApplicationRecord
   def accept!(order_number:, ordered_on:, order_pdf: nil)
     with_lock do
       raise InvalidTransition, "accept requires state sent, was #{state}" unless sent?
-      raise InvalidTransition, "order date is required" if ordered_on.blank?
+      self.ordered_on = ordered_on
+      raise InvalidTransition, "order date is missing or invalid" if self.ordered_on.nil?
       self.accepted_version = versions.where.not(sent_at: nil).order(:version_number).last
       self.accepted_at = Time.current
       self.order_number = order_number
-      self.ordered_on = ordered_on
       attach_order_pdf(order_pdf) if order_pdf
       self.state = "accepted"
       draft_version&.destroy

--- a/test/models/offer_test.rb
+++ b/test/models/offer_test.rb
@@ -41,6 +41,13 @@ class OfferTest < ActiveSupport::TestCase
     assert offers(:sent_offer).reload.sent?
   end
 
+  test "accept rejects an unparseable order date" do
+    offer = offers(:sent_offer)
+    assert_raises(Offer::InvalidTransition) { offer.accept!(order_number: "x", ordered_on: "banana") }
+    assert offer.reload.sent?
+    assert_nil offer.ordered_on
+  end
+
   test "reject stamps rejected_at" do
     offer = offers(:sent_offer)
     offer.reject!


### PR DESCRIPTION
## Bug

`Offer#accept!` checked `ordered_on.blank?` on the raw argument before assignment. An unparseable date string (e.g. `"banana"` or `"2026-13-99"`) is non-blank, so it passed the check, and Rails' date cast then turned it into `nil` on assignment — leaving an accepted offer with `ordered_on = nil`. Later, `OfferMilestoneConverter#convert!` uses `@offer.ordered_on` (date comparison and `delivery_start_date`), so milestone conversion 500ed with a `NoMethodError`/`ArgumentError`.

## Fix

Assign `ordered_on` first, then raise `InvalidTransition, "order date is missing or invalid"` if the cast result is nil. Blank input still raises as before; the raise sits inside `with_lock` before `save!`, so the offer stays in state `sent`. The controller already rescues `Offer::InvalidTransition` into a user-visible alert — no controller change needed.

## Test

New regression test in `test/models/offer_test.rb`: `accept!` with an unparseable date string raises `InvalidTransition` and the offer stays `sent` with `ordered_on` nil. Verified red before the fix, green after; full suite passes (podman GID-mapping FOP flakes re-run green individually).

🤖 Generated with [Claude Code](https://claude.com/claude-code)