### PR TITLE
Enforce unique sales tax class names and indicator codes

### DIFF
--- a/app/models/sales_tax_customer_class.rb
+++ b/app/models/sales_tax_customer_class.rb
@@ -2,5 +2,5 @@ class SalesTaxCustomerClass < ApplicationRecord
   has_many :sales_tax_rates, dependent: :restrict_with_exception
   has_many :customers, dependent: :restrict_with_exception
 
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: true
 end

--- a/app/models/sales_tax_product_class.rb
+++ b/app/models/sales_tax_product_class.rb
@@ -1,8 +1,7 @@
 class SalesTaxProductClass < ApplicationRecord
   has_many :sales_tax_rates, dependent: :restrict_with_exception
 
-  validates :name, :indicator_code, presence: true
-  validates :indicator_code, uniqueness: true
+  validates :name, :indicator_code, presence: true, uniqueness: true
 
   before_save :unset_other_defaults, if: -> { is_default? && is_default_changed? }
 

--- a/db/migrate/20260802120000_unique_index_sales_tax_rates.rb
+++ b/db/migrate/20260802120000_unique_index_sales_tax_rates.rb
@@ -1,4 +1,4 @@
-class DedupeAndIndexSalesTaxRates < ActiveRecord::Migration[8.0]
+class UniqueIndexSalesTaxRates < ActiveRecord::Migration[8.0]
   # This will crash if the uniqueness is not satisfied.
   def up
     add_index :sales_tax_rates,

--- a/db/migrate/20260802130000_unique_index_sales_tax_classes.rb
+++ b/db/migrate/20260802130000_unique_index_sales_tax_classes.rb
@@ -1,0 +1,14 @@
+class UniqueIndexSalesTaxClasses < ActiveRecord::Migration[8.0]
+  # This will crash if the uniqueness is not satisfied.
+  def up
+    add_index :sales_tax_product_classes, :indicator_code, unique: true
+    add_index :sales_tax_product_classes, :name, unique: true
+    add_index :sales_tax_customer_classes, :name, unique: true
+  end
+
+  def down
+    remove_index :sales_tax_product_classes, :indicator_code
+    remove_index :sales_tax_product_classes, :name
+    remove_index :sales_tax_customer_classes, :name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_02_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_02_130000) do
   create_table "acceptance_submissions", force: :cascade do |t|
     t.integer "attachment_id"
     t.datetime "created_at", null: false
@@ -434,6 +434,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_02_120000) do
     t.string "name"
     t.datetime "updated_at", null: false
     t.boolean "vat_id_required", default: true, null: false
+    t.index ["name"], name: "index_sales_tax_customer_classes_on_name", unique: true
   end
 
   create_table "sales_tax_product_classes", force: :cascade do |t|
@@ -442,7 +443,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_02_120000) do
     t.boolean "is_default", default: false, null: false
     t.string "name"
     t.datetime "updated_at", null: false
+    t.index ["indicator_code"], name: "index_sales_tax_product_classes_on_indicator_code", unique: true
     t.index ["is_default"], name: "index_sales_tax_product_classes_on_is_default", unique: true, where: "is_default = true"
+    t.index ["name"], name: "index_sales_tax_product_classes_on_name", unique: true
   end
 
   create_table "sales_tax_rates", force: :cascade do |t|

--- a/test/models/sales_tax_customer_class_test.rb
+++ b/test/models/sales_tax_customer_class_test.rb
@@ -7,6 +7,12 @@ class SalesTaxCustomerClassTest < ActiveSupport::TestCase
     assert_includes klass.errors[:name], "can't be blank"
   end
 
+  test "name must be unique" do
+    klass = SalesTaxCustomerClass.new(name: sales_tax_customer_classes(:national).name)
+    assert_not klass.valid?
+    assert_includes klass.errors[:name], "has already been taken"
+  end
+
   test "destroy is blocked when sales_tax_rates reference the class" do
     klass = SalesTaxCustomerClass.create!(name: "Test Region With Rate")
     SalesTaxRate.create!(

--- a/test/models/sales_tax_product_class_test.rb
+++ b/test/models/sales_tax_product_class_test.rb
@@ -1,6 +1,23 @@
 require "test_helper"
 
 class SalesTaxProductClassTest < ActiveSupport::TestCase
+  test "indicator_code must be unique" do
+    klass = SalesTaxProductClass.new(name: "Duplicate Code", indicator_code: sales_tax_product_classes(:standard).indicator_code)
+    assert_not klass.valid?
+    assert_includes klass.errors[:indicator_code], "has already been taken"
+  end
+
+  test "name must be unique" do
+    klass = SalesTaxProductClass.new(name: sales_tax_product_classes(:standard).name, indicator_code: "DUP")
+    assert_not klass.valid?
+    assert_includes klass.errors[:name], "has already been taken"
+  end
+
+  test "database rejects a duplicate indicator_code that skips validation" do
+    klass = SalesTaxProductClass.new(name: "Bypass", indicator_code: sales_tax_product_classes(:standard).indicator_code)
+    assert_raises(ActiveRecord::RecordNotUnique) { klass.save!(validate: false) }
+  end
+
   test "default returns the row flagged as default" do
     assert_equal sales_tax_product_classes(:standard), SalesTaxProductClass.default
   end


### PR DESCRIPTION
## Problem

`SalesTaxProductClass#indicator_code` carried a `uniqueness: true` validation with no backing index. Rails' uniqueness validation is a read-then-write race, so a concurrent create or a double-submitted form could store two rows with the same code — and `indicator_code` flows verbatim into the invoice PDF/XML.

`name` on both tax-class tables had neither a validation nor an index, which also broke the idempotency of `find_or_create_by(name:)` in `db/seeds.rb`.

## Changes

- Migration adding unique indexes on `sales_tax_product_classes.indicator_code`, `sales_tax_product_classes.name`, and `sales_tax_customer_classes.name`.
- Matching model validations: `uniqueness` on `SalesTaxProductClass#name` and `SalesTaxCustomerClass#name`.
- Tests for both validations plus a DB-level test that a validation-skipping write raises `ActiveRecord::RecordNotUnique`.

**No data cleanup.** As with `20260802120000`, the migration crashes on existing duplicates by design — installs reconcile their own data first.

## Drive-by fix

`db/migrate/20260802120000_unique_index_sales_tax_rates.rb` (merged in #634's predecessor) declared `class DedupeAndIndexSalesTaxRates` while its filename implies `UniqueIndexSalesTaxRates`. Rails derives the constant from the filename, so `bundle exec rails db:migrate` aborted there with `NameError: uninitialized constant UniqueIndexSalesTaxRates` and never reached any later migration. Renamed the class to match.

## Testing

- `bundle exec rails test` (SQLite): 1091 runs, 4 failures / 27 errors — identical to the `main` baseline (1087 runs, same 4/27). All pre-existing, all from the `abt-fop` container image being unavailable locally.
- `./bin/postgres-dev test`: same counts; the tax-class tests pass on both adapters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)