### PR TITLE
Constrain every belongs_to at the database level

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -67,6 +67,10 @@ class Customer < ApplicationRecord
     offers.exists?
   end
 
+  def used_in_projects?
+    Project.where(bill_to_customer_id: id).exists?
+  end
+
   def can_be_deleted?
     deletion_blocker.nil?
   end
@@ -127,7 +131,8 @@ class Customer < ApplicationRecord
   def deletion_blocker
     return "invoices" if used_in_invoices?
     return "delivery notes" if used_in_delivery_notes?
-    "offers" if used_in_offers?
+    return "offers" if used_in_offers?
+    "projects" if used_in_projects?
   end
 
   def check_if_used

--- a/db/migrate/20260803202821_add_missing_foreign_keys.rb
+++ b/db/migrate/20260803202821_add_missing_foreign_keys.rb
@@ -1,0 +1,36 @@
+class AddMissingForeignKeys < ActiveRecord::Migration[8.1]
+  # Every `belongs_to` in the app now has a matching database constraint. The
+  # tax-class references were previously held together by before_destroy hooks
+  # alone (SalesTaxProductClass#deletion_blocker says as much); projects
+  # .bill_to_customer_id had no guard at all, so a customer used only as a
+  # project's bill-to could be deleted out from under it.
+  #
+  # This will crash if rows already dangle. What to do with them is the
+  # operator's call:
+  #
+  #   SELECT * FROM projects WHERE bill_to_customer_id IS NOT NULL
+  #     AND bill_to_customer_id NOT IN (SELECT id FROM customers);
+  #
+  # ...and the equivalent for each other column below.
+  def change
+    # Indexes first: Postgres scans the referencing table on every parent
+    # delete. sales_tax_rates.sales_tax_customer_class_id is skipped — it is
+    # already the leading column of the composite unique index.
+    add_index :customers, :sales_tax_customer_class_id
+    add_index :products, :sales_tax_product_class_id
+    add_index :sales_tax_rates, :sales_tax_product_class_id
+    add_index :invoice_lines, :sales_tax_product_class_id
+    add_index :invoice_tax_classes, :sales_tax_product_class_id
+    add_index :invoices, :attachment_id
+    add_index :projects, :bill_to_customer_id
+
+    add_foreign_key :customers, :sales_tax_customer_classes
+    add_foreign_key :products, :sales_tax_product_classes
+    add_foreign_key :sales_tax_rates, :sales_tax_customer_classes
+    add_foreign_key :sales_tax_rates, :sales_tax_product_classes
+    add_foreign_key :invoice_lines, :sales_tax_product_classes
+    add_foreign_key :invoice_tax_classes, :sales_tax_product_classes
+    add_foreign_key :invoices, :attachments
+    add_foreign_key :projects, :customers, column: :bill_to_customer_id
+  end
+end

--- a/db/migrate/20260803202822_disallow_null_on_required_associations.rb
+++ b/db/migrate/20260803202822_disallow_null_on_required_associations.rb
@@ -1,0 +1,17 @@
+class DisallowNullOnRequiredAssociations < ActiveRecord::Migration[8.1]
+  # These columns back required `belongs_to` associations, but the database
+  # accepted NULL — so a foreign key alone still let orphans through, the same
+  # gap DisallowNullInvoiceIdOnInvoiceTaxClasses closed for invoice_tax_classes.
+  # invoice_lines.invoice_id is the one that matters most: the mirror column
+  # delivery_note_lines.delivery_note_id has been NOT NULL all along.
+  #
+  # If this fails, the table still holds rows with NULL in these columns —
+  # inspect and resolve them before re-running.
+  def change
+    change_column_null :invoice_lines, :invoice_id, false
+    change_column_null :customers, :sales_tax_customer_class_id, false
+    change_column_null :products, :sales_tax_product_class_id, false
+    change_column_null :sales_tax_rates, :sales_tax_customer_class_id, false
+    change_column_null :sales_tax_rates, :sales_tax_product_class_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_03_194907) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_03_202822) do
   create_table "acceptance_submissions", force: :cascade do |t|
     t.integer "attachment_id"
     t.datetime "created_at", null: false
