### PR TITLE
Reject out-of-range and non-scalar index filter params

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -116,13 +116,22 @@ class ApplicationController < ActionController::Base
 
   private
 
-  # A query param as an integer, or nil when it is missing, non-numeric, or not
-  # a scalar at all. `?id[]=1&id[]=2` arrives as an Array and `?id[a]=1` as
-  # nested Parameters; both raise on to_i, and both reach the database as
-  # garbage when passed through. Filters treat nil as "not filtered".
+  # Widest column any filter compares against. Ruby happily parses a 40-digit
+  # param into a Bignum, which PostgreSQL then rejects with
+  # NumericValueOutOfRange (SQLite coerces it silently, so the default test
+  # lane cannot see it).
+  BIGINT_RANGE = (-2**63)...(2**63)
+
+  # A query param as an integer, or nil when it is missing, non-numeric, out of
+  # column range, or not a scalar at all. `?id[]=1&id[]=2` arrives as an Array
+  # and `?id[a]=1` as nested Parameters; both raise on to_i, and both reach the
+  # database as garbage when passed through. Filters treat nil as "not filtered".
   def integer_param(name)
     raw = params[name]
-    Integer(raw, exception: false) if raw.is_a?(String)
+    return unless raw.is_a?(String)
+
+    value = Integer(raw, exception: false)
+    value if value && BIGINT_RANGE.cover?(value)
   end
 
   def authenticate

--- a/app/controllers/delivery_notes_controller.rb
+++ b/app/controllers/delivery_notes_controller.rb
@@ -8,6 +8,9 @@ class DeliveryNotesController < ApplicationController
   publishable_document :delivery_note, label: "delivery note"
   document_with_lines line_class: DeliveryNoteLine
 
+  EMAIL_FILTERS = %w[all unsent].freeze
+  ACCEPTANCE_FILTERS = %w[pending].freeze
+
   before_action -> { require_permission!("delivery_notes.view") }, only: %i[index show preview preview_email preview_email_html pdf]
   before_action -> { require_permission!("delivery_notes.edit") }, only: %i[
     new create edit update destroy
@@ -25,8 +28,8 @@ class DeliveryNotesController < ApplicationController
 
   # GET /delivery_notes
   def index
-    @email_filter = params[:email_filter] || "all"
-    @acceptance_filter = params[:acceptance_filter]
+    @email_filter = params[:email_filter].presence_in(EMAIL_FILTERS) || "all"
+    @acceptance_filter = params[:acceptance_filter].presence_in(ACCEPTANCE_FILTERS)
     @selected_customer_id = integer_param(:customer_id)
 
     @delivery_notes = filtered_by_year(DeliveryNote.visible_to(current_user).ordered)

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -13,7 +13,7 @@ class ProjectsController < ApplicationController
     # The dependent project dropdown (searchable_dropdown) scopes options to the
     # chosen customer, always including reusable (customer-less) projects.
     if (customer_id = integer_param(:customer_id))
-      @projects = @projects.where("bill_to_customer_id = ? OR bill_to_customer_id IS NULL", customer_id)
+      @projects = @projects.where(bill_to_customer_id: [ customer_id, nil ])
     end
 
     @projects = @projects.order(:matchcode, :description)

--- a/app/models/concerns/scoped_through_customer.rb
+++ b/app/models/concerns/scoped_through_customer.rb
@@ -38,10 +38,8 @@ module ScopedThroughCustomer
     # the list even when inactive, so an active-only default doesn't drop the
     # currently-selected one.
     def available_customers(user, including: nil)
-      Customer.visible_to(user)
-              .where(id: visible_to(user).select(:customer_id))
-              .where("active = ? OR id = ?", true, including)
-              .order(:name)
+      scope = Customer.visible_to(user).where(id: visible_to(user).select(:customer_id))
+      scope.where(active: true).or(scope.where(id: including)).order(:name)
     end
   end
 

--- a/test/controllers/delivery_notes_controller_test.rb
+++ b/test/controllers/delivery_notes_controller_test.rb
@@ -13,6 +13,11 @@ class DeliveryNotesControllerTest < ActionDispatch::IntegrationTest
   # own concern test). DeliveryNotesController#index uses the same scopes and
   # the same shared dropdown partial.
 
+  test "non-scalar email_filter param falls back to all" do
+    get delivery_notes_url(email_filter: { a: "1" })
+    assert_response :success
+  end
+
   test "should show delivery note" do
     note = delivery_notes(:published_delivery_note)
     assert_nil note.invoice, "fixture should not yet be invoiced"

--- a/test/controllers/invoices_controller_test.rb
+++ b/test/controllers/invoices_controller_test.rb
@@ -144,6 +144,14 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
     assert_select "td", text: "EU-INV"
   end
 
+  test "out-of-range customer_id param is ignored" do
+    create_draft_invoice(customer: customers(:good_eu), internal_reference: "EU-INV", date: Date.current)
+
+    get invoices_url(customer_id: "9" * 40)
+    assert_response :success
+    assert_select "td", text: "EU-INV"
+  end
+
   test "drafts sort newest-first when document_number is null" do
     first  = create_draft_invoice(internal_reference: "DRAFT-FIRST")
     second = create_draft_invoice(internal_reference: "DRAFT-SECOND")

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -46,6 +46,12 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_select "td", text: @project.matchcode
   end
 
+  test "out-of-range customer_id param is ignored" do
+    get projects_url(filter: "all", customer_id: "9" * 40)
+    assert_response :success
+    assert_select "td", text: @project.matchcode
+  end
+
   test "should show project" do
     get project_url(@project)
     assert_response :success

--- a/test/models/concerns/scoped_through_customer_test.rb
+++ b/test/models/concerns/scoped_through_customer_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+# Exercises ScopedThroughCustomer.available_customers once, via the Invoice
+# model. DeliveryNote and Offer include the same concern.
+class ScopedThroughCustomerTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:alice)
+    @customer = customers(:good_eu)
+    create_draft_invoice(customer: @customer, cust_reference: "AVAIL")
+  end
+
+  test "available_customers lists active customers owning a visible document" do
+    assert_includes Invoice.available_customers(@user), @customer
+  end
+
+  test "available_customers drops an inactive customer" do
+    @customer.update!(active: false)
+
+    assert_not_includes Invoice.available_customers(@user), @customer
+  end
+
+  test "available_customers keeps an inactive customer named by including" do
+    @customer.update!(active: false)
+
+    assert_includes Invoice.available_customers(@user, including: @customer.id), @customer
+  end
+
+  test "available_customers omits customers without a visible document" do
+    assert_not_includes Invoice.available_customers(@user), customers(:offer_only_customer)
+  end
+end


