### PR TITLE
Enforce unique document number code; fix sales tax class deletion

### DIFF
--- a/app/controllers/sales_tax_customer_classes_controller.rb
+++ b/app/controllers/sales_tax_customer_classes_controller.rb
@@ -47,8 +47,12 @@ class SalesTaxCustomerClassesController < ApplicationController
   # DELETE /sales_tax_customer_classes/1
   def destroy
     @sales_tax_customer_class = SalesTaxCustomerClass.find(params[:id])
-    @sales_tax_customer_class.destroy
-    redirect_to sales_tax_customer_classes_url
+
+    if @sales_tax_customer_class.destroy
+      redirect_to sales_tax_customer_classes_url, notice: "Sales tax customer class was successfully deleted."
+    else
+      redirect_to sales_tax_customer_classes_url, alert: @sales_tax_customer_class.errors.full_messages.join(", ")
+    end
   end
 
 private

--- a/app/controllers/sales_tax_product_classes_controller.rb
+++ b/app/controllers/sales_tax_product_classes_controller.rb
@@ -47,8 +47,12 @@ class SalesTaxProductClassesController < ApplicationController
   # DELETE /sales_tax_product_classes/1
   def destroy
     @sales_tax_product_class = SalesTaxProductClass.find(params[:id])
-    @sales_tax_product_class.destroy
-    redirect_to sales_tax_product_classes_url
+
+    if @sales_tax_product_class.destroy
+      redirect_to sales_tax_product_classes_url, notice: "Sales tax product class was successfully deleted."
+    else
+      redirect_to sales_tax_product_classes_url, alert: @sales_tax_product_class.errors.full_messages.join(", ")
+    end
   end
 
 private

--- a/app/models/document_number.rb
+++ b/app/models/document_number.rb
@@ -2,6 +2,8 @@ class NoDocumentNumberRangeError < StandardError; end
 class DateNotMonotonicError < StandardError; end
 
 class DocumentNumber < ApplicationRecord
+  validates :code, presence: true, uniqueness: true
+
   def get_next(date)
     if !self.last_date.nil? && date < self.last_date
       raise DateNotMonotonicError.new "New date #{date} is older than previously used date #{self.last_date}"

--- a/app/models/sales_tax_customer_class.rb
+++ b/app/models/sales_tax_customer_class.rb
@@ -1,6 +1,6 @@
 class SalesTaxCustomerClass < ApplicationRecord
-  has_many :sales_tax_rates, dependent: :restrict_with_exception
-  has_many :customers, dependent: :restrict_with_exception
+  has_many :sales_tax_rates, dependent: :restrict_with_error
+  has_many :customers, dependent: :restrict_with_error
 
   validates :name, presence: true, uniqueness: true
 end

--- a/app/models/sales_tax_product_class.rb
+++ b/app/models/sales_tax_product_class.rb
@@ -1,5 +1,12 @@
 class SalesTaxProductClass < ApplicationRecord
+  # Every reference is restricted: the FKs have no database constraint, and
+  # invoice_tax_classes/invoice_lines belong to booked invoices, so a delete
+  # here would silently corrupt accounting records.
   has_many :sales_tax_rates, dependent: :restrict_with_error
+  has_many :products, dependent: :restrict_with_error
+  has_many :invoice_tax_classes, dependent: :restrict_with_error
+  has_many :invoice_lines, dependent: :restrict_with_error
+  has_many :offer_versions, dependent: :restrict_with_error
 
   validates :name, :indicator_code, presence: true, uniqueness: true
 

--- a/app/models/sales_tax_product_class.rb
+++ b/app/models/sales_tax_product_class.rb
@@ -1,5 +1,5 @@
 class SalesTaxProductClass < ApplicationRecord
-  has_many :sales_tax_rates, dependent: :restrict_with_exception
+  has_many :sales_tax_rates, dependent: :restrict_with_error
 
   validates :name, :indicator_code, presence: true, uniqueness: true
 

--- a/db/migrate/20260802140000_unique_index_document_numbers.rb
+++ b/db/migrate/20260802140000_unique_index_document_numbers.rb
@@ -1,0 +1,12 @@
+class UniqueIndexDocumentNumbers < ActiveRecord::Migration[8.1]
+  # This will crash if the uniqueness is not satisfied.
+  def up
+    change_column_null :document_numbers, :code, false
+    add_index :document_numbers, :code, unique: true
+  end
+
+  def down
+    remove_index :document_numbers, :code
+    change_column_null :document_numbers, :code, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_02_130000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_02_140000) do
   create_table "acceptance_submissions", force: :cascade do |t|
     t.integer "attachment_id"
     t.datetime "created_at", null: false
