### PR TITLE
Recheck the offer contact when the customer changes

### DIFF
--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -25,7 +25,10 @@ class Offer < ApplicationRecord
   strips_rich_text_edges :internal_notes
 
   validates :state, inclusion: { in: STATES }
-  validate :customer_contact_must_belong_to_customer, if: :will_save_change_to_customer_contact_id?
+  # Also on a customer change: moving the offer to another customer while the
+  # contact stays put is what leaves the two pointing at different customers.
+  validate :customer_contact_must_belong_to_customer,
+           if: -> { will_save_change_to_customer_contact_id? || will_save_change_to_customer_id? }
 
   after_create :create_initial_version
 

--- a/test/models/offer_test.rb
+++ b/test/models/offer_test.rb
@@ -109,6 +109,14 @@ class OfferTest < ActiveSupport::TestCase
     assert_includes offer.errors[:customer_contact], "must belong to the offer's customer"
   end
 
+  test "customer_contact is rechecked when only the customer changes" do
+    offer = offers(:draft_offer)
+    offer.update!(customer_contact: CustomerContact.create!(customer: offer.customer, name: "C", email: "c@example.com"))
+    offer.customer = customers(:good_eu)
+    assert_not offer.valid?
+    assert_includes offer.errors[:customer_contact], "must belong to the offer's customer"
+  end
+
   test "customer_contact can be assigned if it belongs to the offer's customer" do
     offer = offers(:draft_offer)
     contact = CustomerContact.create!(


### PR DESCRIPTION
`Offer#customer_contact_must_belong_to_customer` ran only on `will_save_change_to_customer_contact_id?`. Moving an offer to a different customer while leaving the contact alone skipped it, so the offer ended up holding a contact belonging to someone else — the exact state the validation exists to prevent. Both `customer_id` and `customer_contact_id` are mass-assignable (`offers_controller.rb:240`).

## What I found before changing anything

Probed the real behavior against fixtures rather than reasoning from the source:

| case | result |
|---|---|
| contact belonging to the offer's customer | valid |
| **nonexistent** contact id | **rejected** — validation error |
| foreign contact assigned on create | rejected |
| **change `customer_id` only, contact untouched** | **valid, and the mismatch persisted** |

Worth noting for the second row: because the check is `CustomerContact.where(id:, customer_id:).exists?`, it covers *existence* as well as scoping. A stale contact id yields a validation error, never an `InvalidForeignKey`. So this column was never part of the optional-FK 500 problem discussed in #666 — I've corrected that PR's description, which cited it as an example.

## Scope of the impact

Narrower than it first appears, and worth stating plainly rather than overselling:

- `Offer#email_recipients` and `#email_salutation_contact` both resolve through `customer.contacts_for_offer` (`offer.rb:128`, `:136`), **not** through `customer_contact`. No mail is misdirected and no salutation is wrong.
- The stale contact surfaces on the offer show page, which renders `@offer.customer_contact.name` directly (`offers/show.html.haml:26-31`).

So this is a data-integrity defect with a UI symptom, not an email leak.

## The fix

The condition now fires on either column changing. The new test fails against the old condition — verified by reverting the fix and watching it go red, so it is not a vacuous test.

## Verification

- Full suite: 1159 runs, 3917 assertions, 0 failures
- `pre-commit run --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)