### PR TITLE
Close the attachment existence oracle

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -2,7 +2,7 @@ class AttachmentsController < ApplicationController
   INLINE_CONTENT_TYPES = %w[application/pdf].freeze
 
   def show
-    @attachment = Attachment.find(params[:id])
+    @attachment = Attachment.find_by(id: params[:id])
     authorize_attachment!(@attachment)
 
     served_type = @attachment.safe_content_type
@@ -19,7 +19,10 @@ class AttachmentsController < ApplicationController
   # An Attachment row is reachable only through a parent record (an Invoice
   # PDF or a DeliveryNote acceptance document). Mirror the parent's team
   # visibility so an attacker can't enumerate attachment ids across teams.
+  # A missing row is denied exactly like a forbidden one: a 404 here next to a
+  # redirect there would tell an attacker which ids exist.
   def authorize_attachment!(attachment)
+    raise ApplicationController::PermissionDenied, "attachment##{params[:id]}" if attachment.nil?
     if Invoice.visible_to(current_user).where(attachment_id: attachment.id).exists?
       return require_permission!("invoices.view")
     end

--- a/test/controllers/attachments_controller_test.rb
+++ b/test/controllers/attachments_controller_test.rb
@@ -33,6 +33,11 @@ class AttachmentsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_path
   end
 
+  test "show denies an unknown attachment id exactly like a forbidden one" do
+    get attachment_url(id: Attachment.maximum(:id).to_i + 1)
+    assert_redirected_to root_path
+  end
+
   test "show denies an attachment whose parent invoice belongs to another team" do
     other_team = Team.create!(name: "OutsideTeam")
     outside_customer = Customer.create!(


### PR DESCRIPTION
`AttachmentsController#show` looked the row up with `Attachment.find` before authorizing, so an unknown id raised `RecordNotFound` (404) while an existing-but-forbidden id hit `PermissionDenied` (302 to root). Any signed-in user could probe the difference to enumerate which attachment ids exist — metadata only, no content leak.

Switch to `find_by` and deny `nil` through the same `PermissionDenied` path, so "doesn't exist" and "not yours" produce identical responses.

Test: unknown id now redirects to root like the existing forbidden-attachment cases (it asserted 404 before the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)