### PR TITLE
Define the /up health check route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
+  # Outside both host constraints: the LB probe carries an arbitrary Host, and
+  # the portal catch-all below would otherwise swallow it.
+  get "up", to: "rails/health#show", as: :rails_health_check
+
   constraints(CustomerPortalHostConstraint.new) do
     scope module: :customer_portal do
       get  "delivery-acceptance/:token", to: "acceptances#show",   as: :delivery_acceptance_upload

--- a/test/integration/health_check_test.rb
+++ b/test/integration/health_check_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+# /up must answer on any host and without auth — the LB probes it directly.
+class HealthCheckTest < ActionDispatch::IntegrationTest
+  test "health check resolves on the app host" do
+    host! Settings.app.host
+    get "/up"
+    assert_response :success
+  end
+
+  test "health check resolves on the customer portal host" do
+    host! Settings.customer_portal.host
+    get "/up"
+    assert_response :success
+  end
+
+  test "health check resolves without authentication" do
+    get "/up"
+    assert_response :success
+  end
+end


### PR DESCRIPTION
`/up` is referenced in three places but was never drawn as a route, so the load balancer probe 404s.

**Verified** before the fix — `GET /up` returned 404 on the app host, the customer portal host, and unauthenticated.

Stale references:
- `config/environments/production.rb:61` — `config.silence_healthcheck_path = "/up"`
- `config/environments/production.rb:94` — `host_authorization` exclusion for `/up`
- `config/initializers/rack_attack.rb:6` — comment reasoning about `/up` under a cache outage
- `docs/migrate-passenger-to-puma.md:62` — smoke test says `curl -I https://<host>/up` should return 200

## Change

Draws the standard `rails/health#show` route, deliberately **outside** both host constraints:

- The probe carries an arbitrary `Host` — which is exactly why `config.host_authorization` excludes `/up`.
- `CustomerPortalHostConstraint`'s `get "*path"` catch-all would otherwise swallow it into a 404 page.

Left throttled by the `req/ip` backstop, matching the deliberate note in `rack_attack.rb`. `config.ssl_options` stays commented out — Apache sets `X-Forwarded-Proto: https`, so `force_ssl` does not redirect the proxied probe.

## Tests

New `test/integration/health_check_test.rb` — 200 on the app host, on the portal host, and unauthenticated. Written first, watched all three fail with 404.

Full suite: 1071 runs, 3685 assertions, 0 failures. `pre-commit run --all-files` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)