### PR TITLE
Seed the issuing business so a fresh install boots

### DIFF
--- a/app/controllers/businesses_controller.rb
+++ b/app/controllers/businesses_controller.rb
@@ -66,7 +66,8 @@ class BusinessesController < ApplicationController
   end
 
   def set_business
-    @business = Business.get_the_issuer! || Business.new
+    @business = Business.get_the_issuer! ||
+      raise(ActiveRecord::RecordNotFound, "No active business; run bin/rails db:seed to create one")
   end
 
   def business_params

--- a/app/views/businesses/show.html.haml
+++ b/app/views/businesses/show.html.haml
@@ -40,7 +40,7 @@
           .col-sm-4
             %strong Address:
           .col-sm-8
-            - @business.address.split("\n").each do |line|
+            - @business.address.to_s.split("\n").each do |line|
               %div= line
 
         .row.mb-2

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -49,7 +49,7 @@
         .mb-2
           %strong Address:
           %div
-            - @data[:business].address.split("\n").each do |line|
+            - @data[:business].address.to_s.split("\n").each do |line|
               %div= line
             %div= country_name(@data[:business].country_iso2)
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -96,30 +96,37 @@ SalesTaxRate.find_or_create_by(
   str.rate = 0.0
 end
 
+Business.find_or_create_by(active: true) do |issuer|
+  issuer.short_name = 'UNCONF'
+  issuer.legal_name = 'Unconfigured Business'
+  issuer.address = "Configure this under\nConfiguration → Business"
+  issuer.country_iso2 = 'AT'
+end
+
 puts "✅ Essential data created"
 
 # Development sample data (only in development environment)
 if Rails.env.development?
   puts "🧪 Creating development sample data..."
 
-  business = Business.find_or_create_by(active: true) do |issuer|
-    issuer.active = true
-    issuer.short_name = 'My Example'
-    issuer.legal_name = 'My Example B.V.'
-    issuer.address = <<~ADDRESS.strip
+  business = Business.get_the_issuer!
+  business.update!(
+    short_name: 'My Example',
+    legal_name: 'My Example B.V.',
+    address: <<~ADDRESS.strip,
       Businessstraat 123
       1234 AB Amsterdam
     ADDRESS
-    issuer.country_iso2 = 'NL'
-    issuer.vat_id = 'NL123456789B01'
-    issuer.bankaccount_bank = "My Bank B.V."
-    issuer.bankaccount_bic = "BICBICBICBIC"
-    issuer.bankaccount_number = "NL91ABNA0417164300"
-    issuer.document_contact_line1 = "www.example.com      hi@example.com"
-    issuer.document_contact_line2 = "voice + xxx xxxxxx"
-    issuer.document_accent_color = "#3366cc"
-    issuer.invoice_footer = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
-  end
+    country_iso2: 'NL',
+    vat_id: 'NL123456789B01',
+    bankaccount_bank: "My Bank B.V.",
+    bankaccount_bic: "BICBICBICBIC",
+    bankaccount_number: "NL91ABNA0417164300",
+    document_contact_line1: "www.example.com      hi@example.com",
+    document_contact_line2: "voice + xxx xxxxxx",
+    document_accent_color: "#3366cc",
+    invoice_footer: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+  )
 
   # Load example logos if they don't exist yet
   if business.pdf_logo.blank?

--- a/docs/production-update.md
+++ b/docs/production-update.md
@@ -81,6 +81,27 @@ If you changed `config/puma.rb` itself, or upgraded the Puma gem, a hot reload w
 systemctl --user restart abt-puma.service
 ```
 
+## First-time database bootstrap
+
+`production-update` only runs `db:migrate`. A brand-new host needs the essential
+data loaded once, before the first login:
+
+```bash
+bundle exec rails db:create   # skip if the database already exists
+bundle exec rails db:migrate
+bundle exec rails db:seed
+bundle exec rails users:invite   # prints the first signup URL
+```
+
+`db:seed` creates the issuing business, the languages, the invoice/delivery-note/offer
+document-number configurations and the sales-tax classes. It is idempotent, but it is
+deliberately *not* part of `production-update`: running it on every deploy would
+resurrect essential rows an operator had removed on purpose.
+
+The seeded business is a placeholder (`UNCONF` / `Unconfigured Business`). Edit it under
+**Configuration → Business** before publishing the first document — the legal name, VAT
+id, address and bank details all appear on invoice PDFs.
+
 ## Apache reverse proxy
 
 Apache terminates TLS on `*:443` and reverse-proxies all dynamic requests to Puma at `127.0.0.1:3000`. Precompiled assets (`/assets`, root-level `favicon.ico`, `robots.txt`, etc.) are served by Apache directly via DocumentRoot, with explicit `ProxyPass !` exclusions ahead of the catch-all proxy.

--- a/test/controllers/businesses_controller_test.rb
+++ b/test/controllers/businesses_controller_test.rb
@@ -158,6 +158,15 @@ class BusinessesControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Offer footer", @business.offer_footer
   end
 
+  test "update on an empty table raises instead of inserting an invisible business" do
+    Business.delete_all
+
+    patch business_url, params: { business: { short_name: "Fresh", legal_name: "Fresh Install GmbH" } }
+
+    assert_response :not_found
+    assert_equal 0, Business.count
+  end
+
   test "should preserve whitespace in contact lines on show page" do
     # Update the fixture to have explicit whitespace
     @business.update!(

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -10,6 +10,13 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     assert_select ".card-body .text-primary", text: /\d+/
   end
 
+  test "should render the dashboard when the business address is blank" do
+    businesses(:one).update!(address: nil)
+
+    get root_url
+    assert_response :success
+  end
+
   test "should display setup warning when not configured" do
     # Clear existing tax configuration. Offers must go first: OfferVersion has
     # a DB-level foreign key to sales_tax_product_classes (unlike invoice


### PR DESCRIPTION
## Problem

`Business` is a singleton the whole app reads through `Business.get_the_issuer!` (`where(active: true).first`) — the application layout, the home dashboard, every mailer, `InvoicePublisher`, `OfferSender`, both renderers, `ViesVerifier` and the currency helpers. It was the one piece of essential data created only inside the `Rails.env.development?` block of `db/seeds.rb`, so on any other fresh database the table is empty and `get_the_issuer!` returns `nil`:

```
GET  /business      -> 500  `.split` on a nil address
GET  /              -> 500  png_logo on nil
POST /invoices      -> 500  money_decimal_places for nil
```

`resource :business` has no `new`/`create`, but `set_business` fell back to `Business.new` and `update` on that new record saved it — with `active = NULL`, because `active` is neither permitted nor defaulted. `get_the_issuer!` never sees such a row, and NULLs don't collide with the unique index on `active`, so every save through `/business/edit` inserted another invisible orphan.

## Changes

- **`db/seeds.rb`** — the Business joins the languages, document numbers and tax classes in the all-environments essential-data block, as an obvious placeholder (`UNCONF` / `Unconfigured Business` / `AT`). No `vat_id`, so nothing fake can reach a rendered PDF; everything else comes from column defaults. The development block now `update!`s that row with the sample values instead of creating its own, so a dev database ends up exactly as before — one row, sample values, example logos.
- **`businesses_controller.rb`** — `set_business` raises `ActiveRecord::RecordNotFound` (→ 404) instead of building a `Business.new`. There is no destroy action for `Business`, so once seeded the row cannot disappear; an empty table means the database was never bootstrapped, and answering that by silently creating a record through a resource with no `create` route is what produced the orphans in the first place.
- **`businesses/show.html.haml`, `home/index.html.haml`** — `address.to_s.split("\n")`. `businesses.address` is nullable, has no presence validation and *is* permitted, so **any existing install can 500 its own home page and business page today** by clearing the address field. Not just a fresh-install symptom.
- **`docs/production-update.md`** — new "First-time database bootstrap" section. Nothing runs `db:seed` on a production host: `production-update` only migrates, and `bin/setup`'s `db:prepare` is dev/test, so a virgin production database has none of the essential data. Documented as a one-time step rather than added to the deploy, which would resurrect essential rows an operator had removed on purpose.

Guarding every `get_the_issuer!` call site was the alternative and isn't realistic — the row is a precondition of the application, not an optional association.

## Verification

- Fresh dev DB via `db:prepare`: 1 row, `active=true`, full sample values, logos loaded.
- Non-development `db:seed` on an emptied table, run twice: 1 row, `valid? == true`, `vat_id` nil, idempotent.
- Throwaway integration probe confirmed `/`, `/business`, `/business/edit` and `/invoices/new` all render against the bare placeholder row.
- New controller test: `PATCH /business` against an empty table returns 404 and leaves the table empty — it inserted an orphan before this change.
- Full suite 1140 runs / 0 failures; system tests 76 runs / 0 failures; `pre-commit run --all-files` clean.

Postgres lane skipped — no lock or concurrency semantics touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)