### PR TITLE
Index invoice_lines by invoice and position

### DIFF
--- a/db/migrate/20260803110000_add_invoice_index_to_invoice_lines.rb
+++ b/db/migrate/20260803110000_add_invoice_index_to_invoice_lines.rb
@@ -1,0 +1,5 @@
+class AddInvoiceIndexToInvoiceLines < ActiveRecord::Migration[8.1]
+  def change
+    add_index :invoice_lines, [ :invoice_id, :position ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_03_100000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_03_110000) do
   create_table "acceptance_submissions", force: :cascade do |t|
     t.integer "attachment_id"
     t.datetime "created_at", null: false
@@ -277,6 +277,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_03_100000) do
     t.text "title"
     t.text "type"
     t.datetime "updated_at", null: false
+    t.index ["invoice_id", "position"], name: "index_invoice_lines_on_invoice_id_and_position"
   end
 
   create_table "invoice_tax_classes", force: :cascade do |t|


### PR DESCRIPTION
Fixes `invoice_lines.invoice_id has no index (perf)` from the consolidated bug list.

`invoice_lines` was the only line table without an index on its owning
document. Every `invoice.invoice_lines` load — edit form, preview, publish,
PDF render, `update_sums`, `setup_tax_classes` — scanned the whole table.

The association is `-> { order(:position, :id) }`, so the index is composite
rather than a bare `invoice_id`; it covers the FK lookup as the leading column
and satisfies the sort. Verified on SQLite:

```
SEARCH invoice_lines USING INDEX index_invoice_lines_on_invoice_id_and_position (invoice_id=?)
```

with no temp b-tree for the ORDER BY.

## Notes

- `delivery_note_lines` already has `[delivery_note_id]` plus a standalone
  `[position]`. Left alone — the perf bug doesn't exist there, and swapping its
  two indexes for a composite is a refactor beyond this report.
- `invoice_tax_classes.invoice_id` is already covered by the leading column of
  `index_invoice_tax_classes_on_invoice_and_product_class`.
- No test: a schema-only change with no behavior to assert, and the repo has no
  index-existence test convention. `db/schema.rb` is the checked-in guard.

## Testing

`bundle exec rails test` — 1118 runs, 3817 assertions, 0 failures, 0 errors.
`pre-commit run --all-files` passes.

Not run through `bin/postgres-dev test`: no lock or concurrency semantics are
involved, and `add_index` is portable. The index name is 45 chars, under
PostgreSQL's 63-char identifier limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)