### PR TITLE
Show days to the payment deadline in the invoice payment badge

### DIFF
--- a/app/helpers/invoices_helper.rb
+++ b/app/helpers/invoices_helper.rb
@@ -1,0 +1,8 @@
+module InvoicesHelper
+  def invoice_payment_status_badge_tag(invoice)
+    label, badge_class = invoice.payment_status_badge
+    return unless label
+
+    content_tag(:span, label, class: "badge #{badge_class}")
+  end
+end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -95,6 +95,19 @@ class Invoice < ApplicationRecord
     self.published? && !self.paid? && self.due_date.present? && self.due_date < Date.current
   end
 
+  # [label, bootstrap background class] for the payment column, or nil when
+  # there is nothing to warn about (draft, or already paid — each view renders
+  # the paid state its own way). Date - Date is whole days, so the day counter
+  # is exact in both directions.
+  def payment_status_badge
+    return nil unless published?
+    return nil if paid?
+    return [ "Unpaid", "bg-warning" ] if due_date.blank?
+
+    days = (due_date - Date.current).to_i
+    days.negative? ? [ "Overdue, #{-days}d", "bg-danger" ] : [ "Unpaid, #{days}d", "bg-warning" ]
+  end
+
   def publish_problems
     problems = []
     return problems if published?

--- a/app/views/invoices/index.html.haml
+++ b/app/views/invoices/index.html.haml
@@ -97,10 +97,8 @@
             - if invoice.published?
               - if invoice.paid?
                 = l(invoice.paid_at.to_date)
-              - elsif invoice.overdue?
-                %span.badge.bg-danger Overdue
               - else
-                %span.badge.bg-warning Unpaid
+                = invoice_payment_status_badge_tag(invoice)
           %td.numeric= format_currency(invoice.sum_net)
           %td
             - if invoice.published? and not invoice.attachment.nil?

--- a/app/views/invoices/show.html.haml
+++ b/app/views/invoices/show.html.haml
@@ -118,10 +118,8 @@
                 .col-sm-8.d-flex.align-items-center.gap-2{data: {controller: 'modal'}}
                   - if @invoice.paid?
                     Paid #{l(@invoice.paid_at.to_date)}
-                  - elsif @invoice.overdue?
-                    %span.badge.bg-danger Overdue
                   - else
-                    %span.badge.bg-warning Unpaid
+                    = invoice_payment_status_badge_tag(@invoice)
                   - if can_edit_invoice
                     - if @invoice.paid?
                       -# button_to wraps the button in a form; the form is the flex

--- a/test/controllers/invoices_controller_paid_test.rb
+++ b/test/controllers/invoices_controller_paid_test.rb
@@ -79,7 +79,7 @@ class InvoicesControllerPaidTest < ActionDispatch::IntegrationTest
     get invoice_path(invoice)
 
     assert_response :success
-    assert_select ".badge.bg-warning", text: "Unpaid"
+    assert_select ".badge.bg-warning", text: /Unpaid/
     assert_select "button", text: /Paid/
     assert_select ".mark-paid-modal form[action=?]", mark_paid_invoice_path(invoice)
     assert_select ".mark-paid-modal input[type='date'][name='paid_at']"
@@ -130,36 +130,37 @@ class InvoicesControllerPaidTest < ActionDispatch::IntegrationTest
     assert_select ".invoice-filter a", text: "Unpaid"
   end
 
-  test "index shows Overdue label for unpaid invoices past due date" do
+  test "index shows Overdue label with days past due for unpaid invoices" do
     invoice = invoices(:published_invoice)
     invoice.update!(paid_at: nil, due_date: Date.current - 1.day)
 
     get invoices_path(year: Date.current.year)
 
     assert_response :success
-    assert_select ".badge.bg-danger", text: "Overdue"
+    assert_select ".badge.bg-danger", text: "Overdue, 1d"
   end
 
-  test "index shows Unpaid label for unpaid invoices not yet past due date" do
+  test "index shows Unpaid label with days remaining for invoices not yet past due date" do
     invoice = invoices(:published_invoice)
     invoice.update!(paid_at: nil, due_date: Date.current + 1.day)
 
     get invoices_path(year: Date.current.year)
 
     assert_response :success
