### PR TITLE
Close two double-submit races

### DIFF
--- a/app/controllers/delivery_notes_controller.rb
+++ b/app/controllers/delivery_notes_controller.rb
@@ -197,72 +197,14 @@ class DeliveryNotesController < ApplicationController
   end
 
   def convert_to_invoice
-    if @delivery_note.invoice_id.present?
-      flash[:error] = "This delivery note has already been converted to an invoice."
-      redirect_to @delivery_note and return
-    end
-
-    begin
-      reference_line = I18n.with_locale(@delivery_note.customer.language.iso_code) do
-        I18n.t("invoice_conversion.reference_line",
-               number: @delivery_note.display_label,
-               date: I18n.l(@delivery_note.date))
-      end
-
-      enhanced_prelude = ActionController::Base.helpers.simple_format(reference_line)
-      if @delivery_note.prelude.present?
-        enhanced_prelude += @delivery_note.prelude.body.to_html
-      end
-
-      # Create invoice from delivery note
-      invoice = Invoice.new(
-        customer: @delivery_note.customer,
-        project: @delivery_note.project,
-        cust_reference: @delivery_note.cust_reference,
-        cust_order: @delivery_note.cust_order,
-        internal_reference: @delivery_note.internal_reference,
-        prelude: enhanced_prelude
-      )
-
-      default_sales_tax_product_class_id = SalesTaxProductClass.default&.id
-
-      ActiveRecord::Base.transaction do
-        invoice.save!
-        # Copy delivery note lines to invoice lines without triggering callbacks that cause issues
-        @delivery_note.delivery_note_lines.each do |dn_line|
-          # Create invoice line with direct attributes
-          attrs = {
-            invoice_id: invoice.id,
-            type: dn_line.type,
-            title: dn_line.title,
-            description: dn_line.description,
-            position: dn_line.position
-          }
-
-          # Set appropriate fields based on line type
-          if dn_line.type == "item"
-            attrs[:quantity] = (dn_line.quantity&.to_f || 1.0).to_f
-            # Leave the rate blank: delivery notes carry no prices, and a blank
-            # rate blocks publishing until the user enters a real price.
-            attrs[:sales_tax_product_class_id] = default_sales_tax_product_class_id
-          else
-            attrs[:amount] = 0
-          end
-
-          # Insert directly to avoid callbacks
-          InvoiceLine.create!(attrs)
-        end
-
-        # Link the invoice to the delivery note
-        @delivery_note.update!(invoice: invoice)
-
-        flash[:notice] = "Invoice draft created successfully from delivery note."
-        redirect_to invoice
-      end
-    rescue StandardError => e
-      flash[:error] = "Failed to convert delivery note to invoice: #{e.message}"
-      redirect_to @delivery_note
-    end
+    invoice = DeliveryNoteInvoiceConverter.new(@delivery_note).convert!
+    redirect_to invoice, notice: "Invoice draft created successfully from delivery note."
+  rescue DeliveryNoteInvoiceConverter::NotConvertible
+    flash[:error] = "This delivery note has already been converted to an invoice."
+    redirect_to @delivery_note
+  rescue StandardError => e
+    flash[:error] = "Failed to convert delivery note to invoice: #{e.message}"
+    redirect_to @delivery_note
   end
 
   def bulk_send_emails

--- a/app/services/delivery_note_invoice_converter.rb
+++ b/app/services/delivery_note_invoice_converter.rb
@@ -1,0 +1,63 @@
+class DeliveryNoteInvoiceConverter
+  include LockedConversion
+
+  def initialize(delivery_note)
+    @delivery_note = delivery_note
+  end
+
+  private
+
+  def conversion_source = @delivery_note
+
+  def convert_locked!
+    raise NotConvertible, "delivery note already converted" if @delivery_note.invoice_id.present?
+
+    invoice = Invoice.new(customer: @delivery_note.customer, project: @delivery_note.project,
+                          cust_reference: @delivery_note.cust_reference,
+                          cust_order: @delivery_note.cust_order,
+                          internal_reference: @delivery_note.internal_reference,
+                          prelude: prelude)
+    invoice.save!
+    default_product_class_id = SalesTaxProductClass.default&.id
+    @delivery_note.delivery_note_lines.each do |line|
+      InvoiceLine.create!(line_attributes(line, invoice, default_product_class_id))
+    end
+    @delivery_note.update!(invoice: invoice)
+    invoice
+  end
+
+  def prelude
+    reference_line = I18n.with_locale(@delivery_note.customer.language.iso_code) do
+      I18n.t("invoice_conversion.reference_line",
+             number: @delivery_note.display_label,
+             date: I18n.l(@delivery_note.date))
+    end
+
+    html = ActionController::Base.helpers.simple_format(reference_line)
+    html += @delivery_note.prelude.body.to_html if @delivery_note.prelude.present?
+    html
+  end
+
+  # Built as plain attributes and inserted directly, bypassing the line
+  # callbacks that recompute invoice sums per line.
+  def line_attributes(line, invoice, default_product_class_id)
+    attrs = {
+      invoice_id: invoice.id,
+      type: line.type,
+      title: line.title,
+      description: line.description,
+      position: line.position
+    }
+
+    if line.type == "item"
+      attrs[:quantity] = (line.quantity&.to_f || 1.0).to_f
+      # Leave the rate blank: delivery notes carry no prices, and a blank rate
+      # blocks publishing until the user enters a real price.
+      attrs[:sales_tax_product_class_id] = default_product_class_id
+    else
+      attrs[:amount] = 0
+    end
+
+    attrs
+  end
+end

