### PR TITLE
Stop drawing Active Storage routes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ For testing against PostgreSQL (matches production environment):
 - Propshaft + dartsass-rails + importmap. SCSS sources in `app/assets/stylesheets/` compile via `rails dartsass:build` (or `dartsass:watch`) into `app/assets/builds/`; Propshaft serves/digests the result. The `bootstrap` gem is `require: false` — only its SCSS is used, via a Dart Sass `--load-path` (`config/initializers/assets.rb`).
 - `test/test_helper.rb` rebuilds the CSS when stale, so `bundle exec rails test` needs no manual build step.
 - The trix toolbar icon partial (`_trix_icon_shapes.scss`) is generated from the bootstrap-icons gem by `lib/tasks/trix_icons.rake`, hooked into every dartsass build.
+- Active Storage routes are not drawn (`config.active_storage.draw_routes = false`) — nothing attaches files, and the built-in direct-upload/disk endpoints sit outside the host constraints and accept unauthenticated writes. Rich text therefore goes through `rich_text_field`, never `f.rich_text_area` directly: ActionText defaults the trix upload URLs to Active Storage route helpers that no longer exist, so a direct call raises `NoMethodError` at render time.
 
 ### Shared Concerns
 - `PublishableDocument`, `DocumentWithLines` (controllers) - draft/published guards and line-form plumbing for Invoice + DeliveryNote
@@ -154,7 +155,7 @@ For testing against PostgreSQL (matches production environment):
 
 See [`docs/code-style.md`](docs/code-style.md) for the canonical style reference (HAML, Bootstrap, Stimulus, tests, status badges, action button icons, formatting, comments, commit messages). Read it before writing code.
 
-UI helpers live in `app/helpers/application_helper.rb` (page chrome: `breadcrumbs`, `page_header`, `action_button`, `destroy_link`, `list_action_link`, `action_buttons_wrapper`) and `app/helpers/action_buttons_helper.rb` (per-verb wrappers: `delete_button`, `pdf_button`, `preview_button`, `publish_button`, `unpublish_button`, `unblock_button`, `reset_passkeys_button`, `audit_log_button`, `save_button`, `nav_button`). Read the source for signatures.
+UI helpers live in `app/helpers/application_helper.rb` (page chrome: `breadcrumbs`, `page_header`, `action_button`, `destroy_link`, `list_action_link`, `action_buttons_wrapper`, `rich_text_field`) and `app/helpers/action_buttons_helper.rb` (per-verb wrappers: `delete_button`, `pdf_button`, `preview_button`, `publish_button`, `unpublish_button`, `unblock_button`, `reset_passkeys_button`, `audit_log_button`, `save_button`, `nav_button`). Read the source for signatures.
 
 ## Claude Operational Notes
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -218,6 +218,16 @@ module ApplicationHelper
     Rails.application.config.x.app_version
   end
 
+  # Trix editor bound to the rich-text controller, which strips the file tools
+  # and blocks attachments. The blank upload URLs are load-bearing: ActionText
+  # otherwise defaults them to Active Storage route helpers, and those routes
+  # are not drawn (config/application.rb). They must be non-nil — ActionText
+  # fills the defaults in with `||=`.
+  def rich_text_field(form, method)
+    form.rich_text_area method,
+      data: { controller: "rich-text", direct_upload_url: "", blob_url_template: "" }
+  end
+
   def country_options
     @country_options ||= ISO3166::Country.all
       .map { |c| [ c.iso_short_name, c.alpha2 ] }

--- a/app/views/customers/_form.html.haml
+++ b/app/views/customers/_form.html.haml
@@ -112,7 +112,7 @@
       .col-lg-8
         .card
           .card-body
-            = f.rich_text_area :offer_boilerplate, data: { controller: 'rich-text' }
+            = rich_text_field f, :offer_boilerplate
     %hr
     .row.mb-3
       = f.label :notes, class: 'col-lg-2 col-md-3 col-form-label'

--- a/app/views/delivery_notes/_form.html.haml
+++ b/app/views/delivery_notes/_form.html.haml
@@ -100,7 +100,7 @@
             %label.form-label Prelude
             .card
               .card-body
-                = f.rich_text_area :prelude, data: { controller: 'rich-text' }
+                = rich_text_field f, :prelude
 
     - unless @delivery_note.id.nil?
       %div{data: {controller: 'delivery-note-lines'}}

--- a/app/views/invoices/_form.html.haml
+++ b/app/views/invoices/_form.html.haml
@@ -92,7 +92,7 @@
             %label.form-label Prelude
             .card
               .card-body
-                = f.rich_text_area :prelude, data: { controller: 'rich-text' }
+                = rich_text_field f, :prelude
 
       - unless @invoice.id.nil?
         %div{data: {controller: 'invoice-lines', invoice_lines_currency_symbol_value: currency_symbol, invoice_lines_money_decimal_places_value: current_money_decimal_places, invoice_lines_import_url_value: import_lines_invoice_path(@invoice)}}

