### PR TITLE
Leave field names and ids alone when reordering lines

### DIFF
--- a/app/javascript/controllers/base_lines_controller.js
+++ b/app/javascript/controllers/base_lines_controller.js
@@ -124,31 +124,16 @@ export default class extends Controller {
     }
   }
 
+  // Only `position` carries the order. The index inside field names and ids is an
+  // arbitrary nested-attributes key — renumbering it would desync every `<label for>`
+  // in the row, so leave both alone.
   reindexFormFields() {
-    // Update positions based on current DOM order
     this.containerTarget.querySelectorAll('[data-line-index]').forEach((line, index) => {
-      // Update the position field to reflect the new order
       const positionField = line.querySelector('input[name*="[position]"]')
       if (positionField) {
         positionField.value = index + 1 // 1-based positions
       }
 
-      // Update all form fields within this line to use the correct index
-      line.querySelectorAll('input, select, textarea').forEach(field => {
-        const lineType = this.getLineType()
-        if (field.name && field.name.includes(`${lineType}[`)) {
-          // Replace the index in the field name
-          field.name = field.name.replace(new RegExp(`${lineType}\\[\\d+\\]`), `${lineType}[${index}]`)
-        }
-
-        // Also update the id attribute
-        const idPrefix = this.getIdPrefix()
-        if (field.id && field.id.includes(idPrefix)) {
-          field.id = field.id.replace(new RegExp(`${idPrefix}\\d+`), `${idPrefix}${index}`)
-        }
-      })
-
-      // Update the data-line-index attribute
       line.setAttribute('data-line-index', index)
     })
   }
@@ -208,9 +193,5 @@ export default class extends Controller {
   // Abstract methods to be implemented by subclasses
   getLineType() {
     throw new Error('getLineType() must be implemented by subclass')
-  }
-
-  getIdPrefix() {
-    throw new Error('getIdPrefix() must be implemented by subclass')
   }
 }

--- a/app/javascript/controllers/delivery_note_lines_controller.js
+++ b/app/javascript/controllers/delivery_note_lines_controller.js
@@ -4,9 +4,4 @@ export default class extends BaseLinesController {
   getLineType() {
     return 'delivery_note_lines'
   }
-
-  getIdPrefix() {
-    return 'delivery_note_delivery_note_lines_attributes_'
-  }
-
 }

--- a/app/javascript/controllers/invoice_lines_controller.js
+++ b/app/javascript/controllers/invoice_lines_controller.js
@@ -190,9 +190,4 @@ export default class extends BaseLinesController {
   getLineType() {
     return 'invoice_lines'
   }
-
-  getIdPrefix() {
-    return 'invoice_invoice_lines_attributes_'
-  }
-
 }

--- a/app/javascript/controllers/offer_milestones_controller.js
+++ b/app/javascript/controllers/offer_milestones_controller.js
@@ -52,5 +52,4 @@ export default class extends BaseLinesController {
   }
 
   getLineType() { return 'offer_milestones' }
-  getIdPrefix() { return 'offer_draft_version_attributes_milestones_attributes_' }
 }

--- a/test/system/offer_form_test.rb
+++ b/test/system/offer_form_test.rb
@@ -32,6 +32,22 @@ class OfferFormTest < ApplicationSystemTestCase
     assert_equal [ 1, 2 ], milestones.map(&:position)
   end
 
+  test "clicking a milestone label reaches its own row after reordering" do
+    version = offers(:draft_offer).draft_version
+    version.milestones.create!(position: 2, title: "Middle", amount: 100, trigger: "on_acceptance")
+    visit edit_offer_path(offers(:draft_offer))
+    within all("[data-line-index]").last do
+      click_on "▲"
+    end
+    within first("[data-line-index]") do
+      find("label", text: "Skip delivery note").click
+    end
+    click_on "Save"
+    assert_text "Offer updated"
+    milestones = offers(:draft_offer).reload.draft_version.milestones
+    assert_equal [ [ "Middle", true ], [ "Concept", false ] ], milestones.map { |m| [ m.title, m.skip_delivery_note ] }
+  end
+
   test "milestone description and skip flag are not dropped on submit" do
     visit edit_offer_path(offers(:draft_offer))
     within first("[data-line-index]") do


### PR DESCRIPTION
`reindexFormFields()` renumbered every field's `id` to the new DOM index but never touched the sibling `<label for>`. After a ▲/▼ reorder, each offer-milestone label pointed at a field that had moved to a different row: clicking **Skip delivery note** on one milestone toggled another milestone's checkbox, and the wrong flag was saved.

The renumbering has no purpose — `position` carries the order, and the index inside `offer[draft_version_attributes][milestones_attributes][…]` is an arbitrary nested-attributes key. The paired name-rewrite branch never matched anything either (it tested for `invoice_lines[` against the real `invoice_lines_attributes[`, likewise for delivery notes and milestones), so it went with it. `getIdPrefix()` then had no callers and is removed from the base class and all three subclasses.

Invoice and delivery-note line partials use bare `%label` with no `for`, so only the milestone form was user-visibly affected.

## Test

New system test reorders two milestones, clicks the first row's **Skip delivery note** label, and asserts the flag landed on that milestone. It fails on `main` with the flags swapped:

```
--- expected
+++ actual
-[["Middle", true], ["Concept", false]]
+[["Middle", false], ["Concept", true]]
```

`bundle exec rails test` — 1118 runs, 0 failures. `npm run lint` and `pre-commit run --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)