### PR TITLE
Fail loudly when essential seed data can't be created

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -22,16 +22,16 @@ Team.find_or_create_by!(builtin: true, name: Team::DEFAULT_NAME) do |t|
 end
 
 # Languages (required for customer language selection)
-english = Language.find_or_create_by(iso_code: 'en') do |lang|
+english = Language.find_or_create_by!(iso_code: 'en') do |lang|
   lang.title = 'English'
 end
 
-german = Language.find_or_create_by(iso_code: 'de') do |lang|
+german = Language.find_or_create_by!(iso_code: 'de') do |lang|
   lang.title = 'German'
 end
 
 # Document number configuration for invoices
-DocumentNumber.find_or_create_by(code: 'invoice') do |dn|
+DocumentNumber.find_or_create_by!(code: 'invoice') do |dn|
   dn.format = '%{year}%<number>04d'
   dn.sequence = 0
   dn.last_number = nil
@@ -39,7 +39,7 @@ DocumentNumber.find_or_create_by(code: 'invoice') do |dn|
 end
 
 # Document number configuration for delivery notes
-DocumentNumber.find_or_create_by(code: 'delivery_note') do |dn|
+DocumentNumber.find_or_create_by!(code: 'delivery_note') do |dn|
   dn.format = '%{year}%<number>04d'
   dn.sequence = 0
   dn.last_number = nil
@@ -47,7 +47,7 @@ DocumentNumber.find_or_create_by(code: 'delivery_note') do |dn|
 end
 
 # Document number configuration for offers
-DocumentNumber.find_or_create_by(code: 'offer') do |dn|
+DocumentNumber.find_or_create_by!(code: 'offer') do |dn|
   dn.format = '%{date}-%<number>02d'
   dn.sequence = 0
   dn.last_number = nil
@@ -55,48 +55,48 @@ DocumentNumber.find_or_create_by(code: 'offer') do |dn|
 end
 
 # Sales tax customer classes (required for the system to work)
-national_class = SalesTaxCustomerClass.find_or_create_by(name: 'National') do |stcc|
+national_class = SalesTaxCustomerClass.find_or_create_by!(name: 'National') do |stcc|
   stcc.invoice_note = ''
 end
 
-eu_class = SalesTaxCustomerClass.find_or_create_by(name: 'EU') do |stcc|
+eu_class = SalesTaxCustomerClass.find_or_create_by!(name: 'EU') do |stcc|
   stcc.invoice_note = 'Reverse Charge - VAT is payable by the customer'
 end
 
-export_class = SalesTaxCustomerClass.find_or_create_by(name: 'EXPORT') do |stcc|
+export_class = SalesTaxCustomerClass.find_or_create_by!(name: 'EXPORT') do |stcc|
   stcc.invoice_note = 'EXPORT TO NON-EU COUNTRY'
   stcc.vat_id_required = false
 end
 
 # Sales tax product classes
-standard_product = SalesTaxProductClass.find_or_create_by(name: 'Standard Goods') do |stpc|
+standard_product = SalesTaxProductClass.find_or_create_by!(name: 'Standard Goods') do |stpc|
   stpc.indicator_code = 'STD'
   stpc.is_default = true
 end
 
 # Sales tax rates (connecting customer and product classes)
-SalesTaxRate.find_or_create_by(
+SalesTaxRate.find_or_create_by!(
   sales_tax_customer_class: national_class,
   sales_tax_product_class: standard_product
 ) do |str|
   str.rate = 20.0
 end
 
-SalesTaxRate.find_or_create_by(
+SalesTaxRate.find_or_create_by!(
   sales_tax_customer_class: eu_class,
   sales_tax_product_class: standard_product
 ) do |str|
   str.rate = 0.0
 end
 
-SalesTaxRate.find_or_create_by(
+SalesTaxRate.find_or_create_by!(
   sales_tax_customer_class: export_class,
   sales_tax_product_class: standard_product
 ) do |str|
   str.rate = 0.0
 end
 
-Business.find_or_create_by(active: true) do |issuer|
+Business.find_or_create_by!(active: true) do |issuer|
   issuer.short_name = 'UNCONF'
   issuer.legal_name = 'Unconfigured Business'
   issuer.address = "Configure this under\nConfiguration → Business"


### PR DESCRIPTION
`db/seeds.rb` starts with an essential-data block — the rows a fresh install
needs to boot at all: languages, the invoice/delivery-note/offer number formats,
sales tax classes and rates, and the issuing business. Every one of them used
`find_or_create_by`, which returns an **unsaved** record when validation fails
instead of raising. A fresh install would print `✅ Essential data created` and
then come up missing the records every later request depends on — no issuer, no
document numbering, no tax rates.

`Group` and `Team` at the top of the same block already used `find_or_create_by!`;
this brings the remaining 13 call sites in line. Nothing else changes: the same
records, the same attributes, still idempotent on re-run.

The development sample data below the `Rails.env.development?` guard is
deliberately untouched — it is dev-only convenience, and a much larger diff for
much lower stakes.

## Testing
- `bundle exec rails db:reset` then a second `bundle exec rails db:seed` — fresh
  seed and re-seed both clean on SQLite
- `db:drop db:create db:migrate db:seed` plus a repeat `db:seed` against the
  PostgreSQL lane — fresh migrate-from-zero install and re-seed both clean
- `bundle exec rails test` — 1151 runs, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
