### PR TITLE
Re-read converter guards under the lock

### DIFF
--- a/app/controllers/delivery_notes_controller.rb
+++ b/app/controllers/delivery_notes_controller.rb
@@ -202,8 +202,8 @@ class DeliveryNotesController < ApplicationController
   def convert_to_invoice
     invoice = DeliveryNoteInvoiceConverter.new(@delivery_note).convert!
     redirect_to invoice, notice: "Invoice draft created successfully from delivery note."
-  rescue DeliveryNoteInvoiceConverter::NotConvertible
-    flash[:error] = "This delivery note has already been converted to an invoice."
+  rescue DeliveryNoteInvoiceConverter::NotConvertible => e
+    flash[:error] = e.message
     redirect_to @delivery_note
   rescue StandardError => e
     flash[:error] = "Failed to convert delivery note to invoice: #{e.message}"

--- a/app/models/delivery_note.rb
+++ b/app/models/delivery_note.rb
@@ -12,6 +12,7 @@ class DeliveryNote < ApplicationRecord
 
   validates :customer_id, presence: true
   validates :delivery_start_date, presence: true
+  validates :invoice_id, uniqueness: true, allow_nil: true
   validate :delivery_end_date_after_start_date
   scope :with_pending_acceptance, -> { where(id: AcceptanceSubmission.pending.select(:delivery_note_id)) }
   scope :email_unsent, -> {

--- a/app/services/delivery_note_invoice_converter.rb
+++ b/app/services/delivery_note_invoice_converter.rb
@@ -1,6 +1,8 @@
 class DeliveryNoteInvoiceConverter
   include LockedConversion
 
+  class NotConvertible < LockedConversion::NotConvertible; end
+
   def initialize(delivery_note)
     @delivery_note = delivery_note
   end
@@ -9,8 +11,12 @@ class DeliveryNoteInvoiceConverter
 
   def conversion_source = @delivery_note
 
+  # The controller's require_published ran before the lock, so re-check it here:
+  # an unpublish that commits in between must not leave a draft note owning a
+  # billing invoice. Messages are user-facing — the controller shows them.
   def convert_locked!
-    raise NotConvertible, "delivery note already converted" if @delivery_note.invoice_id.present?
+    raise NotConvertible, "Draft delivery notes can not be used for this action." unless @delivery_note.published?
+    raise NotConvertible, "This delivery note has already been converted to an invoice." if @delivery_note.invoice_id.present?
 
     invoice = Invoice.new(customer: @delivery_note.customer, project: @delivery_note.project,
                           cust_reference: @delivery_note.cust_reference,
@@ -50,7 +56,7 @@ class DeliveryNoteInvoiceConverter
     }
 
     if line.type == "item"
-      attrs[:quantity] = (line.quantity&.to_f || 1.0).to_f
+      attrs[:quantity] = (line.quantity || 1).to_f
       # Leave the rate blank: delivery notes carry no prices, and a blank rate
       # blocks publishing until the user enters a real price.
       attrs[:sales_tax_product_class_id] = default_product_class_id

--- a/app/services/locked_conversion.rb
+++ b/app/services/locked_conversion.rb
@@ -1,12 +1,9 @@
-# Turning a document into follow-on billing documents must happen at most once:
-# a double-clicked "Convert" button fires two requests that both read the
-# not-yet-converted state and both create documents. #convert! reloads the
-# source record under a row lock and runs the guards plus the writes in one
-# transaction, so concurrent converts serialize and the loser sees the
-# converted state and raises NotConvertible instead of double-billing.
-#
-# Includers supply #conversion_source (the record to lock) and #convert_locked!
-# (guards plus writes).
+# Serializes conversion into billing documents: #convert! reloads the source row
+# under a lock, so a double-clicked "Convert" hits the converted state instead of
+# double-billing. Includers supply #conversion_source (the row to lock) and
+# #convert_locked! (guards plus writes), raise their own NotConvertible subclass
+# so callers can tell converters apart, and — since only the source row is
+# reloaded — re-read anything else their guards consult.
 module LockedConversion
   class NotConvertible < StandardError; end
 

--- a/app/services/offer_milestone_converter.rb
+++ b/app/services/offer_milestone_converter.rb
@@ -1,6 +1,8 @@
 class OfferMilestoneConverter
   include LockedConversion
 
+  class NotConvertible < LockedConversion::NotConvertible; end
+
   def initialize(milestone)
     @milestone = milestone
     @version = milestone.offer_version
@@ -11,7 +13,12 @@ class OfferMilestoneConverter
 
   def conversion_source = @milestone
 
+  # The lock covers the milestone row only, and #initialize captured the version
+  # and offer before it: re-read them so an offer reopened in between is seen.
   def convert_locked!
+    @version = @milestone.offer_version
+    @offer = @version.offer
+
     raise NotConvertible, "offer is not accepted" unless @offer.accepted?
     raise NotConvertible, "milestone belongs to a non-accepted version" unless @version.id == @offer.accepted_version_id
     raise NotConvertible, "milestone already converted" if @milestone.converted?

--- a/test/models/delivery_note_test.rb
+++ b/test/models/delivery_note_test.rb
@@ -16,10 +16,10 @@ class DeliveryNoteTest < ActiveSupport::TestCase
   test "an invoice can back only one delivery note" do
     invoice = invoices(:published_invoice)
     delivery_notes(:published_delivery_note).update!(invoice: invoice)
+    other = delivery_notes(:draft_delivery_note)
 
-    assert_raises(ActiveRecord::RecordNotUnique) do
-      delivery_notes(:draft_delivery_note).update!(invoice: invoice)
-    end
+    assert_not other.update(invoice: invoice)
+    assert_raises(ActiveRecord::RecordNotUnique) { other.update_column(:invoice_id, invoice.id) }
   end
 
   test "email_unsent scope returns delivery notes without email_sent_at that have customer email" do

--- a/test/services/delivery_note_invoice_converter_test.rb
+++ b/test/services/delivery_note_invoice_converter_test.rb
@@ -1,6 +1,18 @@
 require "test_helper"
 
 class DeliveryNoteInvoiceConverterTest < ActiveSupport::TestCase
+  test "a delivery note unpublished behind our back cannot convert" do
+    note = delivery_notes(:published_delivery_note)
+    stale = DeliveryNote.find(note.id)
+    note.update!(published: false)
+
+    assert_no_difference("Invoice.count") do
+      assert_raises(DeliveryNoteInvoiceConverter::NotConvertible) do
+        DeliveryNoteInvoiceConverter.new(stale).convert!
+      end
+    end
+  end
+
   test "a delivery note converted behind our back cannot convert again" do
     note = delivery_notes(:published_delivery_note)
     stale = DeliveryNote.find(note.id)

--- a/test/services/offer_milestone_converter_test.rb
+++ b/test/services/offer_milestone_converter_test.rb
@@ -71,6 +71,15 @@ class OfferMilestoneConverterTest < ActiveSupport::TestCase
     assert_nil milestone.delivery_note_id
   end
 
+  test "a milestone whose offer was reopened behind our back cannot convert" do
+    converter = OfferMilestoneConverter.new(offer_milestones(:sent_ms_two))
+    Offer.find(@offer.id).reopen!
+
+    assert_no_difference("Invoice.count") do
+      assert_raises(OfferMilestoneConverter::NotConvertible) { converter.convert! }
+    end
+  end
+
   test "milestone description lands after the reference in the line description" do
     milestone = offer_milestones(:sent_ms_two)
     milestone.update!(description: "Detailed scope")

--- a/test/services/offer_milestone_scaffolder_test.rb
+++ b/test/services/offer_milestone_scaffolder_test.rb
@@ -53,7 +53,7 @@ class OfferMilestoneScaffolderTest < ActiveSupport::TestCase
   end
 
   test "refuses when the draft already has milestones" do
-    @version.milestones.load
+    @version.milestones.load # load-bearing: only with_lock's reload clears this stale cache
     OfferVersion.find(@version.id).milestones.create!(title: "Existing", amount: 1, trigger: "on_acceptance", position: 1)
 
     assert_no_difference("OfferMilestone.count") do


### PR DESCRIPTION
Follow-up to review comments on #637.

## Guards that never re-read

`LockedConversion#convert!` locks and reloads the *source row only*. Both converters had guards over other state that still read what `#initialize` captured before the lock:

- **`DeliveryNoteInvoiceConverter` never checked `published?`.** The controller's `require_published` runs in a `before_action`, well before the lock. A racing unpublish that commits in between left a draft delivery note owning a billing invoice — exactly the state that guard exists to prevent. Now re-checked inside `convert_locked!`.
- **`OfferMilestoneConverter` read `@offer`/`@version` from `#initialize`.** `Offer#reopen!` locks the *offers* row, so the two never serialize; a reopen committing mid-convert left `@offer.accepted?` and the accepted-version check passing against stale objects, and billed a milestone of an offer that is no longer accepted. Both are now re-read from the reloaded milestone.

The `LockedConversion` comment is shorter and no longer claims guards see fresh state for free — it says only the source row is reloaded and that includers must re-read anything else.

## Error classes

Moving `NotConvertible` into the shared module made both converters' constants resolve to the same class, so `rescue OfferMilestoneConverter::NotConvertible` in `offers_controller` also caught delivery-note refusals. Each converter now defines its own subclass. The delivery-note messages are user-facing and the controller shows the actual reason, instead of hardcoding "already been converted" — which would have been wrong copy for the new `published?` refusal.

## Smaller items from the same review

- `delivery_notes.invoice_id` got its unique index in #637 but not the matching `validates :invoice_id, uniqueness: true, allow_nil: true` that `OfferMilestone` carries. Added; the model test now covers both layers.
- `(line.quantity&.to_f || 1.0).to_f` — dead outer `to_f`, carried over verbatim during the extraction.
- Marked `@version.milestones.load` in the scaffolder test as load-bearing. Without it that regression test passes against the unfixed code.

Not taken: restructuring `convert_to_invoice` so the success `redirect_to` sits outside the catch-all rescue (it can't raise for a persisted record with a route, so the double-render it guards against is unreachable — only the `e.message` change was worth making), a pre-flight duplicate check in the #637 migration (the repo's other unique-index migrations use the same bare "will crash if not satisfied" form), hoisting cheap queries out of the critical section (contention here is one user double-clicking), and folding the scaffolder into `LockedConversion` (it isn't a conversion — `convert!`/`NotConvertible` don't fit).

## Testing

Two new regression tests, each watched failing first: a delivery note unpublished behind the converter's back, and a milestone whose offer was reopened behind the converter's back. Both created documents before the fix.

Full suite green: `bundle exec rails test` (1118 runs, SQLite) and `./bin/postgres-dev test` (PostgreSQL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)