### PR TITLE
Close the gaps the foreign-key sweep left behind

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -19,6 +19,7 @@ class Customer < ApplicationRecord
   has_many :invoices
   has_many :delivery_notes
   has_many :offers
+  has_many :billed_projects, class_name: "Project", foreign_key: :bill_to_customer_id, inverse_of: :bill_to_customer
   has_many :customer_contacts, dependent: :destroy
   has_many :vat_verifications, class_name: "CustomerVatVerification", dependent: :destroy
 
@@ -68,7 +69,7 @@ class Customer < ApplicationRecord
   end
 
   def used_in_projects?
-    Project.where(bill_to_customer_id: id).exists?
+    billed_projects.exists?
   end
 
   def can_be_deleted?
@@ -142,7 +143,7 @@ class Customer < ApplicationRecord
   end
 
   def sync_project_teams
-    Project.where(bill_to_customer_id: id).update_all(team_id: team_id, updated_at: Time.current)
+    billed_projects.update_all(team_id: team_id, updated_at: Time.current)
   end
 
   def normalise_vat_id

--- a/app/models/sales_tax_product_class.rb
+++ b/app/models/sales_tax_product_class.rb
@@ -27,9 +27,8 @@ class SalesTaxProductClass < ApplicationRecord
     "Cannot delete product tax class that is used in #{blocker}"
   end
 
-  # Every association is checked because only offer_versions has a database
-  # foreign key; nothing else would stop a delete from leaving dangling
-  # references on published invoices.
+  # Every association now has a database foreign key behind it. This check
+  # stays so the user gets a named reason instead of an InvalidForeignKey.
   def deletion_blocker
     return "tax rates" if sales_tax_rates.exists?
     return "products" if products.exists?

--- a/app/views/customers/show.html.haml
+++ b/app/views/customers/show.html.haml
@@ -1,9 +1,10 @@
 - offers_action = nav_button('Offers', offers_path(customer_id: @customer.id, year: 'all'), permission: 'offers.view', data: { turbo_prefetch: false })
 - invoices_action = nav_button('Invoices', invoices_path(customer_id: @customer.id, year: 'all'), permission: 'invoices.view', data: { turbo_prefetch: false })
 - delivery_notes_action = nav_button('Delivery Notes', delivery_notes_path(customer_id: @customer.id, year: 'all'), permission: 'delivery_notes.view', data: { turbo_prefetch: false })
+- projects_action = nav_button('Projects', projects_path(customer_id: @customer.id), permission: 'projects.view', data: { turbo_prefetch: false })
 - delete_action = delete_button(@customer, confirm: "Are you sure you want to delete customer \"#{@customer.matchcode}\" (#{@customer.name})?", permission: 'customers.edit') if @customer.can_be_deleted?
 - edit_action = action_button('Edit', edit_customer_path(@customer), permission: 'customers.edit')
-= breadcrumbs ['Customers', customers_path], @customer.matchcode, actions: [offers_action, delivery_notes_action, invoices_action, delete_action], action: edit_action do
+= breadcrumbs ['Customers', customers_path], @customer.matchcode, actions: [offers_action, delivery_notes_action, invoices_action, projects_action, delete_action], action: edit_action do
   - unless @customer.active?
     = badge_tag(:neutral, 'Inactive')
 

--- a/db/migrate/20260803215407_index_remaining_foreign_keys_and_require_invoice_tax_class_product_class.rb
+++ b/db/migrate/20260803215407_index_remaining_foreign_keys_and_require_invoice_tax_class_product_class.rb
@@ -1,0 +1,27 @@
+class IndexRemainingForeignKeysAndRequireInvoiceTaxClassProductClass < ActiveRecord::Migration[8.1]
+  # Two gaps the previous sweep left behind.
+  #
+  # invoices.customer_id, invoices.project_id and offers.accepted_version_id
+  # are the last foreign keys without a covering index — invoices is the table
+  # that grows without bound, and Customer#used_in_invoices? runs on every row
+  # of the customers list.
+  #
+  # invoice_tax_classes.sales_tax_product_class_id backs a required
+  # `belongs_to` but still accepted NULL, so the foreign key added alongside it
+  # was satisfied by orphans. It also left the unique index on
+  # (invoice_id, sales_tax_product_class_id) unable to dedupe in PostgreSQL,
+  # where NULLs are all distinct — an invoice could accumulate any number of
+  # NULL-class rows, each summed into sum_total.
+  #
+  # The NOT NULL will crash if such rows exist. What to do with them is the
+  # operator's call:
+  #
+  #   SELECT * FROM invoice_tax_classes WHERE sales_tax_product_class_id IS NULL;
+  def change
+    add_index :invoices, :customer_id
+    add_index :invoices, :project_id
+    add_index :offers, :accepted_version_id
+
+    change_column_null :invoice_tax_classes, :sales_tax_product_class_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_03_213704) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_03_215407) do
   create_table "acceptance_submissions", force: :cascade do |t|
     t.integer "attachment_id"
     t.datetime "created_at", null: false