--- a/app/views/offers/_form.html.haml
+++ b/app/views/offers/_form.html.haml
@@ -102,7 +102,7 @@
                 = vf.label :prelude, 'Prelude', class: 'form-label'
                 .card
                   .card-body
-                    = vf.rich_text_area :prelude, data: { controller: 'rich-text' }
+                    = rich_text_field vf, :prelude
             .col-sm-4
               .mb-3
                 = vf.label :salutation_override, 'Salutation override', class: 'form-label'

--- a/app/views/offers/show.html.haml
+++ b/app/views/offers/show.html.haml
@@ -215,7 +215,7 @@
           %h5.mb-0 Internal Notes
         .card-body
           = form_with model: @offer, url: update_internal_notes_offer_path(@offer), method: :patch do |form|
-            = form.rich_text_area :internal_notes, data: { controller: 'rich-text' }
+            = rich_text_field form, :internal_notes
             .text-end.mt-2
               = form.submit 'Save', class: 'btn btn-primary'
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -57,6 +57,15 @@ module Abt
     # (image_processing, ruby-vips/libvips, ImageMagick) is needed.
     config.active_storage.variant_processor = :disabled
 
+    # Nothing attaches files, so don't expose the built-in endpoints. They are
+    # drawn outside the host constraints in config/routes.rb and inherit from
+    # ActiveStorage::BaseController, so unauthenticated callers could otherwise
+    # POST /rails/active_storage/direct_uploads and PUT the returned
+    # disk-service token to write arbitrary bytes to the storage root.
+    # ActionText computes rich_text_area's upload URLs from these routes —
+    # ApplicationHelper#rich_text_field supplies blank ones instead.
+    config.active_storage.draw_routes = false
+
     # Route Solid Queue's ActiveRecord models to the dedicated queue database
     # in all environments so the jobs status page can read them.
     config.solid_queue.connects_to = { database: { writing: :queue } }

--- a/deploy/apache/abt-app.conf
+++ b/deploy/apache/abt-app.conf
@@ -11,6 +11,12 @@ ServerAlias customer-portal.example.com
 
 DocumentRoot /srv/abt/public
 
+# Ceiling on request bodies, in bytes. The largest upload the app accepts is
+# Attachment::MAX_SIZE_MB (25 MB); this leaves headroom for multipart framing
+# and stops an oversized body from reaching Puma at all. Raise this whenever
+# MAX_SIZE_MB is raised, or uploads fail at the proxy with a bare 413.
+LimitRequestBody 33554432
+
 <Directory /srv/abt/public>
   Require all granted
   Options -Indexes

--- a/test/integration/active_storage_routes_test.rb
+++ b/test/integration/active_storage_routes_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+# Active Storage exists only as ActionText plumbing — nothing in the app
+# attaches files and the editor blocks attachments. Its routes stay undrawn so
+# the unauthenticated direct-upload and disk-service endpoints cannot be used
+# to write attacker-controlled bytes to the production disk. These endpoints
+# inherit from ActiveStorage::BaseController, so neither the host constraints
+# in config/routes.rb nor ApplicationController's filters apply to them.
+class ActiveStorageRoutesTest < ActionDispatch::IntegrationTest
+  BLOB_PARAMS = {
+    blob: { filename: "evil.html", byte_size: 6, checksum: "rL0Y20zC+Fzt72VPzMSk2A==",
+            content_type: "text/html" }
+  }.freeze
+
+  test "direct upload endpoint is not routable on the app host" do
+    host! Settings.app.host
+    assert_no_difference -> { ActiveStorage::Blob.count } do
+      post "/rails/active_storage/direct_uploads", params: BLOB_PARAMS
+    end
+    assert_response :not_found
+  end
+
+  test "direct upload endpoint is not routable on the customer portal host" do
+    host! Settings.customer_portal.host
+    assert_no_difference -> { ActiveStorage::Blob.count } do
+      post "/rails/active_storage/direct_uploads", params: BLOB_PARAMS
+    end
+    assert_response :not_found
+  end
+
+  # Asserted against the route set rather than over HTTP: the disk controller
+  # answers an unrecognised token with the same 404 a missing route gives.
+  test "disk service upload endpoint is not routable" do
+    assert_raises(ActionController::RoutingError) do
+      Rails.application.routes.recognize_path("/rails/active_storage/disk/sometoken", method: :put)
+    end
+  end
+end


### PR DESCRIPTION
The built-in direct-upload and disk-service endpoints let an unauthenticated caller write arbitrary bytes to the storage root on both hosts: they are drawn outside the constraints in config/routes.rb and inherit from ActiveStorage::BaseController, so neither AppHostConstraint, CustomerPortalHostConstraint nor ApplicationController's filters apply. CSRF is no barrier — a token is harvestable from the unauthenticated login and portal pages. Nothing in the app attaches files, so the routes are dead weight.

- Set config.active_storage.draw_routes = false
- Add ApplicationHelper#rich_text_field, used by all five trix editors. ActionText defaults the trix upload URLs to Active Storage route helpers, so it needs blank non-nil ones to render without those routes
- Cap Apache request bodies at 32 MB, above Attachment::MAX_SIZE_MB