### PR TITLE
Surface server error messages in the email preview modal

### DIFF
--- a/app/javascript/controllers/generic_email_preview_controller.js
+++ b/app/javascript/controllers/generic_email_preview_controller.js
@@ -38,7 +38,7 @@ export default class extends ModalController {
       const response = await fetch(this.sendUrlValue, {
         method: 'POST',
         headers: {
-          'X-CSRF-Token': document.querySelector('[name="csrf-token"]').getAttribute('content'),
+          'X-CSRF-Token': document.querySelector('[name="csrf-token"]')?.getAttribute('content') || '',
           'Accept': 'application/json'
         }
       })
@@ -55,9 +55,11 @@ export default class extends ModalController {
           window.location.reload()
         }, 1000)
       } else {
-        throw new Error(`HTTP ${response.status}`)
+        const data = await response.json().catch(() => ({}))
+        throw new Error(data.error || `Request failed (${response.status})`)
       }
     } catch (error) {
+      this.showSendError(error.message)
       sendButton.textContent = 'Error - Try Again'
       sendButton.classList.remove('btn-success')
       sendButton.classList.add('btn-danger')
@@ -85,7 +87,8 @@ export default class extends ModalController {
     try {
       const response = await fetch(`${this.previewUrlValue}.json`)
       if (!response.ok) {
-        throw new Error(`HTTP ${response.status}`)
+        const data = await response.json().catch(() => ({}))
+        throw new Error(data.error || `Request failed (${response.status})`)
       }
 
       const data = await response.json()
@@ -111,10 +114,20 @@ export default class extends ModalController {
       this.contentTarget.innerHTML = `
         <div class="alert alert-danger">
           <h6>Error loading email preview</h6>
-          <p class="mb-0">Please try again or contact support if the problem persists.</p>
+          <p class="mb-0">${this.escapeHTML(error.message)}</p>
         </div>
       `
     }
+  }
+
+  showSendError(message) {
+    let alert = this.contentTarget.querySelector('.email-preview-send-error')
+    if (!alert) {
+      alert = document.createElement('div')
+      alert.className = 'alert alert-danger email-preview-send-error'
+      this.contentTarget.prepend(alert)
+    }
+    alert.textContent = message
   }
 
   setupFormatToggle() {

--- a/test/system/email_preview_test.rb
+++ b/test/system/email_preview_test.rb
@@ -58,6 +58,18 @@ class EmailPreviewTest < ApplicationSystemTestCase
     end
   end
 
+  test "send failure shows the server error message in the modal" do
+    visit invoice_path(@invoice)
+
+    click_on "Send"
+    assert_selector "iframe.email-preview-iframe", wait: 5
+
+    @invoice.customer.customer_contacts.destroy_all
+    click_on "Send E-Mail"
+
+    assert_selector ".email-preview-send-error", text: "No recipient configured.", wait: 5
+  end
+
   test "post-publish banner strips the published query param so reloads don't re-trigger auto-download" do
     visit invoice_path(@invoice, published: 1)
     assert_selector ".alert-success", text: "booked"


### PR DESCRIPTION
## Bug

`generic_email_preview_controller.js` swallowed the server's JSON `error` field on failed requests, in two layers:

- Both the preview-load and send fetches threw a bare `HTTP <status>` on `!response.ok`, discarding the response body.
- The load path's outer `catch` then replaced even that with a fixed "Please try again or contact support" string, so fixing the throw alone would not have surfaced anything.

The send path was worse: a failure (e.g. the 422 `{"error": "No recipient configured."}` from `EmailableDocument#send_email`) only flipped the button to "Error - Try Again" with no message at all.

## Fix

Follows the `passkey_controller.js#postJSON`/`showError` pattern:

- Failed responses are parsed for `data.error`, falling back to `Request failed (<status>)` only when the field is absent.
- The load-failure alert now shows the thrown message (escaped) instead of generic text.
- Send failures prepend a visible `alert-danger` with the server message above the preview; the button retry behavior is unchanged. No auto-reload anywhere in the error path.
- The CSRF meta tag lookup is null-safe so a missing tag no longer turns every send failure into `Cannot read properties of null`.

## Test

System test opens the preview for a published invoice, removes the customer's contacts server-side, clicks Send E-Mail, and asserts the modal shows "No recipient configured."

`bundle exec rails test`: 1066 runs, 0 failures. `bundle exec rails test test/system/`: 71 runs, 0 failures. `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)