### PR TITLE
Dump the database before migrating in production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@
 # Ignore the default SQLite database.
 /db/*.sqlite3*
 
+# Ignore database dumps written by `rails db:backup`.
+/backups
+
 /.generators
 /.idea
 /.rakeTasks

--- a/bin/production-update
+++ b/bin/production-update
@@ -115,6 +115,25 @@ precompile_assets() {
     fi
 }
 
+# Dump the database before migrating. A failed backup aborts the deploy;
+# set SKIP_DB_BACKUP=1 to deploy anyway (e.g. when backups are handled by infra).
+backup_database() {
+    if [[ -n "${SKIP_DB_BACKUP:-}" ]]; then
+        print_warning "SKIP_DB_BACKUP is set; skipping the pre-migration database backup."
+        return 0
+    fi
+
+    print_status "Backing up the database..."
+
+    if bundle exec rails db:backup; then
+        print_success "Database backup completed successfully."
+    else
+        print_error "Database backup failed. Refusing to migrate without a backup."
+        print_error "Fix the backup, or re-run with SKIP_DB_BACKUP=1 to proceed regardless."
+        exit 1
+    fi
+}
+
 # Function to run database migrations
 migrate_database() {
     print_status "Running database migrations..."
@@ -271,6 +290,7 @@ main() {
     update_gems
     install_systemd_units
     precompile_assets
+    backup_database
     migrate_database
     restart_puma
     restart_jobs_worker

--- a/docs/production-update.md
+++ b/docs/production-update.md
@@ -36,13 +36,16 @@ The script sets `RAILS_ENV=production` for the entire session and performs the f
 5. **Asset Compilation**
    - Runs `bundle exec rails assets:precompile`
 
-6. **Database Migration**
+6. **Database Backup**
+   - Runs `bundle exec rails db:backup` (see [Database backups](#database-backups)). A failed backup aborts the deploy before any migration runs; set `SKIP_DB_BACKUP=1` to deploy without one.
+
+7. **Database Migration**
    - Runs `bundle exec rails db:migrate`
 
-7. **Application Restart**
+8. **Application Restart**
    - Runs `systemctl --user reload abt-puma.service`, which `ExecReload`s `SIGUSR2` for a Puma hot-restart. Sub-second window where the listener is briefly closed; Apache buffers the request and retries.
 
-8. **Jobs Worker Restart**
+9. **Jobs Worker Restart**
    - Runs `systemctl --user restart abt-jobs.service` to restart the Solid Queue worker so it picks up new code and updated recurring schedules.
 
 ### Requirements
@@ -101,6 +104,27 @@ resurrect essential rows an operator had removed on purpose.
 The seeded business is a placeholder (`UNCONF` / `Unconfigured Business`). Edit it under
 **Configuration → Business** before publishing the first document — the legal name, VAT
 id, address and bank details all appear on invoice PDFs.
+
+## Database backups
+
+`bundle exec rails db:backup` dumps the **primary** database with `pg_dump --format=custom` and writes it to `backups/<database>-<UTC timestamp>.dump` in the application root — outside `public/`, and git-ignored. The directory is created mode `0700` and each dump is written mode `0600`; a dump is assembled under a `.part` name and renamed only on success, so a failed run never leaves a truncated file that looks complete.
+
+- Requires the `postgresql-client` package (`pg_dump`) on the app host, at a version at least as new as the server.
+- PostgreSQL only. In development (SQLite) the task aborts with an explanatory message.
+- The `cache` and `queue` databases are **not** dumped — they hold transient Solid Cache / Solid Queue state and are rebuilt from `db/cache_schema.rb` and `db/queue_schema.rb`.
+- Override the destination with `ABT_BACKUP_DIR=/srv/backups/abt`.
+
+```bash
+RAILS_ENV=production bundle exec rails db:backup
+```
+
+Restore into an empty database:
+
+```bash
+pg_restore --clean --if-exists --no-owner --dbname=abt_production backups/abt_production-20260803T101500Z.dump
+```
+
+**Retention is not managed.** Every deploy adds a dump and nothing removes old ones — put the directory under whatever rotation/offsite policy the host already uses, or prune it from cron. These files contain all customer and invoice data; they are only as protected as the app host.
 
 ## Apache reverse proxy
 

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,0 +1,45 @@
+namespace :db do
+  desc "Dump the primary database to a timestamped pg_dump file in backups/ (PostgreSQL only; cache/queue databases are not dumped)"
+  task backup: :environment do
+    config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, name: "primary")
+    abort "No primary database configured for #{Rails.env}." if config.nil?
+
+    settings = config.configuration_hash
+    unless settings[:adapter].to_s.start_with?("postgresql")
+      abort "db:backup requires PostgreSQL, but the primary database for #{Rails.env} uses adapter #{settings[:adapter].inspect}."
+    end
+
+    dir = Pathname.new(ENV["ABT_BACKUP_DIR"].presence || Rails.root.join("backups").to_s)
+    FileUtils.mkdir_p(dir, mode: 0o700)
+
+    timestamp = Time.now.utc.strftime("%Y%m%dT%H%M%SZ")
+    target = dir.join("#{settings[:database]}-#{timestamp}.dump")
+    partial = Pathname.new("#{target}.part")
+
+    command = [
+      "pg_dump",
+      "--format=custom",
+      "--no-owner",
+      "--no-privileges",
+      "--file=#{partial}"
+    ]
+    command << "--host=#{settings[:host]}" if settings[:host].present?
+    command << "--port=#{settings[:port]}" if settings[:port].present?
+    command << "--username=#{settings[:username]}" if settings[:username].present?
+    command << "--dbname=#{settings[:database]}"
+
+    env = {}
+    env["PGPASSWORD"] = settings[:password].to_s if settings[:password].present?
+
+    puts "Dumping #{settings[:database]} to #{target} ..."
+    unless system(env, *command)
+      FileUtils.rm_f(partial)
+      abort "pg_dump failed; no backup written. Is the postgresql-client package installed and the database reachable?"
+    end
+
+    File.chmod(0o600, partial)
+    FileUtils.mv(partial, target)
+    puts "Wrote #{target} (#{ActiveSupport::NumberHelper.number_to_human_size(target.size)})."
+    puts "Restore with: pg_restore --clean --if-exists --no-owner --dbname=#{settings[:database]} #{target}"
+  end
+end


### PR DESCRIPTION
`bin/production-update` ran `db:migrate` with no backup step, and the repo had no `db:backup` task — the only mention of backups anywhere was a prose line in `docs/migrate-passenger-to-puma.md` assuming infra handled it.

## `rails db:backup`

- `pg_dump --format=custom --no-owner --no-privileges` of the **primary** database.
- Writes `backups/<database>-<UTC timestamp>.dump` — repo root, outside `public/`, git-ignored. Directory `0700`, file `0600`.
- Assembled under a `.part` name, renamed only on clean exit, so a failed run leaves nothing rather than a truncated file that looks restorable.
- Aborts with the adapter name on non-PostgreSQL (SQLite dev), and on `pg_dump` failure.
- `ABT_BACKUP_DIR` overrides the destination. Prints the matching `pg_restore` command on success.

`cache` and `queue` are not dumped — transient Solid Cache / Solid Queue state, rebuilt from their schema files; a queue dump would capture in-flight jobs too.

## Deploy wiring

`backup_database()` runs between `precompile_assets` and `migrate_database`. Failure aborts the deploy before the schema is touched; `SKIP_DB_BACKUP=1` opts out where infra already covers this.

## Not included

**Retention.** Every deploy adds a dump and nothing removes one. Auto-deleting backups isn't something to add unasked, so the docs point it at existing rotation instead. Also worth stating plainly: these dumps live on the app host at the same durability as the app, and contain all customer and invoice data — better than nothing before a migration, not offsite backup.

## Testing

Against the running PG 17 dev container via the CI lane (`RAILS_ENV=test` + `DATABASE_URL`):

- Dump written; `pg_restore --list` reads it as a valid 414-entry custom archive.
- `git check-ignore` confirms the file is ignored; modes verified `0700`/`0600`.
- Missing-database run exits non-zero with zero `.part` leftovers.
- SQLite dev run aborts with the adapter message.
- `pre-commit run --all-files` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)