### PR TITLE
Hold the Admin group above one active member

### DIFF
--- a/app/controllers/account/blocks_controller.rb
+++ b/app/controllers/account/blocks_controller.rb
@@ -3,11 +3,15 @@ class Account::BlocksController < ApplicationController
   allow_without_permission_check
 
   def create
-    current_user.block!(
-      reason: "user self-requested",
-      actor: current_user,
-      request: request
-    )
+    AdminFloor.protect! do
+      current_user.block!(
+        reason: "user self-requested",
+        actor: current_user,
+        request: request
+      )
+    end
     sign_out_and_redirect(notice: "Your account has been blocked at your request.")
+  rescue AdminFloor::Violation => e
+    redirect_to account_profile_path, alert: e.message
   end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -112,19 +112,10 @@ class GroupsController < ApplicationController
     new_ids = Array(user_ids).reject(&:blank?).map(&:to_i)
     new_users = User.where(id: new_ids).to_a
 
-    if group.admin? && new_users.empty?
-      group.errors.add(:base, "Admin group must have at least one member")
-      return
-    end
-
     # Only existing admins can change the Admin group's membership in either
     # direction. Without this, a `groups.manage` user could grant themselves
     # Admin membership (inheriting bypass_team_scoping + the admin-only
-    # credential primitives) OR demote other admins. The remove direction is
-    # the more dangerous primitive: `has_many through` collection assignment
-    # silently swallows `prevent_removing_last_admin`'s `throw :abort`, so a
-    # single PATCH with one admin id in user_ids would otherwise delete every
-    # other admin's GroupMembership without raising.
+    # credential primitives) OR demote other admins.
     if group.admin? && !current_user.groups.include?(group)
       added   = new_users.map(&:id) - group.user_ids
       removed = group.user_ids - new_users.map(&:id)
@@ -134,6 +125,8 @@ class GroupsController < ApplicationController
       end
     end
 
-    group.users = new_users
+    AdminFloor.protect! { group.users = new_users }
+  rescue AdminFloor::Violation => e
+    group.errors.add(:base, e.message)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -32,7 +32,12 @@ class UsersController < ApplicationController
       redirect_to user_path(@user), alert: "Reason is required." and return
     end
 
-    @user.block!(reason: reason, actor: current_user, request: request)
+    begin
+      AdminFloor.protect! { @user.block!(reason: reason, actor: current_user, request: request) }
+    rescue AdminFloor::Violation => e
+      redirect_to user_path(@user), alert: e.message and return
+    end
+
     redirect_to user_path(@user), notice: "User #{@user.username} blocked."
   end
 
@@ -73,11 +78,6 @@ class UsersController < ApplicationController
     new_groups = Group.where(id: new_ids).to_a
 
     admin_group = Group.admin
-    if admin_group && @user.groups.include?(admin_group) && !new_groups.include?(admin_group)
-      if admin_group.users.where.not(id: @user.id).none?
-        redirect_to user_path(@user), alert: "Cannot remove the last member of the Admin group." and return
-      end
-    end
 
     # Only admins can change Admin-group membership in either direction.
     # `groups.manage` alone is insufficient: the add direction is admin
@@ -94,7 +94,11 @@ class UsersController < ApplicationController
     end
 
     previous = @user.groups.pluck(:id).to_set
-    @user.groups = new_groups
+    begin
+      AdminFloor.protect! { @user.groups = new_groups }
+    rescue AdminFloor::Violation => e
+      redirect_to user_path(@user), alert: e.message and return
+    end
     added   = new_ids.to_set - previous
     removed = previous - new_ids.to_set
     if added.any? || removed.any?

--- a/app/models/group_membership.rb
+++ b/app/models/group_membership.rb
@@ -8,10 +8,12 @@ class GroupMembership < ApplicationRecord
 
   private
 
+  # Defence in depth only: the controllers use collection assignment, whose
+  # `delete_all` never reaches this callback. AdminFloor holds that line.
   def prevent_removing_last_admin
     return unless group.admin?
-    if group.group_memberships.where.not(id: id).none?
-      errors.add(:base, "Cannot remove the last member of the Admin group")
+    if group.users.active.where.not(id: user_id).none?
+      errors.add(:base, "Cannot remove the last active member of the Admin group")
       throw :abort
     end
   end

