### PR TITLE
Skip lines marked for destruction in invoice sum calculation

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -170,6 +170,7 @@ private
     self[:sum_net] = 0
     self[:sum_total] = 0
     self.invoice_lines.each do |line|
+      next if line.marked_for_destruction?
       line.calculate_amount
 
       if line.is_item?

--- a/test/models/invoice_test.rb
+++ b/test/models/invoice_test.rb
@@ -112,6 +112,15 @@ class InvoiceTest < ActiveSupport::TestCase
     assert_equal invoice.sum_net + itc.value, invoice.sum_total
   end
 
+  test "update_sums excludes lines marked for destruction via nested attributes" do
+    invoice = license_invoice_with_tax_config
+    line = invoice.invoice_lines.find_by(rate: 15000)
+    invoice.update!(invoice_lines_attributes: [ { id: line.id, _destroy: true } ])
+    invoice.reload
+    assert_equal 3000, invoice.sum_net
+    assert_in_delta 3600.0, invoice.sum_total, 0.0001
+  end
+
   test "update_sums skips a published invoice" do
     invoice = invoices(:published_invoice)
     invoice.update_columns(sum_net: 999.99, sum_total: 1234.56)


### PR DESCRIPTION
## Bug

Deleting an invoice line through the nested edit form (`_destroy`) left the invoice's persisted `sum_net`/`sum_total` stale: `update_sums` runs in `before_save` and iterated all `invoice_lines`, including lines marked for destruction, so the sums were computed as if the removed line still existed. The stale values persisted until publish recalculated them.

## Fix

`update_sums` now skips `marked_for_destruction?` lines, so sums reflect only the surviving lines immediately after a save that destroys lines.

`DeliveryNote` needs no mirroring — it has no persisted derived sum columns.

Regression test: `test/models/invoice_test.rb` deletes a line via nested attributes and asserts the persisted sums.

🤖 Generated with [Claude Code](https://claude.com/claude-code)