### PR DESCRIPTION
Follow-up to #632. That PR stopped `?customer_id[]=1&customer_id[]=2` and
`?customer_id=abc` from 500ing, but two hostile shapes still got through. Both
were found by sweeping every query param that reaches a filter or a finder with
array / nested-hash / non-numeric / 40-digit / negative values.

### `?customer_id=<40 digits>` — 500 on PostgreSQL

Hits `/projects`, `/invoices`, `/delivery_notes` and `/offers`.

`integer_param` returned any valid Ruby Integer, Bignums included, and two raw
SQL fragments interpolated it — `projects_controller.rb` and
`ScopedThroughCustomer.available_customers`. PostgreSQL rejects it with
`NumericValueOutOfRange`; the raise surfaces in the view, since the relation is
lazy.

**SQLite coerces the value silently and returns 200**, so the default test lane
cannot see this — same warning class as the `FOR UPDATE` note in CLAUDE.md. The
regression tests only fail on `bin/postgres-dev test`.

### `?email_filter[a]=1` on `/delivery_notes` — 500 on any adapter

`@email_filter` kept the `ActionController::Parameters` object, and the view
passed it to `delivery_notes_path` → `UnfilteredParameters`. `offers#index`
already validates its equivalent via `presence_in`; this applies the same to
`email_filter` and `acceptance_filter`.

## Commits

1. **Bound `integer_param` to the bigint range** — the actual fix; out-of-range
   input is now "not filtered", like any other invalid value.
2. **Compare customer filter ids through the query builder** — removes both raw
   fragments so an out-of-range id cannot reach PostgreSQL uncast even if it
   gets past a caller's validation. Adds coverage for
   `available_customers(including:)`, which had none.
3. **Validate delivery-note index filter params.**

## Verified

- Each commit was tested individually on PostgreSQL via `git rebase --exec`; all
  three are green, so the history bisects.
- Both rewritten queries were mutation-tested — dropping the `.or(including)`
  branch or the `nil` from the projects array fails a test, so neither rewrite is
  silently unguarded.
- Full suite green on both lanes: 1110 runs, 0 failures.
- The hostile-param sweep re-run reports 0 bad outcomes across 96 combinations.

## Not changed

The year filter looks like the same pattern but isn't. Both the hash form and
the fragment form raise `PG::DatetimeFieldOverflow` for an out-of-range year —
the overflow is in PostgreSQL's `date` type, not in the bind-vs-fragment
distinction — so `SELECTABLE_YEARS` remains the necessary guard there.

`customer_contacts_controller.rb` binds `@customer.id` from a loaded record, and
every `find(params[:id])` site takes its id from a route segment, which always
wins over a query-string override. Both verified unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)