### PR TITLE
Reject non-scalar tokens and submission ids

### DIFF
--- a/app/controllers/delivery_notes_controller.rb
+++ b/app/controllers/delivery_notes_controller.rb
@@ -131,7 +131,7 @@ class DeliveryNotesController < ApplicationController
   end
 
   def accept_acceptance
-    submission = @delivery_note.acceptance_submissions.find(params[:submission_id])
+    submission = @delivery_note.acceptance_submissions.find(integer_param(:submission_id))
     submission.accept!(by: current_user)
     redirect_to @delivery_note, notice: "Acceptance document confirmed."
   rescue AcceptanceSubmission::StaleSubmission
@@ -141,7 +141,7 @@ class DeliveryNotesController < ApplicationController
   end
 
   def reject_acceptance
-    submission = @delivery_note.acceptance_submissions.find(params[:submission_id])
+    submission = @delivery_note.acceptance_submissions.find(integer_param(:submission_id))
     submission.reject!(by: current_user)
     redirect_to @delivery_note, notice: "Submission rejected; the upload link is open again."
   rescue AcceptanceSubmission::StaleSubmission

--- a/app/models/concerns/digested_token.rb
+++ b/app/models/concerns/digested_token.rb
@@ -12,5 +12,14 @@ module DigestedToken
     def digest_token(plaintext)
       Digest::SHA256.hexdigest(plaintext)
     end
+
+    # Digest of a token supplied by a request, or nil when it cannot identify a
+    # record. Tokens arrive from params and cookies, so a caller can send an
+    # Array (`?token[]=a&token[]=b`) or nested Parameters instead of a string;
+    # both raise in the digest. Never returns a digest of a blank token, so a
+    # lookup can't match a row whose digest column is empty.
+    def lookup_digest(plaintext)
+      digest_token(plaintext) if plaintext.is_a?(String) && plaintext.present?
+    end
   end
 end

--- a/app/models/delivery_note.rb
+++ b/app/models/delivery_note.rb
@@ -63,8 +63,8 @@ class DeliveryNote < ApplicationRecord
   end
 
   def self.find_by_acceptance_upload_token(plaintext)
-    return nil if plaintext.blank?
-    find_by(acceptance_upload_token_digest: digest_token(plaintext))
+    return nil unless (digest = lookup_digest(plaintext))
+    find_by(acceptance_upload_token_digest: digest)
   end
 
   def acceptance_upload_open?(now: Time.current)

--- a/app/models/user_email.rb
+++ b/app/models/user_email.rb
@@ -33,8 +33,8 @@ class UserEmail < ApplicationRecord
   end
 
   def self.find_by_confirmation_token(plaintext)
-    return nil if plaintext.blank?
-    where(confirmation_token_digest: digest_token(plaintext))
+    return nil unless (digest = lookup_digest(plaintext))
+    where(confirmation_token_digest: digest)
       .where("confirmation_expires_at > ?", Time.current)
       .where(confirmed_at: nil)
       .first

--- a/app/models/user_invite.rb
+++ b/app/models/user_invite.rb
@@ -46,8 +46,8 @@ class UserInvite < ApplicationRecord
   end
 
   def self.find_usable(plaintext)
-    return nil if plaintext.blank?
-    usable.where(token_digest: digest_token(plaintext)).first
+    return nil unless (digest = lookup_digest(plaintext))
+    usable.where(token_digest: digest).first
   end
 
   # Atomically claim the invite. The conditional UPDATE re-checks the `usable`

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -26,8 +26,8 @@ class UserSession < ApplicationRecord
   end
 
   def self.authenticate(plaintext)
-    return nil if plaintext.blank?
-    active.where(token_digest: digest_token(plaintext)).first
+    return nil unless (digest = lookup_digest(plaintext))
+    active.where(token_digest: digest).first
   end
 
   def terminate!(reason:, actor:, request: nil)

--- a/test/controllers/account/email_confirmations_controller_test.rb
+++ b/test/controllers/account/email_confirmations_controller_test.rb
@@ -12,6 +12,13 @@ class Account::EmailConfirmationsControllerTest < ActionDispatch::IntegrationTes
     assert email.reload.confirmed?
   end
 
