### PR TITLE
Stop orphaning invoice lines and tax classes

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -73,10 +73,10 @@ class Invoice < ApplicationRecord
   has_one :delivery_note, dependent: :nullify
   has_one :offer_milestone
 
-  has_many :invoice_lines, -> { order(:position, :id) }, after_add: :line_addedremoved, after_remove: :line_addedremoved
+  has_many :invoice_lines, -> { order(:position, :id) }, dependent: :delete_all, after_add: :line_addedremoved, after_remove: :line_addedremoved
   accepts_nested_attributes_for :invoice_lines, allow_destroy: true, reject_if: :all_blank
 
-  has_many :invoice_tax_classes
+  has_many :invoice_tax_classes, dependent: :delete_all
 
   before_save :update_customer
   before_save :update_sums

--- a/db/migrate/20260803145012_add_foreign_keys_to_invoice_child_tables.rb
+++ b/db/migrate/20260803145012_add_foreign_keys_to_invoice_child_tables.rb
@@ -1,0 +1,15 @@
+class AddForeignKeysToInvoiceChildTables < ActiveRecord::Migration[8.1]
+  # Invoice declared neither `dependent:` nor a foreign key for its lines and
+  # tax classes, so every destroyed invoice left both behind. delivery_note_lines
+  # has had the matching constraint all along; the invoice side was missed.
+  #
+  # This will crash if rows are already orphaned. What to do with them is the
+  # operator's call, not something to decide silently here:
+  #
+  #   SELECT * FROM invoice_lines WHERE invoice_id NOT IN (SELECT id FROM invoices);
+  #   SELECT * FROM invoice_tax_classes WHERE invoice_id NOT IN (SELECT id FROM invoices);
+  def change
+    add_foreign_key :invoice_lines, :invoices
+    add_foreign_key :invoice_tax_classes, :invoices
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_03_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_03_145012) do
   create_table "acceptance_submissions", force: :cascade do |t|
     t.integer "attachment_id"
     t.datetime "created_at", null: false
@@ -591,6 +591,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_03_120000) do
   add_foreign_key "group_memberships", "groups"
   add_foreign_key "group_memberships", "users"
   add_foreign_key "group_permissions", "groups"
+  add_foreign_key "invoice_lines", "invoices"
+  add_foreign_key "invoice_tax_classes", "invoices"
   add_foreign_key "invoices", "customers"
   add_foreign_key "invoices", "projects"
   add_foreign_key "offer_milestones", "delivery_notes"

--- a/test/models/invoice_test.rb
+++ b/test/models/invoice_test.rb
@@ -424,6 +424,14 @@ class InvoiceTest < ActiveSupport::TestCase
     assert_not(warnings.any? { |w| w.include?("rejected by VIES") })
   end
 
+  test "destroying an invoice deletes its lines and tax classes" do
+    invoice = create_invoice_with_item_line
+
+    assert_difference([ "InvoiceLine.count", "InvoiceTaxClass.count" ], -1) do
+      invoice.destroy
+    end
+  end
+
   test "prelude stores and reads rich text" do
     invoice = invoices(:draft_invoice)
     invoice.update!(prelude: "<div>Hello <strong>world</strong></div>")


### PR DESCRIPTION
## The bug

`Invoice` declared both child associations with no `dependent:` option, and neither table had a foreign key:

```ruby
has_many :invoice_lines, -> { order(:position, :id) }, after_add: ..., after_remove: ...
has_many :invoice_tax_classes
```

So destroying an invoice left both behind. Reproduced on Postgres 17:

```
before destroy -> lines: 1, tax_classes: 1
after  destroy -> lines: 1, tax_classes: 1
```

`InvoicesController#destroy` is reachable for drafts, so these accumulate in production.

## Why it went unnoticed

`Invoice` is the only document model that got this wrong:

| model | association | `dependent:` | FK |
|---|---|---|---|
| `DeliveryNote` | `delivery_note_lines` | `:delete_all` | ✅ |
| `DeliveryNote` | `acceptance_submissions` | `:destroy` | ✅ |
| `Offer` | `versions` | `:destroy` | ✅ |
| `OfferVersion` | `milestones` | `:destroy` | ✅ |
| `Invoice` | `invoice_lines` | ❌ | ❌ |
| `Invoice` | `invoice_tax_classes` | ❌ | ❌ |

Tests never caught it because transactional fixtures roll the orphans back.

## Fix

Mirror the delivery-note shape at both layers:

- `dependent: :delete_all` on both associations. Neither `InvoiceLine` nor `InvoiceTaxClass` has destroy callbacks or children of its own, so `delete_all` is sufficient — same choice as `delivery_note_lines`.
- Foreign keys `invoice_lines → invoices` and `invoice_tax_classes → invoices`, so the DB backstops any path that bypasses the association.

The migration adds the constraints and nothing else. **If rows are already orphaned it will crash** — deciding what to do with them is the operator's call, not something to settle silently during a deploy, so the diagnostic queries sit in a comment instead of a `DELETE`:

```sql
SELECT * FROM invoice_lines WHERE invoice_id NOT IN (SELECT id FROM invoices);
SELECT * FROM invoice_tax_classes WHERE invoice_id NOT IN (SELECT id FROM invoices);
```

Reversible (`db:rollback:primary` verified, then re-migrated).

No index work needed: both child tables already have an index leading with `invoice_id` (`index_invoice_lines_on_invoice_id_and_position` from #647, and `index_invoice_tax_classes_on_invoice_and_product_class`).

No bulk `Invoice` deletes exist anywhere in `app/` or `lib/`, so nothing else trips the new constraint.

## Verification

After the change, on Postgres 17:

```
before destroy -> lines: 1, tax_classes: 1
after  destroy -> lines: 0, tax_classes: 0
FK backstop -> enforced (violates foreign key constraint "fk_rails_93b334df88")
leftover orphans: 0
```

The FK line is a deliberate bypass — a raw `Invoice.where(id: ...).delete_all` that skips the association — confirming the DB layer holds independently of the Rails layer.

- `bundle exec rails test` — 1131 runs, 3848 assertions, 0 failures
- `./bin/postgres-dev test` — 1131 runs, 3848 assertions, 0 failures
- `pre-commit run --all-files` — passed

One regression test added (`destroying an invoice deletes its lines and tax classes`), confirmed failing before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)