### PR TITLE
Back group and team name uniqueness with LOWER(name) indexes

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -12,6 +12,10 @@ class Group < ApplicationRecord
 
   validates :name, presence: true, uniqueness: { case_sensitive: false }, length: { maximum: 60 }
   validates :description, length: { maximum: 200 }
+
+  # Backed by the unique LOWER(name) index; the strip keeps padded variants from
+  # slipping past it.
+  normalizes :name, with: ->(v) { v.strip }
   validate :prevent_name_change_if_builtin
 
   before_destroy :prevent_destroy_if_builtin, prepend: true

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -12,6 +12,10 @@ class Team < ApplicationRecord
   validates :name, presence: true, uniqueness: { case_sensitive: false }, length: { maximum: 60 }
   validates :description, length: { maximum: 200 }
 
+  # Backed by the unique LOWER(name) index; the strip keeps padded variants from
+  # slipping past it.
+  normalizes :name, with: ->(v) { v.strip }
+
   before_destroy :prevent_destroy_if_builtin
   before_destroy :prevent_destroy_if_used
 

--- a/db/migrate/20260803120000_case_insensitive_group_and_team_name_indexes.rb
+++ b/db/migrate/20260803120000_case_insensitive_group_and_team_name_indexes.rb
@@ -1,0 +1,26 @@
+class CaseInsensitiveGroupAndTeamNameIndexes < ActiveRecord::Migration[8.1]
+  # Group and Team validate name uniqueness with case_sensitive: false, but the
+  # indexes were byte-exact, so the DB never backed the validation. Swap them
+  # for LOWER(name) indexes, matching the matchcode indexes on customers/projects.
+  #
+  # Strip first: Group/Team now normalize name with .strip, and an unstripped
+  # existing row would no longer be findable by its own name.
+  #
+  # This will crash if the resulting uniqueness is not satisfied.
+  def up
+    execute "UPDATE groups SET name = TRIM(name) WHERE name <> TRIM(name)"
+    execute "UPDATE teams SET name = TRIM(name) WHERE name <> TRIM(name)"
+
+    remove_index :groups, :name, name: "index_groups_on_name"
+    remove_index :teams, :name, name: "index_teams_on_name"
+    add_index :groups, "LOWER(name)", unique: true, name: "index_groups_on_lower_name"
+    add_index :teams, "LOWER(name)", unique: true, name: "index_teams_on_lower_name"
+  end
+
+  def down
+    remove_index :groups, name: "index_groups_on_lower_name"
+    remove_index :teams, name: "index_teams_on_lower_name"
+    add_index :groups, :name, unique: true, name: "index_groups_on_name"
+    add_index :teams, :name, unique: true, name: "index_teams_on_name"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_03_110000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_03_120000) do
   create_table "acceptance_submissions", force: :cascade do |t|
     t.integer "attachment_id"
     t.datetime "created_at", null: false
@@ -259,7 +259,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_03_110000) do
     t.string "description"
     t.string "name", null: false
     t.datetime "updated_at", null: false
-    t.index ["name"], name: "index_groups_on_name", unique: true
+    t.index "LOWER(name)", name: "index_groups_on_lower_name", unique: true
   end
 
   create_table "invoice_lines", force: :cascade do |t|
@@ -478,8 +478,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_03_110000) do
     t.string "description"
     t.string "name", null: false
     t.datetime "updated_at", null: false
+    t.index "LOWER(name)", name: "index_teams_on_lower_name", unique: true
     t.index ["default"], name: "index_teams_unique_default", unique: true, where: "\"default\""
-    t.index ["name"], name: "index_teams_on_name", unique: true
   end
 
   create_table "user_audit_events", force: :cascade do |t|

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -7,6 +7,15 @@ class GroupTest < ActiveSupport::TestCase
     assert_includes group.errors[:name], "can't be blank"
   end
 
+  test "database rejects names differing only in case" do
+    Group.create!(name: "Marketing")
+    assert_raises(ActiveRecord::RecordNotUnique) { Group.new(name: "marketing").save!(validate: false) }
+  end
+
+  test "name is stripped" do
+    assert_equal "Spaced", Group.create!(name: "  Spaced  ").name
+  end
+
   test "permissions= syncs the join table" do
     group = Group.create!(name: "Test Group")
     group.permissions = %w[customers.view invoices.view]

--- a/test/models/team_test.rb
+++ b/test/models/team_test.rb
@@ -13,6 +13,11 @@ class TeamTest < ActiveSupport::TestCase
     refute dup.valid?
   end
 
+  test "database rejects names differing only in case" do
+    Team.create!(name: "Marketing")
+    assert_raises(ActiveRecord::RecordNotUnique) { Team.new(name: "marketing").save!(validate: false) }
+  end
+
   test "built-in team cannot be destroyed" do
     default = teams(:default)
     refute default.destroy


### PR DESCRIPTION
## The bug

`Group` and `Team` validate `name` with `uniqueness: { case_sensitive: false }`, but `index_groups_on_name` / `index_teams_on_name` were byte-exact. The database never backed the validation:

- `"Sales"` and `"sales"` could both land — the validation only held by luck of serialization.
- A same-name race produced an unrescued `ActiveRecord::RecordNotUnique` 500.

## The fix

- **Migration** — swap both byte-exact indexes for unique `LOWER(name)` expression indexes, mirroring `20260525120000_add_unique_matchcode_indexes.rb`, which fixed the identical bug for `customers.matchcode` / `projects.matchcode`. The index expression now matches the `LOWER(name) = LOWER(?)` query the validation already issues.
- **`normalizes :name, with: ->(v) { v.strip }`** on both models, so `"Sales "` collides with `"Sales"` too.

`normalizes … downcase` — the `User` / `UserEmail` fix — is **not** usable here: `Group::ADMIN_NAME = "Admin"` and `Group#admin?` compare the stored name literally, so downcasing would disable the last-admin protection, the admin-only permission validation, and the permission filter in `Group#permissions=`.

## Notes for review

- **No controller rescue.** `RecordNotUnique` stays the last-resort backstop on a genuine race, matching every other unique index in this repo — `document_numbers`, `sales_tax_product_classes`, and `delivery_notes.invoice_id` all have tests asserting it raises rather than a rescue. Deliberate; say the word if you want the 500 turned into a re-rendered form error instead.
- **The migration fails loudly** if production already holds case-colliding names — no auto-rename. These are tiny hand-curated tables, and a silent rename would be worse than an aborted deploy.
- **The `TRIM` step is not incidental.** `normalizes` applies to finders as well as writes, so an existing unstripped row would stop matching its own name; the migration trims before building the index so the uniqueness check sees post-strip data.
- **The DB-backstop test is in both model tests**, unlike the usual "mirror the fix, test it once" rule — these are two independent indexes with no shared code path, so a test on one does not protect the other. The `.strip` test is in `group_test.rb` only.

## Verification

| Lane | Result |
|---|---|
| `bundle exec rails test` (SQLite) | 1121 runs, 3820 assertions, **0 failures, 0 errors** |
| `./bin/postgres-dev test` (PostgreSQL 17) | 1121 runs, 3820 assertions, **0 failures, 0 errors** |
| `pre-commit run --all-files` | all passed |

Ran on both lanes because expression-index syntax and schema dumping are adapter-specific and production is Postgres. Rollback verified: `db:rollback:primary` restores the byte-exact indexes and re-migrating reproduces the schema exactly.

The three new tests were confirmed failing before the fix — both `RecordNotUnique` assertions reported `nothing was raised`, i.e. the old index accepting a case-dupe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)