### PR TITLE
Show the internal reference in the reporting-address digests

### DIFF
--- a/app/views/expiring_offers_mailer/expiring_report.html.haml
+++ b/app/views/expiring_offers_mailer/expiring_report.html.haml
@@ -31,6 +31,7 @@
   %thead
     %tr
       %th= t('mailers.expiring_offers.columns.offer_number')
+      %th= t('mailers.expiring_offers.columns.internal_reference')
       %th= t('mailers.expiring_offers.columns.customer')
       %th= t('mailers.expiring_offers.columns.expired_on')
       %th.numeric= t('mailers.expiring_offers.columns.total')
@@ -38,6 +39,7 @@
     - @offers.each do |offer|
       %tr
         %td= link_to offer.document_number, AbsoluteUrl.offer(offer)
+        %td= offer.internal_reference
         %td= offer.customer.name
         %td= l(offer.expires_at) if offer.expires_at
         %td.numeric= sprintf('%.2f', offer.current_sent_version.sum_net)

--- a/app/views/expiring_offers_mailer/expiring_report.text.erb
+++ b/app/views/expiring_offers_mailer/expiring_report.text.erb
@@ -3,6 +3,7 @@
 <%= t('mailers.expiring_offers.main_message', count: @offers.size) %>
 
 <% @offers.each do |offer| %>
-<%= "#{offer.document_number}  #{offer.customer.name}  #{t('mailers.expiring_offers.short.expired_on')} #{l(offer.expires_at) if offer.expires_at}  #{sprintf('%.2f', offer.current_sent_version.sum_net)}" %>
+<% reference = "#{t('mailers.expiring_offers.short.internal_reference')} #{offer.internal_reference}  " if offer.internal_reference.present? %>
+<%= "#{offer.document_number}  #{reference}#{offer.customer.name}  #{t('mailers.expiring_offers.short.expired_on')} #{l(offer.expires_at) if offer.expires_at}  #{sprintf('%.2f', offer.current_sent_version.sum_net)}" %>
 <%= AbsoluteUrl.offer(offer) %>
 <% end %>

--- a/app/views/overdue_invoices_mailer/overdue_report.html.haml
+++ b/app/views/overdue_invoices_mailer/overdue_report.html.haml
@@ -31,6 +31,7 @@
   %thead
     %tr
       %th= t('mailers.overdue_invoices.columns.invoice_number')
+      %th= t('mailers.overdue_invoices.columns.internal_reference')
       %th= t('mailers.overdue_invoices.columns.customer')
       %th= t('mailers.overdue_invoices.columns.invoice_date')
       %th= t('mailers.overdue_invoices.columns.due_date')
@@ -40,6 +41,7 @@
     - @invoices.each do |invoice|
       %tr
         %td= invoice.document_number
+        %td= invoice.internal_reference
         %td= invoice.customer.matchcode
         %td= l(invoice.date) if invoice.date
         %td= l(invoice.due_date) if invoice.due_date

--- a/app/views/overdue_invoices_mailer/overdue_report.text.erb
+++ b/app/views/overdue_invoices_mailer/overdue_report.text.erb
@@ -4,5 +4,6 @@
 
 <% @invoices.each do |invoice| %>
 <% days_overdue = (@today - invoice.due_date).to_i %>
-<%= "#{invoice.document_number}  #{invoice.customer.matchcode}  #{t('mailers.overdue_invoices.short.invoice_date')} #{l(invoice.date) if invoice.date}  #{t('mailers.overdue_invoices.short.due_date')} #{l(invoice.due_date) if invoice.due_date}  #{sprintf('%.2f', invoice.sum_total)}  #{t('mailers.overdue_invoices.short.days_overdue', days: days_overdue)}" %>
+<% reference = "#{t('mailers.overdue_invoices.short.internal_reference')} #{invoice.internal_reference}  " if invoice.internal_reference.present? %>
+<%= "#{invoice.document_number}  #{reference}#{invoice.customer.matchcode}  #{t('mailers.overdue_invoices.short.invoice_date')} #{l(invoice.date) if invoice.date}  #{t('mailers.overdue_invoices.short.due_date')} #{l(invoice.due_date) if invoice.due_date}  #{sprintf('%.2f', invoice.sum_total)}  #{t('mailers.overdue_invoices.short.days_overdue', days: days_overdue)}" %>
 <% end %>