@@ -169,7 +169,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_03_194907) do
     t.text "offer_milestone_templates_below"
     t.integer "offer_validity_days"
     t.integer "payment_terms_days", default: 30, null: false
-    t.integer "sales_tax_customer_class_id"
+    t.integer "sales_tax_customer_class_id", null: false
     t.text "supplier_number"
     t.integer "team_id", null: false
     t.datetime "updated_at", null: false
@@ -178,6 +178,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_03_194907) do
     t.index "LOWER(matchcode)", name: "index_customers_on_lower_matchcode", unique: true
     t.index ["language_id"], name: "index_customers_on_language_id"
     t.index ["name"], name: "index_customers_on_name"
+    t.index ["sales_tax_customer_class_id"], name: "index_customers_on_sales_tax_customer_class_id"
     t.index ["team_id"], name: "index_customers_on_team_id"
   end
 
@@ -268,7 +269,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_03_194907) do
     t.decimal "amount"
     t.datetime "created_at", null: false
     t.text "description"
-    t.integer "invoice_id"
+    t.integer "invoice_id", null: false
     t.integer "position"
     t.decimal "quantity"
     t.decimal "rate"
@@ -280,6 +281,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_03_194907) do
     t.text "type"
     t.datetime "updated_at", null: false
     t.index ["invoice_id", "position"], name: "index_invoice_lines_on_invoice_id_and_position"
+    t.index ["sales_tax_product_class_id"], name: "index_invoice_lines_on_sales_tax_product_class_id"
   end
 
   create_table "invoice_tax_classes", force: :cascade do |t|
@@ -294,6 +296,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_03_194907) do
     t.datetime "updated_at", null: false
     t.decimal "value"
     t.index ["invoice_id", "sales_tax_product_class_id"], name: "index_invoice_tax_classes_on_invoice_and_product_class", unique: true
+    t.index ["sales_tax_product_class_id"], name: "index_invoice_tax_classes_on_sales_tax_product_class_id"
   end
 
   create_table "invoices", force: :cascade do |t|
@@ -323,6 +326,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_03_194907) do
     t.text "tax_note"
     t.string "token"
     t.datetime "updated_at", null: false
+    t.index ["attachment_id"], name: "index_invoices_on_attachment_id"
     t.index ["date"], name: "index_invoices_on_date"
     t.index ["document_number"], name: "index_invoices_on_document_number", unique: true
     t.index ["paid_at"], name: "index_invoices_on_paid_at"
@@ -415,9 +419,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_03_194907) do
     t.datetime "created_at", null: false
     t.text "description"
     t.decimal "rate"
-    t.integer "sales_tax_product_class_id"
+    t.integer "sales_tax_product_class_id", null: false
     t.string "title"
     t.datetime "updated_at", null: false
+    t.index ["sales_tax_product_class_id"], name: "index_products_on_sales_tax_product_class_id"
     t.index ["title"], name: "index_products_on_title"
   end
 
@@ -431,6 +436,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_03_194907) do
     t.integer "team_id", null: false
     t.datetime "updated_at", null: false
     t.index "LOWER(matchcode)", name: "index_projects_on_lower_matchcode", unique: true
+    t.index ["bill_to_customer_id"], name: "index_projects_on_bill_to_customer_id"
     t.index ["team_id"], name: "index_projects_on_team_id"
   end
 
@@ -457,10 +463,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_03_194907) do
   create_table "sales_tax_rates", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.decimal "rate"