--- a/app/services/admin_floor.rb
+++ b/app/services/admin_floor.rb
@@ -1,0 +1,36 @@
+# The Admin group must keep at least one active (non-blocked) member;
+# recovering from zero needs a database console.
+#
+# Checked as a post-condition under a row lock, because the pre-checks can't
+# hold the line: the UI's `user.groups = [...]` is a `has_many :through`
+# assignment that drops join rows with `delete_all`, never reaching
+# GroupMembership#prevent_removing_last_admin, and two admins racing a
+# check-then-act both see someone else remaining. `had_admin` keeps an install
+# already at zero from wedging unrelated membership edits.
+module AdminFloor
+  class Violation < StandardError
+    def initialize(msg = "That would leave the Admin group without an active member.")
+      super
+    end
+  end
+
+  def self.protect!
+    group = Group.admin
+    return yield if group.nil?
+
+    Group.transaction(requires_new: true) do
+      group.lock!
+      had_admin = active_admin?(group)
+      result = yield
+      raise Violation if had_admin && !active_admin?(group)
+      result
+    end
+  end
+
+  # Uncached: both reads issue identical SQL on one connection, so the
+  # post-condition must not be servable from the request's query cache.
+  def self.active_admin?(group)
+    Group.uncached { group.users.active.exists? }
+  end
+  private_class_method :active_admin?
+end

--- a/test/controllers/account/blocks_controller_test.rb
+++ b/test/controllers/account/blocks_controller_test.rb
@@ -4,22 +4,31 @@ class Account::BlocksControllerTest < ActionDispatch::IntegrationTest
   skip_default_signin!
 
   test "self-block sets blocked_at and terminates all sessions" do
-    sign_in_as(users(:alice))
-    other_session, _plain = UserSession.create_for!(user: users(:alice), request: nil)
+    sign_in_as(users(:bob))
+    other_session, _plain = UserSession.create_for!(user: users(:bob), request: nil)
 
     post account_block_path
     assert_response :redirect
 
-    assert users(:alice).reload.blocked?
-    assert_equal "user self-requested", users(:alice).blocked_reason
+    assert users(:bob).reload.blocked?
+    assert_equal "user self-requested", users(:bob).blocked_reason
     assert other_session.reload.terminated_at.present?
   end
 
   test "self-block records audit event" do
-    sign_in_as(users(:alice))
+    sign_in_as(users(:bob))
     assert_difference -> { UserAuditEvent.where(action: "blocked").count }, 1 do
       post account_block_path
     end
+  end
+
+  test "the last active admin cannot self-block" do
+    groups(:admin).users << users(:blocked_carol)
+    sign_in_as(users(:alice))
+
+    post account_block_path
+    assert_redirected_to account_profile_path
+    assert_not users(:alice).reload.blocked?
   end
 
   test "unauthenticated user cannot self-block" do

--- a/test/controllers/groups_controller_test.rb
+++ b/test/controllers/groups_controller_test.rb
@@ -165,7 +165,7 @@ class GroupsControllerTest < ActionDispatch::IntegrationTest
       group: { description: groups(:admin).description, user_ids: [] }
     }
     assert_response :unprocessable_content
-    assert_select ".alert-danger li", text: "Admin group must have at least one member"
+    assert_select ".alert-danger li", text: "That would leave the Admin group without an active member."
     assert_includes groups(:admin).reload.users, users(:alice)
   end
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -161,4 +161,29 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     post user_emails_path(carol), params: { user_email: { address: "evil@example.com" } }
     assert_redirected_to root_path
   end
+
+  test "blocking the last active admin is refused" do
+    helpdesk = Group.create!(name: "Helpdesk")
+    helpdesk.permissions = %w[users.view users.block]
+    users(:bob).groups << helpdesk
+    sign_in_as(users(:bob))
+
+    post block_user_path(users(:alice)), params: { reason: "lockout attempt" }
+    assert_redirected_to user_path(users(:alice))
+    assert_not users(:alice).reload.blocked?
+  end
+
+  test "update_groups refuses to remove the last active admin" do
+    sign_in_as(users(:alice))
+    patch update_groups_user_path(users(:alice)), params: { group_ids: [ groups(:sales).id ] }
+    assert_redirected_to user_path(users(:alice))
+    assert_includes groups(:admin).reload.users, users(:alice)
+  end
+
+  test "update_groups does not count a blocked admin towards the floor" do
+    groups(:admin).users << users(:blocked_carol)
+    sign_in_as(users(:alice))
+    patch update_groups_user_path(users(:alice)), params: { group_ids: [] }
+    assert_includes groups(:admin).reload.users, users(:alice)
+  end
 end

