### PR TITLE
Run bin/postgres-dev test against PostgreSQL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,8 +35,9 @@ For testing against PostgreSQL (matches production environment):
 - `./bin/postgres-dev start` - Start PostgreSQL container
 - `./bin/postgres-dev setup` - Create and setup PostgreSQL database
 - `./bin/postgres-dev server` - Run Rails server with PostgreSQL
-- `./bin/postgres-dev test` - Run tests with PostgreSQL
+- `./bin/postgres-dev test` - Run tests against PostgreSQL (`RAILS_ENV=test` + `DATABASE_URL`, same as CI)
 - See `docs/postgres-dev.md` for complete documentation
+- The default `bundle exec rails test` lane is SQLite, whose adapter silently drops `FOR UPDATE`. Any change to `with_lock`/`lock!` or a concurrency guard is unverified until it runs through `./bin/postgres-dev test`.
 
 ## Architecture Overview
 

--- a/bin/postgres-dev
+++ b/bin/postgres-dev
@@ -6,6 +6,23 @@ set -e
 COMPOSE_FILE="docker-compose.postgres.yml"
 RAILS_ENV="development_postgres"
 
+# The test lane mirrors .github/workflows/ci.yml: RAILS_ENV=test plus a
+# DATABASE_URL that overrides the primary connection. Rails applies
+# DATABASE_URL to the primary database only, so the cache/queue databases stay
+# on SQLite here exactly as they do in CI. A separate `test_postgres`
+# environment is not an option — test/test_helper.rb forces RAILS_ENV=test.
+TEST_DATABASE_URL="postgres://abt_user:abt_password@localhost:5433/abt_test"
+
+# The precompiled darwin pg gem segfaults in PG::Connection#connect_start when
+# Rails' parallel test runner forks workers (libpq touches the macOS GSS
+# framework, which is not fork-safe). Disabling GSSAPI encryption negotiation
+# avoids it; nothing here talks to a Kerberised server. Harmless on Linux, so
+# it stays unconditional rather than uname-gated.
+rails_test_env() {
+  PGGSSENCMODE=disable RAILS_ENV=test DATABASE_URL="$TEST_DATABASE_URL" \
+    bundle exec rails "$@"
+}
+
 case "$1" in
   start)
     echo "Starting PostgreSQL container..."
@@ -52,8 +69,30 @@ case "$1" in
     ;;
 
   test)
-    echo "Running tests with PostgreSQL..."
-    RAILS_ENV=$RAILS_ENV bundle exec rake test
+    shift
+    echo "Running tests against $TEST_DATABASE_URL ..."
+    rails_test_env db:prepare
+    rails_test_env test "$@"
+    ;;
+
+  system-test)
+    shift
+    echo "Running system tests against $TEST_DATABASE_URL ..."
+    export HEADLESS=1
+    rails_test_env db:prepare
+    # `rails test:system` ignores path arguments; `rails test` honours them and
+    # runs system tests when the path is under test/system.
+    if [ "$#" -eq 0 ]; then
+      rails_test_env test:system
+    else
+      rails_test_env test "$@"
+    fi
+    ;;
+
+  test-reset)
+    echo "Dropping and recreating the PostgreSQL test database..."
+    rails_test_env db:drop
+    rails_test_env db:prepare
     ;;
 
   migrate)
@@ -80,18 +119,20 @@ case "$1" in
     ;;
 
   *)
-    echo "Usage: $0 {start|stop|setup|console|server|test|migrate|reset|status}"
+    echo "Usage: $0 {start|stop|setup|console|server|test|system-test|test-reset|migrate|reset|status}"
     echo ""
     echo "Commands:"
-    echo "  start   - Start PostgreSQL container"
-    echo "  stop    - Stop PostgreSQL container"
-    echo "  setup   - Create and setup database"
-    echo "  console - Start Rails console with PostgreSQL"
-    echo "  server  - Start Rails server with PostgreSQL"
-    echo "  test    - Run tests with PostgreSQL"
-    echo "  migrate - Run database migrations"
-    echo "  reset   - Drop, create, migrate and seed database"
-    echo "  status  - Check container status"
+    echo "  start       - Start PostgreSQL container"
+    echo "  stop        - Stop PostgreSQL container"
+    echo "  setup       - Create and setup development database"
+    echo "  console     - Start Rails console with PostgreSQL"
+    echo "  server      - Start Rails server with PostgreSQL"
+    echo "  test        - Run tests against PostgreSQL (extra args go to 'rails test')"
+    echo "  system-test - Run system tests against PostgreSQL, headless"
+    echo "  test-reset  - Drop and recreate the PostgreSQL test database"
+    echo "  migrate     - Run database migrations"
+    echo "  reset       - Drop, create, migrate and seed development database"
+    echo "  status      - Check container status"
     exit 1
     ;;
 esac

--- a/config/application.rb
+++ b/config/application.rb
@@ -60,5 +60,10 @@ module Abt
     # Route Solid Queue's ActiveRecord models to the dedicated queue database
     # in all environments so the jobs status page can read them.
     config.solid_queue.connects_to = { database: { writing: :queue } }
+
+    # db/schema.rb is owned by the SQLite development lane. Migrating any other
+    # environment against PostgreSQL (bin/postgres-dev, CI's test env) would
+    # otherwise rewrite it in PostgreSQL dialect, which SQLite then can't load.
+    config.active_record.dump_schema_after_migration = Rails.env.development?
   end
 end