--- a/app/services/locked_conversion.rb
+++ b/app/services/locked_conversion.rb
@@ -1,0 +1,16 @@
+# Turning a document into follow-on billing documents must happen at most once:
+# a double-clicked "Convert" button fires two requests that both read the
+# not-yet-converted state and both create documents. #convert! reloads the
+# source record under a row lock and runs the guards plus the writes in one
+# transaction, so concurrent converts serialize and the loser sees the
+# converted state and raises NotConvertible instead of double-billing.
+#
+# Includers supply #conversion_source (the record to lock) and #convert_locked!
+# (guards plus writes).
+module LockedConversion
+  class NotConvertible < StandardError; end
+
+  def convert!
+    conversion_source.with_lock { convert_locked! }
+  end
+end

--- a/app/services/offer_milestone_converter.rb
+++ b/app/services/offer_milestone_converter.rb
@@ -1,5 +1,5 @@
 class OfferMilestoneConverter
-  class NotConvertible < StandardError; end
+  include LockedConversion
 
   def initialize(milestone)
     @milestone = milestone
@@ -7,14 +7,9 @@ class OfferMilestoneConverter
     @offer = @version.offer
   end
 
-  # with_lock reloads the milestone under a row lock and runs guards plus
-  # document creation in one transaction, so concurrent converts serialize and
-  # the second one sees converted? and raises instead of double-billing.
-  def convert!
-    @milestone.with_lock { convert_locked! }
-  end
-
   private
+
+  def conversion_source = @milestone
 
   def convert_locked!
     raise NotConvertible, "offer is not accepted" unless @offer.accepted?

--- a/app/services/offer_milestone_scaffolder.rb
+++ b/app/services/offer_milestone_scaffolder.rb
@@ -8,7 +8,17 @@ class OfferMilestoneScaffolder
     @total = BigDecimal(total.to_s)
   end
 
+  # with_lock reloads the version under a row lock and runs the guard plus the
+  # inserts in one transaction, so a double-clicked Scaffold button lays down
+  # one milestone set rather than two summing to double the offer — the same
+  # pattern LockedConversion applies to milestone conversion.
   def apply_to(version)
+    version.with_lock { apply_locked!(version) }
+  end
+
+  private
+
+  def apply_locked!(version)
     raise MilestonesPresent if version.milestones.any?
 
     rows = parse_rows
@@ -29,8 +39,6 @@ class OfferMilestoneScaffolder
       end
     milestones
   end
-
-  private
 
   # Without a threshold the "below" template always applies.
   def template_source

--- a/db/migrate/20260802160000_unique_index_delivery_notes_invoice.rb
+++ b/db/migrate/20260802160000_unique_index_delivery_notes_invoice.rb
@@ -1,0 +1,12 @@
+class UniqueIndexDeliveryNotesInvoice < ActiveRecord::Migration[8.0]
+  # This will crash if the uniqueness is not satisfied.
+  def up
+    remove_index :delivery_notes, :invoice_id
+    add_index :delivery_notes, :invoice_id, unique: true, where: "invoice_id IS NOT NULL"
+  end
+
+  def down
+    remove_index :delivery_notes, :invoice_id
+    add_index :delivery_notes, :invoice_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_02_150000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_02_160000) do
   create_table "acceptance_submissions", force: :cascade do |t|
     t.integer "attachment_id"
     t.datetime "created_at", null: false