@@ -291,7 +291,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_03_213704) do
     t.string "name"
     t.decimal "net"
     t.decimal "rate"
-    t.integer "sales_tax_product_class_id"
+    t.integer "sales_tax_product_class_id", null: false
     t.decimal "total"
     t.datetime "updated_at", null: false
     t.decimal "value"
@@ -327,9 +327,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_03_213704) do
     t.string "token"
     t.datetime "updated_at", null: false
     t.index ["attachment_id"], name: "index_invoices_on_attachment_id"
+    t.index ["customer_id"], name: "index_invoices_on_customer_id"
     t.index ["date"], name: "index_invoices_on_date"
     t.index ["document_number"], name: "index_invoices_on_document_number", unique: true
     t.index ["paid_at"], name: "index_invoices_on_paid_at"
+    t.index ["project_id"], name: "index_invoices_on_project_id"
     t.index ["published", "date"], name: "index_invoices_on_published_and_date"
     t.index ["published"], name: "index_invoices_on_published"
   end
@@ -406,6 +408,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_03_213704) do
     t.datetime "sent_at"
     t.string "state", default: "draft", null: false
     t.datetime "updated_at", null: false
+    t.index ["accepted_version_id"], name: "index_offers_on_accepted_version_id"
     t.index ["customer_contact_id"], name: "index_offers_on_customer_contact_id"
     t.index ["customer_id"], name: "index_offers_on_customer_id"
     t.index ["date"], name: "index_offers_on_date"


### PR DESCRIPTION
Follow-up to #663 (merged). Addresses the review findings against the merged state. The schema changes go in a **new migration** rather than amending #663's — those are already applied and would never re-run.

## `invoice_tax_classes.sales_tax_product_class_id` was left nullable

It backs a required `belongs_to`, so the foreign key added in #663 was satisfiable by orphans — exactly the gap that PR set out to close, and it made five other columns NOT NULL while missing this one.

The sharper consequence is in PostgreSQL: NULLs are all distinct, so the unique index on `(invoice_id, sales_tax_product_class_id)` could not dedupe them. An invoice could accumulate any number of NULL-class tax rows, each folded into `sum_total` by `Invoice#update_sums`.

Safe to constrain — `invoice.rb:301` always builds these with a class.

## Three foreign keys still had no covering index

`invoices.customer_id`, `invoices.project_id`, `offers.accepted_version_id`. `invoices` is the table that grows without bound, and `Customer#used_in_invoices?` runs per row on the customers list. All 56 foreign-key columns are covered after this.

## A comment that #663 made false

`SalesTaxProductClass#deletion_blocker` said "only offer_versions has a database foreign key; nothing else would stop a delete from leaving dangling references on published invoices." #663 added the other four. The comment claimed the `before_destroy` guard was the only protection, which would mislead anyone deciding whether to keep it. Replaced with why the guard still earns its place: a named reason instead of an `InvalidForeignKey`.

## Consistency and discoverability

- `Customer#used_in_projects?` hand-rolled `Project.where(bill_to_customer_id:)` while its three siblings use associations, and `sync_project_teams` already duplicated that scope. Added `has_many :billed_projects`; both now read like the rest of the model.
- The customer page gained a **Projects** button. Offers, Delivery Notes and Invoices each had one, so all three pre-existing deletion blockers were reachable from the page. The projects blocker added in #663 was not — a customer with no documents lost its Delete button with nothing on screen explaining why.

## Deliberately not addressed

**Stale id in a permitted param for an `optional: true` belongs_to raises `InvalidForeignKey` (500) rather than a validation error**, because Rails only checks existence for *required* associations. This wants its own change rather than being folded in here.

*Correction to an earlier version of this description:* I first called this pre-existing and cited `offers.customer_contact_id` as an example. That example is wrong — `Offer` validates that column explicitly (`offer.rb:28`, `:209`), and because the check is `CustomerContact.where(id:, customer_id:).exists?` it rejects a nonexistent id as a validation error, never reaching the constraint. The two columns that genuinely behave this way are `projects.bill_to_customer_id` (`team_must_match_customer` returns early when the lookup is nil, `project.rb:66`) and `invoice_lines.sales_tax_product_class_id` — and both got their foreign key in #663, so this is a behavior change that PR introduced, not something that already shipped. Previously a stale id silently persisted as a dangling reference; now it 500s. Neither is right, and a validation error is.

Also left alone, as judgment calls worth stating: the customers-index N+1 grows from three EXISTS per row to four (marginal, and the fix is a preload refactor of a pre-existing pattern); and `publish_problems` renders an empty product-class name for a nil class, which predates #663 — only its reachability changed.

## Migrations and production data

The NOT NULL will crash if `invoice_tax_classes` holds NULL-class rows, and names the `SELECT` to inspect them. No data is touched; what happens to those rows is the operator's call.

## Verification

- SQLite: 1158 runs, 3914 assertions, 0 failures
- PostgreSQL, database dropped and rebuilt from scratch: 1158 runs, 0 failures
- System tests: 76 runs, 0 failures
- `pre-commit run --all-files` passes; no `db/schema.rb` drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)