-    t.integer "sales_tax_customer_class_id"
-    t.integer "sales_tax_product_class_id"
+    t.integer "sales_tax_customer_class_id", null: false
+    t.integer "sales_tax_product_class_id", null: false
     t.datetime "updated_at", null: false
     t.index ["sales_tax_customer_class_id", "sales_tax_product_class_id"], name: "index_sales_tax_rates_on_customer_and_product_class", unique: true
+    t.index ["sales_tax_product_class_id"], name: "index_sales_tax_rates_on_sales_tax_product_class_id"
   end
 
   create_table "team_memberships", force: :cascade do |t|
@@ -584,6 +591,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_03_194907) do
   add_foreign_key "customer_vat_verifications", "customers"
   add_foreign_key "customer_vat_verifications", "users", column: "performed_by_user_id"
   add_foreign_key "customers", "languages"
+  add_foreign_key "customers", "sales_tax_customer_classes"
   add_foreign_key "customers", "teams"
   add_foreign_key "delivery_note_lines", "delivery_notes"
   add_foreign_key "delivery_notes", "attachments", column: "acceptance_attachment_id"
@@ -594,7 +602,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_03_194907) do
   add_foreign_key "group_memberships", "users"
   add_foreign_key "group_permissions", "groups"
   add_foreign_key "invoice_lines", "invoices"
+  add_foreign_key "invoice_lines", "sales_tax_product_classes"
   add_foreign_key "invoice_tax_classes", "invoices"
+  add_foreign_key "invoice_tax_classes", "sales_tax_product_classes"
+  add_foreign_key "invoices", "attachments"
   add_foreign_key "invoices", "customers"
   add_foreign_key "invoices", "projects"
   add_foreign_key "offer_milestones", "delivery_notes"
@@ -608,7 +619,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_03_194907) do
   add_foreign_key "offers", "customers"
   add_foreign_key "offers", "offer_versions", column: "accepted_version_id"
   add_foreign_key "offers", "projects"
+  add_foreign_key "products", "sales_tax_product_classes"
+  add_foreign_key "projects", "customers", column: "bill_to_customer_id"
   add_foreign_key "projects", "teams"
+  add_foreign_key "sales_tax_rates", "sales_tax_customer_classes"
+  add_foreign_key "sales_tax_rates", "sales_tax_product_classes"
   add_foreign_key "team_memberships", "teams"
   add_foreign_key "team_memberships", "users"
   add_foreign_key "user_audit_events", "users", column: "actor_user_id", on_delete: :nullify

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -17,15 +17,8 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "should display setup warning when not configured" do
-    # Clear existing tax configuration. Offers must go first: OfferVersion has
-    # a DB-level foreign key to sales_tax_product_classes (unlike invoice
-    # lines/tax classes, which have none), so any fixture referencing a
-    # product class blocks its deletion until the referencing offer is gone.
-    Offer.destroy_all
+  test "should display setup warning when no tax rates are configured" do
     SalesTaxRate.delete_all
-    SalesTaxCustomerClass.delete_all
-    SalesTaxProductClass.delete_all
 
     get root_url
     assert_response :success

--- a/test/models/customer_test.rb
+++ b/test/models/customer_test.rb
@@ -120,6 +120,13 @@ class CustomerTest < ActiveSupport::TestCase
     assert create_customer.destroy
   end
 
+  test "before_destroy rejects destroy when a project bills to the customer" do
+    customer = create_customer
+    Project.create!(matchcode: "BILLTO", bill_to_customer: customer, team: customer.team)
+    assert_not customer.destroy
+    assert_includes customer.errors[:base], "Cannot delete customer that has been used in projects"
+  end
+
   test "before_destroy rejects destroy when delivery notes reference the customer" do
     customer = create_customer
     DeliveryNote.create!(customer: customer, project: projects(:reusable_project), delivery_start_date: Date.current)

--- a/test/models/invoice_test.rb
+++ b/test/models/invoice_test.rb
@@ -230,7 +230,8 @@ class InvoiceTest < ActiveSupport::TestCase
   test "publish_problems reports a missing tax config using the line title" do
     invoice = license_invoice_with_tax_config
     line = invoice.invoice_lines.find_by(type: "item")