@@ -216,7 +216,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_02_150000) do
     t.index ["customer_id"], name: "index_delivery_notes_on_customer_id"
     t.index ["date"], name: "index_delivery_notes_on_date"
     t.index ["document_number"], name: "index_delivery_notes_on_document_number", unique: true
-    t.index ["invoice_id"], name: "index_delivery_notes_on_invoice_id"
+    t.index ["invoice_id"], name: "index_delivery_notes_on_invoice_id", unique: true, where: "invoice_id IS NOT NULL"
     t.index ["project_id"], name: "index_delivery_notes_on_project_id"
     t.index ["published"], name: "index_delivery_notes_on_published"
   end

--- a/test/models/delivery_note_test.rb
+++ b/test/models/delivery_note_test.rb
@@ -13,6 +13,15 @@ class DeliveryNoteTest < ActiveSupport::TestCase
     assert_includes delivery_note.errors[:delivery_start_date], "can't be blank"
   end
 
+  test "an invoice can back only one delivery note" do
+    invoice = invoices(:published_invoice)
+    delivery_notes(:published_delivery_note).update!(invoice: invoice)
+
+    assert_raises(ActiveRecord::RecordNotUnique) do
+      delivery_notes(:draft_delivery_note).update!(invoice: invoice)
+    end
+  end
+
   test "email_unsent scope returns delivery notes without email_sent_at that have customer email" do
     delivery_note = delivery_notes(:published_delivery_note)
     delivery_note.update_column(:email_sent_at, nil)

--- a/test/services/delivery_note_invoice_converter_test.rb
+++ b/test/services/delivery_note_invoice_converter_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+class DeliveryNoteInvoiceConverterTest < ActiveSupport::TestCase
+  test "a delivery note converted behind our back cannot convert again" do
+    note = delivery_notes(:published_delivery_note)
+    stale = DeliveryNote.find(note.id)
+    DeliveryNoteInvoiceConverter.new(note).convert!
+
+    assert_no_difference("Invoice.count") do
+      assert_raises(DeliveryNoteInvoiceConverter::NotConvertible) do
+        DeliveryNoteInvoiceConverter.new(stale).convert!
+      end
+    end
+  end
+end

--- a/test/services/offer_milestone_scaffolder_test.rb
+++ b/test/services/offer_milestone_scaffolder_test.rb
@@ -53,9 +53,13 @@ class OfferMilestoneScaffolderTest < ActiveSupport::TestCase
   end
 
   test "refuses when the draft already has milestones" do
-    @version.milestones.create!(title: "Existing", amount: 1, trigger: "on_acceptance", position: 1)
-    assert_raises(OfferMilestoneScaffolder::MilestonesPresent) do
-      OfferMilestoneScaffolder.new(@customer, 100).apply_to(@version)
+    @version.milestones.load
+    OfferVersion.find(@version.id).milestones.create!(title: "Existing", amount: 1, trigger: "on_acceptance", position: 1)
+
+    assert_no_difference("OfferMilestone.count") do
+      assert_raises(OfferMilestoneScaffolder::MilestonesPresent) do
+        OfferMilestoneScaffolder.new(@customer, 100).apply_to(@version)
+      end
     end
   end
 


### PR DESCRIPTION
Two check-then-act windows that a double-clicked button walks straight through. Each is a separate commit.

**Delivery-note → invoice conversion** (`delivery_notes_controller.rb`) — checked `invoice_id`, then created the invoice in separate steps: two clicks produced two draft invoices, one orphaned, both billable. The conversion moves into `DeliveryNoteInvoiceConverter`, which shares the row-lock pattern with `OfferMilestoneConverter` (#619) through a new `LockedConversion` module: `convert!` reloads the source under a row lock so the guards re-read fresh state. A partial unique index on `delivery_notes.invoice_id` now backs `Invoice has_one :delivery_note`, matching what `offer_milestones` already had.

**Milestone scaffolder** (`offer_milestone_scaffolder.rb`) — checked for existing milestones, then created them: two clicks laid down two milestone sets and doubled `sum_net`. Guard and inserts now run inside `version.with_lock`.

The third double-submit race in this set — bulk email queuing the same document twice — is handled separately: claiming at enqueue time conflicts with #345 (`email_sent_at` must record actual delivery so a failed send stays in the Unsent filter), so it needs its own claim column rather than reusing `email_sent_at`.

## Testing

Each fix has a regression test that fails without it (stale in-memory state walks the unguarded check-then-act). Full suite green on both lanes: `bundle exec rails test` (1093 runs, SQLite) and `./bin/postgres-dev test` (PostgreSQL) — the latter matters because SQLite silently drops `FOR UPDATE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)