--- a/app/views/upcoming_offer_deliveries_mailer/upcoming_report.html.haml
+++ b/app/views/upcoming_offer_deliveries_mailer/upcoming_report.html.haml
@@ -27,6 +27,7 @@
   %thead
     %tr
       %th= t('mailers.upcoming_offer_deliveries.columns.offer_number')
+      %th= t('mailers.upcoming_offer_deliveries.columns.internal_reference')
       %th= t('mailers.upcoming_offer_deliveries.columns.customer')
       %th= t('mailers.upcoming_offer_deliveries.columns.delivery_date')
       %th= t('mailers.upcoming_offer_deliveries.columns.missing')
@@ -34,6 +35,7 @@
     - @entries.each do |entry|
       %tr
         %td= link_to entry[:offer].document_number, AbsoluteUrl.offer(entry[:offer])
+        %td= entry[:offer].internal_reference
         %td= entry[:offer].customer.name
         %td= l(entry[:offer].accepted_version.delivery_date)
         %td= entry[:missing].join('; ')

--- a/app/views/upcoming_offer_deliveries_mailer/upcoming_report.text.erb
+++ b/app/views/upcoming_offer_deliveries_mailer/upcoming_report.text.erb
@@ -3,6 +3,7 @@
 <%= t('mailers.upcoming_offer_deliveries.main_message', count: @entries.size) %>
 
 <% @entries.each do |entry| %>
-<%= "#{entry[:offer].document_number}  #{entry[:offer].customer.name}  #{t('mailers.upcoming_offer_deliveries.short.delivery')} #{l(entry[:offer].accepted_version.delivery_date)}  #{entry[:missing].join('; ')}" %>
+<% reference = "#{t('mailers.upcoming_offer_deliveries.short.internal_reference')} #{entry[:offer].internal_reference}  " if entry[:offer].internal_reference.present? %>
+<%= "#{entry[:offer].document_number}  #{reference}#{entry[:offer].customer.name}  #{t('mailers.upcoming_offer_deliveries.short.delivery')} #{l(entry[:offer].accepted_version.delivery_date)}  #{entry[:missing].join('; ')}" %>
 <%= AbsoluteUrl.offer(entry[:offer]) %>
 <% end %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -14,12 +14,14 @@ de:
       main_message: "Es gibt %{count} unbezahlte Rechnung(en), deren Fälligkeitsdatum überschritten ist."
       columns:
         invoice_number: "Rechnungsnr."
+        internal_reference: "Interne Ref."
         customer: "Kunde"
         invoice_date: "Rechnungsdatum"
         due_date: "Fälligkeitsdatum"
         gross_amount: "Bruttobetrag"
         days_overdue: "Tage überfällig"
       short:
+        internal_reference: "Ref:"
         invoice_date: "Datum:"
         due_date: "Fällig:"
         days_overdue: "%{days} Tage überfällig"
@@ -35,10 +37,12 @@ de:
         other: "Es gibt %{count} Angebote, deren Gültigkeit abgelaufen ist."
       columns:
         offer_number: "Angebotsnr."
+        internal_reference: "Interne Ref."
         customer: "Kunde"
         expired_on: "Abgelaufen am"
         total: "Summe"
       short:
+        internal_reference: "Ref:"
         expired_on: "Abgelaufen:"
 
     upcoming_offer_deliveries:
@@ -52,10 +56,12 @@ de:
         other: "%{count} angenommene Angebote brauchen Verrechnungsaufmerksamkeit: Liefertermin innerhalb von 5 Tagen oder ein Meilenstein bei Auftrag ist noch nicht gebucht."
       columns:
         offer_number: "Angebotsnr."
+        internal_reference: "Interne Ref."
         customer: "Kunde"
         delivery_date: "Liefertermin"
         missing: "Offen"
       short:
+        internal_reference: "Ref:"
         delivery: "Lieferung:"
       status:
         unconverted:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,12 +90,14 @@ en:
       main_message: "There are %{count} unpaid invoice(s) past their due date."
       columns:
         invoice_number: "Invoice no."
+        internal_reference: "Internal ref."
         customer: "Customer"
         invoice_date: "Invoice date"
         due_date: "Due date"
         gross_amount: "Gross amount"
         days_overdue: "Days overdue"
       short:
+        internal_reference: "Ref:"
         invoice_date: "Date:"
         due_date: "Due:"
         days_overdue: "%{days} days overdue"
@@ -111,10 +113,12 @@ en:
         other: "There are %{count} offers whose validity has expired."
       columns:
         offer_number: "Offer no."
