### PR TITLE
Fix three CSV import bugs

### DIFF
--- a/app/controllers/concerns/upload_checks.rb
+++ b/app/controllers/concerns/upload_checks.rb
@@ -4,10 +4,12 @@
 module UploadChecks
   # Returns :missing, :too_large, :wrong_type, or nil when the file is an
   # acceptable upload of expected_type. Callers map the symbol to their own wording.
+  # expected_type: nil skips the sniff — Marcel reports plain-text formats such
+  # as CSV as application/octet-stream, so an equality check rejects valid input.
   def upload_error(file, expected_type:, max_bytes: Attachment::MAX_SIZE_BYTES)
     return :missing if file.blank? || !file.is_a?(ActionDispatch::Http::UploadedFile)
     return :too_large if file.size > max_bytes
-    return :wrong_type if Attachment.detect_content_type(file.tempfile) != expected_type
+    return :wrong_type if expected_type && Attachment.detect_content_type(file.tempfile) != expected_type
     nil
   end
 

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -3,6 +3,7 @@ class InvoicesController < ApplicationController
   include PublishableDocument
   include DocumentWithLines
   include YearFilteredIndex
+  include UploadChecks
 
   publishable_document :invoice, label: "invoice"
   document_with_lines line_class: InvoiceLine
@@ -139,7 +140,9 @@ class InvoicesController < ApplicationController
   # the editor to inject. Read-only — nothing is persisted here.
   def import_lines
     file = params[:file]
-    raise ArgumentError, "No file uploaded" if file.blank?
+    if (message = csv_upload_error(file))
+      return render json: { error: message }, status: :unprocessable_content
+    end
 
     lines = TymeCsvImporter.new(file, customer: @invoice.customer).lines
     render json: { lines: lines }
@@ -159,6 +162,15 @@ class InvoicesController < ApplicationController
 protected
   def set_invoice
     @invoice = Invoice.visible_to(current_user).find(params[:id])
+  end
+
+  # No content-type sniff: CSV has no magic bytes, and a body that isn't a
+  # Tyme CSV is already rejected by the importer's header check.
+  def csv_upload_error(file)
+    case upload_error(file, expected_type: nil, max_bytes: TymeCsvImporter::MAX_SIZE_BYTES)
+    when :missing then "Please choose a CSV file to import."
+    when :too_large then "CSV file is too large (maximum is #{TymeCsvImporter::MAX_SIZE_MB} MB)."
+    end
   end
 
   # EmailableDocument hooks.

