### PR TITLE
Reject blank issuer email addresses in the database

### DIFF
--- a/app/models/business.rb
+++ b/app/models/business.rb
@@ -11,7 +11,7 @@ class Business < ApplicationRecord
   # CLF). Bounding it also keeps stored values exact on SQLite's float-backed
   # decimal columns.
   validates :money_decimal_places, numericality: { only_integer: true, in: 0..4 }
-  validates :reporting_email, presence: true
+  validates :reporting_email, :document_email_from, presence: true
   validates :reporting_email, :document_email_from, :document_email_auto_bcc, :document_email_reply_to,
             format: { with: URI::MailTo::EMAIL_REGEXP, allow_blank: true }
   validates :website_url, allow_blank: true,

--- a/app/views/businesses/edit.html.haml
+++ b/app/views/businesses/edit.html.haml
@@ -99,7 +99,7 @@
 
           .mb-3
             = form.label :document_email_from, 'Email From', class: 'form-label'
-            = form.email_field :document_email_from, class: 'form-control'
+            = form.email_field :document_email_from, class: 'form-control', required: true
 
           .mb-3
             = form.label :document_email_reply_to, 'Email Reply-To', class: 'form-label'

--- a/db/migrate/20260803194907_require_non_blank_business_emails.rb
+++ b/db/migrate/20260803194907_require_non_blank_business_emails.rb
@@ -1,0 +1,10 @@
+class RequireNonBlankBusinessEmails < ActiveRecord::Migration[8.1]
+  def change
+    # NOT NULL alone still admits "", and mail with a blank sender or recipient
+    # is a silent no-op the report jobs then record as delivered.
+    add_check_constraint :businesses, "trim(reporting_email) <> ''",
+                         name: "businesses_reporting_email_not_blank"
+    add_check_constraint :businesses, "trim(document_email_from) <> ''",
+                         name: "businesses_document_email_from_not_blank"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_03_160219) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_03_194907) do
   create_table "acceptance_submissions", force: :cascade do |t|
     t.integer "attachment_id"
     t.datetime "created_at", null: false
@@ -105,6 +105,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_03_160219) do
     t.integer "vat_id_recheck_days", default: 90, null: false
     t.string "website_url"
     t.index ["active"], name: "index_businesses_on_active", unique: true
+    t.check_constraint "trim(document_email_from) <> ''", name: "businesses_document_email_from_not_blank"
+    t.check_constraint "trim(reporting_email) <> ''", name: "businesses_reporting_email_not_blank"
   end
 
   create_table "customer_contact_projects", force: :cascade do |t|

--- a/test/models/business_test.rb
+++ b/test/models/business_test.rb
@@ -44,11 +44,22 @@ class BusinessTest < ActiveSupport::TestCase
     end
   end
 
-  test "reporting_email is required" do
-    company = businesses(:one)
-    company.reporting_email = ""
-    assert_not company.valid?
-    assert_includes company.errors[:reporting_email], "can't be blank"
+  test "reporting_email and document_email_from are required" do
+    [ :reporting_email, :document_email_from ].each do |field|
+      company = businesses(:one)
+      company.assign_attributes(field => "")
+      assert_not company.valid?, "expected blank #{field} to be invalid"
+      assert_includes company.errors[field], "can't be blank"
+    end
+  end
+
+  test "the database rejects blank sender and reporting addresses when validations are bypassed" do
+    [ :reporting_email, :document_email_from ].each do |field|
+      error = assert_raises(ActiveRecord::StatementInvalid) do
+        Business.transaction(requires_new: true) { businesses(:one).update_column(field, "  ") }
+      end
+      assert_match "businesses_#{field}_not_blank", error.message
+    end
   end
 
   test "valid email values are accepted on all three email fields" do
@@ -76,10 +87,6 @@ class BusinessTest < ActiveSupport::TestCase
   test "get_the_issuer! returns nil when no active issuer exists" do
     businesses(:one).update!(active: false)
     assert_nil Business.get_the_issuer!
-  end
-
-  test "reporting_email backfills from document_email_auto_bcc on existing fixture rows" do
-    assert_equal businesses(:one).document_email_auto_bcc, businesses(:one).reporting_email
   end
 
   test "website_url must be http(s) when present" do


### PR DESCRIPTION
`businesses.reporting_email` and `businesses.document_email_from` are `NOT NULL`,
but that still admits `""` and whitespace-only values — anything that writes those
columns outside the model (`update_column`, a console fix-up, a hand-written SQL
patch) can leave the issuer without a report recipient or without a sender.

Mail with a blank address is a silent no-op under the test and development
delivery methods, and the report jobs treat a completed delivery as proof the
report went out. `ExpiringOffersReportJob` is the worst case: it flips the offers
to `expired` and stamps `reported_expired_at` immediately after `deliver_now`, so
a batch of offers gets marked reported forever without anyone having been told.

This adds `CHECK (trim(<column>) <> '')` on both columns so the invariant holds
where the mailers already rely on it, instead of teaching each of them a
blank-address guard.

`document_email_from` also had no presence validation at all — only a format
check with `allow_blank` — so it gains `validates presence: true` alongside
`reporting_email` and the `required` attribute on its form field. The DB
constraint is the backstop; the validation is what users actually see.

No backfill: the migration fails loudly on a deployment that already holds a
blank value, which is the operator's call to fix.

Also drops `reporting_email backfills from document_email_auto_bcc on existing
fixture rows`, which asserted a property of `businesses.yml` rather than of any
code, and only existed while the backfill migration was new.

## Testing
- `bundle exec rails test` — 1151 runs, 0 failures
- `./bin/postgres-dev test test/models/business_test.rb` — both constraints apply
  and fire on PostgreSQL too (the new test asserts the constraint name in the
  error, so it can't pass on a poisoned transaction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