@@ -222,13 +222,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_02_130000) do
   end
 
   create_table "document_numbers", force: :cascade do |t|
-    t.string "code"
+    t.string "code", null: false
     t.datetime "created_at", null: false
     t.string "format"
     t.date "last_date"
     t.string "last_number"
     t.integer "sequence"
     t.datetime "updated_at", null: false
+    t.index ["code"], name: "index_document_numbers_on_code", unique: true
   end
 
   create_table "group_memberships", force: :cascade do |t|

--- a/test/controllers/sales_tax_customer_classes_controller_test.rb
+++ b/test/controllers/sales_tax_customer_classes_controller_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class SalesTaxCustomerClassesControllerTest < ActionDispatch::IntegrationTest
+  test "destroy removes a customer class that has no rates or customers" do
+    customer_class = SalesTaxCustomerClass.create!(name: "Unused", invoice_note: "")
+
+    assert_difference("SalesTaxCustomerClass.count", -1) do
+      delete sales_tax_customer_class_url(customer_class)
+    end
+    assert_redirected_to sales_tax_customer_classes_url
+  end
+
+  test "destroy reports an error instead of raising when rates reference the customer class" do
+    customer_class = sales_tax_customer_classes(:national)
+
+    assert_no_difference("SalesTaxCustomerClass.count") do
+      delete sales_tax_customer_class_url(customer_class)
+    end
+    assert_redirected_to sales_tax_customer_classes_url
+    assert_match(/sales tax rates/i, flash[:alert])
+  end
+end

--- a/test/controllers/sales_tax_product_classes_controller_test.rb
+++ b/test/controllers/sales_tax_product_classes_controller_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class SalesTaxProductClassesControllerTest < ActionDispatch::IntegrationTest
+  test "destroy removes a product class that has no rates" do
+    product_class = SalesTaxProductClass.create!(name: "Reduced", indicator_code: "RED")
+
+    assert_difference("SalesTaxProductClass.count", -1) do
+      delete sales_tax_product_class_url(product_class)
+    end
+    assert_redirected_to sales_tax_product_classes_url
+  end
+
+  test "destroy reports an error instead of raising when rates reference the product class" do
+    product_class = sales_tax_product_classes(:standard)
+
+    assert_no_difference("SalesTaxProductClass.count") do
+      delete sales_tax_product_class_url(product_class)
+    end
+    assert_redirected_to sales_tax_product_classes_url
+    assert_match(/sales tax rates/i, flash[:alert])
+  end
+end

--- a/test/models/document_number_test.rb
+++ b/test/models/document_number_test.rb
@@ -40,6 +40,24 @@ class DocumentNumberTest < ActiveSupport::TestCase
     assert_nothing_raised { dn.get_next(Date.new(2014, 1, 10)) }
   end
 
+  test "rejects a duplicate code" do
+    duplicate = DocumentNumber.new(code: "invoice", format: "%<number>04d", sequence: 0)
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:code], "has already been taken"
+  end
+
+  test "rejects a blank code" do
+    dn = DocumentNumber.new(format: "%<number>04d", sequence: 0)
+    assert_not dn.valid?
+    assert_includes dn.errors[:code], "can't be blank"
+  end
+
+  test "the database rejects a duplicate code inserted without validations" do
+    assert_raises(ActiveRecord::RecordNotUnique) do
+      DocumentNumber.insert!({ code: "invoice", format: "%<number>04d", sequence: 0 })
+    end
+  end
+
   test "get_next_for raises NoDocumentNumberRangeError for unknown code" do
     assert_raises(NoDocumentNumberRangeError) do
       DocumentNumber.get_next_for("does-not-exist", Date.current)

--- a/test/models/sales_tax_customer_class_test.rb
+++ b/test/models/sales_tax_customer_class_test.rb
@@ -20,7 +20,8 @@ class SalesTaxCustomerClassTest < ActiveSupport::TestCase
       sales_tax_product_class: sales_tax_product_classes(:standard),
       rate: 5
     )
-    assert_raises(ActiveRecord::DeleteRestrictionError) { klass.destroy }
+    assert_not klass.destroy
+    assert_includes klass.errors[:base], "Cannot delete record because dependent sales tax rates exist"
   end
 
   test "destroy is blocked when customers reference the class" do
@@ -34,7 +35,8 @@ class SalesTaxCustomerClassTest < ActiveSupport::TestCase
       vat_id: "EU171717171",
       country_iso2: "NL"
     )
-    assert_raises(ActiveRecord::DeleteRestrictionError) { klass.destroy }
+    assert_not klass.destroy
+    assert_includes klass.errors[:base], "Cannot delete record because dependent customers exist"
   end
 
   test "destroy succeeds when no rates or customers reference the class" do

