### PR TITLE
Stop bulk email double-submits from queuing twice

### DIFF
--- a/app/controllers/concerns/emailable_document.rb
+++ b/app/controllers/concerns/emailable_document.rb
@@ -69,12 +69,38 @@ module EmailableDocument
     end
   end
 
+  # How long a queued-but-not-yet-delivered document stays claimed. Mailer jobs
+  # carry no retry_on, so a raising delivery fails for good on the first try;
+  # once the window passes the document is offered for sending again rather
+  # than sitting there looking sent.
+  EMAIL_CLAIM_WINDOW = 10.minutes
+
+  # Claims documents for the mail queue and returns the ones actually claimed.
+  # email_sent_at is stamped by the mailer once delivery succeeds (#345), so
+  # filtering on it alone lets two submissions of the bulk form arriving before
+  # that job runs both queue the same document — the customer gets it twice.
+  # The conditional UPDATE (UserInvite#consume! pattern) hands each document to
+  # exactly one submission, and claims a document whose earlier send never
+  # landed once EMAIL_CLAIM_WINDOW has passed.
+  def claim_for_email(documents)
+    stale = EMAIL_CLAIM_WINDOW.ago
+    documents.select do |document|
+      document.class
+        .where(id: document.id, email_sent_at: nil)
+        .where("email_queued_at IS NULL OR email_queued_at < ?", stale)
+        .update_all(email_queued_at: Time.current) == 1
+    end
+  end
+
   # Shared scaffolding for the bulk "email the selected published documents"
   # action: parse the checkbox ids, guard an empty selection, load the
   # visible, published, not-yet-emailed scope, and build the queued/skipped
   # notice. The block
   # receives that scope and returns [queued, skipped]; how each document type
   # groups recipients and delivers differs, so that stays in the host.
+  # Whatever the block reports as neither queued nor skipped was already sent
+  # or is still claimed by a recent send — say so rather than reporting a bare
+  # "0 emails queued".
   def bulk_send_document_emails(model, ids_param:, redirect_path:, noun:)
     ids = (params[ids_param] || []).reject(&:blank?)
     if ids.empty?
@@ -84,9 +110,11 @@ module EmailableDocument
 
     scope = model.visible_to(current_user).where(id: ids, published: true, email_sent_at: nil)
     queued, skipped = yield(scope)
+    unavailable = ids.length - queued - skipped
 
     notice = "#{queued} emails queued for sending."
     notice += " #{skipped} skipped (no recipients)." if skipped > 0
+    notice += " #{unavailable} skipped (already sent or queued)." if unavailable > 0
     redirect_to redirect_path, notice: notice
   end
 end

--- a/app/controllers/delivery_notes_controller.rb
+++ b/app/controllers/delivery_notes_controller.rb
@@ -223,17 +223,20 @@ class DeliveryNotesController < ApplicationController
           next
         end
 
-        if dns.length == 1
-          token = acceptance_token_for(dns.first)
-          DeliveryNoteMailer.with(delivery_note: dns.first, acceptance_token: token).customer_email.deliver_later
+        claimed = claim_for_email(dns)
+        next if claimed.empty?
+
+        if claimed.length == 1
+          token = acceptance_token_for(claimed.first)
+          DeliveryNoteMailer.with(delivery_note: claimed.first, acceptance_token: token).customer_email.deliver_later
         else
-          acceptance_tokens = dns.each_with_object({}) do |dn, tokens|
+          acceptance_tokens = claimed.each_with_object({}) do |dn, tokens|
             token = acceptance_token_for(dn)
             tokens[dn.id.to_s] = token if token
           end
-          DeliveryNoteMailer.with(delivery_notes: dns, recipients: recipients, acceptance_tokens: acceptance_tokens).bulk_customer_email.deliver_later
+          DeliveryNoteMailer.with(delivery_notes: claimed, recipients: recipients, acceptance_tokens: acceptance_tokens).bulk_customer_email.deliver_later
         end
-        queued += dns.length
+        queued += claimed.length
       end
 
       [ queued, skipped ]

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -147,16 +147,10 @@ class InvoicesController < ApplicationController
 
   def bulk_send_emails
     bulk_send_document_emails(Invoice, ids_param: :invoice_ids, redirect_path: invoices_path, noun: "invoices") do |invoices|
-      queued = skipped = 0
-      invoices.each do |invoice|
-        if invoice.emailable?
-          InvoiceMailer.with(invoice: invoice).customer_email.deliver_later
-          queued += 1
-        else
-          skipped += 1
-        end
-      end
-      [ queued, skipped ]
+      sendable, skipped = invoices.partition(&:emailable?)
+      claimed = claim_for_email(sendable)
+      claimed.each { |invoice| InvoiceMailer.with(invoice: invoice).customer_email.deliver_later }
+      [ claimed.length, skipped.length ]
     end
   end
 

