### PR TITLE
Enforce unique sales tax rate per class pair

### DIFF
--- a/app/models/sales_tax_rate.rb
+++ b/app/models/sales_tax_rate.rb
@@ -4,4 +4,6 @@ class SalesTaxRate < ApplicationRecord
 
   validates :rate, presence: true, inclusion: 0..100
   validates :sales_tax_customer_class, :sales_tax_product_class, presence: true
+  validates :sales_tax_product_class_id, uniqueness: { scope: :sales_tax_customer_class_id,
+                                                       message: "already has a rate for this customer class" }
 end

--- a/db/migrate/20260802120000_unique_index_sales_tax_rates.rb
+++ b/db/migrate/20260802120000_unique_index_sales_tax_rates.rb
@@ -1,0 +1,14 @@
+class DedupeAndIndexSalesTaxRates < ActiveRecord::Migration[8.0]
+  # This will crash if the uniqueness is not satisfied.
+  def up
+    add_index :sales_tax_rates,
+              [ :sales_tax_customer_class_id, :sales_tax_product_class_id ],
+              unique: true,
+              name: "index_sales_tax_rates_on_customer_and_product_class"
+  end
+
+  def down
+    remove_index :sales_tax_rates,
+                 name: "index_sales_tax_rates_on_customer_and_product_class"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_02_113219) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_02_120000) do
   create_table "acceptance_submissions", force: :cascade do |t|
     t.integer "attachment_id"
     t.datetime "created_at", null: false
@@ -451,6 +451,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_02_113219) do
     t.integer "sales_tax_customer_class_id"
     t.integer "sales_tax_product_class_id"
     t.datetime "updated_at", null: false
+    t.index ["sales_tax_customer_class_id", "sales_tax_product_class_id"], name: "index_sales_tax_rates_on_customer_and_product_class", unique: true
   end
 
   create_table "team_memberships", force: :cascade do |t|

--- a/test/models/sales_tax_rate_test.rb
+++ b/test/models/sales_tax_rate_test.rb
@@ -27,6 +27,21 @@ class SalesTaxRateTest < ActiveSupport::TestCase
     assert_includes rate.errors[:sales_tax_product_class], "can't be blank"
   end
 
+  test "rejects duplicate customer class and product class pair" do
+    SalesTaxRate.create!(
+      sales_tax_customer_class: @customer_class,
+      sales_tax_product_class: @product_class,
+      rate: 10
+    )
+    duplicate = SalesTaxRate.new(
+      sales_tax_customer_class: @customer_class,
+      sales_tax_product_class: @product_class,
+      rate: 20
+    )
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:sales_tax_product_class_id], "already has a rate for this customer class"
+  end
+
   test "rate accepts 0, intermediate values, and 100" do
     [ 0, 10, 20, 100 ].each do |valid_rate|
       rate = SalesTaxRate.new(


### PR DESCRIPTION
## Bug

`SalesTaxRate` had only presence validations and no unique index on `(sales_tax_customer_class_id, sales_tax_product_class_id)`. Two rates for the same pair (double-submit or concurrent create) made `Invoice#setup_tax_classes` build duplicate `InvoiceTaxClass` rows for the same product class, which hit the unique index from `20260526172314_dedupe_and_index_invoice_tax_classes` — every invoice create/save for affected customers 500ed.

## Fix

- Scoped uniqueness validation on `SalesTaxRate` (`sales_tax_product_class_id` unique per `sales_tax_customer_class_id`)
- ~~Migration `20260802120000_dedupe_and_index_sales_tax_rates` deletes duplicate rows (keeps the lowest id per pair) and adds a unique composite index, mirroring the invoice_tax_classes precedent~~
- Regression test: duplicate pair is rejected by validation

Test suite: 1067 runs, 3680 assertions, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)