### PR TITLE
Harden bulk email id params and the skipped count

### DIFF
--- a/app/controllers/concerns/emailable_document.rb
+++ b/app/controllers/concerns/emailable_document.rb
@@ -107,15 +107,24 @@ module EmailableDocument
   # or is still claimed by a recent send — say so rather than reporting a bare
   # "0 emails queued".
   def bulk_send_document_emails(model, ids_param:, redirect_path:, noun:)
-    ids = (params[ids_param] || []).reject(&:blank?)
+    # permit(key => []) is the shape check: a scalar `?ids=1` or a nested
+    # `?ids[a]=1` is not an array of scalars, so strong params drops it and this
+    # lands on the empty-selection branch instead of raising. Ids that are
+    # garbage or out of column range need no filtering — `where` matches
+    # nothing for them.
+    ids = params.permit(ids_param => []).fetch(ids_param, []).compact_blank
     if ids.empty?
       redirect_to redirect_path, alert: "No #{noun} selected."
       return
     end
 
+    # Counted off the documents that were candidates at all: an id for a draft,
+    # for another team's document, or for nothing must not be reported back as
+    # already sent.
+    candidates = model.visible_to(current_user).where(id: ids, published: true).count
     scope = model.visible_to(current_user).where(id: ids, published: true, email_sent_at: nil)
     queued, skipped = yield(scope)
-    unavailable = ids.length - queued - skipped
+    unavailable = candidates - queued - skipped
 
     notice = "#{queued} emails queued for sending."
     notice += " #{skipped} skipped (no recipients)." if skipped > 0

--- a/app/services/offer_milestone_converter.rb
+++ b/app/services/offer_milestone_converter.rb
@@ -5,16 +5,15 @@ class OfferMilestoneConverter
 
   def initialize(milestone)
     @milestone = milestone
-    @version = milestone.offer_version
-    @offer = @version.offer
   end
 
   private
 
   def conversion_source = @milestone
 
-  # The lock covers the milestone row only, and #initialize captured the version
-  # and offer before it: re-read them so an offer reopened in between is seen.
+  # The lock covers the milestone row only, so the version and offer are read
+  # here rather than in #initialize: an offer reopened between construction and
+  # the lock has to be seen.
   def convert_locked!
     @version = @milestone.offer_version
     @offer = @version.offer

--- a/db/migrate/20260802160000_unique_index_delivery_notes_invoice.rb
+++ b/db/migrate/20260802160000_unique_index_delivery_notes_invoice.rb
@@ -1,4 +1,4 @@
-class UniqueIndexDeliveryNotesInvoice < ActiveRecord::Migration[8.0]
+class UniqueIndexDeliveryNotesInvoice < ActiveRecord::Migration[8.1]
   # This will crash if the uniqueness is not satisfied.
   def up
     remove_index :delivery_notes, :invoice_id

--- a/test/controllers/invoices_controller_email_test.rb
+++ b/test/controllers/invoices_controller_email_test.rb
@@ -215,6 +215,24 @@ class InvoicesControllerEmailTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "bulk_send_emails ignores an ids param that is not an array" do
+    assert_enqueued_emails 0 do
+      post bulk_send_emails_invoices_path, params: { invoice_ids: "1" }
+      post bulk_send_emails_invoices_path, params: { invoice_ids: { a: "1" } }
+    end
+
+    assert_equal "No invoices selected.", flash[:alert]
+  end
+
+  test "bulk_send_emails does not report unsendable ids as already sent" do
+    unsent = invoices(:published_invoice)
+
+    post bulk_send_emails_invoices_path,
+         params: { invoice_ids: [ unsent.id, invoices(:draft_invoice).id ] }
+
+    assert_equal "1 emails queued for sending.", flash[:notice]
+  end
+
   test "bulk_send_emails handles empty selection" do
     post bulk_send_emails_invoices_path, params: { invoice_ids: [] }
 


### PR DESCRIPTION
Review follow-ups on my own merged work (#638, #644).

## The ids param crashed on anything but an array

`bulk_send_document_emails` called `.reject(&:blank?)` straight on `params[ids_param]`, so `POST /invoices/bulk_send_emails` with `invoice_ids=1` raised `NoMethodError: undefined method 'reject' for an instance of String`, and `invoice_ids[a]=1` raised on `Parameters#reject` — a 500 either way.

Strong parameters is the built-in check for exactly this: `params.permit(key => [])` permits an array of permitted scalars and drops anything else, so a scalar or nested value comes back as absent and the action lands on its existing empty-selection branch. `compact_blank` replaces the `.reject(&:blank?)` that was there for empty checkbox values.

Values that are garbage or out of column range are deliberately *not* filtered: `where(id: [...])` matches nothing for them rather than raising. Verified on both adapters, scalar and array — Rails returns 0 rows, no exception. (`params.expect(key => [])` would raise `ParameterMissing` on a missing key, which is wrong here: submitting the form with nothing ticked is a normal case that has to keep producing "No invoices selected.")

## "Already sent or queued" was claimed for ids that were never candidates

`unavailable = ids.length - queued - skipped` counted every submitted id, so a draft, another team's document, an unknown id or a repeated id was reported to the user as already sent. It is now counted off the documents that were actually candidates (`visible_to`, `published`), which also dedupes.

## Also

- `OfferMilestoneConverter#initialize` still loaded the version and offer that `convert_locked!` overwrites since #644 — two wasted queries, and it left pre-lock state reachable, which is what that commit was fixing. The lock-time read is now the only one.
- Migration `20260802160000` was the only one of its same-day siblings declaring `ActiveRecord::Migration[8.0]`; the schema and its neighbours are `[8.1]`.

Not taken from the same review: mapping `RecordNotUnique` to the friendly "already converted" flash. The converter links a delivery note to an invoice it just created, so no other row can hold that id, and the model validation added in #644 would fire first — the raw driver message can't reach the user by that path.

## Testing

Two new tests, both watched failing first: the non-array ids param (crashed with `NoMethodError`), and the draft-invoice selection (reported "1 skipped (already sent or queued)").

Full suite green on both lanes: `bundle exec rails test` (1153 runs, SQLite) and `./bin/postgres-dev test` (1153 runs, PostgreSQL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)