### PR TITLE
Claim a document on single send too

### DIFF
--- a/app/controllers/concerns/emailable_document.rb
+++ b/app/controllers/concerns/emailable_document.rb
@@ -63,6 +63,11 @@ module EmailableDocument
       return
     end
     email_for_sending.deliver_later
+    # Stamped, but never gated on: sending one document is a deliberate act and
+    # must stay available as a resend. Marking it queued is what keeps a bulk
+    # send started before this job runs from queuing the same document again.
+    # Offers reach this action too, and have no bulk send to guard against.
+    document.update_column(:email_queued_at, Time.current) if document.has_attribute?(:email_queued_at)
     respond_to do |format|
       format.html { redirect_to document, notice: "E-Mail queued for sending." }
       format.json { head :ok }

--- a/test/controllers/invoices_controller_email_test.rb
+++ b/test/controllers/invoices_controller_email_test.rb
@@ -206,6 +206,15 @@ class InvoicesControllerEmailTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "send_email claims the invoice so a following bulk send skips it" do
+    invoice = invoices(:published_invoice)
+
+    assert_enqueued_emails 1 do
+      post send_email_invoice_path(invoice)
+      post bulk_send_emails_invoices_path, params: { invoice_ids: [ invoice.id ] }
+    end
+  end
+
   test "bulk_send_emails handles empty selection" do
     post bulk_send_emails_invoices_path, params: { invoice_ids: [] }
 


### PR DESCRIPTION
#638 claimed documents on `email_queued_at` before queuing a bulk send, but left the single-document send path alone. The two paths therefore still duplicate:

1. Open an invoice, click Send E-Mail — job queued, `email_sent_at` still nil (it is stamped on delivery, #345), `email_queued_at` still NULL.
2. Before that job runs, go to the Unsent filter, where the invoice still appears, tick it and submit.
3. `claim_for_email` sees `email_queued_at IS NULL`, claims it, and queues a second copy.

The customer gets the document twice — the exact failure the claim was added to prevent. For delivery notes each send also mints a fresh acceptance token, so the second mail invalidates the link in the first.

`send_email` now stamps `email_queued_at` after enqueuing. It is deliberately **not** gated on the claim: sending one document is an explicit act and has to stay available as a resend, which is why the single path never filtered on `email_sent_at` either. Stamping alone is enough to make the bulk path skip it for `EMAIL_CLAIM_WINDOW`.

Offers reach this shared action too and have no bulk send, so no claim column — hence the attribute check rather than a migration adding a write-only column to `offers`.

## Testing

New test, watched failing first (2 jobs enqueued): a single send followed by a bulk send of the same invoice queues one email. Delivery notes go through the same shared action.

Full suite green on both lanes: `bundle exec rails test` (1152 runs, SQLite) and `./bin/postgres-dev test` (1152 runs, PostgreSQL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)