--- a/app/javascript/controllers/invoice_lines_controller.js
+++ b/app/javascript/controllers/invoice_lines_controller.js
@@ -1,11 +1,12 @@
 import BaseLinesController from "controllers/base_lines_controller"
 
 export default class extends BaseLinesController {
-  static targets = ["container", "total", "importError"]
+  static targets = ["container", "total", "importError", "importLabel"]
   static values = { currencySymbol: String, moneyDecimalPlaces: Number, importUrl: String }
 
   connect() {
     super.connect()
+    this.importing = false
     this.updateTotal()
   }
 
@@ -32,11 +33,14 @@ export default class extends BaseLinesController {
   }
 
   // Uploads the CSV and injects the parsed lines into the open editor for review.
+  // Imports append, so a second one starting mid-flight would silently duplicate
+  // every line — hold the picker shut until the first has landed.
   async importCsv(event) {
     const input = event.target
     const file = input.files[0]
-    if (!file) return
+    if (!file || this.importing) return
 
+    this.setImporting(true)
     this.clearImportError()
 
     try {
@@ -66,6 +70,15 @@ export default class extends BaseLinesController {
       this.showError(e.message)
     } finally {
       input.value = "" // allow re-selecting the same file
+      this.setImporting(false)
+    }
+  }
+
+  setImporting(importing) {
+    this.importing = importing
+    if (this.hasImportLabelTarget) {
+      this.importLabelTarget.classList.toggle("disabled", importing)
+      this.importLabelTarget.querySelector('input[type="file"]').disabled = importing
     }
   }
 

--- a/app/services/tyme_csv_importer.rb
+++ b/app/services/tyme_csv_importer.rb
@@ -5,6 +5,10 @@ require "time"
 # per (task, calendar month). Rate comes from the CSV, quantity is the summed
 # duration in decimal hours, and all text is rendered in the customer's locale.
 class TymeCsvImporter
+  # A month of tracked time is a few hundred rows; the cap only has to keep an
+  # unbounded body out of the whole-file read and CSV.parse below.
+  MAX_SIZE_MB = 2
+  MAX_SIZE_BYTES = MAX_SIZE_MB.megabytes
   REQUIRED_COLUMNS = %w[project task start duration rate note].freeze
   LEGAL_SUFFIXES = /\b(gmbh|ag|ltd|inc|llc|kg|co|corp|b\.?v|e\.?u)\.?\b/
 

--- a/app/services/tyme_csv_importer.rb
+++ b/app/services/tyme_csv_importer.rb
@@ -36,11 +36,11 @@ class TymeCsvImporter
     missing = REQUIRED_COLUMNS - table.headers
     raise ArgumentError, "CSV is missing columns: #{missing.join(', ')}" if missing.any?
 
-    table.map do |row|
+    table.each_with_index.map do |row, index|
       {
         client: row["project"],
         task: row["task"],
-        date: Time.parse(row["start"]).to_date,
+        date: parse_date(row["start"], index + 1),
         minutes: row["duration"].to_i,
         rate: row["rate"],
         note: row["note"]
@@ -48,6 +48,14 @@ class TymeCsvImporter
     end
   rescue CSV::MalformedCSVError => e
     raise ArgumentError, "CSV could not be parsed: #{e.message}"
+  end
+
+  # A blank cell reaches Time.parse as nil (TypeError), garbage as a String
+  # (ArgumentError). Both are user input and must surface as one 422.
+  def parse_date(value, row_number)
+    Time.parse(value.to_s).to_date
+  rescue ArgumentError, TypeError
+    raise ArgumentError, "CSV row #{row_number} has an unreadable start value: #{value.inspect}"
   end
 
   def build_line(task, entries)

--- a/app/views/invoices/_form.html.haml
+++ b/app/views/invoices/_form.html.haml
@@ -111,7 +111,7 @@
           = action_buttons_wrapper do
             %button.btn.btn-info{type: 'button', data: {action: 'click->invoice-lines#addLine'}}
               + Add Line
-            %label.btn.btn-outline-secondary.mb-0
+            %label.btn.btn-outline-secondary.mb-0{data: {invoice_lines_target: 'importLabel'}}
               Import CSV
               = file_field_tag :file, accept: 'text/csv,.csv', class: 'd-none', data: {action: 'change->invoice-lines#importCsv'}
 

--- a/test/controllers/invoices_controller_test.rb
+++ b/test/controllers/invoices_controller_test.rb
@@ -535,6 +535,28 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
     assert JSON.parse(response.body)["error"].present?
   end
 
+  test "import_lines rejects a file param that is not an upload" do
+    invoice = create_draft_invoice(cust_reference: "IMPORT")
+
+    post import_lines_invoice_url(invoice),
+      params: { file: "project;task;start;duration;rate;note\nClient;Task;2025-04-01T09:00:00+02:00;60;100;Work\n" }
+
+    assert_response :unprocessable_content
+    assert JSON.parse(response.body)["error"].present?
+  end
+
+  test "import_lines rejects a CSV larger than the import limit" do
+    invoice = create_draft_invoice(cust_reference: "IMPORT")
+    row = "Client;Task;2025-04-01T09:00:00+02:00;60;100;Work\n"
+    oversized = "project;task;start;duration;rate;note\n" +
+      row * (TymeCsvImporter::MAX_SIZE_BYTES / row.bytesize + 1)
+
+    post import_lines_invoice_url(invoice), params: { file: csv_upload(oversized) }
+
+    assert_response :unprocessable_content
+    assert_match(/too large/, JSON.parse(response.body)["error"])
+  end
+
   def csv_upload(body, filename: "import.csv")
     Rack::Test::UploadedFile.new(StringIO.new(body), "text/csv", original_filename: filename)
   end

--- a/test/controllers/invoices_controller_test.rb
+++ b/test/controllers/invoices_controller_test.rb
@@ -524,4 +524,18 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_content
     assert JSON.parse(response.body)["error"].present?
   end
+
+  test "import_lines returns a 422 error when a row has a blank start cell" do
+    invoice = create_draft_invoice(cust_reference: "IMPORT")
+
+    post import_lines_invoice_url(invoice),
+      params: { file: csv_upload("project;task;start;duration;rate;note\nClient;Task;;60;100;Work\n") }
+
+    assert_response :unprocessable_content
+    assert JSON.parse(response.body)["error"].present?
+  end
+
+  def csv_upload(body, filename: "import.csv")
+    Rack::Test::UploadedFile.new(StringIO.new(body), "text/csv", original_filename: filename)
+  end
 end

--- a/test/services/tyme_csv_importer_test.rb
+++ b/test/services/tyme_csv_importer_test.rb
@@ -87,4 +87,16 @@ class TymeCsvImporterTest < ActiveSupport::TestCase
     headerless = "type;project;task\ntimed;X;Y\n"
     assert_raises(ArgumentError) { TymeCsvImporter.new(headerless, customer: customers(:good_eu)).lines }
   end
+
+  test "raises a directed error when a start cell is blank" do
+    csv = "project;task;start;duration;rate;note\nClient;Task;;60;100;Work\n"
+    error = assert_raises(ArgumentError) { TymeCsvImporter.new(csv, customer: customers(:good_eu)).lines }
+    assert_match(/row 1/, error.message)
+  end
+
+  test "raises a directed error when a start cell is not a timestamp" do
+    csv = "project;task;start;duration;rate;note\nClient;Task;whenever;60;100;Work\n"
+    error = assert_raises(ArgumentError) { TymeCsvImporter.new(csv, customer: customers(:good_eu)).lines }
+    assert_match(/row 1/, error.message)
+  end
 end

--- a/test/system/customer_contacts_test.rb
+++ b/test/system/customer_contacts_test.rb
@@ -27,8 +27,12 @@ class CustomerContactsTest < ApplicationSystemTestCase
       click_button "Add"
     end
 
-    # Row appears, add-link resets, no page navigation.
-    new_contact = @customer.customer_contacts.find_by(email: "new@example.com")
+    # Row appears, add-link resets, no page navigation. Wait for the appended
+    # row before querying: click_button returns on dispatch, so a DB read here
+    # races the Turbo submit.
+    assert_selector "#customer_contacts_tbody", text: "New Person"
+
+    new_contact = @customer.customer_contacts.find_by!(email: "new@example.com")
     assert_selector "##{ActionView::RecordIdentifier.dom_id(new_contact)}", text: "New Person"
     assert_selector "#new_customer_contact a", text: "+ Add contact"
     assert_current_path customer_path(@customer)
@@ -117,7 +121,9 @@ class CustomerContactsTest < ApplicationSystemTestCase
       click_button "Add"
     end
 
-    new_contact = empty_customer.customer_contacts.find_by(email: "first@example.com")
+    assert_selector "#customer_contacts_tbody", text: "First Contact"
+
+    new_contact = empty_customer.customer_contacts.find_by!(email: "first@example.com")
     assert_selector "##{ActionView::RecordIdentifier.dom_id(new_contact)}"
     assert_no_selector "#customer_contacts_empty_message"
 

--- a/test/system/invoice_csv_import_test.rb
+++ b/test/system/invoice_csv_import_test.rb
@@ -12,6 +12,7 @@ class InvoiceCsvImportTest < ApplicationSystemTestCase
     attach_file("file", Rails.root.join("test/fixtures/files/tyme_sample.csv"), make_visible: true)
 
     assert_selector "[data-line-index]", count: initial + 3
+    assert_no_selector "input[name='file'][disabled]", visible: :all
     new_lines = all("[data-line-index]").last(3)
 
     titles = new_lines.map { |line| line.find('input[name*="[title]"]').value }


### PR DESCRIPTION
## Summary

Three independent bugs in the invoice CSV import, one commit each.

### A blank `start` cell 500d the import
An empty cell reaches `Time.parse` as `nil`, which raises `TypeError`, but
`import_lines` rescues only `ArgumentError` — so a single blank cell in an
otherwise fine export produced a 500 instead of telling the user which row was
bad. Both `nil` and unparseable strings now surface as one `ArgumentError`
naming the offending row.

### Unbounded, non-file input reached `CSV.parse`
`import_lines` fed any `file` param straight into `TymeCsvImporter`, which
reads the whole thing into a String before parsing (several times its size in
memory) — reachable by any `invoices.edit` holder. Now routed through the
shared `UploadChecks` guard, which also rejects a param that isn't an upload
at all. Cap is `TymeCsvImporter::MAX_SIZE_MB` (2 MB; a month of tracked time
is a few hundred rows). Apache already caps request bodies at 32 MB
(`deploy/apache/abt-app.conf`), but nothing bounded the CSV itself.

Marcel reports CSV as `application/octet-stream` — it has no magic bytes — so
the guard gained an opt-out for the content sniff rather than a bogus
`expected_type`. Non-CSV content is still rejected: binary input raises
`CSV::InvalidEncodingError` (a `MalformedCSVError` subclass, already rescued),
and anything else fails the importer's required-column check.

### No in-flight guard on `importCsv`
Imports append rather than replace, so two overlapping runs both injected
their lines and the editor silently ended up with every row twice. The handler
now holds a flag for the duration and disables the picker while the request is
in flight.

## Testing

- `bundle exec rails test` — 1143 runs, 0 failures (baseline 1138 + 5 new)
- `bundle exec rails test test/system/invoice_csv_import_test.rb` — happy path
  intact; the added assertion was confirmed to fail when the re-enable is
  removed, so it does guard a stuck-disabled picker
- `npm run lint`, `pre-commit run --all-files` — clean

No lock or `with_lock` changes here, so the SQLite lane is sufficient; the
Postgres lane was not required.

The JS re-entry race itself has no automated test — the repo has no JS unit
lane, and forcing a deterministic overlap through Capybara would need the
server stalled mid-request. The guard is a plain flag plus a disabled input.

## Unrelated: flaky contacts system test

CI failed on `CustomerContactsTest#test_empty-state_message_hides_when_first_contact_is_added...`.
Not caused by these changes — both add-contact tests query the database on the
line right after `click_button`, which returns as soon as the click is
dispatched. The Turbo submit was still in flight, so `find_by` returned nil and
`dom_id(nil)` raised. Confirmed by sleeping in `CustomerContactsController#create`,
which reproduces the same `ArgumentError` in both tests; both pass with the wait
in place. Happy to split this into its own PR if you'd rather.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
