### PR TITLE
Let the issuer turn off the automatic BCC

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -20,14 +20,14 @@ class ApplicationMailer < ActionMailer::Base
   end
 
   # Send the standard document email envelope. From comes from the default
-  # configured at class level, bcc from the issuer, reply-to from the issuer
-  # when set (blank → header omitted). No-op when `to` is blank.
+  # configured at class level, bcc and reply-to from the issuer when set
+  # (blank → header omitted). No-op when `to` is blank.
   def document_mail(to:, subject:, cc: nil)
     return if to.blank?
     mail(
       to: to,
       cc: cc,
-      bcc: @issuer.document_email_auto_bcc,
+      bcc: @issuer.document_email_auto_bcc.presence,
       reply_to: @issuer.document_email_reply_to.presence,
       subject: subject
     )

--- a/app/models/business.rb
+++ b/app/models/business.rb
@@ -17,6 +17,7 @@ class Business < ApplicationRecord
   validates :website_url, allow_blank: true,
             format: { with: %r{\Ahttps?://\S+\z}i, message: "must be a valid http:// or https:// URL" }
   normalizes :website_url, with: ->(url) { url.strip }
+  normalizes :document_email_auto_bcc, :document_email_reply_to, with: ->(email) { email.strip.presence }
 
   # This app requires that there is exactly *one* business in the database.
   def self.get_the_issuer!

--- a/db/migrate/20260803213704_make_document_email_auto_bcc_optional.rb
+++ b/db/migrate/20260803213704_make_document_email_auto_bcc_optional.rb
@@ -1,0 +1,17 @@
+class MakeDocumentEmailAutoBccOptional < ActiveRecord::Migration[8.1]
+  def up
+    # Blank means "no BCC", matching document_email_reply_to. Existing rows keep
+    # whatever address they hold; only new installs start without a BCC.
+    change_column_null :businesses, :document_email_auto_bcc, true
+    change_column_default :businesses, :document_email_auto_bcc, from: "bcc@example.com", to: nil
+
+    # "" was the only way to express "no BCC" while the column was NOT NULL.
+    execute "UPDATE businesses SET document_email_auto_bcc = NULL WHERE trim(document_email_auto_bcc) = ''"
+  end
+
+  def down
+    execute "UPDATE businesses SET document_email_auto_bcc = '' WHERE document_email_auto_bcc IS NULL"
+    change_column_default :businesses, :document_email_auto_bcc, from: nil, to: "bcc@example.com"
+    change_column_null :businesses, :document_email_auto_bcc, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_03_202822) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_03_213704) do
   create_table "acceptance_submissions", force: :cascade do |t|
     t.integer "attachment_id"
     t.datetime "created_at", null: false
@@ -86,7 +86,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_03_202822) do
     t.string "document_accent_color"
     t.string "document_contact_line1"
     t.string "document_contact_line2"
-    t.string "document_email_auto_bcc", default: "bcc@example.com", null: false
+    t.string "document_email_auto_bcc"
     t.string "document_email_from", default: "from@example.com", null: false
     t.string "document_email_reply_to"
     t.string "invoice_footer"

--- a/test/controllers/businesses_controller_test.rb
+++ b/test/controllers/businesses_controller_test.rb
@@ -138,6 +138,14 @@ class BusinessesControllerTest < ActionDispatch::IntegrationTest
     assert_equal "reports@example.com", @business.reload.reporting_email
   end
 
+  test "update stores a cleared document_email_auto_bcc as NULL" do
+    patch business_url, params: {
+      business: { document_email_auto_bcc: "" }
+    }
+    assert_redirected_to business_url
+    assert_nil @business.reload.document_email_auto_bcc
+  end
+
   test "update rejects vat_id_recheck_days of zero" do
     original = @business.vat_id_recheck_days
     patch business_url, params: {

--- a/test/fixtures/businesses.yml
+++ b/test/fixtures/businesses.yml
@@ -13,6 +13,7 @@ one:
   bankaccount_bic: BICBICBICBIC
   bankaccount_number: NL91ABNA0417164300
   reporting_email: bcc@example.com
+  document_email_auto_bcc: bcc@example.com
   document_contact_line1: "www.example.com      hi@example.com"
   document_contact_line2: "voice + xxx xxxxxx"
   document_accent_color: "#3366cc"

--- a/test/mailers/invoice_mailer_test.rb
+++ b/test/mailers/invoice_mailer_test.rb
@@ -36,6 +36,13 @@ class InvoiceMailerTest < ActionMailer::TestCase
     assert_nil mail.reply_to
   end
 
+  test "customer_email omits Bcc when the issuer has no auto-BCC configured" do
+    businesses(:one).update!(document_email_auto_bcc: nil)
+    mail = InvoiceMailer.with(invoice: invoices(:published_invoice)).customer_email
+
+    assert_nil mail.bcc
+  end
+
   test "customer_email skips contacts whose project does not match the invoice's project" do
     # good_eu_project_one_lead is scoped to project `one`. An invoice on
     # project `two` should NOT include that contact.


### PR DESCRIPTION
`document_email_auto_bcc` was `NOT NULL` with a `bcc@example.com` default, so an
issuer had no way to say "don't BCC our own outgoing mail". Clearing the field in
the form stored `""` — which the `NOT NULL` happily accepted — and
`ApplicationMailer#document_mail` passed that straight through as the `Bcc`
header, unlike `document_email_reply_to`, which is read through `.presence` so a
blank omits the header.

This makes the column behave exactly like `document_email_reply_to`.

## What changed

| | before | after |
|---|---|---|
| column | `NOT NULL`, default `bcc@example.com` | nullable, no default |
| `document_mail` | `bcc: …auto_bcc` | `bcc: …auto_bcc.presence` |
| blank value | stored as `""` | normalized to `NULL` |

Blank has to mean `NULL` rather than `""`, or the two spellings drift apart again
the moment someone clears the field — the form posts `""`, not `nil`. So the
migration converts existing blanks, and a `normalizes` declaration converts them
on write, for `auto_bcc` and `reply_to` alike. (Rails implements `normalizes` as
an attribute *type*, so it also covers raw writes like `update_column` — only
literal SQL slips past.)

The rest was already consistent with `reply_to` and needed no change: the format
validation carries `allow_blank: true`, the form field has no `required`
attribute, `businesses/show` renders it the same way, and the controller already
permits the param.

An install that has an address configured keeps it. Only fresh installs change:
they start with no BCC instead of the placeholder `bcc@example.com`, which was
never a real mailbox.

## Fixture note

`test/fixtures/businesses.yml` was never setting this column; it was inheriting
the DB default. With the default gone, the two mailer tests asserting
`mail.bcc == ["bcc@example.com"]` began failing on a `nil` Bcc. The fixture now
names the address explicitly, so those tests assert what they were written to
assert.

## Testing
- `bundle exec rails test` — 1158 runs, 0 failures
- `./bin/postgres-dev test test/controllers/businesses_controller_test.rb
  test/mailers/ test/models/business_test.rb` against a dropped-and-recreated
  database — 88 runs, 0 failures, so the change applies migrating from zero on
  PostgreSQL
- Blank-to-`NULL` conversion checked against a `""` written in literal SQL (the
  only way to get one past the normalizer), then `db:migrate:redo` — `""` before,
  `NULL` after, on both SQLite and PostgreSQL. `redo` exercises the `down` path
  too, which has to restore `NOT NULL`.
- `bundle exec rails db:reset` — a fresh install seeds with `auto_bcc = nil` and
  `reply_to = nil`, `document_email_from` still defaulted

🤖 Generated with [Claude Code](https://claude.com/claude-code)