--- a/docs/postgres-dev.md
+++ b/docs/postgres-dev.md
@@ -28,27 +28,64 @@ You need either:
 4. **Run tests with PostgreSQL:**
    ```bash
    ./bin/postgres-dev test
+   ./bin/postgres-dev test test/models/invoice_test.rb   # extra args go to `rails test`
    ```
 
 ## Available Commands
 
 - `./bin/postgres-dev start` - Start PostgreSQL container
 - `./bin/postgres-dev stop` - Stop PostgreSQL container
-- `./bin/postgres-dev setup` - Create and setup database
+- `./bin/postgres-dev setup` - Create and setup development database
 - `./bin/postgres-dev console` - Start Rails console with PostgreSQL
 - `./bin/postgres-dev server` - Start Rails server with PostgreSQL
-- `./bin/postgres-dev test` - Run tests with PostgreSQL
+- `./bin/postgres-dev test` - Run tests against PostgreSQL
+- `./bin/postgres-dev system-test` - Run system tests against PostgreSQL, headless
+- `./bin/postgres-dev test-reset` - Drop and recreate the PostgreSQL test database
 - `./bin/postgres-dev migrate` - Run database migrations
-- `./bin/postgres-dev reset` - Drop, create, migrate and seed database
+- `./bin/postgres-dev reset` - Drop, create, migrate and seed development database
 - `./bin/postgres-dev status` - Check container status
 
 ## Configuration
 
-- **Database:** `abt_development_postgres`
+- **Database:** `abt_development` (dev lane), `abt_test` (test lane)
 - **Username:** `abt_user`
 - **Password:** `abt_password`
 - **Port:** `5433` (to avoid conflicts with system PostgreSQL)
-- **Rails Environment:** `development_postgres`
+- **Rails Environment:** `development_postgres` (dev lane), `test` (test lane)
+
+## The Test Lane
+
+The test lane deliberately mirrors `.github/workflows/ci.yml`: it runs with
+`RAILS_ENV=test` and points `DATABASE_URL` at the container. Rails applies
+`DATABASE_URL` to the **primary** database only, so the Solid Cache and Solid
+Queue databases stay on SQLite here exactly as they do in CI.
+
+A separate `test_postgres` environment is not an option — `test/test_helper.rb`
+sets `ENV["RAILS_ENV"] = "test"` unconditionally, so any other `RAILS_ENV`
+passed to a test run is silently discarded and the suite lands back on SQLite.
+`DATABASE_URL` is the only override that survives that.
+
+This is the only lane that exercises row locking. Rails' SQLite adapter silently
+drops the lock clause — `Invoice.lock.to_sql` yields `SELECT "invoices".* FROM
+"invoices"` on SQLite and `... FOR UPDATE` on PostgreSQL — so `with_lock` /
+`lock!` in `InvoicePublisher`, `OfferMilestoneConverter`, `DocumentNumber` and
+friends still opens a transaction in the default `bundle exec rails test` run but
+takes no row lock. Any change to a lock or a concurrency guard should be checked
+here.
+
+`db:prepare` runs before every test invocation: it creates and seeds `abt_test`
+on first use and applies pending migrations afterwards. Use `test-reset` to
+start over.
+
+On macOS the lane exports `PGGSSENCMODE=disable`. Without it the precompiled
+`pg` darwin gem segfaults in `PG::Connection#connect_start` in every worker as
+soon as the suite crosses the 50-test parallelisation threshold and Rails forks
+— libpq reaches into the macOS GSS framework, which is not fork-safe. CI runs on
+Linux and never hits this.
+
+Migrating a non-development environment no longer rewrites `db/schema.rb`
+(`config.active_record.dump_schema_after_migration` in `config/application.rb`),
+so the PostgreSQL lanes can't leave the SQLite lane with a schema it cannot load.
 
 ## Database Connection
 


### PR DESCRIPTION
`bin/postgres-dev test` passed `RAILS_ENV=development_postgres`, which `test/test_helper.rb:1` overwrites with `"test"`. Every run landed back on `db/test.sqlite3`, and SQLite's Arel visitor drops the lock clause entirely, so no `with_lock` / `lock!` in `InvoicePublisher`, `OfferMilestoneConverter` or `DocumentNumber` has ever been exercised by a test.

```
Invoice.lock.to_sql
# SQLite:     SELECT "invoices".* FROM "invoices"
# PostgreSQL: SELECT "invoices".* FROM "invoices" FOR UPDATE
```

## Approach

Mirror `.github/workflows/ci.yml` rather than invent a fourth environment: `RAILS_ENV=test` plus a `DATABASE_URL` pointing at the dev container. `DATABASE_URL` applies to the primary database only, so Solid Cache and Solid Queue stay on SQLite exactly as they do in CI. It is also the only override that survives the forced `RAILS_ENV`.

## Notes

- **`PGGSSENCMODE=disable`** — without it the precompiled `pg-*-arm64-darwin` gem segfaults in `PG::Connection#connect_start` in all 8 workers the moment the suite crosses the 50-test parallelisation threshold and Rails forks; libpq reaches into the macOS GSS framework, which is not fork-safe. Linux/CI never hits this, which is why it stayed invisible.
- **`dump_schema_after_migration`** — migrating a PostgreSQL environment rewrote `db/schema.rb` in PostgreSQL dialect (`enable_extension "pg_catalog.plpgsql"`, …), which SQLite then cannot load. Now dumped from the development environment only. Verified load-bearing by flipping it back.
- `system-test` shells out to `rails test` when given a path, because `rails test:system` silently ignores path arguments.

## Verification

```
1068 runs, 3682 assertions, 0 failures, 0 errors, 0 skips   # ./bin/postgres-dev test
  71 runs,  302 assertions, 0 failures, 0 errors, 0 skips   # ./bin/postgres-dev system-test
```

`pre-commit run --all-files` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)