+        internal_reference: "Internal ref."
         customer: "Customer"
         expired_on: "Expired on"
         total: "Total"
       short:
+        internal_reference: "Ref:"
         expired_on: "Expired:"
 
     upcoming_offer_deliveries:
@@ -128,10 +132,12 @@ en:
         other: "%{count} accepted offers need invoicing attention: delivery is within 5 days or an on-order milestone is not yet booked."
       columns:
         offer_number: "Offer no."
+        internal_reference: "Internal ref."
         customer: "Customer"
         delivery_date: "Delivery date"
         missing: "Missing"
       short:
+        internal_reference: "Ref:"
         delivery: "Delivery:"
       status:
         unconverted:

--- a/test/mailers/overdue_invoices_mailer_test.rb
+++ b/test/mailers/overdue_invoices_mailer_test.rb
@@ -5,10 +5,10 @@ class OverdueInvoicesMailerTest < ActionMailer::TestCase
     ActionMailer::Base.deliveries.clear
 
     @overdue_a = invoices(:published_invoice)
-    @overdue_a.update_columns(due_date: 10.days.ago.to_date, paid_at: nil)
+    @overdue_a.update_columns(due_date: 10.days.ago.to_date, paid_at: nil, internal_reference: "PROJ-42")
 
     @overdue_b = invoices(:auto_email_invoice)
-    @overdue_b.update_columns(due_date: 3.days.ago.to_date, paid_at: nil)
+    @overdue_b.update_columns(due_date: 3.days.ago.to_date, paid_at: nil, internal_reference: "PROJ-43")
   end
 
   test "overdue_report builds an email to the issuer's reporting_email" do
@@ -31,6 +31,7 @@ class OverdueInvoicesMailerTest < ActionMailer::TestCase
 
     invoices.each do |inv|
       assert_match inv.document_number, html
+      assert_match inv.internal_reference, html
       assert_match inv.customer.matchcode, html
       assert_match inv.date.strftime("%d.%m.%Y"), html
       assert_match inv.due_date.strftime("%d.%m.%Y"), html
@@ -48,10 +49,19 @@ class OverdueInvoicesMailerTest < ActionMailer::TestCase
     text = mail.text_part.body.to_s
 
     assert_match @overdue_a.document_number, text
+    assert_match "Ref: PROJ-42", text
     assert_match @overdue_a.customer.matchcode, text
     assert_match @overdue_a.date.strftime("%d.%m.%Y"), text
     assert_match @overdue_a.due_date.strftime("%d.%m.%Y"), text
     assert_match sprintf("%.2f", @overdue_a.sum_total), text
     assert_match "10 days overdue", text
+  end
+
+  test "overdue_report text omits the reference label for an invoice without one" do
+    @overdue_a.update_columns(internal_reference: nil)
+
+    mail = OverdueInvoicesMailer.with(invoices: [ @overdue_a ]).overdue_report
+
+    assert_no_match(/Ref:/, mail.text_part.body.to_s)
   end
 end


### PR DESCRIPTION
The three digests that go to the issuer's `reporting_email` — overdue invoices, expired offers, upcoming offer deliveries — identified each row only by document number and customer. The internal reference is what these documents are tracked by internally, so it now sits next to the document number in both the HTML table and the text part.

`VatVerificationsReportMailer` also goes to the reporting address but is customer-scoped, and customers have no internal reference — left untouched. `AcceptanceSubmissionMailer` is prose about a single delivery note rather than a table, and was left alone as well.

## Notes

The text lines are two-space-separated with labelled short fields (`Date:`, `Due:`). An unconditional field would leave a doubled separator and a dangling label whenever the reference is unset, so it is emitted only when present. The HTML cell is simply empty.

```
INV-2024-001  Ref: PROJ-42  GOOD  Date: 04.08.2026  Due: 25.07.2026  121.00  10 days overdue
INV-2024-002  AUTOEMAIL  Date: 04.08.2026  Due: 01.08.2026  297.50  3 days overdue
```

New `columns.internal_reference` / `short.internal_reference` keys landed in both `en.yml` and `de.yml`.

## Testing

Regression tests cover the overdue digest only (set reference shows in both parts, unset reference emits no stray `Ref:` label); the other two mailers get the identical production change without a mirrored test. All three render in both formats under the existing job tests.

`bundle exec rails test` — 1160 runs, 3922 assertions, 0 failures. `pre-commit run --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)