### PR TITLE
Validate the invoice index filter param

### DIFF
--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -8,6 +8,8 @@ class InvoicesController < ApplicationController
   publishable_document :invoice, label: "invoice"
   document_with_lines line_class: InvoiceLine
 
+  FILTERS = %w[all unsent unpaid].freeze
+
   before_action -> { require_permission!("invoices.view") }, only: %i[index show preview preview_email preview_email_html]
   before_action -> { require_permission!("invoices.edit") }, only: %i[
     new create edit update destroy
@@ -25,7 +27,7 @@ class InvoicesController < ApplicationController
 
   # GET /invoices
   def index
-    @filter = params[:filter] || "all"
+    @filter = params[:filter].presence_in(FILTERS) || "all"
     @selected_customer_id = integer_param(:customer_id)
 
     @invoices = filtered_by_year(Invoice.visible_to(current_user).ordered)

--- a/test/controllers/invoices_controller_test.rb
+++ b/test/controllers/invoices_controller_test.rb
@@ -6,6 +6,11 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "non-scalar filter param falls back to all" do
+    get invoices_url(filter: { a: "1" })
+    assert_response :success
+  end
+
   test "should get index with year filter" do
     create_draft_invoice(customer: customers(:good_eu), internal_reference: "2023-TEST", date: Date.new(2023, 6, 15))
     create_draft_invoice(internal_reference: "2024-TEST", date: Date.new(2024, 6, 15))


### PR DESCRIPTION
The delivery-note index got `presence_in(EMAIL_FILTERS)` in #642; the invoice index kept `params[:filter] || "all"`.

`GET /invoices?filter[a]=1` puts an `ActionController::Parameters` into `@filter`, which the view hands to `invoices_path(year: year, filter: @filter, ...)` at `index.html.haml:28` — `unable to convert unpermitted parameters to hash`, rendered as a 500.

Same fix and same regression test as the delivery-note side.

## Testing

`bundle exec rails test` — 1152 runs, 0 failures. The new test errors with `ActionView::Template::Error` without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)