### PR TITLE
Refuse milestone reopen once the linked document is published

### DIFF
--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -171,6 +171,8 @@ class OffersController < ApplicationController
     milestone = accepted_milestone!
     milestone.reopen_link!
     redirect_to @offer, notice: "Milestone link cleared."
+  rescue OfferMilestone::NotReopenable => e
+    redirect_to @offer, alert: e.message
   end
 
   protected

--- a/app/models/offer_milestone.rb
+++ b/app/models/offer_milestone.rb
@@ -1,4 +1,6 @@
 class OfferMilestone < ApplicationRecord
+  class NotReopenable < StandardError; end
+
   TRIGGERS = %w[on_order on_acceptance on_date].freeze
   TRIGGER_LABELS = {
     "on_order" => "Upon order",
@@ -34,7 +36,13 @@ class OfferMilestone < ApplicationRecord
     trigger == "on_order"
   end
 
+  def link_reopenable?
+    !invoice&.published? && !delivery_note&.published?
+  end
+
   def reopen_link!
+    raise NotReopenable, "linked invoice is already published" if invoice&.published?
+    raise NotReopenable, "linked delivery note is already published" if delivery_note&.published?
     update!(invoice: nil, delivery_note: nil)
   end
 

--- a/app/views/offers/_conversion_rows.html.haml
+++ b/app/views/offers/_conversion_rows.html.haml
@@ -23,7 +23,7 @@
               = link_to milestone.invoice.display_name, milestone.invoice
               - if milestone.delivery_note
                 = link_to milestone.delivery_note.display_name, milestone.delivery_note
-              - if @offer.accepted? && can?('offers.convert')
+              - if @offer.accepted? && can?('offers.convert') && milestone.link_reopenable?
                 = button_to 'Reopen link', reopen_milestone_link_offer_path(@offer, milestone_id: milestone.id), method: :post, class: 'btn btn-sm btn-outline-secondary', form: { class: 'button_to ms-auto' }, data: { 'turbo-confirm': 'Clear the conversion link for this milestone?' }
             - elsif @offer.accepted? && can?('offers.convert')
               = button_to icon_label(:send, 'Convert'), convert_milestone_offer_path(@offer, milestone_id: milestone.id), method: :post, class: 'btn btn-sm btn-info', form: { class: 'button_to ms-auto' }

--- a/test/controllers/offers_controller_test.rb
+++ b/test/controllers/offers_controller_test.rb
@@ -416,6 +416,17 @@ class OffersControllerTest < ActionDispatch::IntegrationTest
     assert_nil milestone.delivery_note_id
   end
 
+  test "reopen_milestone_link redirects with alert when the linked invoice is published" do
+    offer = offers(:sent_offer)
+    offer.accept!(order_number: "PO", ordered_on: Date.current)
+    milestone = offer_milestones(:sent_ms_two)
+    OfferMilestoneConverter.new(milestone).convert!.update!(published: true)
+    post reopen_milestone_link_offer_url(offer, milestone_id: milestone.id)
+    assert_redirected_to offer_url(offer)
+    assert flash[:alert].present?
+    assert milestone.reload.invoice_id.present?
+  end
+
   test "scaffold_milestones re-renders when the offer params are invalid" do
     offer = offers(:draft_offer)
     offer.draft_version.milestones.destroy_all

--- a/test/models/offer_milestone_test.rb
+++ b/test/models/offer_milestone_test.rb
@@ -20,6 +20,26 @@ class OfferMilestoneTest < ActiveSupport::TestCase
     assert_equal version.milestones.sum(:amount), version.reload.sum_net
   end
 
+  test "reopen_link! refuses when the linked invoice is published" do
+    offer = offers(:sent_offer)
+    offer.accept!(order_number: "PO", ordered_on: Date.current)
+    milestone = offer_milestones(:sent_ms_two)
+    invoice = OfferMilestoneConverter.new(milestone).convert!
+    invoice.update!(published: true)
+    assert_raises(OfferMilestone::NotReopenable) { milestone.reload.reopen_link! }
+    assert_equal invoice.id, milestone.reload.invoice_id
+  end
+
+  test "reopen_link! refuses when the linked delivery note is published" do
+    offer = offers(:sent_offer)
+    offer.accept!(order_number: "PO", ordered_on: Date.current)
+    milestone = offer_milestones(:sent_ms_two)
+    OfferMilestoneConverter.new(milestone).convert!
+    milestone.reload.delivery_note.update!(published: true)
+    assert_raises(OfferMilestone::NotReopenable) { milestone.reopen_link! }
+    assert milestone.reload.delivery_note_id.present?
+  end
+
   test "default_skip_delivery_note true only for on_order" do
     m = OfferMilestone.new(trigger: "on_order")
     assert m.default_skip_delivery_note


### PR DESCRIPTION
## Bug

`OfferMilestone#reopen_link!` cleared the conversion link unconditionally, and the "Reopen link" button was gated only on `accepted? && can?('offers.convert')`. After the linked invoice was published (publishing is irreversible), a user could still clear the link and convert the milestone again — a second invoice for the same milestone.

## Fix

- `reopen_link!` raises `OfferMilestone::NotReopenable` when the linked invoice or delivery note is published; `OffersController#reopen_milestone_link` rescues it and redirects with an alert (same pattern as `convert_milestone` / `NotConvertible`).
- `_conversion_rows.html.haml` hides the "Reopen link" button once a linked document is published (`OfferMilestone#link_reopenable?`).

## Tests

- Model: `reopen_link!` refuses when the linked invoice / delivery note is published, link stays intact.
- Controller: `reopen_milestone_link` redirects with an alert instead of clearing the link when the invoice is published.

All three failed before the fix and pass after; full suite green (modulo the known podman GID FOP flake, which passes on individual re-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)