### PR TITLE
Fix the searchable dropdown's XSS and its error/race handling

### DIFF
--- a/app/javascript/controllers/error_notification_controller.js
+++ b/app/javascript/controllers/error_notification_controller.js
@@ -42,7 +42,9 @@ export default class extends Controller {
   handleFetchError(event) {
     const error = {
       id: Date.now(),
-      message: "Connection failed - server unreachable",
+      // Turbo's own event carries only the failed request; controllers that
+      // dispatch this event for a server error pass the message along.
+      message: event.detail?.message || "Connection failed - server unreachable",
       timestamp: new Date(),
       type: "network"
     }

--- a/app/javascript/controllers/error_notification_controller.js
+++ b/app/javascript/controllers/error_notification_controller.js
@@ -6,6 +6,7 @@ export default class extends Controller {
 
   connect() {
     this.errors = []
+    this.nextErrorId = 1
     this.maxErrorsValue = this.maxErrorsValue || 5
     this.updateDisplay()
 
@@ -41,7 +42,7 @@ export default class extends Controller {
 
   handleFetchError(event) {
     const error = {
-      id: Date.now(),
+      id: this.nextErrorId++,
       // Turbo's own event carries only the failed request; controllers that
       // dispatch this event for a server error pass the message along.
       message: event.detail?.message || "Connection failed - server unreachable",
@@ -53,7 +54,7 @@ export default class extends Controller {
 
   handleFrameMissing(event) {
     const error = {
-      id: Date.now(),
+      id: this.nextErrorId++,
       message: "Page content missing or server error",
       timestamp: new Date(),
       type: "server"
@@ -65,7 +66,7 @@ export default class extends Controller {
     const response = event.detail.fetchResponse
     if (response && !response.succeeded) {
       const error = {
-        id: Date.now(),
+        id: this.nextErrorId++,
         message: `Form submission failed (${response.statusCode || 'Unknown error'})`,
         timestamp: new Date(),
         type: "form"
@@ -76,7 +77,7 @@ export default class extends Controller {
 
   handleOffline(event) {
     const error = {
-      id: Date.now(),
+      id: this.nextErrorId++,
       message: "You are now offline",
       timestamp: new Date(),
       type: "network"
@@ -187,7 +188,7 @@ export default class extends Controller {
   testError(event) {
     const message = event?.params?.message || "Test error"
     const error = {
-      id: Date.now(),
+      id: this.nextErrorId++,
       message: message,
       timestamp: new Date(),
       type: "test"

--- a/app/javascript/controllers/searchable_dropdown_controller.js
+++ b/app/javascript/controllers/searchable_dropdown_controller.js
@@ -264,13 +264,31 @@ export default class extends Controller {
   }
 
   updateSelectDisplay(item) {
+    this.renderSelection(item.name, item.subtext)
+  }
+
+  // Build the display as DOM nodes. Name and subtext are read back out of the
+  // option markup through textContent, which undoes the server's escaping, so
+  // interpolating them into innerHTML re-parses a customer named
+  // "<img onerror=...>" as markup. Pass a Node as subtext to keep the option's
+  // own subtext markup (matchcode plus any icons).
+  renderSelection(name, subtext) {
     const display = this.selectTarget.querySelector('.select-display')
-    if (display) {
-      display.innerHTML = `
-        <div class="fw-normal">${item.name}</div>
-        <div class="small text-muted">${item.subtext}</div>
-      `
+    if (!display) return
+
+    const nameElement = document.createElement('div')
+    nameElement.className = 'fw-normal'
+    nameElement.textContent = name
+
+    const subtextElement = document.createElement('div')
+    subtextElement.className = 'small text-muted'
+    if (subtext instanceof Node) {
+      subtextElement.append(...subtext.cloneNode(true).childNodes)
+    } else {
+      subtextElement.textContent = subtext || ''
     }
+
+    display.replaceChildren(nameElement, subtextElement)
   }
 
   validateCurrentItem() {
@@ -455,19 +473,10 @@ export default class extends Controller {
         const selectedOption = this.dropdownTarget.querySelector(`[data-item-id="${this.currentItemIdValue}"]`)
 
         if (selectedOption) {
-          const name = selectedOption.querySelector('.fw-normal').textContent
-          const subtextElement = selectedOption.querySelector('.small')
-
-          let subtextHTML = ''
-          if (subtextElement) {
-            // Preserve the entire structure of the subtext, including any icons or additional elements
-            subtextHTML = subtextElement.innerHTML
-          }
-
-          display.innerHTML = `
-            <div class="fw-normal">${name}</div>
-            <div class="small text-muted">${subtextHTML}</div>
-          `
+          this.renderSelection(
+            selectedOption.querySelector('.fw-normal').textContent,
+            selectedOption.querySelector('.small')
+          )
           this.markAsValid()
         } else {
           // Item not found in new options - try to restore from stored display

--- a/app/javascript/controllers/searchable_dropdown_controller.js
+++ b/app/javascript/controllers/searchable_dropdown_controller.js
@@ -142,10 +142,8 @@ export default class extends Controller {
         }
       })
 
-      if (!response.ok) {
-        this.handleError(`Failed to load ${this.itemNameValue}s: ${await this.responseErrorMessage(response)}`)
-        this.restoreDisplayOrShowError()
-        this.isLoading = false
+      if (!response.ok || response.redirected) {
+        this.reportLoadFailure(`Failed to load ${this.itemNameValue}s: ${await this.responseErrorMessage(response)}`)
         return
       }
 
@@ -161,10 +159,15 @@ export default class extends Controller {
 
       Turbo.renderStreamMessage(turboStreamHtml)
     } catch (error) {
-      this.handleError(`Error loading ${this.itemNameValue}s: ${error.message}`)
-      this.restoreDisplayOrShowError()
-      this.isLoading = false
+      this.reportLoadFailure(`Error loading ${this.itemNameValue}s: ${error.message}`)
     }
+  }
+
+  reportLoadFailure(message) {
+    this.handleError(message)
+    this.showDropdownMessage(`Could not load ${this.itemNameValue}s`)
+    this.restoreDisplayOrShowError()
+    this.isLoading = false
   }
 
   handleError(message) {
@@ -176,8 +179,12 @@ export default class extends Controller {
   }
 
   // Prefer the server's JSON error field. Error responses that render HTML
-  // report their status instead: their body is a whole page.
+  // report their status instead: their body is a whole page. A permission
+  // denial or an expired session answers a turbo_stream request with a
+  // redirect, which fetch follows into a 200 that renders as nothing.
   async responseErrorMessage(response) {
+    if (response.redirected) return "not signed in or not permitted"
+
     const body = await response.text().catch(() => '')
 
     try {
@@ -469,10 +476,17 @@ export default class extends Controller {
       display.innerHTML = `<span class="text-muted">${this.dependentSelectPromptValue}</span>`
     }
 
+    this.showDropdownMessage(this.dependentSelectPromptValue)
+  }
+
+  showDropdownMessage(message) {
     const dropdownContent = this.dropdownTarget.querySelector('.dropdown-content')
-    if (dropdownContent) {
-      dropdownContent.innerHTML = `<div class="dropdown-item text-muted">${this.dependentSelectPromptValue}</div>`
-    }
+    if (!dropdownContent) return
+
+    const item = document.createElement('div')
+    item.className = 'dropdown-item text-muted'
+    item.textContent = message
+    dropdownContent.replaceChildren(item)
   }
 
   hideLoading() {

--- a/app/javascript/controllers/searchable_dropdown_controller.js
+++ b/app/javascript/controllers/searchable_dropdown_controller.js
@@ -56,33 +56,25 @@ export default class extends Controller {
     }
 
     // Remove dependent field event listeners
-    if (this.hasDependentFieldTarget) {
-      this.dependentFieldTarget.removeEventListener('blur', this.boundDependentChangedHandler)
-      this.dependentFieldTarget.removeEventListener('change', this.boundDependentChangedHandler)
-      this.dependentFieldTarget.removeEventListener('input', this.boundDependentChangedHandler)
-    } else if (this.dependentFieldSelectorValue) {
-      // Remove external field listeners
-      const externalField = document.querySelector(this.dependentFieldSelectorValue)
-      if (externalField) {
-        externalField.removeEventListener('change', this.boundDependentChangedHandler)
-        externalField.removeEventListener('input', this.boundDependentChangedHandler)
-      }
+    if (this.dependentField) {
+      this.dependentField.removeEventListener('blur', this.boundDependentChangedHandler)
+      this.dependentField.removeEventListener('change', this.boundDependentChangedHandler)
+      this.dependentField.removeEventListener('input', this.boundDependentChangedHandler)
+      this.dependentField = null
     }
   }
 
   setupEventListeners() {
-    // Listen for dependent field changes
-    if (this.hasDependentFieldTarget) {
-      this.dependentFieldTarget.addEventListener('blur', this.boundDependentChangedHandler)
-      this.dependentFieldTarget.addEventListener('change', this.boundDependentChangedHandler)
-      this.dependentFieldTarget.addEventListener('input', this.boundDependentChangedHandler)
-    } else if (this.dependentFieldSelectorValue) {
-      // Use document selector if no local target is available
-      const externalField = document.querySelector(this.dependentFieldSelectorValue)
-      if (externalField) {
-        externalField.addEventListener('change', this.boundDependentChangedHandler)
-        externalField.addEventListener('input', this.boundDependentChangedHandler)
-      }
+    // Listen for dependent field changes. Resolve the field once and keep the
+    // node: disconnect() has to hand removeEventListener the very node the
+    // listeners went on, and a Turbo render can put a different node behind
+    // the selector in between.
+    this.dependentField = this.resolveDependentField()
+
+    if (this.dependentField) {
+      this.dependentField.addEventListener('blur', this.boundDependentChangedHandler)
+      this.dependentField.addEventListener('change', this.boundDependentChangedHandler)
+      this.dependentField.addEventListener('input', this.boundDependentChangedHandler)
     }
 
     // Setup search functionality
@@ -96,6 +88,12 @@ export default class extends Controller {
 
     // Close dropdown when clicking outside
     document.addEventListener('click', this.boundDocumentClickHandler)
+  }
+
+  resolveDependentField() {
+    if (this.hasDependentFieldTarget) return this.dependentFieldTarget
+    if (this.dependentFieldSelectorValue) return document.querySelector(this.dependentFieldSelectorValue)
+    return null
   }
 
   handleDocumentClick(event) {

--- a/app/javascript/controllers/searchable_dropdown_controller.js
+++ b/app/javascript/controllers/searchable_dropdown_controller.js
@@ -15,6 +15,7 @@ export default class extends Controller {
   }
 
   connect() {
+    this.loadSequence = 0
     this.boundDocumentClickHandler = this.handleDocumentClick.bind(this)
     this.boundDependentChangedHandler = this.dependentChanged.bind(this)
     this.boundFilterOptions = this.filterOptions.bind(this)
@@ -36,6 +37,10 @@ export default class extends Controller {
   }
 
   disconnect() {
+    // Abandon whatever load is in flight
+    this.loadSequence++
+    this.stopObservingDropdown()
+
     // Remove document event listener
     document.removeEventListener('click', this.boundDocumentClickHandler)
 
@@ -117,6 +122,8 @@ export default class extends Controller {
   }
 
   async loadItems() {
+    const sequence = ++this.loadSequence
+
     try {
       // Store current display before potentially showing loading
       this.storeCurrentDisplay()
@@ -142,12 +149,15 @@ export default class extends Controller {
         }
       })
 
+      if (this.superseded(sequence)) return
+
       if (!response.ok || response.redirected) {
         this.reportLoadFailure(`Failed to load ${this.itemNameValue}s: ${await this.responseErrorMessage(response)}`)
         return
       }
 
       const turboStreamHtml = await response.text()
+      if (this.superseded(sequence)) return
 
       // Use MutationObserver to watch for DOM changes
       this.observeDropdownChanges(() => {
@@ -159,8 +169,18 @@ export default class extends Controller {
 
       Turbo.renderStreamMessage(turboStreamHtml)
     } catch (error) {
+      if (this.superseded(sequence)) return
+
       this.reportLoadFailure(`Error loading ${this.itemNameValue}s: ${error.message}`)
     }
+  }
+
+  // A dependent field can change again while a load is in flight. Only the
+  // newest load may render: an older one would push options for the wrong
+  // dependent into the list, and its observer would fire on the newer load's
+  // render and tear that one down before it attached its listeners.
+  superseded(sequence) {
+    return sequence !== this.loadSequence
   }
 
   reportLoadFailure(message) {
@@ -234,6 +254,8 @@ export default class extends Controller {
   }
 
   observeDropdownChanges(callback) {
+    this.stopObservingDropdown()
+
     const observer = new MutationObserver((mutations) => {
       // The Turbo Stream re-render always adds .dropdown-content, even when
       // there are no options (empty-state message only)
@@ -246,16 +268,25 @@ export default class extends Controller {
       )
 
       if (contentReplaced) {
-        observer.disconnect()
+        this.stopObservingDropdown()
         callback()
       }
     })
+
+    this.dropdownObserver = observer
 
     // Observe changes to the dropdown target
     observer.observe(this.dropdownTarget, {
       childList: true,
       subtree: true
     })
+  }
+
+  stopObservingDropdown() {
+    if (this.dropdownObserver) {
+      this.dropdownObserver.disconnect()
+      this.dropdownObserver = null
+    }
   }
 
   selectItem(item) {

--- a/app/javascript/controllers/searchable_dropdown_controller.js
+++ b/app/javascript/controllers/searchable_dropdown_controller.js
@@ -142,23 +142,24 @@ export default class extends Controller {
         }
       })
 
-      if (response.ok) {
-        const turboStreamHtml = await response.text()
-
-        // Use MutationObserver to watch for DOM changes
-        this.observeDropdownChanges(() => {
-          this.attachOptionEventListeners()
-          this.reattachSearchListener()
-          this.validateCurrentItem()
-          this.hideLoading()
-        })
-
-        Turbo.renderStreamMessage(turboStreamHtml)
-      } else {
-        this.handleError(`Failed to load ${this.itemNameValue}s: ${response.statusText}`)
+      if (!response.ok) {
+        this.handleError(`Failed to load ${this.itemNameValue}s: ${await this.responseErrorMessage(response)}`)
         this.restoreDisplayOrShowError()
         this.isLoading = false
+        return
       }
+
+      const turboStreamHtml = await response.text()
+
+      // Use MutationObserver to watch for DOM changes
+      this.observeDropdownChanges(() => {
+        this.attachOptionEventListeners()
+        this.reattachSearchListener()
+        this.validateCurrentItem()
+        this.hideLoading()
+      })
+
+      Turbo.renderStreamMessage(turboStreamHtml)
     } catch (error) {
       this.handleError(`Error loading ${this.itemNameValue}s: ${error.message}`)
       this.restoreDisplayOrShowError()
@@ -169,14 +170,24 @@ export default class extends Controller {
   handleError(message) {
     // Dispatch a custom event to trigger the error notification system
     const errorEvent = new CustomEvent('turbo:fetch-request-error', {
-      detail: {
-        response: {
-          statusCode: 500,
-          statusText: message
-        }
-      }
+      detail: { message }
     })
     document.dispatchEvent(errorEvent)
+  }
+
+  // Prefer the server's JSON error field. Error responses that render HTML
+  // report their status instead: their body is a whole page.
+  async responseErrorMessage(response) {
+    const body = await response.text().catch(() => '')
+
+    try {
+      const error = JSON.parse(body).error
+      if (error) return error
+    } catch {
+      // not a JSON body
+    }
+
+    return response.statusText || `HTTP ${response.status}`
   }
 
   attachOptionEventListeners() {

--- a/test/system/searchable_dropdown_test.rb
+++ b/test/system/searchable_dropdown_test.rb
@@ -45,4 +45,31 @@ class SearchableDropdownTest < ApplicationSystemTestCase
     assert_selector ".error-notification-error-message",
                     text: "Failed to load projects: not signed in or not permitted"
   end
+
+  test "rapid customer switches leave a usable project list" do
+    visit "/invoices/#{@invoice.id}/edit"
+    assert_no_text "Loading...", wait: 10
+
+    switch_customer_twice(customers(:good_eu), customers(:good_national))
+
+    within ".project-dropdown" do
+      find("[data-searchable-dropdown-target='select']").click
+      find(".searchable-option[data-item-id='#{projects(:reusable_project).id}']", wait: 10).click
+    end
+
+    assert_equal projects(:reusable_project).id.to_s,
+                 find("#invoice_project_id", visible: false).value
+  end
+
+  private
+
+  def switch_customer_twice(first, second)
+    page.execute_script(<<~JS)
+      const field = document.querySelector('#invoice_customer_id')
+      field.value = '#{first.id}'
+      field.dispatchEvent(new Event('change', { bubbles: true }))
+      field.value = '#{second.id}'
+      field.dispatchEvent(new Event('change', { bubbles: true }))
+    JS
+  end
 end

--- a/test/system/searchable_dropdown_test.rb
+++ b/test/system/searchable_dropdown_test.rb
@@ -1,0 +1,34 @@
+require "application_system_test_case"
+
+class SearchableDropdownTest < ApplicationSystemTestCase
+  MARKUP_NAME = '<img src=x class="xss-probe">'.freeze
+
+  setup do
+    @invoice = invoices(:draft_invoice)
+  end
+
+  test "pre-selected customer name renders as text, not markup" do
+    @invoice.customer.update_column(:name, MARKUP_NAME)
+    visit "/invoices/#{@invoice.id}/edit"
+
+    # The subtext span appears only once the controller has re-rendered the
+    # display from the loaded options.
+    assert_selector ".customer-dropdown .select-display .small span", wait: 10
+    assert_no_selector ".customer-dropdown img.xss-probe", visible: :all
+    assert_selector ".customer-dropdown .select-display .fw-normal", text: MARKUP_NAME
+  end
+
+  test "customer name picked from the option list renders as text, not markup" do
+    customer = customers(:good_eu)
+    customer.update_column(:name, MARKUP_NAME)
+    visit "/invoices/#{@invoice.id}/edit"
+
+    within ".customer-dropdown" do
+      find("[data-searchable-dropdown-target='select']").click
+      find(".searchable-option[data-item-id='#{customer.id}']", wait: 10).click
+    end
+
+    assert_selector ".customer-dropdown .select-display .fw-normal", text: MARKUP_NAME
+    assert_no_selector ".customer-dropdown img.xss-probe", visible: :all
+  end
+end

--- a/test/system/searchable_dropdown_test.rb
+++ b/test/system/searchable_dropdown_test.rb
@@ -31,4 +31,18 @@ class SearchableDropdownTest < ApplicationSystemTestCase
     assert_selector ".customer-dropdown .select-display .fw-normal", text: MARKUP_NAME
     assert_no_selector ".customer-dropdown img.xss-probe", visible: :all
   end
+
+  test "denied option request reports the failure instead of loading forever" do
+    group_permissions(:admin_projects_view).destroy!
+    visit "/invoices/#{@invoice.id}/edit"
+
+    within ".project-dropdown" do
+      find("[data-searchable-dropdown-target='select']").click
+      assert_selector ".dropdown-content", text: "Could not load projects", wait: 10
+    end
+
+    find("[data-controller='error-notification'] .nav-link").click
+    assert_selector ".error-notification-error-message",
+                    text: "Failed to load projects: not signed in or not permitted"
+  end
 end


### PR DESCRIPTION
Six independent JS fixes from the audit list, one per commit.

- **Render dropdown selections as DOM nodes** (JS4) — the dropdown read the display name back out of the option markup with `textContent`, undoing the server's escaping, and pushed it into `innerHTML`. A customer named `<img …>` injected an element into the select display, both on click and on every page load with a pre-selected customer. CSP blocks script execution, so the impact was defacement, same posture as #608.
- **Surface the real error behind a failed dropdown load** (JS1) — every failure reached the navbar notification as "Connection failed - server unreachable": the dropdown never read the response and the notification discarded its event.
- **Report denied dropdown loads instead of leaving "Loading..."** (JS3) — a permission denial answers the turbo_stream request with a redirect; the option list sat at "Loading..." forever. Note: the reported "`response.ok` true, silent no-op" does not happen here — the dashboard's `respond_to` rejects a turbo-stream `Accept`, so the followed redirect 406s. The redirect check still earns its place: it names the actual cause instead of reporting "Not Acceptable".
- **Let only the newest dropdown load render** (JS5) — two quick customer switches left the project list dead. The first response's MutationObserver fired on its own render and disconnected the second response's observer with it, so the second list never got its click listeners. Reproduced in a test before fixing.
- **Give each notification error its own id** (JS8) — errors keyed on `Date.now()` shared an id within a millisecond, so dismissing one removed both.
- **Keep the dropdown's dependent field node for teardown** (JS9 leak) — the field was resolved through a document selector at connect *and* again at disconnect, so after a Turbo render the listeners stayed on the old node.

## Testing

`bundle exec rails test` (1136 runs, 0 failures), `bundle exec rails test test/system/` (76 runs, 0 failures), `npm run lint`.

New system tests in `test/system/searchable_dropdown_test.rb`: XSS on both the load and the click path, the denied-load report, and the two-switch race. Each was confirmed to fail against the unfixed code. The denied-load test also covers JS1, asserting the notification carries the server's reason rather than the generic network text.

No test for JS8 or JS9. The JS9 leak needs a Turbo replacement of the dependent field with the dropdown still mounted and leaves nothing observable behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)