+  test "rejects a non-scalar token" do
+    get account_email_confirmation_path(token: [ "a", "b" ])
+    assert_response :redirect
+    follow_redirect!
+    assert_match(/invalid or expired/i, flash[:alert] || "")
+  end
+
   test "rejects an invalid token" do
     get account_email_confirmation_path(token: "nope")
     assert_response :redirect

--- a/test/controllers/delivery_notes_controller_test.rb
+++ b/test/controllers/delivery_notes_controller_test.rb
@@ -510,6 +510,16 @@ class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
     assert_match(/newer submission/i, flash[:alert])
   end
 
+  test "accept_acceptance with a non-scalar submission_id is not found" do
+    dn, first = pending_submission
+    second = AcceptanceSubmission.submit!(delivery_note: dn,
+      uploaded_file: fixture_file_upload("acceptance.pdf", "application/pdf"), ip: "1.1.1.1")
+
+    post accept_acceptance_delivery_note_url(dn, submission_id: [ first.id, second.id ])
+    assert_response :not_found
+    assert_nil dn.reload.acceptance_attachment_id
+  end
+
   test "reject_acceptance marks the submission rejected and redirects" do
     dn, sub = pending_submission
     post reject_acceptance_delivery_note_url(dn, submission_id: sub.id)

--- a/test/controllers/invites_controller_test.rb
+++ b/test/controllers/invites_controller_test.rb
@@ -20,6 +20,11 @@ class InvitesControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
+  test "show with non-scalar token returns 404" do
+    get invite_path(token: [ "pending-signup-token", "other" ])
+    assert_response :not_found
+  end
+
   test "show with unknown token returns 404" do
     get invite_path(token: "totally-bogus")
     assert_response :not_found


### PR DESCRIPTION
Follow-up to #632, found while auditing it. Same defect class — a raw query param reaching code that assumes a scalar — but a different family, so it is split out.

> **Stacked on #632.** Base is `year-filter-param-cast` because the `submission_id` fix uses `ApplicationController#integer_param`, introduced there. Retarget to `main` once #632 merges.

## Failure modes

| Request | Before | After |
|---|---|---|
| `GET /invites?token[]=a&token[]=b` | `TypeError: no implicit conversion of Array into String` → 500 | 404, invite-invalid page |
| `GET /account/email_confirmations?token[]=a&token[]=b` | `TypeError` → 500 | redirect, "invalid or expired" |
| `POST .../accept_acceptance?submission_id[]=1&submission_id[]=2` | `NoMethodError: undefined method 'accept!' for an instance of Array` → 500 | 404 |

The two token endpoints are `allow_unauthenticated_access`, so these were reachable without signing in. `rack-attack` rate-limits them but does not prevent the 500.

The `submission_id` case is narrower than it looks: `find` with an array raises `RecordNotFound` unless **every** id exists and belongs to that note, in which case it returns an Array and the next call blows up. It needs an authenticated user holding `delivery_notes.review_acceptance` and a note with two or more submissions.

## Change

`DigestedToken.lookup_digest` returns a digest only for a non-blank String, nil otherwise. All four token finders — `UserInvite.find_usable`, `UserEmail.find_by_confirmation_token`, `UserSession.authenticate`, `DeliveryNote.find_by_acceptance_upload_token` — now guard on it instead of `plaintext.blank?`.

Guarding in the model rather than at each controller covers the two finders whose input is currently safe (`UserSession` reads a cookie, the customer-portal token is a route segment) and any future caller. It also structurally prevents a digest of a blank token being used in a `where`, which would match a row with an empty digest column.

`submission_id` uses `integer_param`, so a non-scalar or non-numeric value becomes nil and `find` raises `RecordNotFound` → 404, matching what a bogus scalar id already did.

## Testing

- Three regression tests, one per endpoint. All three fail on the base branch with the exact errors above.
- `bundle exec rails test` — 1087 runs, 0 failures. `bundle exec rails test test/system/` — 71 runs, 0 failures. `pre-commit run --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)