### PR TITLE
Extract the invoice header badges into Invoice#status_badges

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -95,6 +95,24 @@ class Invoice < ApplicationRecord
     self.published? && !self.paid? && self.due_date.present? && self.due_date < Date.current
   end
 
+  # Every { level:, text: } the show-page header carries, in render order.
+  # "Booked" means published and nothing more, so it drops as soon as a later
+  # state supersedes it; "Sent" stacks, since email and payment are independent.
+  def status_badges
+    return [ { level: :info, text: "Draft" } ] unless published?
+
+    sent = email_sent_at.present?
+    badges = []
+    badges << { level: :success, text: "Booked" } unless sent || paid? || overdue?
+    if paid?
+      badges << { level: :success, text: "Paid" }
+    elsif overdue?
+      badges << { level: :danger, text: "Overdue" }
+    end
+    badges << { level: :success, text: "Sent" } if sent
+    badges
+  end
+
   # { level:, text: } for the payment column, or nil when there is nothing to
   # warn about (draft, or already paid — each view renders the paid state its
   # own way). Date - Date is whole days, so the day counter is exact in both

--- a/app/views/invoices/show.html.haml
+++ b/app/views/invoices/show.html.haml
@@ -5,20 +5,8 @@
 - pdf_or_preview = @invoice.attachment ? pdf_button(@invoice.attachment) : preview_button(preview_invoice_path(@invoice))
 - delete_action = delete_button(@invoice, confirm: "Are you sure you want to delete invoice \"#{@invoice.display_label}\"?") if !@invoice.published? && can_edit_invoice && !@invoice.offer_milestone
 = breadcrumbs ['Invoices', invoices_path], @invoice.display_label, actions: [pdf_or_preview, delete_action], action: edit_action do
-  - if !@invoice.published?
-    = badge_tag(:info, 'Draft')
-  - else
-    - sent = @invoice.email_sent_at.present?
-    - paid = @invoice.paid?
-    - overdue = @invoice.overdue?
-    - unless sent || paid || overdue
-      = badge_tag(:success, 'Booked')
-    - if paid
-      = badge_tag(:success, 'Paid')
-    - elsif overdue
-      = badge_tag(:danger, 'Overdue')
-    - if sent
-      = badge_tag(:success, 'Sent')
+  - @invoice.status_badges.each do |badge|
+    = status_badge_tag(badge)
 
 -# Single generic-email-preview controller scope so the modal can be rendered
 -# once at the bottom and serve every trigger site on the page.

--- a/test/models/invoice_test.rb
+++ b/test/models/invoice_test.rb
@@ -67,6 +67,26 @@ class InvoiceTest < ActiveSupport::TestCase
     assert_not invoice.overdue?
   end
 
+  test "status_badges drops Booked once a later state supersedes it and stacks Sent" do
+    booked = { level: :success, text: "Booked" }
+    paid = { level: :success, text: "Paid" }
+    overdue = { level: :danger, text: "Overdue" }
+    sent = { level: :success, text: "Sent" }
+    past = 3.days.ago.to_date
+
+    cases = {
+      Invoice.new(published: false) => [ { level: :info, text: "Draft" } ],
+      Invoice.new(published: true) => [ booked ],
+      Invoice.new(published: true, paid_at: Time.current) => [ paid ],
+      Invoice.new(published: true, due_date: past) => [ overdue ],
+      Invoice.new(published: true, email_sent_at: Time.current) => [ sent ],
+      Invoice.new(published: true, paid_at: Time.current, email_sent_at: Time.current) => [ paid, sent ],
+      Invoice.new(published: true, due_date: past, email_sent_at: Time.current) => [ overdue, sent ]
+    }
+
+    cases.each { |invoice, expected| assert_equal expected, invoice.status_badges }
+  end
+
   test "payment_status_badge counts the days to or past the due date" do
     cases = {
       Invoice.new(published: true, due_date: 6.days.from_now.to_date) => { level: :warning, text: "Unpaid, 6d" },


### PR DESCRIPTION
Follows #645. Pure refactor — identical rendered output, verified by the existing `assert_select` assertions on `invoices/show`.

## Why

After #645, invoices were the only document type whose status logic still lived in a template. `DeliveryNote#status_badge` and `Offer#status_badge` are model methods with unit tests; the invoice equivalent was a nine-line cascade in `invoices/show.html.haml`, and the rule it encodes was covered only indirectly:

- **"Booked" drops once a later state supersedes it** — the `unless sent || paid || overdue` guard, which is `docs/code-style.md`'s "hide superseded badges" rule.
- **"Sent" stacks with Paid/Overdue** — email and payment are independent axes.

Both now live in a model method with a table-driven test pinning all seven outcomes.

## Why an array

`status_badges` returns an array where the other two models return one badge. That is the honest shape rather than an inconsistency: an invoice moves along two independent axes, so `Paid` and `Sent` are true at the same time. An offer's lifecycle is one state at a time, so a single badge loses nothing there.

The view becomes:

```haml
- @invoice.status_badges.each do |badge|
  = status_badge_tag(badge)
```

No new helper — `status_badge_tag` already handles one badge, and iterating in the template is clearer than a plural wrapper with a single caller.

## Naming

`status_badges`, not `header_status_badges`. It is used only in the header today, but no model in the repo names a page region, and the sibling `payment_status_badge` names a *facet* rather than a call site. The plural already signals "a stack" without claiming to be the canonical status.

## Verification

- `bundle exec rails test` — 1137 runs, 0 failures
- `bundle exec rails test test/system/` — 72 runs, 0 failures
- rubocop clean

Rendering is unchanged: `invoices_controller_test.rb` and `invoices_controller_paid_test.rb` already assert the header badges (`Draft`, `Booked`, `Overdue`, and the Overdue-vs-Unpaid exclusions) and still pass untouched.

## Not here

The header renders `Booked`, `Sent` and `Paid` all as `:success`, which reads against the "don't spend `:success` on an intermediate rung" rule added in #645. Left alone deliberately so this stays a behaviour-preserving extraction — now that the cascade is a tested model method, changing it is a one-line diff with an obvious test to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)