--- a/db/migrate/20260803100000_add_email_queued_at_to_documents.rb
+++ b/db/migrate/20260803100000_add_email_queued_at_to_documents.rb
@@ -1,0 +1,6 @@
+class AddEmailQueuedAtToDocuments < ActiveRecord::Migration[8.1]
+  def change
+    add_column :invoices, :email_queued_at, :datetime
+    add_column :delivery_notes, :email_queued_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_02_160000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_03_100000) do
   create_table "acceptance_submissions", force: :cascade do |t|
     t.integer "attachment_id"
     t.datetime "created_at", null: false
@@ -205,6 +205,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_02_160000) do
     t.date "delivery_end_date"
     t.date "delivery_start_date", null: false
     t.string "document_number"
+    t.datetime "email_queued_at"
     t.datetime "email_sent_at"
     t.text "internal_reference"
     t.integer "invoice_id"
@@ -307,6 +308,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_02_160000) do
     t.date "date"
     t.string "document_number"
     t.date "due_date"
+    t.datetime "email_queued_at"
     t.datetime "email_sent_at"
     t.text "internal_reference"
     t.date "paid_at"

--- a/test/controllers/invoices_controller_email_test.rb
+++ b/test/controllers/invoices_controller_email_test.rb
@@ -166,6 +166,8 @@ class InvoicesControllerEmailTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to invoices_path
     assert_equal "2 emails queued for sending.", flash[:notice]
+    # email_sent_at records delivery, not enqueue (#345)
+    assert_nil invoice1.reload.email_sent_at
   end
 
   test "bulk_send_emails excludes already-sent invoices" do
@@ -179,8 +181,29 @@ class InvoicesControllerEmailTest < ActionDispatch::IntegrationTest
     end
     perform_enqueued_jobs
 
-    assert_equal "1 emails queued for sending.", flash[:notice]
+    assert_equal "1 emails queued for sending. 1 skipped (already sent or queued).", flash[:notice]
     assert_equal sent_at, sent_invoice.reload.email_sent_at
+  end
+
+  test "bulk_send_emails queues nothing extra when the form is submitted twice" do
+    invoice = invoices(:published_invoice)
+
+    assert_enqueued_emails 1 do
+      2.times { post bulk_send_emails_invoices_path, params: { invoice_ids: [ invoice.id ] } }
+    end
+
+    assert_equal "0 emails queued for sending. 1 skipped (already sent or queued).", flash[:notice]
+  end
+
+  test "bulk_send_emails offers a document again once its claim goes stale" do
+    invoice = invoices(:published_invoice)
+    post bulk_send_emails_invoices_path, params: { invoice_ids: [ invoice.id ] }
+
+    travel EmailableDocument::EMAIL_CLAIM_WINDOW + 1.minute do
+      assert_enqueued_emails 1 do
+        post bulk_send_emails_invoices_path, params: { invoice_ids: [ invoice.id ] }
+      end
+    end
   end
 
   test "bulk_send_emails handles empty selection" do


### PR DESCRIPTION
Split out of #637, where the first attempt at this fix was contested — correctly.

## The bug

`bulk_send_document_emails` filters the selection on `email_sent_at IS NULL`, but that column is stamped by the mailer when delivery actually succeeds, not at enqueue. A second submission arriving while the first batch is still sitting in the queue therefore sees `nil` again and queues everything a second time — the customer gets each document twice. #618 narrowed this but could not close it, because the enqueue path has nothing to check.

## Why not just claim on `email_sent_at`

That was the first attempt, and it walks straight back into #345 (`20e771f`): `email_sent_at` deliberately records *delivery*, so a permanently failed send leaves the document in the Unsent filter for the user to retry. Mailer jobs here carry no `retry_on`, so a raising delivery fails for good on the first try — stamping at enqueue would silently drop those documents out of Unsent, and nobody would notice the customer never got the invoice.

## What this does instead

A separate `email_queued_at` column, claimed with a conditional `UPDATE` (the `UserInvite#consume!` pattern in this repo) before anything is queued; only claimed documents get a job. Both bulk senders share `EmailableDocument#claim_for_email`.

- `email_sent_at` keeps meaning "delivered" — #345 semantics untouched, and a failed send still shows as Unsent.
- The claim goes stale after `EMAIL_CLAIM_WINDOW` (10 minutes), so a document whose send never landed is offered for sending again instead of sitting there looking queued forever. No release-on-failure hook to get wrong, and a killed worker heals itself.
- The notice now reports documents skipped as already sent or queued, instead of answering a double-click with a bare "0 emails queued for sending."

## Testing

Three tests around the bulk path, on the invoice side (the delivery-note sender shares the same helper):

- double submit queues one job, not two — fails without the claim
- queuing does not stamp `email_sent_at` — verified to fail under the rejected `email_sent_at` claim
- a stale claim is offered again — verified to fail if the claim never expires

Full suite green on both lanes: `bundle exec rails test` (1093 runs, SQLite) and `./bin/postgres-dev test` (1093 runs, PostgreSQL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)