--- a/test/models/sales_tax_product_class_test.rb
+++ b/test/models/sales_tax_product_class_test.rb
@@ -18,6 +18,39 @@ class SalesTaxProductClassTest < ActiveSupport::TestCase
     assert_raises(ActiveRecord::RecordNotUnique) { klass.save!(validate: false) }
   end
 
+  test "destroy is blocked when products reference the class" do
+    klass = SalesTaxProductClass.create!(name: "Product Only", indicator_code: "PRO")
+    Product.create!(title: "Widget", rate: 10, sales_tax_product_class: klass)
+
+    assert_not klass.destroy
+    assert_includes klass.errors[:base], "Cannot delete record because dependent products exist"
+  end
+
+  test "destroy is blocked when invoice tax classes reference the class" do
+    klass = SalesTaxProductClass.create!(name: "Tax Class Only", indicator_code: "ITC")
+    InvoiceTaxClass.create!(invoice: invoices(:published_invoice), sales_tax_product_class: klass,
+                            name: klass.name, indicator_code: klass.indicator_code, rate: 20, net: 0)
+
+    assert_not klass.destroy
+    assert_includes klass.errors[:base], "Cannot delete record because dependent invoice tax classes exist"
+  end
+
+  test "destroy is blocked when invoice lines reference the class" do
+    klass = SalesTaxProductClass.create!(name: "Line Only", indicator_code: "LIN")
+    invoice_lines(:draft_item).update!(sales_tax_product_class: klass)
+
+    assert_not klass.destroy
+    assert_includes klass.errors[:base], "Cannot delete record because dependent invoice lines exist"
+  end
+
+  test "destroy is blocked when offer versions reference the class" do
+    klass = SalesTaxProductClass.create!(name: "Offer Only", indicator_code: "OFF")
+    offer_versions(:draft_offer_v1).update!(sales_tax_product_class: klass)
+
+    assert_not klass.destroy
+    assert_includes klass.errors[:base], "Cannot delete record because dependent offer versions exist"
+  end
+
   test "default returns the row flagged as default" do
     assert_equal sales_tax_product_classes(:standard), SalesTaxProductClass.default
   end


### PR DESCRIPTION
## `document_numbers` had zero indexes

`DocumentNumber.get_next_for` does `lock.find_by(code:)`, which assumes one row per code. Duplicate rows (concurrent seeds, console work) made it pick an arbitrary one, so publishing minted numbers from whichever row won — duplicate or gapped document numbers, and a 500 on publish. Only reachable via seeds/console; no UI path inserts `DocumentNumber` rows.

- Migration adds a unique index on `document_numbers.code` and `NOT NULL` on the column. No data fix-up — the migration fails if uniqueness or non-nullness is already violated (same shape as #635).
- `DocumentNumber` validates `code` for presence and uniqueness, so the app path reports an error instead of hitting `RecordNotUnique`.

The index, not the validation, is the actual fix: the validation still races, the index does not.

## Deleting any sales tax class 500s

`sales_tax_product_classes_controller.rb` and `sales_tax_customer_classes_controller.rb` called bare `.destroy` while the models declared `dependent: :restrict_with_exception`. Only `PermissionDenied` and CSRF are rescued, so `ActiveRecord::DeleteRestrictionError` reached the user as a 500. Seeds give every class a rate, so Delete was a guaranteed 500.

Switched both associations to `restrict_with_error` and used the destroy if/else + alert pattern already used by `Customer`, `Project`, `Group` and `Team`. The two model tests that asserted the old exception now assert the returned error.

## Missing restrictions on `SalesTaxProductClass`

Only `sales_tax_rates` was guarded. `products` and `invoice_tax_classes` are required `belongs_to` associations, so deleting a class that had products but no rate left them with a dangling FK — and none of these FKs has a database constraint to catch it. `invoice_tax_classes` and `invoice_lines` hang off booked invoices, where that silently corrupts accounting records.

Every reference is now restricted, including the optional `invoice_lines` and `offer_versions` FKs. `SalesTaxCustomerClass` was already complete (`sales_tax_rates` + `customers` are its only referents).

Note that `restrict_with_error` aborts at the first violated association, so the alert names one association even when several are referencing.

## Testing

- `bundle exec rails test` — 1102 runs, 0 failures.
- `./bin/postgres-dev test` — 1102 runs, 0 failures.
- Replayed all migrations from zero on a scratch PostgreSQL database; confirmed `index_document_numbers_on_code` is unique and `code` is `NOT NULL`.
- Both new controller tests were confirmed to fail with `DeleteRestrictionError` before the fix, and all four new restriction tests were confirmed to fail with the association declarations removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)