--- a/test/services/admin_floor_test.rb
+++ b/test/services/admin_floor_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class AdminFloorTest < ActiveSupport::TestCase
+  test "rolls back a mutation that leaves the Admin group empty" do
+    assert_raises(AdminFloor::Violation) do
+      AdminFloor.protect! { groups(:admin).group_memberships.delete_all }
+    end
+    assert_includes groups(:admin).reload.users, users(:alice)
+  end
+
+  test "blocked members do not satisfy the floor" do
+    groups(:admin).users << users(:blocked_carol)
+    assert_raises(AdminFloor::Violation) do
+      AdminFloor.protect! { users(:alice).groups = [] }
+    end
+    assert_includes groups(:admin).reload.users, users(:alice)
+  end
+
+  test "allows a removal that leaves another active admin behind" do
+    groups(:admin).users << users(:bob)
+    AdminFloor.protect! { users(:alice).groups = [] }
+    assert_equal [ users(:bob) ], groups(:admin).reload.users.to_a
+  end
+
+  test "allows unrelated mutations when the Admin group is already empty" do
+    groups(:admin).group_memberships.delete_all
+    AdminFloor.protect! { users(:bob).groups = [ groups(:sales) ] }
+    assert_includes users(:bob).reload.groups, groups(:sales)
+  end
+
+  test "returns the block's value" do
+    assert_equal :done, AdminFloor.protect! { :done }
+  end
+end


### PR DESCRIPTION
## The bug

Three separate holes let the Admin group reach zero usable members:

1. **The `delete_all` bypass.** `UsersController#update_groups` and `GroupsController#assign_members` change membership with `has_many :through` collection assignment (`@user.groups = ...`). Rails removes the join rows with `delete_all`, so `GroupMembership#prevent_removing_last_admin` never runs — it was dead code on the paths the UI actually uses.
2. **Check-then-act.** The two pre-checks counted admins and then acted, with no lock. Two admins (or two tabs) each see one other admin remaining and both proceed.
3. **No guard at all on the block paths.** `users#block` had no last-admin check, and `account/blocks#create` (self-block) had none either — so a sole admin self-blocking, or any `users.block` holder blocking the sole admin, was a *single-request* lockout, no race needed. All three existing guards also counted *blocked* users as admins.

Recovery from zero needs a database console: `users.block` is not admin-only, the Admin group can't be destroyed or renamed, and nobody left can grant membership.

## The fix

One post-condition guard, `AdminFloor.protect!`, wrapping the four mutation sites. It locks the Admin group row, then re-reads whether an active admin remains:

- A **post-condition** doesn't care *how* the rows disappeared, so the `delete_all` bypass stops mattering.
- The **row lock** serializes concurrent mutations, closing the race the pre-checks structurally could not.
- `users.active` makes the floor *active* admins, fixing the blocked-counted-as-admin hole in one place instead of three.
- `had_admin` means an install already at zero isn't wedged out of unrelated membership edits.

The two redundant pre-checks are removed. `GroupMembership#prevent_removing_last_admin` stays as defence in depth for console and `dependent: :destroy` paths, with its predicate aligned to active members.

## Verification

Full suite green on both lanes: **1127 runs, 3842 assertions, 0 failures** on SQLite and on `bin/postgres-dev test`.

The lock itself can't be exercised by any committed test — SQLite drops `FOR UPDATE`, and the interleaving needs two live connections — so it was verified with a throwaway two-thread probe against PostgreSQL. Both threads delete their own membership, then wait on a shared absolute deadline so both reach the post-condition before either commits:

| | result |
|---|---|
| lock removed | 3/3 **FAIL** — both commit, Admin group emptied (reproduces P2) |
| lock in place | 3/3 **PASS** — one commits, one refused, one active admin remains |

That probe also caught a real defect in the first draft: `AdminFloor` issues identical SQL twice on one connection, so the post-condition could be served the pre-mutation answer from the request's query cache. Writes do invalidate that cache today, but the reads are now explicitly `uncached` rather than resting on a caching side effect.


🤖 Generated with [Claude Code](https://claude.com/claude-code)