-    assert_select ".badge.bg-warning", text: "Unpaid"
-    assert_select ".badge.bg-danger", text: "Overdue", count: 0
+    assert_select ".badge.bg-warning", text: "Unpaid, 1d"
+    assert_select ".badge.bg-danger", text: /Overdue/, count: 0
   end
 
-  test "show page shows Overdue label for unpaid invoices past due date" do
+  test "show page shows Overdue label with days past due, header badge stays terse" do
     invoice = invoices(:published_invoice)
     invoice.update!(paid_at: nil, due_date: Date.current - 1.day)
 
     get invoice_path(invoice)
 
     assert_response :success
+    assert_select ".badge.bg-danger", text: "Overdue, 1d"
     assert_select ".badge.bg-danger", text: "Overdue"
-    assert_select ".badge.bg-warning", text: "Unpaid", count: 0
+    assert_select ".badge.bg-warning", text: /Unpaid/, count: 0
   end
 
   test "unpaid filter includes overdue invoices" do
@@ -170,6 +171,6 @@ class InvoicesControllerPaidTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "a", text: invoice.document_number
-    assert_select ".badge.bg-danger", text: "Overdue"
+    assert_select ".badge.bg-danger", text: "Overdue, 5d"
   end
 end

--- a/test/models/invoice_test.rb
+++ b/test/models/invoice_test.rb
@@ -67,6 +67,25 @@ class InvoiceTest < ActiveSupport::TestCase
     assert_not invoice.overdue?
   end
 
+  test "payment_status_badge counts the days to or past the due date" do
+    cases = {
+      Invoice.new(published: true, due_date: 6.days.from_now.to_date) => [ "Unpaid, 6d", "bg-warning" ],
+      Invoice.new(published: true, due_date: Date.current) => [ "Unpaid, 0d", "bg-warning" ],
+      Invoice.new(published: true, due_date: 3.days.ago.to_date) => [ "Overdue, 3d", "bg-danger" ],
+      Invoice.new(published: true, due_date: nil) => [ "Unpaid", "bg-warning" ],
+      Invoice.new(published: true, due_date: 3.days.ago.to_date, paid_at: Time.current) => nil,
+      Invoice.new(published: false, due_date: 3.days.ago.to_date) => nil
+    }
+
+    cases.each do |invoice, expected|
+      if expected.nil?
+        assert_nil invoice.payment_status_badge
+      else
+        assert_equal expected, invoice.payment_status_badge
+      end
+    end
+  end
+
   test "update_customer copies customer fields to the draft invoice on save" do
     invoice = invoices(:draft_invoice)
     invoice.customer.update!(supplier_number: "SUP-001", country_iso2: "AT")


### PR DESCRIPTION
The invoice list's payment column showed a bare `Unpaid` / `Overdue`. It now carries a whole-day counter, so a row says how much time is left rather than just that time exists.

| state | before | after |
|---|---|---|
| due in 6 days | `Unpaid` | `Unpaid, 6d` |
| due today | `Unpaid` | `Unpaid, 0d` |
| 3 days past due | `Overdue` | `Overdue, 3d` |
| no `due_date` on record | `Unpaid` | `Unpaid` |
| paid | date | date |

The overdue case already had its own red state (`Invoice#overdue?`), so this extends it rather than adding one.

### Notes

- `Invoice#payment_status_badge` returns `[label, background class]`, following `Offer#status_badge`. Deliberately not `DeliveryNote#status_badge`'s `{level:}` shape — `status_badge_tag` maps `danger → bg-secondary`, which would have quietly turned the Overdue badge grey.
- `due_date` is a `date` column, so `due_date - Date.current` is a Rational over whole days and `.to_i` is exact in both directions. Comparing against `Date.current` (not `Time.current`) keeps it out of seconds arithmetic, and makes the counter flip at local midnight — the same basis `overdue?` and `OverdueInvoicesReportJob` already use.
- The list and show-page status row previously duplicated the three-way branch byte-for-byte; both now call `invoice_payment_status_badge_tag`. The paid rendering stays per-view (bare date vs. `Paid <date>`), as does the show-page header badge, which stays terse next to the title.
- Helper lives in a new `InvoicesHelper` rather than `ApplicationHelper`, and is name-prefixed, since Rails includes all helpers globally.

### Testing

`bundle exec rails test` (1103 runs, 0 failures), `bundle exec rails test test/system/` (71 runs, 0 failures), `pre-commit run --all-files`.

Four existing assertions pinned the exact badge text and were updated in place rather than duplicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)