### PR TITLE
Stop persisting the DRAFT sentinel during invoice preview

### DIFF
--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -104,9 +104,11 @@ class InvoicesController < ApplicationController
     pdf = nil
 
     ActiveRecord::Base.transaction(requires_new: true) do
-      @invoice.document_number = "DRAFT"
       publisher.prepare!
       problems = @invoice.publish_problems
+      # After prepare!'s save: document_number is UNIQUE, and persisting the
+      # sentinel would block every other preview until this render finishes.
+      @invoice.document_number = "DRAFT"
       pdf = InvoiceRenderer.new(@invoice, issuer).render if problems.empty?
       raise ActiveRecord::Rollback, "preview only"
     end


### PR DESCRIPTION
## Root cause

`InvoicesController#preview` assigned the sentinel *before* `InvoicePublisher#prepare!`:

```ruby
@invoice.document_number = "DRAFT"
publisher.prepare!          # -> @invoice.save
```

`prepare!`'s `save` therefore wrote `"DRAFT"` into `invoices.document_number`, which carries a **UNIQUE** index (`index_invoices_on_document_number`). The preview transaction then held that index entry across the entire FOP render before rolling back. There is no model-level uniqueness validation, so nothing intercepts the write.

## Measured impact

Two concurrent previews of **different** invoices, run through the real code path (`InvoicePublisher#prepare!` on separate connections) against Postgres 17. Holder holds for 3 s; waiter starts 1 s in:

| sentinel assigned | waiter's `prepare!` | |
|---|---|---|
| before `prepare!` (old) | **2008 ms** | blocked until the holder rolled back |
| after `prepare!` (new) | **34 ms** | no wait — completed ~2 s before the holder released |

So the sentinel turned what should be a per-invoice row lock into an **app-wide serialization point across all invoice previews**, for the full duration of each FOP render.

No 500 path in practice: the transaction always rolls back, so a committed `'DRAFT'` never exists and `RecordNotUnique` does not fire. The cost is the serialization, plus needless write traffic on a GET.

## Fix

Move the assignment after `prepare!` so the sentinel is in-memory only:

```ruby
publisher.prepare!
problems = @invoice.publish_problems
@invoice.document_number = "DRAFT"
```

`InvoiceRenderer` reads `@invoice.document_number` off the in-memory object (`emit_xml` → `xml_root.number`), so the rendered PDF is unchanged. The surrounding transaction stays — `prepare!` legitimately persists the customer snapshot and `invoice_tax_classes`, and the renderer reads those back from the DB.

Side benefit: a preview of an otherwise-unchanged invoice now issues no `UPDATE` at all, where before the sentinel guaranteed one every time.

`DeliveryNotesController#preview` and `OffersController#preview` already render without persisting anything — invoice preview was the outlier, so there is nothing to mirror.

## Residual, unchanged by this PR

Preview still writes its own invoice row inside the transaction, so **two previews of the same invoice** still serialize (measured: 2030 ms under the same setup). That is a per-document lock, which is the expected shape. Whether preview should write at all is a separate design question.

## Verification

- `bundle exec rails test` — 1118 runs, 3817 assertions, 0 failures
- `./bin/postgres-dev test` — 1118 runs, 3817 assertions, 0 failures
- `pre-commit run --all-files` — passed
- concurrency measured directly on Postgres 17 (table above), via a throwaway threaded harness that is not part of the suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)