### PR TITLE
Fix CSV import dropping lines on save due to key collisions

### DIFF
--- a/app/javascript/controllers/base_lines_controller.js
+++ b/app/javascript/controllers/base_lines_controller.js
@@ -1,6 +1,8 @@
 import { Controller } from "@hotwired/stimulus"
 import { AutoResizeTextareaMixin } from "mixins/auto_resize_textarea_mixin"
 
+let lastLineKey = 0
+
 export default class extends Controller {
   static targets = ["container"]
 
@@ -36,9 +38,11 @@ export default class extends Controller {
 
     const newContent = template.content.cloneNode(true)
 
-    // Replace NEW_RECORD with current timestamp to ensure uniqueness
-    const timestamp = new Date().getTime()
-    const html = newContent.querySelector('div').outerHTML.replace(/NEW_RECORD/g, timestamp)
+    // Key must be integer-like (params.expect drops other keys) and unique even for
+    // same-millisecond appends (CSV import), so bump a timestamp-seeded counter
+    const key = Math.max(Date.now(), lastLineKey + 1)
+    lastLineKey = key
+    const html = newContent.querySelector('div').outerHTML.replace(/NEW_RECORD/g, key)
 
     // Create a temporary container and set its HTML
     const tempDiv = document.createElement('div')

--- a/test/system/invoice_csv_import_test.rb
+++ b/test/system/invoice_csv_import_test.rb
@@ -34,5 +34,11 @@ class InvoiceCsvImportTest < ApplicationSystemTestCase
       assert_equal sole_tax_class, line.find('select[name*="[sales_tax_product_class_id]"]').value,
         "the only tax class should be auto-selected"
     end
+
+    click_button "Save"
+    assert_text "Invoice was successfully updated"
+    persisted_titles = @invoice.reload.invoice_lines.pluck(:title)
+    assert_equal initial + 3, persisted_titles.size
+    titles.each { |title| assert_includes persisted_titles, title }
   end
 end


### PR DESCRIPTION
## Bug

`appendLineFromTemplate` in `base_lines_controller.js` keyed new nested-attribute rows with `new Date().getTime()`. CSV import appends rows in a synchronous `forEach`, so multiple rows land in the same millisecond and get identical keys — Rails merges them in params and only the last imported line survives when the form is saved.

## Fix

Replace the bare timestamp with a timestamp-seeded monotonic counter (`Math.max(Date.now(), lastLineKey + 1)`), so every appended row gets a unique key. Keys must stay integer-like because `params.expect` with the array-of-hashes syntax drops non-integer keys. Delivery notes share the same base controller, so both document types are covered.

## Test

Extended the existing CSV import system test to submit the form after importing and assert all imported lines persist. Before the fix it failed intermittently (only the last same-millisecond line saved); after the fix it passes consistently (5/5 runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)