-    line.update_columns(sales_tax_product_class_id: 999_999)
+    unconfigured = SalesTaxProductClass.create!(name: "Reduced", indicator_code: "RED")
+    line.update_columns(sales_tax_product_class_id: unconfigured.id)
 
     problems = invoice.reload.publish_problems
     assert(problems.any? { |p| p.include?(line.title) && p.include?("tax configuration") })


### PR DESCRIPTION
Audit of every `*_id` column against the declared foreign keys. Eight `belongs_to` associations had no database constraint, and five columns backing required associations accepted NULL.

## Missing foreign keys

| Table | Column | Association |
|---|---|---|
| `customers` | `sales_tax_customer_class_id` | required |
| `products` | `sales_tax_product_class_id` | required |
| `sales_tax_rates` | `sales_tax_customer_class_id` | required |
| `sales_tax_rates` | `sales_tax_product_class_id` | required |
| `invoice_tax_classes` | `sales_tax_product_class_id` | required |
| `invoice_lines` | `sales_tax_product_class_id` | `optional: true` |
| `invoices` | `attachment_id` | `optional: true` |
| `projects` | `bill_to_customer_id` | `optional: true` |

Each gets a supporting index, since Postgres scans the referencing table on every parent delete. `sales_tax_rates.sales_tax_customer_class_id` needs none — already the leading column of the composite unique index.

Most of these were defense in depth: both tax-class models already blocked deletion in `before_destroy`, and `SalesTaxProductClass` documents exactly why ("only offer_versions has a database foreign key").

## The one live hole

`Customer#deletion_blocker` checked invoices, delivery notes and offers, but never projects — and `projects.bill_to_customer_id` had no foreign key either. A customer referenced solely as a project's bill-to had nothing stopping its deletion, leaving the column dangling and reading as nil through `belongs_to optional: true`. Added `used_in_projects?` to the chain, with a regression test.

## NOT NULL

`invoice_lines.invoice_id`, `customers.sales_tax_customer_class_id`, `products.sales_tax_product_class_id` and both `sales_tax_rates` columns.

`invoice_lines.invoice_id` is the one that matters: its mirror `delivery_note_lines.delivery_note_id` has been NOT NULL all along, and a nullable column let orphaned rows satisfy the foreign key added earlier — the same gap already closed for `invoice_tax_classes`.

## Test changes

Application creates were already covered by the Rails 5+ required `belongs_to` default, and seeds set every association. But two tests were exploiting the absent constraints:

- **`home_controller_test`** deleted every tax class to simulate an unconfigured install; its own comment documented the pre-FK state. Reaching "no tax classes at all" now means demolishing customers, invoices, offers and projects first, so it deletes the tax rates instead — a real limb of the `is_setup_done` chain. Worth noting: the "no classes exist" limbs are no longer reachable in tests without tearing down the fixture graph. That is a genuine coverage reduction, and a direct consequence of the constraints being correct.
- **`invoice_test`** faked a missing tax config with `update_columns(sales_tax_product_class_id: 999_999)`. It now creates a real product class with no configured rate — same branch, and closer to how the problem actually arises.

## Migrations and production data

Neither migration touches data. Both crash on pre-existing orphans and name the `SELECT` to inspect them; what happens to those rows is the operator's call.

## Verification

- SQLite lane: 1152 runs, 3896 assertions, 0 failures, 0 errors (baseline before: 1151, 0 failures)
- **PostgreSQL lane** (`./bin/postgres-dev test`): both migrations apply clean, 1152 runs, 0 failures. FK enforcement differs between engines and production is Postgres, so the SQLite lane alone would not settle this.
- `pre-commit run --all-files` passes
- `db/schema.rb` picked up no PG dialect

🤖 Generated with [Claude Code](https://claude.com/claude-code)